### PR TITLE
Xpress Validation

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -145,6 +145,15 @@ extern CFeeRate minRelayTxFee;
 extern bool fAlerts;
 extern bool fEnableReplacement;  // BU TODO is this RBF flag?
 
+// Xpress Validation: begin section
+/**
+ * Transactions that have already been accepted into the memory pool do not need to be
+ * re-verified and can avoid having to do a second and expensive CheckInputs() when 
+ * processing a new block.  (Protected by cs_main)
+ */
+static std::set<uint256> setPreVerifiedTxHash;
+// Xpress Validation: end section
+
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex *pindexBestHeader;
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -547,15 +547,22 @@ void HandleBlockMessage(CNode *pfrom, const string &strCommand, CBlock &block, c
     // the block didn't arrive from some other peer.  This code ALSO cleans up the thin block that
     // was passed to us (&block), so do not use it after this.
     {
+        int nTotalThinBlocksInFlight = 0;
         LOCK(cs_vNodes);
         BOOST_FOREACH(CNode* pnode, vNodes) {
             if (pnode->mapThinBlocksInFlight.count(inv.hash)) {
                 pnode->mapThinBlocksInFlight.erase(inv.hash); 
                 pnode->thinBlockWaitingForTxns = -1;
                 pnode->thinBlock.SetNull();
-                if (pnode != pfrom) LogPrintf("Removing thinblock in flight %s from %s (%d)\n",inv.hash.ToString(), pnode->addrName.c_str(), pnode->id);
             }
+            if (pnode->mapThinBlocksInFlight.size() > 0)
+                nTotalThinBlocksInFlight++;
         }
+
+        // When we no longer have any thinblocks in flight then clear the set
+        // just to make sure we don't somehow get growth over time.
+        if (nTotalThinBlocksInFlight == 0)
+            setPreVerifiedTxHash.clear();
     }
 
     // Clear the thinblock timer used for preferential download
@@ -668,7 +675,4 @@ void SendXThinBlock(CBlock &block, CNode* pfrom, const CInv &inv)
             LogPrint("thin", "Sent regular block instead - thinblock size: %d vs block size: %d => tx hashes: %d transactions: %d  peerid=%d\n", nSizeThinBlock, nSizeBlock, thinBlock.vTxHashes.size(), thinBlock.mapMissingTx.size(), pfrom->id);
         }
     }
-
 }
-
-


### PR DESCRIPTION
Building on Xtreme Thinblocks, Xpress Validation
allows for a much faster and more scalable approach
to validating a block.  Because most transactions have
already been validated when entering the memory pool
we only have to validate new transactions arriving in the
XThinblock before re-assembling the block.
