### PR TITLE
Separated InBound and OutBound Thinblock stats

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -354,7 +354,9 @@ bool MarkBlockAsReceived(const uint256& hash) {
         // BUIP010 Xtreme Thinblocks: begin section
         int64_t getdataTime = itInFlight->second.second->nTime;
         int64_t now = GetTimeMicros();
-        LogPrint("thin", "Received block %s in %.2f seconds\n", hash.ToString(), (now - getdataTime) / 1000000.0);
+        double nResponseTime = (now - getdataTime) / 1000000.0;
+        LogPrint("thin", "Received block %s in %.2f seconds\n", hash.ToString(), nResponseTime);
+        CThinBlockStats::UpdateResponseTime(nResponseTime);
         // BUIP010 Xtreme Thinblocks: end section
         CNodeState *state = State(itInFlight->second.first);
         nQueuedValidatedHeaders -= itInFlight->second.second->fValidatedHeaders;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5294,6 +5294,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             pfrom->PushMessage(NetMsgType::GET_XBLOCKTX, thinBlockTx);
             LogPrint("thin", "Missing %d transactions for xthinblock, re-requesting\n", 
                       pfrom->thinBlockWaitingForTxns);
+            CThinBlockStats::UpdateInBoundReRequestedTx(pfrom->thinBlockWaitingForTxns);
         }
     }
 
@@ -5391,6 +5392,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             setPreVerifiedTxHash.clear(); // Xpress Validation - clear the set since we do not do XVal on regular blocks
             LogPrint("thin", "Missing %d Thinblock transactions, re-requesting a regular block\n",  
                        pfrom->thinBlockWaitingForTxns);
+            CThinBlockStats::UpdateInBoundReRequestedTx(pfrom->thinBlockWaitingForTxns);
+
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5270,9 +5270,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                      );
 
             // Update run-time statistics of thin block bandwidth savings
-            CThinBlockStats::Update(nSizeThinBlock, blockSize);
-            std::string ss = CThinBlockStats::ToString();
-            LogPrint("thin", "thin block stats: %s\n", ss.c_str());
+            CThinBlockStats::UpdateInBound(nSizeThinBlock, blockSize);
+            LogPrint("thin", "thin block stats: %s\n", CThinBlockStats::ToString());
 
             HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, inv);  // clears the thin block
             BOOST_FOREACH(uint64_t &cheapHash, thinBlock.vTxHashes)
@@ -5374,9 +5373,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                      );
 
             // Update run-time statistics of thin block bandwidth savings
-            CThinBlockStats::Update(nSizeThinBlock, blockSize);
-            std::string ss = CThinBlockStats::ToString();
-            LogPrint("thin", "thin block stats: %s\n", ss.c_str());
+            CThinBlockStats::UpdateInBound(nSizeThinBlock, blockSize);
+            LogPrint("thin", "thin block stats: %s\n", CThinBlockStats::ToString());
 
             HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, inv);
             BOOST_FOREACH(uint256 &hash, thinBlock.vTxHashes)
@@ -5437,9 +5435,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                      );
 
             // Update run-time statistics of thin block bandwidth savings
