### PR TITLE
Added a separate bloom filter specifically for XThinblocks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5634,23 +5634,17 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         CBloomFilter filter;
         vRecv >> filter;
     
-        // BUIP010 Xtreme Thinblocks - begin section
-        LoadFilter(pfrom, &filter);
-
-        //if (!filter.IsWithinSizeConstraints())
-        //    // There is no excuse for sending a too-large filter
-        //    Misbehaving(pfrom->GetId(), 100);
-        //else
-        //{
-        //    LOCK(pfrom->cs_filter);
-        //    delete pfrom->pfilter;
-        //    pfrom->pfilter = new CBloomFilter(filter);
-        //    pfrom->pfilter->UpdateEmptyFull();
-        //}
-        //pfrom->fRelayTxes = true;
-
-        // BUIP010 Xtreme Thinblocks - end section
-
+        if (!filter.IsWithinSizeConstraints())
+            // There is no excuse for sending a too-large filter
+            Misbehaving(pfrom->GetId(), 100);
+        else
+        {
+            LOCK(pfrom->cs_filter);
+            delete pfrom->pfilter;
+            pfrom->pfilter = new CBloomFilter(filter);
+            pfrom->pfilter->UpdateEmptyFull();
+        }
+        pfrom->fRelayTxes = true;
     }
 
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2320,6 +2320,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     nNextInvSend = 0;
     fRelayTxes = false;
     pfilter = new CBloomFilter();
+    pThinBlockFilter = new CBloomFilter(); // BUIP010 - Xtreme Thinblocks
     nPingNonceSent = 0;
     nPingUsecStart = 0;
     nPingUsecTime = 0;
@@ -2363,6 +2364,10 @@ CNode::~CNode()
 
     if (pfilter)
         delete pfilter;
+    // BUIP010 - Xtreme Thinblocks - begin section
+    if (pThinBlockFilter)
+        delete pThinBlockFilter;
+    // BUIP010 - Xtreme Thinblocks - end section
 
     GetNodeSignals().FinalizeNode(GetId());
 }

--- a/src/net.h
+++ b/src/net.h
@@ -366,6 +366,7 @@ public:
     CSemaphoreGrant grantOutbound;
     CCriticalSection cs_filter;
     CBloomFilter* pfilter;
+    CBloomFilter* pThinBlockFilter; // BU - Xtreme Thinblocks: a bloom filter which is separate from the one used by SPV wallets
     int nRefCount;
     NodeId id;
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -581,11 +581,12 @@ void LoadFilter(CNode *pfrom, CBloomFilter *filter)
     else
     {
         LOCK(pfrom->cs_filter);
-        delete pfrom->pfilter;
-        pfrom->pfilter = new CBloomFilter(*filter);
-        pfrom->pfilter->UpdateEmptyFull();
+        delete pfrom->pThinBlockFilter;
+        pfrom->pThinBlockFilter = new CBloomFilter(*filter);
+        pfrom->pThinBlockFilter->UpdateEmptyFull();
     }
-    pfrom->fRelayTxes = true;
+    uint64_t nSizeFilter = ::GetSerializeSize(*pfrom->pThinBlockFilter, SER_NETWORK, PROTOCOL_VERSION);
+    LogPrint("thin", "Thinblock Bloom filter size: %d\n", nSizeFilter);
 }
 
 void HandleBlockMessage(CNode *pfrom, const string &strCommand, CBlock &block, const CInv &inv)
@@ -707,13 +708,14 @@ void CheckNodeSupportForThinBlocks()
 
 void SendXThinBlock(CBlock &block, CNode* pfrom, const CInv &inv)
 {
+    LOCK(pfrom->cs_filter);
     if (inv.type == MSG_XTHINBLOCK)
     {
-        CXThinBlock xThinBlock(block, pfrom->pfilter);
+        CXThinBlock xThinBlock(block, pfrom->pThinBlockFilter);
         int nSizeBlock = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
         if (xThinBlock.collision == true) // If there is a cheapHash collision in this block then send a normal thinblock
         {
-            CThinBlock thinBlock(block, *pfrom->pfilter);
+            CThinBlock thinBlock(block, *pfrom->pThinBlockFilter);
             int nSizeThinBlock = ::GetSerializeSize(xThinBlock, SER_NETWORK, PROTOCOL_VERSION);
             if (nSizeThinBlock < nSizeBlock) {
                 pfrom->PushMessage(NetMsgType::THINBLOCK, thinBlock);
@@ -740,7 +742,7 @@ void SendXThinBlock(CBlock &block, CNode* pfrom, const CInv &inv)
     }
     else if (inv.type == MSG_THINBLOCK)
     {
-        CThinBlock thinBlock(block, *pfrom->pfilter);
+        CThinBlock thinBlock(block, *pfrom->pThinBlockFilter);
         int nSizeBlock = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
         int nSizeThinBlock = ::GetSerializeSize(thinBlock, SER_NETWORK, PROTOCOL_VERSION);
         if (nSizeThinBlock < nSizeBlock) { // Only send a thinblock if smaller than a regular block


### PR DESCRIPTION
Added pnode->pThinBlockFilter so as to keep us from
potentially having a conflict with pnode->pfilter which
is used by SPV wallets.  We don't want any potential
conflicts or have to worry about clearing or deleting
the filter after each use.
