### PR TITLE
Buip010.stats

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5214,6 +5214,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                      nSizeThinBlock,
                      ((float) blockSize) / ((float) nSizeThinBlock)
                      );
+
+            // Update run-time statistics of thin block bandwidth savings
+            CThinBlockStats::Update(nSizeThinBlock, blockSize);
+            std::string ss = CThinBlockStats::ToString();
+            LogPrint("thin", "thin block stats: %s\n", ss.c_str());
+
             HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, inv);  // clears the thin block
             BOOST_FOREACH(uint64_t &cheapHash, thinBlock.vTxHashes)
                 EraseOrphanTx(mapPartialTxHash[cheapHash]);
@@ -5307,6 +5313,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                      nSizeThinBlock,
                      ((float) blockSize) / ((float) nSizeThinBlock)
                      );
+
+            // Update run-time statistics of thin block bandwidth savings
+            CThinBlockStats::Update(nSizeThinBlock, blockSize);
+            std::string ss = CThinBlockStats::ToString();
+            LogPrint("thin", "thin block stats: %s\n", ss.c_str());
+
             HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, inv);
             BOOST_FOREACH(uint256 &hash, thinBlock.vTxHashes)
                 EraseOrphanTx(hash);
@@ -5359,6 +5371,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                      nSizeThinBlockTx,
                      ((float) blockSize) / ( (float) pfrom->nSizeThinBlock + (float) nSizeThinBlockTx )
                      );
+
+            // Update run-time statistics of thin block bandwidth savings
+            CThinBlockStats::Update(nSizeThinBlockTx + pfrom->nSizeThinBlock, blockSize);
+            std::string ss = CThinBlockStats::ToString();
+            LogPrint("thin", "thin block stats: %s\n", ss.c_str());
+
             std::vector<CTransaction> vTx = pfrom->thinBlock.vtx;
             HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, inv);
             for (unsigned int i = 0; i < vTx.size(); i++)

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -16,6 +16,8 @@
 #include "util.h"
 #include "utilstrencodings.h"
 #include "version.h"
+#include "thinblock.h"
+#include "unlimited.h"
 
 #include <boost/foreach.hpp>
 #include <boost/lexical_cast.hpp>
@@ -412,6 +414,20 @@ static UniValue GetNetworksInfo()
     return networks;
 }
 
+// BitcoinUnlimited BUIP010 : Start
+static UniValue GetThinBlockStats()
+{
+    UniValue obj(UniValue::VOBJ);
+    bool enabled = IsThinBlocksEnabled();
+    obj.push_back(Pair("enabled", enabled));
+    if (enabled) {
+        obj.push_back(Pair("summary", CThinBlockStats::ToString()));
+    }
+    return obj;
+}
+// BitcoinUnlimited BUIP010 : End
+
+
 UniValue getnetworkinfo(const UniValue& params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
@@ -445,6 +461,7 @@ UniValue getnetworkinfo(const UniValue& params, bool fHelp)
             "  ,...\n"
             "  ]\n"
             "  \"warnings\": \"...\"                    (string) any network warnings (such as alert messages) \n"
+            "  \"thinblockstats\": \"...\"              (string) thin block related statistics \n" 
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getnetworkinfo", "")
@@ -475,6 +492,9 @@ UniValue getnetworkinfo(const UniValue& params, bool fHelp)
         }
     }
     obj.push_back(Pair("localaddresses", localAddresses));
+// BitcoinUnlimited BUIP010: Start
+    obj.push_back(Pair("thinblockstats", GetThinBlockStats()));
+// BitcoinUnlimited BUIP010: End
     obj.push_back(Pair("warnings",       GetWarnings("statusbar")));
     return obj;
 }

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -3,6 +3,14 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "thinblock.h"
+#include <sstream>
+#include <iomanip>
+
+// Start statistics at zero
+uint64_t CThinBlockStats::nOriginalSize = 0;
+uint64_t CThinBlockStats::nThinSize = 0;
+uint64_t CThinBlockStats::nBlocks = 0;
+
 
 CThinBlock::CThinBlock(const CBlock& block, CBloomFilter& filter)
 {
@@ -87,3 +95,32 @@ CXThinBlockTx::CXThinBlockTx(uint256 blockHash, std::vector<uint64_t>& vHashesTo
     for (unsigned int i = 0; i < n; i++)
         mapTx[vHashesToRequest[i]] = tx;
 }
+
+
+
+void CThinBlockStats::Update(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize)
+{
+	CThinBlockStats::nOriginalSize += nOriginalBlockSize;
+	CThinBlockStats::nThinSize += nThinBlockSize;
+	CThinBlockStats::nBlocks++;
+}
+
+
+std::string CThinBlockStats::ToString()
+{
+	static const char *units[] = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
+	int i = 0;
+	double size = double( CThinBlockStats::nOriginalSize - CThinBlockStats::nThinSize );
+	while (size > 1024) {
+		size /= 1024;
+		i++;
+	}
+
+	std::ostringstream ss;
+	ss << std::fixed << std::setprecision(2);
+	ss << CThinBlockStats::nBlocks << " thin " << ((CThinBlockStats::nBlocks>1) ? "blocks have" : "block has") << " saved " << size << units[i] << " of bandwidth";
+	std::string s = ss.str();
+	return s;
+}
+
+

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -78,4 +78,21 @@ public:
         READWRITE(mapTx);
     }
 };
+
+// This class stores statistics for thin block derived protocols.
+class CThinBlockStats
+{
+private:
+	static uint64_t nOriginalSize;
+	static uint64_t nThinSize;
+	static uint64_t nBlocks;
+public:
+	static void Update(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
+	static std::string ToString();
+};
+
+
+
+
+
 #endif // BITCOIN_THINBLOCK_H


### PR DESCRIPTION
Keep running total of bandwidth saved from using thin blocks and extreme thin blocks.
- Add class CThinBlockStats to maintain stats
- Update stats when thin block has been assembled successfully & write stats to debug.log:

> 2016-03-08 23:08:31 thin block stats: 1 thin block has saved 156.79KB of bandwidth
> 2016-03-08 23:17:24 thin block stats: 2 thin blocks have saved 573.60KB of bandwidth
> 2016-03-08 23:42:05 thin block stats: 3 thin blocks have saved 1.48MB of bandwidth
> 2016-03-08 23:47:20 thin block stats: 4 thin blocks have saved 1.92MB of bandwidth
- Return stats in RPC call 'getnetworkinfo':

>  "thinblockstats": {
>     "enabled": true,
>     "summary": "2 thin blocks have saved 573.60KB of bandwidth"
>   },
> ...
>   "thinblockstats": {
>     "enabled": true,
>     "summary": "4 thin blocks have saved 1.92MB of bandwidth"
>   },