-            CThinBlockStats::Update(nSizeThinBlockTx + pfrom->nSizeThinBlock, blockSize);
-            std::string ss = CThinBlockStats::ToString();
-            LogPrint("thin", "thin block stats: %s\n", ss.c_str());
+            CThinBlockStats::UpdateInBound(nSizeThinBlockTx + pfrom->nSizeThinBlock, blockSize);
+            LogPrint("thin", "thin block stats: %s\n", CThinBlockStats::ToString());
 
             std::vector<CTransaction> vTx = pfrom->thinBlock.vtx;
             HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, inv);

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -424,6 +424,8 @@ static UniValue GetThinBlockStats()
         obj.push_back(Pair("summary", CThinBlockStats::ToString()));
         obj.push_back(Pair("summary", CThinBlockStats::InBoundPercentToString()));
         obj.push_back(Pair("summary", CThinBlockStats::OutBoundPercentToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::ResponseTimeToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::ValidationTimeToString()));
     }
     return obj;
 }

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -422,6 +422,7 @@ static UniValue GetThinBlockStats()
     obj.push_back(Pair("enabled", enabled));
     if (enabled) {
         obj.push_back(Pair("summary", CThinBlockStats::ToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::MempoolLimiterBytesSavedToString()));
         obj.push_back(Pair("summary", CThinBlockStats::InBoundPercentToString()));
         obj.push_back(Pair("summary", CThinBlockStats::OutBoundPercentToString()));
         obj.push_back(Pair("summary", CThinBlockStats::ResponseTimeToString()));

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -426,6 +426,9 @@ static UniValue GetThinBlockStats()
         obj.push_back(Pair("summary", CThinBlockStats::OutBoundPercentToString()));
         obj.push_back(Pair("summary", CThinBlockStats::ResponseTimeToString()));
         obj.push_back(Pair("summary", CThinBlockStats::ValidationTimeToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::OutBoundBloomFiltersToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::InBoundBloomFiltersToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::ReRequestedTxToString()));
     }
     return obj;
 }

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -422,11 +422,12 @@ static UniValue GetThinBlockStats()
     obj.push_back(Pair("enabled", enabled));
     if (enabled) {
         obj.push_back(Pair("summary", CThinBlockStats::ToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::InBoundPercentToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::OutBoundPercentToString()));
     }
     return obj;
 }
 // BitcoinUnlimited BUIP010 : End
-
 
 UniValue getnetworkinfo(const UniValue& params, bool fHelp)
 {

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -12,6 +12,7 @@
 CStatHistory<uint64_t> CThinBlockStats::nOriginalSize("thin/blockSize", STAT_OP_SUM | STAT_KEEP);
 CStatHistory<uint64_t> CThinBlockStats::nThinSize("thin/thinSize", STAT_OP_SUM | STAT_KEEP);
 CStatHistory<uint64_t> CThinBlockStats::nBlocks("thin/numBlocks", STAT_OP_SUM | STAT_KEEP);
+CStatHistory<uint64_t> CThinBlockStats::nMempoolLimiterBytesSaved("nSize", STAT_OP_SUM | STAT_KEEP);
 std::map<int64_t, std::pair<uint64_t, uint64_t> > CThinBlockStats::mapThinBlocksInBound;
 std::map<int64_t, int> CThinBlockStats::mapThinBlocksInBoundReRequestedTx;
 std::map<int64_t, std::pair<uint64_t, uint64_t> > CThinBlockStats::mapThinBlocksOutBound;
@@ -200,6 +201,11 @@ void CThinBlockStats::UpdateInBoundReRequestedTx(int nReRequestedTx)
         if ((*mi).first < nTimeCutoff)
             CThinBlockStats::mapThinBlocksInBoundReRequestedTx.erase(mi);
     }
+}
+
+void CThinBlockStats::UpdateMempoolLimiterBytesSaved(unsigned int nBytesSaved)
+{
+    CThinBlockStats::nMempoolLimiterBytesSaved += nBytesSaved;
 }
 
 std::string CThinBlockStats::ToString()
@@ -421,5 +427,21 @@ std::string CThinBlockStats::ReRequestedTxToString()
     std::ostringstream ss;
     ss << std::fixed << std::setprecision(1);
     ss << "Re-request rate (last 24hrs): " << nReRequestRate << "% Total re-requests:" << nTotalReRequests;
+    return ss.str();
+}
+
+std::string CThinBlockStats::MempoolLimiterBytesSavedToString()
+{
+    static const char *units[] = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
+    int i = 0;
+    double size = (double)CThinBlockStats::nMempoolLimiterBytesSaved();
+    while (size > 1000) {
+	size /= 1000;
+	i++;
+    }
+
+    std::ostringstream ss;
+    ss << std::fixed << std::setprecision(2);
+    ss << "Thinblock mempool limiting has saved " << size << units[i] << " of bandwidth";
     return ss.str();
 }

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "thinblock.h"
+#include "utiltime.h"
 #include <sstream>
 #include <iomanip>
 
