### PR TITLE
Adding Transactions Per Second output to the debug window

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1296,6 +1296,9 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
             if (!pool.exists(hash))
                 return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool full");
         }
+
+        // BU: update tx per second when a tx is valid and accepted
+        pool.UpdateTransactionsPerSecond();
     }
 
     SyncWithWallets(tx, NULL);

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -99,6 +99,13 @@ size_t ClientModel::getMempoolDynamicUsage() const
     return mempool.DynamicMemoryUsage();
 }
 
+// BU: begin
+double ClientModel::getTransactionsPerSecond() const
+{
+    return mempool.TransactionsPerSecond();
+}
+// BU: end
+
 double ClientModel::getVerificationProgress(const CBlockIndex *tipIn) const
 {
     CBlockIndex *tip = const_cast<CBlockIndex *>(tipIn);
@@ -116,6 +123,7 @@ void ClientModel::updateTimer()
     // the following calls will aquire the required lock
     Q_EMIT mempoolSizeChanged(getMempoolSize(), getMempoolDynamicUsage());
     Q_EMIT bytesChanged(getTotalBytesRecv(), getTotalBytesSent());
+    Q_EMIT transactionsPerSecondChanged(getTransactionsPerSecond()); // BU:
 }
 
 void ClientModel::updateNumConnections(int numConnections)

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -58,6 +58,9 @@ public:
     //! Return the dynamic memory usage of the mempool
     size_t getMempoolDynamicUsage() const;
     
+    //! BU: Return the transactions per second that are accepted into the mempool
+    double getTransactionsPerSecond() const;
+
     quint64 getTotalBytesRecv() const;
     quint64 getTotalBytesSent() const;
 
@@ -95,6 +98,7 @@ Q_SIGNALS:
     void mempoolSizeChanged(long count, size_t mempoolSizeInBytes);
     void alertsChanged(const QString &warnings);
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);
+    void transactionsPerSecondChanged(double tansactionsPerSecond);  // BU:
 
     //! Fired when a message should be reported to the user
     void message(const QString &title, const QString &message, unsigned int style);

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -387,6 +387,30 @@
          </property>
         </widget>
        </item>
+       <item row="17" column="0">
+        <widget class="QLabel" name="labelTransactionsPerSecond">
+         <property name="text">
+          <string>Transactions per second</string>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="1">
+        <widget class="QLabel" name="transactionsPerSecond">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+
        <item row="14" column="2" rowspan="3">
         <layout class="QVBoxLayout" name="verticalLayoutDebugButton">
          <property name="spacing">

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -351,6 +351,9 @@ void RPCConsole::setClientModel(ClientModel *model)
 
         connect(model, SIGNAL(mempoolSizeChanged(long,size_t)), this, SLOT(setMempoolSize(long,size_t)));
 
+        // BU:
+        connect(model, SIGNAL(transactionsPerSecondChanged(double)), this, SLOT(setTransactionsPerSecond(double)));
+
         // set up peer table
         ui->peerWidget->setModel(model->getPeerTableModel());
         ui->peerWidget->verticalHeader()->hide();
@@ -544,6 +547,16 @@ void RPCConsole::setMempoolSize(long numberOfTxs, size_t dynUsage)
     else
         ui->mempoolSize->setText(QString::number(dynUsage/1000000.0, 'f', 2) + " MB");
 }
+
+// BU: begin
+void RPCConsole::setTransactionsPerSecond(double nTxPerSec)
+{
+    if (nTxPerSec < 100)
+        ui->transactionsPerSecond->setText(QString::number(nTxPerSec, 'f', 2));
+    else
+        ui->transactionsPerSecond->setText(QString::number((uint64_t)nTxPerSec));
+}
+// BU: end
 
 void RPCConsole::on_lineEdit_returnPressed()
 {

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -86,6 +86,8 @@ public Q_SLOTS:
     void setNumBlocks(int count, const QDateTime& blockDate, double nVerificationProgress);
     /** Set size (number of transactions and memory usage) of the mempool in the UI */
     void setMempoolSize(long numberOfTxs, size_t dynUsage);
+    /** BU: Set tx's per second in the UI */
+    void setTransactionsPerSecond(double nTxPerSec);
     /** Go forward or back in history */
     void browseHistory(int offset);
     /** Scroll console view to end */

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -998,3 +998,22 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<uint256>* pvNoSpendsRe
     if (maxFeeRateRemoved > CFeeRate(0))
         LogPrint("mempool", "Removed %u txn, rolling minimum fee bumped to %s\n", nTxnRemoved, maxFeeRateRemoved.ToString());
 }
+
+// BU: begin
+void CTxMemPool::UpdateTransactionsPerSecond()
+{
+    static int64_t nLastTime = GetTime();
+    double nSecondsToAverage = 60; // Length of time in seconds to smooth the tx rate over
+    int64_t nNow = GetTime();
+
+    // Decay the previous tx rate.  
+    int64_t nDeltaTime = nNow - nLastTime;
+    if (nDeltaTime > 0) {
+        nTxPerSec -= (nTxPerSec / nSecondsToAverage) * nDeltaTime;
+        nLastTime = nNow;
+    }
+
+    // Add the new tx to the rate
+    nTxPerSec += 1/nSecondsToAverage; // The amount that the new tx will add to the tx rate
+}
+// BU: end

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -339,6 +339,8 @@ private:
 
     void trackPackageRemoved(const CFeeRate& rate);
 
+    double nTxPerSec; //BU: tx's per second accepted into the mempool
+
 public:
 
     static const int ROLLING_FEE_HALFLIFE = 60 * 60 * 12; // public only for testing
@@ -493,6 +495,9 @@ public:
     /** Expire all transaction (and their dependencies) in the mempool older than time. Return the number of removed transactions. */
     int Expire(int64_t time);
 
+    /** BU: Every transaction that is accepted into the mempool will call this method to update the current value*/
+    void UpdateTransactionsPerSecond();
+
     unsigned long size()
     {
         LOCK(cs);
@@ -510,6 +515,14 @@ public:
         LOCK(cs);
         return (mapTx.count(hash) != 0);
     }
+
+    // BU: begin
+    double TransactionsPerSecond()
+    {
+        LOCK(cs);
+        return nTxPerSec;
+    }
+    // BU: end
 
     bool lookup(uint256 hash, CTransaction& result) const;
 


### PR DESCRIPTION
I think this will come in handy as we gear up for more on chain scale testing.  It gives an average tps rate over the last 60 seconds.  I found using 10 seconds or less was just to variable to be of much use.

I'm wondering if we should also add this as a new rpc command, or add it to getnetworkinfo?
