### PR TITLE
fixed detection of cross connected thinblock nodes using ipv6 addresses

### DIFF
--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -519,7 +519,7 @@ bool HaveConnectThinblockNodes()
     {
         LOCK(cs_vNodes);
         BOOST_FOREACH (CNode* pnode, vNodes) {
-           int pos = pnode->addrName.find(":");
+           int pos = pnode->addrName.rfind(":");
            if (pos <= 0 )
                vNodesIP.push_back(pnode->addrName);
            else
@@ -538,7 +538,7 @@ bool HaveConnectThinblockNodes()
     int nConnectionsOpen = 0;
     BOOST_FOREACH(const std::string& strAddrNode, mapMultiArgs["-connect-thinblock"]) {
         std::string strThinblockNode;
-        int pos = strAddrNode.find(":");
+        int pos = strAddrNode.rfind(":");
         if (pos <= 0 )
             strThinblockNode = strAddrNode;
         else


### PR DESCRIPTION
The detection of cross connected nodes removes the port from the address. Ipv6 addresses are formatted with multiple ":" (i.e. [1:1::1:1:1:1:1]:8333), so that we should start the find from the end of the string.