@@ -10,6 +11,8 @@
 CStatHistory<uint64_t> CThinBlockStats::nOriginalSize("thin/blockSize",STAT_OP_SUM | STAT_KEEP);
 CStatHistory<uint64_t> CThinBlockStats::nThinSize("thin/thinSize",STAT_OP_SUM | STAT_KEEP);
 CStatHistory<uint64_t> CThinBlockStats::nBlocks("thin/numBlocks",STAT_OP_SUM | STAT_KEEP);
+std::map<int64_t, std::pair<uint64_t, uint64_t> > CThinBlockStats::mapThinBlocksInBound;
+std::map<int64_t, std::pair<uint64_t, uint64_t> > CThinBlockStats::mapThinBlocksOutBound;
 
 
 CThinBlock::CThinBlock(const CBlock& block, CBloomFilter& filter)
@@ -96,31 +99,87 @@ CXRequestThinBlockTx::CXRequestThinBlockTx(uint256 blockHash, std::set<uint64_t>
     setCheapHashesToRequest = setHashesToRequest;
 }
 
-
-
-void CThinBlockStats::Update(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize)
+void CThinBlockStats::UpdateInBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize)
 {
-	CThinBlockStats::nOriginalSize += nOriginalBlockSize;
-	CThinBlockStats::nThinSize += nThinBlockSize;
-	CThinBlockStats::nBlocks+=1;
+    CThinBlockStats::nOriginalSize += nOriginalBlockSize;
+    CThinBlockStats::nThinSize += nThinBlockSize;
+    CThinBlockStats::nBlocks += 1;
+    CThinBlockStats::mapThinBlocksInBound[GetTimeMillis()] = std::pair<uint64_t, uint64_t>(nThinBlockSize, nOriginalBlockSize);
+
+    // Delete any entries that are more than 24 hours old
+    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+    for (std::map<int64_t, std::pair<uint64_t, uint64_t> >::iterator mi = CThinBlockStats::mapThinBlocksInBound.begin(); mi != CThinBlockStats::mapThinBlocksInBound.end(); ++mi) {
+        if ((*mi).first < nTimeCutoff)
+            CThinBlockStats::mapThinBlocksInBound.erase(mi);
+    }
 }
 
+void CThinBlockStats::UpdateOutBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize)
+{
+    CThinBlockStats::nOriginalSize += nOriginalBlockSize;
+    CThinBlockStats::nThinSize += nThinBlockSize;
+    CThinBlockStats::nBlocks += 1;
+    CThinBlockStats::mapThinBlocksOutBound[GetTimeMillis()] = std::pair<uint64_t, uint64_t>(nThinBlockSize, nOriginalBlockSize);
 
+    // Delete any entries that are more than 24 hours old
+    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+    for (std::map<int64_t, std::pair<uint64_t, uint64_t> >::iterator mi = CThinBlockStats::mapThinBlocksOutBound.begin(); mi != CThinBlockStats::mapThinBlocksOutBound.end(); ++mi) {
+        if ((*mi).first < nTimeCutoff)
+            CThinBlockStats::mapThinBlocksOutBound.erase(mi);
+    }
+}
 std::string CThinBlockStats::ToString()
 {
-	static const char *units[] = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
-	int i = 0;
-	double size = double( CThinBlockStats::nOriginalSize() - CThinBlockStats::nThinSize() );
-	while (size > 1024) {
-		size /= 1024;
-		i++;
-	}
+    static const char *units[] = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
+    int i = 0;
+    double size = double( CThinBlockStats::nOriginalSize() - CThinBlockStats::nThinSize() );
+    while (size > 1000) {
+	size /= 1000;
+	i++;
+    }
 
-	std::ostringstream ss;
-	ss << std::fixed << std::setprecision(2);
-	ss << CThinBlockStats::nBlocks() << " thin " << ((CThinBlockStats::nBlocks()>1) ? "blocks have" : "block has") << " saved " << size << units[i] << " of bandwidth";
-	std::string s = ss.str();
-	return s;
+    std::ostringstream ss;
+    ss << std::fixed << std::setprecision(2);
+    ss << CThinBlockStats::nBlocks() << " thin " << ((CThinBlockStats::nBlocks() > 1) ? "blocks have" : "block has") << " saved " << size << units[i] << " of bandwidth";
+    return ss.str();
 }
 
