### PR TITLE
Fix for busy wait loop

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -627,8 +627,11 @@ void SocketSendData(CNode* pnode)
         assert(data.size() > pnode->nSendOffset);
 
         int amt2Send = min((int64_t)(data.size() - pnode->nSendOffset), sendShaper.available(SEND_SHAPER_MIN_FRAG));
-        if (amt2Send == 0)
+        if (amt2Send == 0) {
+            if (sendShaper.available(SEND_SHAPER_MIN_FRAG) != INT_MAX) //Sleep if traffic shaping is turned on
+                MilliSleep(10);
             break;
+        }
         int nBytes = send(pnode->hSocket, &data[pnode->nSendOffset], amt2Send, MSG_NOSIGNAL | MSG_DONTWAIT);
         if (nBytes > 0) {
             pnode->nLastSend = GetTime();


### PR DESCRIPTION
If traffic shaping is turned on and we hit
the maximum outgoing byte rate then we will
start to spin and consume cpu.  If you're on a 4
core you probably won't notice anything but you
will consume on an entire core.  On a dual core
it's very noticeable.
