### PR TITLE
Fixes for connect-thinblocks error messages and ThinBlockCapable

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -378,6 +378,9 @@ std::string HelpMessage(HelpMessageMode mode)
     //strUsage += HelpMessageOpt("-peerbloomfilters", strprintf(_("Support filtering of blocks and transaction with bloom filters (default: %u)"), 1));
     //if (showDebug)
     //    strUsage += HelpMessageOpt("-enforcenodebloom", strprintf("Enforce minimum protocol version to limit use of bloom filters (default: %u)", 0));
+    // Enable the XTHIN service
+    if (GetBoolArg("-use-thinblocks", true))
+        nLocalServices |= NODE_XTHIN;
     // BUIP010 Xtreme Thinblocks - end section: we do not allow bloom filters to be turned off
     strUsage += HelpMessageOpt("-port=<port>", strprintf(_("Listen for connections on <port> (default: %u or testnet: %u)"), Params(CBaseChainParams::MAIN).GetDefaultPort(), Params(CBaseChainParams::TESTNET).GetDefaultPort()));
     strUsage += HelpMessageOpt("-proxy=<ip:port>", _("Connect through SOCKS5 proxy"));

--- a/src/net.h
+++ b/src/net.h
@@ -507,7 +507,7 @@ public:
     // BUIP010:
     bool ThinBlockCapable()
     {
-        if (nServices & NODE_XTHIN) return true;
+        if ((nServices & NODE_XTHIN) && (nServices & NODE_BLOOM)) return true;
         return false;
     }
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -601,14 +601,7 @@ void ClearThinBlockTimer(uint256 hash)
 
 bool IsThinBlocksEnabled() 
 {
-    bool fThinblocksEnabled = GetBoolArg("-use-thinblocks", true);
-
-    // Enabling the XTHIN service should really be in init.cpp but because
-    // we want to avoid possile future merge conflicts with Core we can enable
-    // it here as it has little performance impact.
-    if (fThinblocksEnabled)
-        nLocalServices |= NODE_XTHIN;
-    return fThinblocksEnabled;
+    return GetBoolArg("-use-thinblocks", true);
 }
 
 bool IsChainNearlySyncd() 
@@ -768,8 +761,10 @@ void CheckNodeSupportForThinBlocks()
         BOOST_FOREACH(string& strAddr, mapMultiArgs["-connect-thinblock"]) {
             if(CNode* pnode = FindNode(strAddr)) {
                 if(!pnode->ThinBlockCapable()) {
-                    LogPrintf("ERROR: You are trying to use connect-thinblocks but to a node that does not support it - Protocol Version: %d peer=%d\n", 
-                               pnode->nVersion, pnode->id);
+                    bool fBloom = pnode->nServices & NODE_BLOOM;
+                    bool fXthin = pnode->nServices & NODE_XTHIN;
+                    LogPrintf("ERROR: You are trying to use connect-thinblocks but to a node that does not support it - NODE_XTHIN: %d  NODE_BLOOM: %d peer=%d\n", 
+                               fXthin, fBloom, pnode->id);
                 }
             }
         }


### PR DESCRIPTION
ThinBlockCapable() needs to have both XTHIN and BLOOM turned on
in order to be true.  Currently only XTHIN was expected to be on
and it was only assumed that BLOOM filtering would also be turned on.

Fixed error messaging for connect-thinblock which was showing protocol
versions rather than whether BLOOM or XTHIN was turned on as is now
the case.

Moved the turning on for XTHINs to init.cpp where it really should be
which will no longer cause unnecessary ERROR messages relating
to connect-thinblock during startup.