+// Calculate the xthin percentage compression over the last 24 hours
+std::string CThinBlockStats::InBoundPercentToString()
+{
+    double nCompressionRate = 0;
+    uint64_t nThinSizeTotal = 0;
+    uint64_t nOriginalSizeTotal = 0;
+    for (std::map<int64_t, std::pair<uint64_t, uint64_t> >::iterator mi = CThinBlockStats::mapThinBlocksInBound.begin(); mi != CThinBlockStats::mapThinBlocksInBound.end(); ++mi) {
+        nThinSizeTotal += (*mi).second.first;
+        nOriginalSizeTotal += (*mi).second.second;
+    }
 
+    if (nOriginalSizeTotal > 0)
+        nCompressionRate = 100 - (100 * (double)nThinSizeTotal / nOriginalSizeTotal);
+
+    std::ostringstream ss;
+    ss << std::fixed << std::setprecision(1);
+    ss << "Compression for Inbound thinblocks (last 24hrs): " << nCompressionRate << "%";
+    return ss.str();
+}
+
+// Calculate the xthin percentage compression over the last 24 hours
+std::string CThinBlockStats::OutBoundPercentToString()
+{
+    double nCompressionRate = 0;
+    uint64_t nThinSizeTotal = 0;
+    uint64_t nOriginalSizeTotal = 0;
+    for (std::map<int64_t, std::pair<uint64_t, uint64_t> >::iterator mi = CThinBlockStats::mapThinBlocksOutBound.begin(); mi != CThinBlockStats::mapThinBlocksOutBound.end(); ++mi) {
+        nThinSizeTotal += (*mi).second.first;
+        nOriginalSizeTotal += (*mi).second.second;
+    }
+
+    if (nOriginalSizeTotal > 0)
+        nCompressionRate = 100 - (100 * (double)nThinSizeTotal / nOriginalSizeTotal);
+
+    std::ostringstream ss;
+    ss << std::fixed << std::setprecision(1);
+    ss << "Compression for Outbound thinblocks (last 24hrs): " << nCompressionRate << "%";
+    return ss.str();
+}

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -4,6 +4,7 @@
 
 #include "thinblock.h"
 #include "utiltime.h"
+#include "unlimited.h"
 #include <sstream>
 #include <iomanip>
 
