### PR TITLE
Thinblock preferential downloader

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5162,7 +5162,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             vector<CInv> vGetData;
             vGetData.push_back(CInv(MSG_BLOCK, thinBlock.header.GetHash())); 
             pfrom->PushMessage("getdata", vGetData);
-            LogPrintf("thin", "Missing %d Thinblock transactions, re-requesting a regular block\n",  
+            LogPrint("thin", "Missing %d Thinblock transactions, re-requesting a regular block\n",  
                        pfrom->thinBlockWaitingForTxns);
         }
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4597,7 +4597,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                         // BUIP010 Xtreme Thinblocks: begin section
                         CInv inv2(inv);
                         if (IsThinBlocksEnabled() && IsChainNearlySyncd()) {
-                            if (HaveThinblockNodeConnections()) {
+                            if (HaveConnectThinblockNodes() || (HaveThinblockNodes() && CheckThinblockTimer(inv.hash))) {
                                 // Must download a block from a ThinBlock peer
                                 if (pfrom->mapThinBlocksInFlight.size() < 1 && pfrom->nVersion >= THINBLOCKS_VERSION) { // We can only send one thinblock per peer at a time
                                     pfrom->mapThinBlocksInFlight[inv2.hash] = GetTime();
@@ -5947,7 +5947,7 @@ bool SendMessages(CNode* pto)
             BOOST_FOREACH(CBlockIndex *pindex, vToDownload) {
                 // BUIP010 Xtreme Thinblocks: begin section
                 if (IsThinBlocksEnabled() && IsChainNearlySyncd()) {
-                    if (HaveThinblockNodeConnections()) {
+                    if (HaveConnectThinblockNodes() || (HaveThinblockNodes() && CheckThinblockTimer(pindex->GetBlockHash()))) {
                         // Must download a block from a ThinBlock peer
                         if (pto->mapThinBlocksInFlight.size() < 1 && pto->nVersion >= THINBLOCKS_VERSION) { // We can only send one thinblock per peer at a time
                             pto->mapThinBlocksInFlight[pindex->GetBlockHash()] = GetTime();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1469,8 +1469,8 @@ void static ProcessOneShot()
 void ThreadOpenConnections()
 {
     // Connect to specific addresses
-  if ((mapArgs.count("-connect") && mapMultiArgs["-connect"].size() > 0) ||
-      (mapArgs.count("-connect-thinblock") && mapMultiArgs["-connect-thinblock"].size() > 0)) // BUIP010 Xtreme Thinblocks
+    if ((mapArgs.count("-connect") && mapMultiArgs["-connect"].size() > 0) ||
+        (mapArgs.count("-connect-thinblock") && mapMultiArgs["-connect-thinblock"].size() > 0)) // BUIP010 Xtreme Thinblocks
     {
         for (int64_t nLoop = 0;; nLoop++)
         {

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -42,6 +42,9 @@ boost::chrono::steady_clock CLeakyBucket::clock;
 
 void UnlimitedPushTxns(CNode* dest);
 
+// BUIP010 Xtreme Thinblocks Variables
+std::map<uint256, uint64_t> mapThinBlockTimer;
+
 std::string UnlimitedCmdLineHelp()
 {
     std::string strUsage;
@@ -492,7 +495,7 @@ UniValue settrafficshaping(const UniValue& params, bool fHelp)
 /**
  *  BUIP010 Xtreme Thinblocks Section 
  */
-bool HaveThinblockNodeConnections()
+bool HaveConnectThinblockNodes()
 {
     // Strip the port from then list of all the current in and outbound ip addresses
     std::vector<std::string> vNodesIP;
@@ -539,6 +542,44 @@ bool HaveThinblockNodeConnections()
         LogPrint("thin", "You have a cross connected thinblock node - we may download regular blocks until you resolve the issue\n");
     return false; // Connections are either not open or they are cross connected.
 } 
+
+bool HaveThinblockNodes()
+{
+    {
+        LOCK(cs_vNodes);
+        BOOST_FOREACH (CNode* pnode, vNodes)
+            if (pnode->nVersion >= THINBLOCKS_VERSION)
+                return true;
+    }
+    return false;
+}
+
+bool CheckThinblockTimer(uint256 hash)
+{
+    if (!mapThinBlockTimer.count(hash)) {
+        mapThinBlockTimer[hash] = GetTimeMillis();
+        LogPrint("thin", "Starting Preferential Thinblock timer\n");
+    }
+    else {
+        // Check that we have not exceeded the 10 second limit.
+        // If we have then we want to return false so that we can
+        // proceed to download a regular block instead.
+        uint64_t elapsed = GetTimeMillis() - mapThinBlockTimer[hash];
+        if (elapsed > 10000) {
+            LogPrint("thin", "Preferential Thinblock timer exceeded - downloading regular block instead\n");
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ClearThinBlockTimer(uint256 hash)
+{
+    if (mapThinBlockTimer.count(hash)) {
+        mapThinBlockTimer.erase(hash);
+        LogPrint("thin", "Clearing Preferential Thinblock timer\n");
+    }
+}
 
 bool IsThinBlocksEnabled() 
 {
@@ -617,6 +658,9 @@ void HandleBlockMessage(CNode *pfrom, const string &strCommand, CBlock &block, c
             }
         }
     }
+
+    // Clear the thinblock timer used for preferential download
+    ClearThinBlockTimer(inv.hash);
 }
 
 bool ThinBlockMessageHandler(vector<CNode*>& vNodesCopy)

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -58,8 +58,11 @@ extern CLeakyBucket receiveShaper;
 extern CLeakyBucket sendShaper;
 
 // BUIP010 Xtreme Thinblocks:
-extern bool HaveThinblockNodeConnections();
-extern bool IsThinBlocksEnabled();  // has the user enabled thin blocks for this node (command line option)
+extern bool HaveConnectThinblockNodes();
+extern bool HaveThinblockNodes();
+extern bool CheckThinblockTimer(uint256 hash);
+extern bool ClearThinblockTimer(uint256 hash);
+extern bool IsThinBlocksEnabled();
 extern bool IsChainNearlySyncd();
 extern void SendSeededBloomFilter(CNode *pto);
 extern void HandleBlockMessage(CNode *pfrom, const std::string &strCommand, CBlock &block, const CInv &inv);
@@ -69,5 +72,6 @@ extern void SendXThinBlock(CBlock &block, CNode* pfrom, const CInv &inv);
 
 // Handle receiving and sending messages from thin block capable nodes only (so that thin block nodes capable nodes are preferred)
 extern bool ThinBlockMessageHandler(std::vector<CNode*>& vNodesCopy);
+extern std::map<uint256, uint64_t> mapThinBlockTimer;
 
 #endif


### PR DESCRIPTION
It works as follows:

The preferential downloader works for nodes that are casually connected to other thinblock nodes or by the use of "addnode=<ip>"

If a new block announcement has arrived by "inv" and it's not from a thinblock node then a 10 second timer is started.  Every following inv is checked until either it gets one from a thinblock node or the timer is exceeded.  If the timer is exceeded then a regular block is downloaded instead.

You can still use "connect-thinblock=<ip>" for those that always want thinblocks and it will override the timer functionality described above.
