### PR TITLE
fixed cheap hash collision detection

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5159,9 +5159,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             // In that case we would have the same transaction twice, so it is not a real cheap hash collision and we continue normally.
             const uint256 existingHash = mapPartialTxHash[cheapHash];
             if( (!existingHash.IsNull()) ) { // Check if we already have the cheap hash
-                LogPrint("thin", "TX with the same cheap hash was already found\n");
                 if ((existingHash != (*mi).first)) { // Check if it really is a cheap hash collision and not just the same transaction
-                	LogPrint("thin", "TX full hashes are not matching\n");
                     collision = true;
                 }
             }


### PR DESCRIPTION
When I was connected to a slow node, I got several log messages stating:
"TX HASH COLLISION for xthinblock: re-requesting a thinblock"

The problem was that during the time of the request of xthinblocks, my node already received some previously missing transactions. The check for collisions of cheap hashes then found the same cheap hash in the mempool and in the transaction within the xthinblock. Now this is fixed by additionally checking the full hash if there is a cheap hash collision with a transaction received within the xthinblock.