@@ -132,25 +133,31 @@ void CThinBlockStats::UpdateOutBound(uint64_t nThinBlockSize, uint64_t nOriginal
 
 void CThinBlockStats::UpdateResponseTime(double nResponseTime)
 {
-    CThinBlockStats::mapThinBlockResponseTime[GetTimeMillis()] = nResponseTime;
+    // only update stats if IBD is complete
+    if (IsChainNearlySyncd() && IsThinBlocksEnabled()) {
+        CThinBlockStats::mapThinBlockResponseTime[GetTimeMillis()] = nResponseTime;
 
-    // Delete any entries that are more than 24 hours old
-    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
-    for (std::map<int64_t, double>::iterator mi = CThinBlockStats::mapThinBlockResponseTime.begin(); mi != CThinBlockStats::mapThinBlockResponseTime.end(); ++mi) {
-        if ((*mi).first < nTimeCutoff)
-            CThinBlockStats::mapThinBlockResponseTime.erase(mi);
+        // Delete any entries that are more than 24 hours old
+        int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+        for (std::map<int64_t, double>::iterator mi = CThinBlockStats::mapThinBlockResponseTime.begin(); mi != CThinBlockStats::mapThinBlockResponseTime.end(); ++mi) {
+            if ((*mi).first < nTimeCutoff)
+                CThinBlockStats::mapThinBlockResponseTime.erase(mi);
+        }
     }
 }
 
 void CThinBlockStats::UpdateValidationTime(double nValidationTime)
 {
-    CThinBlockStats::mapThinBlockValidationTime[GetTimeMillis()] = nValidationTime;
+    // only update stats if IBD is complete
+    if (IsChainNearlySyncd() && IsThinBlocksEnabled()) {
+        CThinBlockStats::mapThinBlockValidationTime[GetTimeMillis()] = nValidationTime;
 
-    // Delete any entries that are more than 24 hours old
-    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
-    for (std::map<int64_t, double>::iterator mi = CThinBlockStats::mapThinBlockValidationTime.begin(); mi != CThinBlockStats::mapThinBlockValidationTime.end(); ++mi) {
-        if ((*mi).first < nTimeCutoff)
-            CThinBlockStats::mapThinBlockValidationTime.erase(mi);
+        // Delete any entries that are more than 24 hours old
+        int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+        for (std::map<int64_t, double>::iterator mi = CThinBlockStats::mapThinBlockValidationTime.begin(); mi != CThinBlockStats::mapThinBlockValidationTime.end(); ++mi) {
+            if ((*mi).first < nTimeCutoff)
+                CThinBlockStats::mapThinBlockValidationTime.erase(mi);
+        }
     }
 }
 

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -221,6 +221,13 @@ std::string CThinBlockStats::ToString()
 // Calculate the xthin percentage compression over the last 24 hours
 std::string CThinBlockStats::InBoundPercentToString()
 {
+    // Delete any entries that are more than 24 hours old
+    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+    for (std::map<int64_t, std::pair<uint64_t, uint64_t> >::iterator mi = CThinBlockStats::mapThinBlocksInBound.begin(); mi != CThinBlockStats::mapThinBlocksInBound.end(); ++mi) {
+        if ((*mi).first < nTimeCutoff)
+            CThinBlockStats::mapThinBlocksInBound.erase(mi);
+    }
+
     double nCompressionRate = 0;
     uint64_t nThinSizeTotal = 0;
     uint64_t nOriginalSizeTotal = 0;
@@ -241,6 +248,13 @@ std::string CThinBlockStats::InBoundPercentToString()
 // Calculate the xthin percentage compression over the last 24 hours
 std::string CThinBlockStats::OutBoundPercentToString()
 {
+    // Delete any entries that are more than 24 hours old
+    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+    for (std::map<int64_t, std::pair<uint64_t, uint64_t> >::iterator mi = CThinBlockStats::mapThinBlocksOutBound.begin(); mi != CThinBlockStats::mapThinBlocksOutBound.end(); ++mi) {
+        if ((*mi).first < nTimeCutoff)
+            CThinBlockStats::mapThinBlocksOutBound.erase(mi);
+    }
+
     double nCompressionRate = 0;
     uint64_t nThinSizeTotal = 0;
     uint64_t nOriginalSizeTotal = 0;
@@ -261,6 +275,13 @@ std::string CThinBlockStats::OutBoundPercentToString()
 // Calculate the average inbound xthin bloom filter size
 std::string CThinBlockStats::InBoundBloomFiltersToString()
 {
+    // Delete any entries that are more than 24 hours old
+    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+    for (std::map<int64_t, uint64_t>::iterator mi = CThinBlockStats::mapBloomFiltersInBound.begin(); mi != CThinBlockStats::mapBloomFiltersInBound.end(); ++mi) {
+        if ((*mi).first < nTimeCutoff)
+            CThinBlockStats::mapBloomFiltersInBound.erase(mi);
+    }
+
     uint64_t nInBoundBloomFilters = 0;
     uint64_t nInBoundBloomFilterSize = 0;
     double avgBloomSize = 0;
@@ -287,6 +308,13 @@ std::string CThinBlockStats::InBoundBloomFiltersToString()
 // Calculate the average inbound xthin bloom filter size
 std::string CThinBlockStats::OutBoundBloomFiltersToString()
 {
+    // Delete any entries that are more than 24 hours old
+    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+    for (std::map<int64_t, uint64_t>::iterator mi = CThinBlockStats::mapBloomFiltersOutBound.begin(); mi != CThinBlockStats::mapBloomFiltersOutBound.end(); ++mi) {
+        if ((*mi).first < nTimeCutoff)
+            CThinBlockStats::mapBloomFiltersOutBound.erase(mi);
+    }
+
     uint64_t nOutBoundBloomFilters = 0;
     uint64_t nOutBoundBloomFilterSize = 0;
     double avgBloomSize = 0;
@@ -372,6 +400,13 @@ std::string CThinBlockStats::ValidationTimeToString()
 // Calculate the xthin percentage compression over the last 24 hours
 std::string CThinBlockStats::ReRequestedTxToString()
 {
+    // Delete any entries that are more than 24 hours old
+    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+    for (std::map<int64_t, int>::iterator mi = CThinBlockStats::mapThinBlocksInBoundReRequestedTx.begin(); mi != CThinBlockStats::mapThinBlocksInBoundReRequestedTx.end(); ++mi) {
+        if ((*mi).first < nTimeCutoff)
+            CThinBlockStats::mapThinBlocksInBoundReRequestedTx.erase(mi);
+    }
+
     double nReRequestRate = 0;
     uint64_t nTotalReRequests = 0;
     uint64_t nTotalReRequestedTxs = 0;

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -109,6 +109,7 @@ private:
 	static CStatHistory<uint64_t> nThinSize;
 	static CStatHistory<uint64_t> nBlocks;
 	static CStatHistory<uint64_t> nMempoolLimiterBytesSaved;
+	static CStatHistory<uint64_t> nTotalBloomFilterBytes;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksInBound;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksOutBound;
         static std::map<int64_t, uint64_t> mapBloomFiltersOutBound;

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -110,13 +110,19 @@ private:
 	static CStatHistory<uint64_t> nBlocks;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksInBound;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksOutBound;
+        static std::map<int64_t, double> mapThinBlockResponseTime;
+        static std::map<int64_t, double> mapThinBlockValidationTime;
 
 public:
 	static void UpdateInBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
 	static void UpdateOutBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
+	static void UpdateResponseTime(double nResponseTime);
+	static void UpdateValidationTime(double nValidationTime);
 	static std::string ToString();
         static std::string InBoundPercentToString();
         static std::string OutBoundPercentToString();
+        static std::string ResponseTimeToString();
+        static std::string ValidationTimeToString();
 };
 
 

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -11,7 +11,6 @@
 #include "bloom.h"
 #include "stat.h"
 
-#include <vector>
 
 class CThinBlock
 {
@@ -109,9 +108,15 @@ private:
 	static CStatHistory<uint64_t> nOriginalSize;
 	static CStatHistory<uint64_t> nThinSize;
 	static CStatHistory<uint64_t> nBlocks;
+        static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksInBound;
+        static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksOutBound;
+
 public:
-	static void Update(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
+	static void UpdateInBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
+	static void UpdateOutBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
 	static std::string ToString();
+        static std::string InBoundPercentToString();
+        static std::string OutBoundPercentToString();
 };
 
 

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -108,6 +108,7 @@ private:
 	static CStatHistory<uint64_t> nOriginalSize;
 	static CStatHistory<uint64_t> nThinSize;
 	static CStatHistory<uint64_t> nBlocks;
+	static CStatHistory<uint64_t> nMempoolLimiterBytesSaved;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksInBound;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksOutBound;
         static std::map<int64_t, uint64_t> mapBloomFiltersOutBound;
@@ -115,7 +116,7 @@ private:
         static std::map<int64_t, double> mapThinBlockResponseTime;
         static std::map<int64_t, double> mapThinBlockValidationTime;
         static std::map<int64_t, int> mapThinBlocksInBoundReRequestedTx;
-
+ 
 public:
 	static void UpdateInBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
 	static void UpdateOutBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
@@ -124,6 +125,7 @@ public:
 	static void UpdateResponseTime(double nResponseTime);
 	static void UpdateValidationTime(double nValidationTime);
 	static void UpdateInBoundReRequestedTx(int nReRequestedTx);
+        static void UpdateMempoolLimiterBytesSaved(unsigned int nBytesSaved);
 	static std::string ToString();
         static std::string InBoundPercentToString();
         static std::string OutBoundPercentToString();
@@ -132,6 +134,7 @@ public:
         static std::string ResponseTimeToString();
         static std::string ValidationTimeToString();
         static std::string ReRequestedTxToString();
+        static std::string MempoolLimiterBytesSavedToString();
 };
 
 

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -110,19 +110,28 @@ private:
 	static CStatHistory<uint64_t> nBlocks;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksInBound;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksOutBound;
+        static std::map<int64_t, uint64_t> mapBloomFiltersOutBound;
+        static std::map<int64_t, uint64_t> mapBloomFiltersInBound;
         static std::map<int64_t, double> mapThinBlockResponseTime;
         static std::map<int64_t, double> mapThinBlockValidationTime;
+        static std::map<int64_t, int> mapThinBlocksInBoundReRequestedTx;
 
 public:
 	static void UpdateInBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
 	static void UpdateOutBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
+        static void UpdateOutBoundBloomFilter(uint64_t nBloomFilterSize);
+        static void UpdateInBoundBloomFilter(uint64_t nBloomFilterSize);
 	static void UpdateResponseTime(double nResponseTime);
 	static void UpdateValidationTime(double nValidationTime);
+	static void UpdateInBoundReRequestedTx(int nReRequestedTx);
 	static std::string ToString();
         static std::string InBoundPercentToString();
         static std::string OutBoundPercentToString();
+        static std::string InBoundBloomFiltersToString();
+        static std::string OutBoundBloomFiltersToString();
         static std::string ResponseTimeToString();
         static std::string ValidationTimeToString();
+        static std::string ReRequestedTxToString();
 };
 
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -685,8 +685,10 @@ void HandleBlockMessage(CNode *pfrom, const string &strCommand, CBlock &block, c
     else 
         nLargestBlockSeen = std::max(nSizeBlock, nLargestBlockSeen);
 
+    double nValidationTime = (double)(GetTimeMicros() - startTime) / 1000000.0;
     LogPrint("thin", "Processed Block %s in %.2f seconds\n", inv.hash.ToString(), (double)(GetTimeMicros() - startTime) / 1000000.0);
-    
+    CThinBlockStats::UpdateValidationTime(nValidationTime);
+
     // When we request a thinblock we may get back a regular block if it is smaller than a thinblock
     // Therefore we have to remove the thinblock in flight if it exists and we also need to check that 
     // the block didn't arrive from some other peer.  This code ALSO cleans up the thin block that

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -685,12 +685,17 @@ void HandleBlockMessage(CNode *pfrom, const string &strCommand, CBlock &block, c
             Misbehaving(pfrom->GetId(), nDoS);
         }
     }
-    else 
+    else {
         nLargestBlockSeen = std::max(nSizeBlock, nLargestBlockSeen);
 
-    double nValidationTime = (double)(GetTimeMicros() - startTime) / 1000000.0;
-    LogPrint("thin", "Processed Block %s in %.2f seconds\n", inv.hash.ToString(), (double)(GetTimeMicros() - startTime) / 1000000.0);
-    CThinBlockStats::UpdateValidationTime(nValidationTime);
+        double nValidationTime = (double)(GetTimeMicros() - startTime) / 1000000.0;
+        if (strCommand != NetMsgType::BLOCK) {
+            LogPrint("thin", "Processed ThinBlock %s in %.2f seconds\n", inv.hash.ToString(), (double)(GetTimeMicros() - startTime) / 1000000.0);
+            CThinBlockStats::UpdateValidationTime(nValidationTime);
+        }
+        else
+            LogPrint("thin", "Processed Regular Block %s in %.2f seconds\n", inv.hash.ToString(), (double)(GetTimeMicros() - startTime) / 1000000.0);
+    }
 
     // When we request a thinblock we may get back a regular block if it is smaller than a thinblock
     // Therefore we have to remove the thinblock in flight if it exists and we also need to check that 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -640,7 +640,9 @@ void BuildSeededBloomFilter(CBloomFilter& filterMemPool, std::vector<uint256>& v
          filterMemPool.insert(vMemPoolHashes[i]);
     for (uint64_t i = 0; i < vOrphanHashes.size(); i++)
          filterMemPool.insert(vOrphanHashes[i]);
-    LogPrint("thin", "Created bloom filter: %d bytes\n",::GetSerializeSize(filterMemPool, SER_NETWORK, PROTOCOL_VERSION));
+    uint64_t nSizeFilter = ::GetSerializeSize(filterMemPool, SER_NETWORK, PROTOCOL_VERSION);
+    LogPrint("thin", "Created bloom filter: %d bytes\n", nSizeFilter);
+    CThinBlockStats::UpdateOutBoundBloomFilter(nSizeFilter);
 }
 
 void LoadFilter(CNode *pfrom, CBloomFilter *filter)
@@ -657,6 +659,7 @@ void LoadFilter(CNode *pfrom, CBloomFilter *filter)
     }
     uint64_t nSizeFilter = ::GetSerializeSize(*pfrom->pThinBlockFilter, SER_NETWORK, PROTOCOL_VERSION);
     LogPrint("thin", "Thinblock Bloom filter size: %d\n", nSizeFilter);
+    CThinBlockStats::UpdateInBoundBloomFilter(nSizeFilter);
 }
 
 void HandleBlockMessage(CNode *pfrom, const string &strCommand, CBlock &block, const CInv &inv)

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -788,6 +788,7 @@ void SendXThinBlock(CBlock &block, CNode* pfrom, const CInv &inv)
             int nSizeThinBlock = ::GetSerializeSize(xThinBlock, SER_NETWORK, PROTOCOL_VERSION);
             if (nSizeThinBlock < nSizeBlock) {
                 pfrom->PushMessage(NetMsgType::THINBLOCK, thinBlock);
+                CThinBlockStats::UpdateOutBound(nSizeThinBlock, nSizeBlock);
                 LogPrint("thin", "TX HASH COLLISION: Sent thinblock - size: %d vs block size: %d => tx hashes: %d transactions: %d  peerid=%d\n", nSizeThinBlock, nSizeBlock, xThinBlock.vTxHashes.size(), xThinBlock.vMissingTx.size(), pfrom->id);
             }
             else {
@@ -800,6 +801,7 @@ void SendXThinBlock(CBlock &block, CNode* pfrom, const CInv &inv)
             // Only send a thinblock if smaller than a regular block
             int nSizeThinBlock = ::GetSerializeSize(xThinBlock, SER_NETWORK, PROTOCOL_VERSION);
             if (nSizeThinBlock < nSizeBlock) {
+                CThinBlockStats::UpdateOutBound(nSizeThinBlock, nSizeBlock);
                 pfrom->PushMessage(NetMsgType::XTHINBLOCK, xThinBlock);
                 LogPrint("thin", "Sent xthinblock - size: %d vs block size: %d => tx hashes: %d transactions: %d  peerid=%d\n", nSizeThinBlock, nSizeBlock, xThinBlock.vTxHashes.size(), xThinBlock.vMissingTx.size(), pfrom->id);
             }
@@ -815,6 +817,7 @@ void SendXThinBlock(CBlock &block, CNode* pfrom, const CInv &inv)
         int nSizeBlock = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
         int nSizeThinBlock = ::GetSerializeSize(thinBlock, SER_NETWORK, PROTOCOL_VERSION);
         if (nSizeThinBlock < nSizeBlock) { // Only send a thinblock if smaller than a regular block
+            CThinBlockStats::UpdateOutBound(nSizeThinBlock, nSizeBlock);
             pfrom->PushMessage(NetMsgType::THINBLOCK, thinBlock);
             LogPrint("thin", "Sent thinblock - size: %d vs block size: %d => tx hashes: %d transactions: %d  peerid=%d\n", nSizeThinBlock, nSizeBlock, thinBlock.vTxHashes.size(), thinBlock.vMissingTx.size(), pfrom->id);
         }


### PR DESCRIPTION
This pull shows the compression breakdown of in and outbound thinblock stats over the last 24 hours, as well as the original total savings

getnetworkinfo now shows:

```
Total Thinbock bandwidth saved
% compression InBound thinblocks
% compression OutBound thinblocks
```
