### PR TITLE
Targeted Bloom Filters

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1055,6 +1055,11 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (GetBoolArg("-peerbloomfilters", true))
         nLocalServices |= NODE_BLOOM;
 
+    //BUIP010 Xtreme Thinblocks: begin section Initialize XTHIN service
+    if (GetBoolArg("-use-thinblocks", true))
+        nLocalServices |= NODE_XTHIN;
+    // BUIP010 Xtreme Thinblocks: begin section
+
 #if 0 // BUIP004: mempool replacement is not allowed    
     fEnableReplacement = GetBoolArg("-mempoolreplacement", DEFAULT_ENABLE_REPLACEMENT);
     if ((!fEnableReplacement) && mapArgs.count("-mempoolreplacement")) {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -374,11 +374,9 @@ std::string HelpMessage(HelpMessageMode mode)
     strUsage += HelpMessageOpt("-onion=<ip:port>", strprintf(_("Use separate SOCKS5 proxy to reach peers via Tor hidden services (default: %s)"), "-proxy"));
     strUsage += HelpMessageOpt("-onlynet=<net>", _("Only connect to nodes in network <net> (ipv4, ipv6 or onion)"));
     strUsage += HelpMessageOpt("-permitbaremultisig", strprintf(_("Relay non-P2SH multisig (default: %u)"), DEFAULT_PERMIT_BAREMULTISIG));
-    // BUIP010 Xtreme Thinblocks - begin section: we do not allow bloom filters to be turned off
-    //strUsage += HelpMessageOpt("-peerbloomfilters", strprintf(_("Support filtering of blocks and transaction with bloom filters (default: %u)"), 1));
-    //if (showDebug)
-    //    strUsage += HelpMessageOpt("-enforcenodebloom", strprintf("Enforce minimum protocol version to limit use of bloom filters (default: %u)", 0));
-    // BUIP010 Xtreme Thinblocks - end section: we do not allow bloom filters to be turned off
+    strUsage += HelpMessageOpt("-peerbloomfilters", strprintf(_("Support filtering of blocks and transaction with bloom filters (default: %u)"), 1));
+    if (showDebug)
+        strUsage += HelpMessageOpt("-enforcenodebloom", strprintf("Enforce minimum protocol version to limit use of bloom filters (default: %u)", 0));
     strUsage += HelpMessageOpt("-port=<port>", strprintf(_("Listen for connections on <port> (default: %u or testnet: %u)"), Params(CBaseChainParams::MAIN).GetDefaultPort(), Params(CBaseChainParams::TESTNET).GetDefaultPort()));
     strUsage += HelpMessageOpt("-proxy=<ip:port>", _("Connect through SOCKS5 proxy"));
     strUsage += HelpMessageOpt("-proxyrandomize", strprintf(_("Randomize credentials for every proxy connection. This enables Tor stream isolation (default: %u)"), DEFAULT_PROXYRANDOMIZE));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -354,7 +354,9 @@ bool MarkBlockAsReceived(const uint256& hash) {
         // BUIP010 Xtreme Thinblocks: begin section
         int64_t getdataTime = itInFlight->second.second->nTime;
         int64_t now = GetTimeMicros();
-        LogPrint("thin", "Received block %s in %.2f seconds\n", hash.ToString(), (now - getdataTime) / 1000000.0);
+        double nResponseTime = (now - getdataTime) / 1000000.0;
+        LogPrint("thin", "Received block %s in %.2f seconds\n", hash.ToString(), nResponseTime);
+        CThinBlockStats::UpdateResponseTime(nResponseTime);
         // BUIP010 Xtreme Thinblocks: end section
         CNodeState *state = State(itInFlight->second.first);
         nQueuedValidatedHeaders -= itInFlight->second.second->fValidatedHeaders;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4742,7 +4742,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                                     ss << filterMemPool;
                                     pfrom->PushMessage(NetMsgType::GET_XTHIN, ss);
                                     MarkBlockAsInFlight(pfrom->GetId(), inv.hash, chainparams.GetConsensus());
-                                    LogPrint("thin", "Requesting Thinblock %s from peer %s (%d)\n", inv2.hash.ToString(), pfrom->addrName.c_str(),pfrom->id);
+                                    LogPrint("thin", "Requesting Thinblock %s by INV from peer %s (%d)\n", inv2.hash.ToString(), pfrom->addrName.c_str(),pfrom->id);
                                 }
                             }
                             else {
@@ -4757,10 +4757,10 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                                     ss << inv2;
                                     ss << filterMemPool;
                                     pfrom->PushMessage(NetMsgType::GET_XTHIN, ss);
-                                    LogPrint("thin", "Requesting Thinblock %s from peer %s (%d)\n", inv2.hash.ToString(), pfrom->addrName.c_str(),pfrom->id);
+                                    LogPrint("thin", "Requesting Thinblock %s by INV from peer %s (%d)\n", inv2.hash.ToString(), pfrom->addrName.c_str(),pfrom->id);
                                 }
                                 else {
-                                    LogPrint("thin", "Requesting Regular Block %s from peer %s (%d)\n", inv2.hash.ToString(), pfrom->addrName.c_str(),pfrom->id);
+                                    LogPrint("thin", "Requesting Regular Block %s by INV from peer %s (%d)\n", inv2.hash.ToString(), pfrom->addrName.c_str(),pfrom->id);
                                     vToFetch.push_back(inv2);
                                 }
                                 MarkBlockAsInFlight(pfrom->GetId(), inv.hash, chainparams.GetConsensus());
@@ -4769,7 +4769,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                         else {
                             vToFetch.push_back(inv2);
                             MarkBlockAsInFlight(pfrom->GetId(), inv.hash, chainparams.GetConsensus());
-                            LogPrint("thin", "Requesting Regular Block %s from peer %s (%d)\n", inv2.hash.ToString(), pfrom->addrName.c_str(),pfrom->id);
+                            LogPrint("thin", "Requesting Regular Block %s by INV from peer %s (%d)\n", inv2.hash.ToString(), pfrom->addrName.c_str(),pfrom->id);
                         }
                         // BUIP010 Xtreme Thinblocks: end section
                     }
@@ -6236,7 +6236,7 @@ bool SendMessages(CNode* pto)
                             ss << filterMemPool;
                             pto->PushMessage(NetMsgType::GET_XTHIN, ss);
                             MarkBlockAsInFlight(pto->GetId(), pindex->GetBlockHash(), consensusParams, pindex);
-                            LogPrint("thin", "Requesting thinblock %s (%d) from peer %s (%d)\n", pindex->GetBlockHash().ToString(),
+                            LogPrint("thin", "Requesting Thinblock %s (%d) from peer %s (%d)\n", pindex->GetBlockHash().ToString(),
                                      pindex->nHeight, pto->addrName.c_str(), pto->id);
                         }
                     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5294,6 +5294,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             pfrom->PushMessage(NetMsgType::GET_XBLOCKTX, thinBlockTx);
             LogPrint("thin", "Missing %d transactions for xthinblock, re-requesting\n", 
                       pfrom->thinBlockWaitingForTxns);
+            CThinBlockStats::UpdateInBoundReRequestedTx(pfrom->thinBlockWaitingForTxns);
         }
     }
 
@@ -5391,6 +5392,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             setPreVerifiedTxHash.clear(); // Xpress Validation - clear the set since we do not do XVal on regular blocks
             LogPrint("thin", "Missing %d Thinblock transactions, re-requesting a regular block\n",  
                        pfrom->thinBlockWaitingForTxns);
+            CThinBlockStats::UpdateInBoundReRequestedTx(pfrom->thinBlockWaitingForTxns);
+
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5270,9 +5270,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                      );
 
             // Update run-time statistics of thin block bandwidth savings
-            CThinBlockStats::Update(nSizeThinBlock, blockSize);
-            std::string ss = CThinBlockStats::ToString();
-            LogPrint("thin", "thin block stats: %s\n", ss.c_str());
+            CThinBlockStats::UpdateInBound(nSizeThinBlock, blockSize);
+            LogPrint("thin", "thin block stats: %s\n", CThinBlockStats::ToString());
 
             HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, inv);  // clears the thin block
             BOOST_FOREACH(uint64_t &cheapHash, thinBlock.vTxHashes)
@@ -5374,9 +5373,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                      );
 
             // Update run-time statistics of thin block bandwidth savings
-            CThinBlockStats::Update(nSizeThinBlock, blockSize);
-            std::string ss = CThinBlockStats::ToString();
-            LogPrint("thin", "thin block stats: %s\n", ss.c_str());
+            CThinBlockStats::UpdateInBound(nSizeThinBlock, blockSize);
+            LogPrint("thin", "thin block stats: %s\n", CThinBlockStats::ToString());
 
             HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, inv);
             BOOST_FOREACH(uint256 &hash, thinBlock.vTxHashes)
@@ -5437,9 +5435,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                      );
 
             // Update run-time statistics of thin block bandwidth savings
-            CThinBlockStats::Update(nSizeThinBlockTx + pfrom->nSizeThinBlock, blockSize);
-            std::string ss = CThinBlockStats::ToString();
-            LogPrint("thin", "thin block stats: %s\n", ss.c_str());
+            CThinBlockStats::UpdateInBound(nSizeThinBlockTx + pfrom->nSizeThinBlock, blockSize);
+            LogPrint("thin", "thin block stats: %s\n", CThinBlockStats::ToString());
 
             std::vector<CTransaction> vTx = pfrom->thinBlock.vtx;
             HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, inv);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6021,8 +6021,10 @@ bool SendMessages(CNode* pto)
                    got back an empty response.  */
                 if (pindexStart->pprev)
                     pindexStart = pindexStart->pprev;
-                LogPrint("net", "initial getheaders (%d) to peer=%d (startheight:%d)\n", pindexStart->nHeight, pto->id, pto->nStartingHeight);
-                pto->PushMessage(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexStart), uint256());
+                if (pindexStart->nHeight < pto->nStartingHeight) { // BU Bug fix for Core:  Don't start downloading headers unless our chain is shorter
+                    LogPrint("net", "initial getheaders (%d) to peer=%d (startheight:%d)\n", pindexStart->nHeight, pto->id, pto->nStartingHeight);
+                    pto->PushMessage(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexStart), uint256());
+                }
             }
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4737,7 +4737,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                                     std::vector<uint256> vOrphanHashes;
                                     for (map<uint256, COrphanTx>::iterator mi = mapOrphanTransactions.begin(); mi != mapOrphanTransactions.end(); ++mi)
                                         vOrphanHashes.push_back((*mi).first);
-                                    BuildSeededBloomFilter(filterMemPool, vOrphanHashes);
+                                    BuildSeededBloomFilter(filterMemPool, vOrphanHashes, inv2.hash);
                                     ss << inv2;
                                     ss << filterMemPool;
                                     pfrom->PushMessage(NetMsgType::GET_XTHIN, ss);
@@ -4753,7 +4753,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                                     std::vector<uint256> vOrphanHashes;
                                     for (map<uint256, COrphanTx>::iterator mi = mapOrphanTransactions.begin(); mi != mapOrphanTransactions.end(); ++mi)
                                         vOrphanHashes.push_back((*mi).first);
-                                    BuildSeededBloomFilter(filterMemPool, vOrphanHashes);
+                                    BuildSeededBloomFilter(filterMemPool, vOrphanHashes, inv2.hash);
                                     ss << inv2;
                                     ss << filterMemPool;
                                     pfrom->PushMessage(NetMsgType::GET_XTHIN, ss);
@@ -5271,7 +5271,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             pfrom->thinBlock.vtx.push_back(tx);
         }
         pfrom->thinBlockWaitingForTxns = missingCount;
-        LogPrint("thin", "thinblock waiting for: %d, unnecessary: %d, txs: %d full: %d\n", pfrom->thinBlockWaitingForTxns, unnecessaryCount, pfrom->thinBlock.vtx.size(), mapMissingTx.size());
+        LogPrint("thin", "Thinblock %s waiting for: %d, unnecessary: %d, txs: %d full: %d\n", inv.hash.ToString(), pfrom->thinBlockWaitingForTxns, unnecessaryCount, pfrom->thinBlock.vtx.size(), mapMissingTx.size());
 
         if (pfrom->thinBlockWaitingForTxns == 0) {
             // We have all the transactions now that are in this block: try to reassemble and process.
@@ -5375,7 +5375,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             pfrom->thinBlock.vtx.push_back(tx);
         }
         pfrom->thinBlockWaitingForTxns = missingCount;
-        LogPrint("thin", "thinblock waiting for: %d, unnecessary: %d, txs: %d full: %d\n", pfrom->thinBlockWaitingForTxns, unnecessaryCount, pfrom->thinBlock.vtx.size(), mapMissingTx.size());
+        LogPrint("thin", "Thinblock %s waiting for: %d, unnecessary: %d, txs: %d full: %d\n", inv.hash.ToString(), pfrom->thinBlockWaitingForTxns, unnecessaryCount, pfrom->thinBlock.vtx.size(), mapMissingTx.size());
 
         if (pfrom->thinBlockWaitingForTxns == 0) {
             // We have all the transactions now that are in this block: try to reassemble and process.
@@ -6231,7 +6231,7 @@ bool SendMessages(CNode* pto)
                             std::vector<uint256> vOrphanHashes;
                             for (map<uint256, COrphanTx>::iterator mi = mapOrphanTransactions.begin(); mi != mapOrphanTransactions.end(); ++mi)
                                 vOrphanHashes.push_back((*mi).first);
-                            BuildSeededBloomFilter(filterMemPool, vOrphanHashes);
+                            BuildSeededBloomFilter(filterMemPool, vOrphanHashes, pindex->GetBlockHash());
                             ss << CInv(MSG_XTHINBLOCK, pindex->GetBlockHash());
                             ss << filterMemPool;
                             pto->PushMessage(NetMsgType::GET_XTHIN, ss);
@@ -6247,7 +6247,7 @@ bool SendMessages(CNode* pto)
                             std::vector<uint256> vOrphanHashes;
                             for (map<uint256, COrphanTx>::iterator mi = mapOrphanTransactions.begin(); mi != mapOrphanTransactions.end(); ++mi)
                                 vOrphanHashes.push_back((*mi).first);
-                            BuildSeededBloomFilter(filterMemPool, vOrphanHashes);
+                            BuildSeededBloomFilter(filterMemPool, vOrphanHashes, pindex->GetBlockHash());
                             ss << CInv(MSG_XTHINBLOCK, pindex->GetBlockHash());
                             ss << filterMemPool;
                             pto->PushMessage(NetMsgType::GET_XTHIN, ss);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4431,20 +4431,19 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         return true;
     }
 
-// BUIP010 Extrem Thinblocks:  We need bloom filtering. We do not turn bloom filtering off
-//    if (!(nLocalServices & NODE_BLOOM) &&
-//              (strCommand == NetMsgType::FILTERLOAD ||
-//               strCommand == NetMsgType::FILTERADD ||
-//               strCommand == NetMsgType::FILTERCLEAR))
-//    {
-//        if (pfrom->nVersion >= NO_BLOOM_VERSION) {
-//            Misbehaving(pfrom->GetId(), 100);
-//            return false;
-//        } else if (GetBoolArg("-enforcenodebloom", false)) {
-//            pfrom->fDisconnect = true;
-//            return false;
-//        }
-//    }
+    if (!(nLocalServices & NODE_BLOOM) &&
+              (strCommand == NetMsgType::FILTERLOAD ||
+               strCommand == NetMsgType::FILTERADD ||
+               strCommand == NetMsgType::FILTERCLEAR))
+    {
+        if (pfrom->nVersion >= NO_BLOOM_VERSION) {
+            Misbehaving(pfrom->GetId(), 100);
+            return false;
+        } else if (GetBoolArg("-enforcenodebloom", false)) {
+            pfrom->fDisconnect = true;
+            return false;
+        }
+    }
 
 
     if (strCommand == NetMsgType::VERSION)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1074,7 +1074,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
             LogPrint("mempool", "Rate limit dFreeCount: %g => %g\n", dFreeCount, dFreeCount+nSize);
             if ((dFreeCount + nSize) >= (nFreeLimit*10*1000 * nLargestBlockSeen / BLOCKSTREAM_CORE_MAX_BLOCK_SIZE)) {
                 CThinBlockStats::UpdateMempoolLimiterBytesSaved(nSize);
-                return state.DoS(0, 
+                return state.DoS(0,
                        error("AcceptToMemoryPool : free transaction rejected by rate limiter"),
                        REJECT_INSUFFICIENTFEE, "rate limited free transaction");
             }
@@ -5453,7 +5453,9 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                      ((float) blockSize) / ( (float) pfrom->nSizeThinBlock + (float) nSizeThinBlockTx )
                      );
 
-            // Update run-time statistics of thin block bandwidth savings
+            // Update run-time statistics of thin block bandwidth savings.
+            // We add the original thinblock size with the size of transactions that were re-requested.
+            // This is NOT double counting since we never accounted for the original thinblock due to the re-request.
             CThinBlockStats::UpdateInBound(nSizeThinBlockTx + pfrom->nSizeThinBlock, blockSize);
             LogPrint("thin", "thin block stats: %s\n", CThinBlockStats::ToString());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4733,7 +4733,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                         if (IsThinBlocksEnabled() && IsChainNearlySyncd()) {
                             if (HaveConnectThinblockNodes() || (HaveThinblockNodes() && CheckThinblockTimer(inv.hash))) {
                                 // Must download a block from a ThinBlock peer
-                                if (pfrom->mapThinBlocksInFlight.size() < 1 && pfrom->ThinBlockCapable()) { // We can only send one thinblock per peer at a time
+                                if (pfrom->mapThinBlocksInFlight.size() < 1 && CanThinBlockBeDownloaded(pfrom)) { // We can only send one thinblock per peer at a time
                                     pfrom->mapThinBlocksInFlight[inv2.hash] = GetTime();
                                     inv2.type = MSG_XTHINBLOCK;
                                     std::vector<uint256> vOrphanHashes;
@@ -4744,12 +4744,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                                     ss << filterMemPool;
                                     pfrom->PushMessage(NetMsgType::GET_XTHIN, ss);
                                     MarkBlockAsInFlight(pfrom->GetId(), inv.hash, chainparams.GetConsensus());
-                                    LogPrint("thin", "Requesting Thinblock %s by INV from peer %s (%d)\n", inv2.hash.ToString(), pfrom->addrName.c_str(),pfrom->id);
+                                    LogPrint("thin", "Requesting Thinblock %s by INV from peer %s (%d) pingtime(ms) %d\n", inv2.hash.ToString(), pfrom->addrName.c_str(), pfrom->id, pfrom->nPingUsecTime/1000);
                                 }
                             }
                             else {
                                 // Try to download a thinblock if possible otherwise just download a regular block
-                                if (pfrom->mapThinBlocksInFlight.size() < 1 && pfrom->ThinBlockCapable()) { // We can only send one thinblock per peer at a time
+                                if (pfrom->mapThinBlocksInFlight.size() < 1 && CanThinBlockBeDownloaded(pfrom)) { // We can only send one thinblock per peer at a time
                                     pfrom->mapThinBlocksInFlight[inv2.hash] = GetTime();
                                     inv2.type = MSG_XTHINBLOCK;
                                     std::vector<uint256> vOrphanHashes;
@@ -4759,7 +4759,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                                     ss << inv2;
                                     ss << filterMemPool;
                                     pfrom->PushMessage(NetMsgType::GET_XTHIN, ss);
-                                    LogPrint("thin", "Requesting Thinblock %s by INV from peer %s (%d)\n", inv2.hash.ToString(), pfrom->addrName.c_str(),pfrom->id);
+                                    LogPrint("thin", "Requesting Thinblock %s by INV from peer %s (%d) pingtime(ms) %d\n", inv2.hash.ToString(), pfrom->addrName.c_str(), pfrom->id, pfrom->nPingUsecTime/1000);
                                 }
                                 else {
                                     LogPrint("thin", "Requesting Regular Block %s by INV from peer %s (%d)\n", inv2.hash.ToString(), pfrom->addrName.c_str(),pfrom->id);
@@ -6236,7 +6236,7 @@ bool SendMessages(CNode* pto)
                     CBloomFilter filterMemPool;
                     if (HaveConnectThinblockNodes() || (HaveThinblockNodes() && CheckThinblockTimer(pindex->GetBlockHash()))) {
                         // Must download a block from a ThinBlock peer
-                        if (pto->mapThinBlocksInFlight.size() < 1 && pto->ThinBlockCapable()) { // We can only send one thinblock per peer at a time
+                        if (pto->mapThinBlocksInFlight.size() < 1 && CanThinBlockBeDownloaded(pto)) { // We can only send one thinblock per peer at a time
                             pto->mapThinBlocksInFlight[pindex->GetBlockHash()] = GetTime();
                             std::vector<uint256> vOrphanHashes;
                             for (map<uint256, COrphanTx>::iterator mi = mapOrphanTransactions.begin(); mi != mapOrphanTransactions.end(); ++mi)
@@ -6246,13 +6246,13 @@ bool SendMessages(CNode* pto)
                             ss << filterMemPool;
                             pto->PushMessage(NetMsgType::GET_XTHIN, ss);
                             MarkBlockAsInFlight(pto->GetId(), pindex->GetBlockHash(), consensusParams, pindex);
-                            LogPrint("thin", "Requesting Thinblock %s (%d) from peer %s (%d)\n", pindex->GetBlockHash().ToString(),
-                                     pindex->nHeight, pto->addrName.c_str(), pto->id);
+                            LogPrint("thin", "Requesting Thinblock %s (%d) from peer %s (%d) pingtime(ms) %d\n", pindex->GetBlockHash().ToString(),
+                                     pindex->nHeight, pto->addrName.c_str(), pto->id,  pto->nPingUsecTime/1000);
                         }
                     }
                     else {
                         // Try to download a thinblock if possible otherwise just download a regular block
-                        if (pto->mapThinBlocksInFlight.size() < 1 && pto->ThinBlockCapable()) { // We can only send one thinblock per peer at a time
+                        if (pto->mapThinBlocksInFlight.size() < 1 && CanThinBlockBeDownloaded(pto)) { // We can only send one thinblock per peer at a time
                             pto->mapThinBlocksInFlight[pindex->GetBlockHash()] = GetTime();
                             std::vector<uint256> vOrphanHashes;
                             for (map<uint256, COrphanTx>::iterator mi = mapOrphanTransactions.begin(); mi != mapOrphanTransactions.end(); ++mi)
@@ -6261,8 +6261,8 @@ bool SendMessages(CNode* pto)
                             ss << CInv(MSG_XTHINBLOCK, pindex->GetBlockHash());
                             ss << filterMemPool;
                             pto->PushMessage(NetMsgType::GET_XTHIN, ss);
-                            LogPrint("thin", "Requesting Thinblock %s (%d) from peer %s (%d)\n", pindex->GetBlockHash().ToString(),
-                                     pindex->nHeight, pto->addrName.c_str(), pto->id);
+                            LogPrint("thin", "Requesting Thinblock %s (%d) from peer %s (%d) pingtime(ms) %d\n", pindex->GetBlockHash().ToString(),
+                                     pindex->nHeight, pto->addrName.c_str(), pto->id, pto->nPingUsecTime/1000);
                         }
                         else {
                             vGetData.push_back(CInv(MSG_BLOCK, pindex->GetBlockHash())); 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1075,7 +1075,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
             if ((dFreeCount + nSize) >= (nFreeLimit*10*1000 * nLargestBlockSeen / BLOCKSTREAM_CORE_MAX_BLOCK_SIZE)) {
                 CThinBlockStats::UpdateMempoolLimiterBytesSaved(nSize);
                 return state.DoS(0,
-                       error("AcceptToMemoryPool : free transaction rejected by rate limiter"),
+                       LogPrint("mempool", "AcceptToMemoryPool : free transaction rejected by rate limiter"),
                        REJECT_INSUFFICIENTFEE, "rate limited free transaction");
             }
             dFreeCount += nSize;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1011,10 +1011,9 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
     // no need here to check whether the peer is whitelisted or not.
     std::sort(vEvictionCandidatesByActivity.begin(), vEvictionCandidatesByActivity.end(), CompareNodeActivityBytes);
     vEvictionCandidatesByActivity[0]->fDisconnect = true;
-    LogPrintf("Node disconnected as too inactive %d bytes activity peer %s\n", vEvictionCandidatesByActivity[0]->nActivityBytes, vEvictionCandidatesByActivity[0]->addrName);
-    int i =0;
-    for (i = 0; i < vEvictionCandidatesByActivity.size(); i++) {
-        LogPrintf("Node %s bytes %d candidate %d\n", vEvictionCandidatesByActivity[i]->addrName,  vEvictionCandidatesByActivity[i]->nActivityBytes, i);
+    LogPrint("evict", "Node disconnected because too inactive:%d bytes of activity for peer %s\n", vEvictionCandidatesByActivity[0]->nActivityBytes, vEvictionCandidatesByActivity[0]->addrName);
+    for (unsigned int i = 0; i < vEvictionCandidatesByActivity.size(); i++) {
+        LogPrint("evict", "Node %s bytes %d candidate %d\n", vEvictionCandidatesByActivity[i]->addrName,  vEvictionCandidatesByActivity[i]->nActivityBytes, i);
     }
 
     return true;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -696,7 +696,7 @@ bool CNode::ReceiveMsgBytes(const char* pch, unsigned int nBytes)
         nBytes -= handled;
 
         if (msg.complete()) {
-            // BU: connection slot attackk mitigation.  We don't count PONG responses as bytes received. We don't want to include
+            // BU: connection slot attack mitigation.  We don't count PONG responses as bytes received. We don't want to include
             //     bytes sent or received for nodes that just connect and listen to INV messages.
             std::string strCommand = msg.hdr.GetCommand();
             if (strCommand != NetMsgType::PONG &&
@@ -704,7 +704,22 @@ bool CNode::ReceiveMsgBytes(const char* pch, unsigned int nBytes)
                 strCommand != NetMsgType::ADDR &&
                 strCommand != NetMsgType::VERSION &&
                 strCommand != NetMsgType::VERACK)
+            {
                 nActivityBytes += msg.hdr.nMessageSize;
+
+                // BU: furthermore, if the message is a priority message then move from the back to the front of the deque
+                if (strCommand == NetMsgType::GET_XTHIN || 
+                    strCommand == NetMsgType::XTHINBLOCK || 
+                    strCommand == NetMsgType::THINBLOCK || 
+                    strCommand == NetMsgType::XBLOCKTX || 
+                    strCommand == NetMsgType::GET_XBLOCKTX )
+                {
+                    vRecvMsg.push_front(msg);
+                    vRecvMsg.pop_back();
+                    LogPrint("thin", "Receive Queue: pushed %s to the front of the queue\n", strCommand);
+                }
+            }
+            // BU: end
             msg.nTime = GetTimeMicros();
             messageHandlerCondition.notify_one();
         }
@@ -2570,6 +2585,7 @@ void CNode::EndMessage() UNLOCK_FUNCTION(cs_vSend)
     // BU: connection slot attack mitigation.  We don't want to add bytes for outgoing INV or PING
     //     messages since attackers will often just connect and listen to INV messages.  We want to make
     //     sure that connected nodes are really doing useful work in sending us data or requesting data.
+    std::deque<CSerializeData>::iterator it;
     char strCommand[CMessageHeader::COMMAND_SIZE + 1];
     strncpy(strCommand, &(*(ssSend.begin() + MESSAGE_START_SIZE)), CMessageHeader::COMMAND_SIZE);
     strCommand[CMessageHeader::COMMAND_SIZE] = '\0';
@@ -2579,9 +2595,25 @@ void CNode::EndMessage() UNLOCK_FUNCTION(cs_vSend)
         strcmp(strCommand, NetMsgType::VERSION) != 0 &&
         strcmp(strCommand, NetMsgType::VERACK) != 0 &&
         strcmp(strCommand, NetMsgType::INV) != 0)
+    {
         nActivityBytes += nSize;
 
-    std::deque<CSerializeData>::iterator it = vSendMsg.insert(vSendMsg.end(), CSerializeData());
+        // BU: furthermore, if the message is a priority message then move to the front of the deque
+        if (strcmp(strCommand, NetMsgType::GET_XTHIN) == 0 || 
+            strcmp(strCommand, NetMsgType::XTHINBLOCK) == 0 || 
+            strcmp(strCommand, NetMsgType::THINBLOCK) == 0 || 
+            strcmp(strCommand, NetMsgType::XBLOCKTX) == 0 || 
+            strcmp(strCommand, NetMsgType::GET_XBLOCKTX) == 0 ) {
+            it = vSendMsg.insert(vSendMsg.begin(), CSerializeData());
+            LogPrint("thin", "Send Queue: pushed %s to the front of the queue\n", strCommand);
+        }
+        else
+            it = vSendMsg.insert(vSendMsg.end(), CSerializeData());
+    }
+    else
+        it = vSendMsg.insert(vSendMsg.end(), CSerializeData());
+    // BU: end
+
     ssSend.GetAndClear(*it);
     nSendSize += (*it).size();
 

--- a/src/net.h
+++ b/src/net.h
@@ -515,7 +515,7 @@ public:
     // BUIP010:
     bool ThinBlockCapable()
     {
-        if ((nServices & NODE_XTHIN) && (nServices & NODE_BLOOM)) return true;
+        if (nServices & NODE_XTHIN) return true;
         return false;
     }
 

--- a/src/net.h
+++ b/src/net.h
@@ -515,7 +515,7 @@ public:
     // BUIP010:
     bool ThinBlockCapable()
     {
-        if (nServices & NODE_XTHIN) return true;
+        if ((nServices & NODE_XTHIN) && (nServices & NODE_BLOOM)) return true;
         return false;
     }
 

--- a/src/net.h
+++ b/src/net.h
@@ -387,6 +387,8 @@ public:
     std::map<uint256, uint64_t> mapThinBlocksInFlight; // map of the hashes of thin blocks in flight with the time they were requested.
     double nGetXBlockTxCount; // Count how many get_xblocktx requests are made
     uint64_t nGetXBlockTxLastTime;  // The last time a get_xblocktx request was made
+    double nGetXthinCount; // Count how many get_xthin requests are made
+    uint64_t nGetXthinLastTime;  // The last time a get_xthin request was made
     // BUIP010 Xtreme Thinblocks: end section
 
 protected:

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -424,6 +424,8 @@ static UniValue GetThinBlockStats()
         obj.push_back(Pair("summary", CThinBlockStats::ToString()));
         obj.push_back(Pair("summary", CThinBlockStats::InBoundPercentToString()));
         obj.push_back(Pair("summary", CThinBlockStats::OutBoundPercentToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::ResponseTimeToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::ValidationTimeToString()));
     }
     return obj;
 }

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -422,6 +422,7 @@ static UniValue GetThinBlockStats()
     obj.push_back(Pair("enabled", enabled));
     if (enabled) {
         obj.push_back(Pair("summary", CThinBlockStats::ToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::MempoolLimiterBytesSavedToString()));
         obj.push_back(Pair("summary", CThinBlockStats::InBoundPercentToString()));
         obj.push_back(Pair("summary", CThinBlockStats::OutBoundPercentToString()));
         obj.push_back(Pair("summary", CThinBlockStats::ResponseTimeToString()));

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -426,6 +426,9 @@ static UniValue GetThinBlockStats()
         obj.push_back(Pair("summary", CThinBlockStats::OutBoundPercentToString()));
         obj.push_back(Pair("summary", CThinBlockStats::ResponseTimeToString()));
         obj.push_back(Pair("summary", CThinBlockStats::ValidationTimeToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::OutBoundBloomFiltersToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::InBoundBloomFiltersToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::ReRequestedTxToString()));
     }
     return obj;
 }

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -422,11 +422,12 @@ static UniValue GetThinBlockStats()
     obj.push_back(Pair("enabled", enabled));
     if (enabled) {
         obj.push_back(Pair("summary", CThinBlockStats::ToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::InBoundPercentToString()));
+        obj.push_back(Pair("summary", CThinBlockStats::OutBoundPercentToString()));
     }
     return obj;
 }
 // BitcoinUnlimited BUIP010 : End
-
 
 UniValue getnetworkinfo(const UniValue& params, bool fHelp)
 {

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -12,6 +12,7 @@
 CStatHistory<uint64_t> CThinBlockStats::nOriginalSize("thin/blockSize", STAT_OP_SUM | STAT_KEEP);
 CStatHistory<uint64_t> CThinBlockStats::nThinSize("thin/thinSize", STAT_OP_SUM | STAT_KEEP);
 CStatHistory<uint64_t> CThinBlockStats::nBlocks("thin/numBlocks", STAT_OP_SUM | STAT_KEEP);
+CStatHistory<uint64_t> CThinBlockStats::nMempoolLimiterBytesSaved("nSize", STAT_OP_SUM | STAT_KEEP);
 std::map<int64_t, std::pair<uint64_t, uint64_t> > CThinBlockStats::mapThinBlocksInBound;
 std::map<int64_t, int> CThinBlockStats::mapThinBlocksInBoundReRequestedTx;
 std::map<int64_t, std::pair<uint64_t, uint64_t> > CThinBlockStats::mapThinBlocksOutBound;
@@ -200,6 +201,11 @@ void CThinBlockStats::UpdateInBoundReRequestedTx(int nReRequestedTx)
         if ((*mi).first < nTimeCutoff)
             CThinBlockStats::mapThinBlocksInBoundReRequestedTx.erase(mi);
     }
+}
+
+void CThinBlockStats::UpdateMempoolLimiterBytesSaved(unsigned int nBytesSaved)
+{
+    CThinBlockStats::nMempoolLimiterBytesSaved += nBytesSaved;
 }
 
 std::string CThinBlockStats::ToString()
@@ -421,5 +427,21 @@ std::string CThinBlockStats::ReRequestedTxToString()
     std::ostringstream ss;
     ss << std::fixed << std::setprecision(1);
     ss << "Re-request rate (last 24hrs): " << nReRequestRate << "% Total re-requests:" << nTotalReRequests;
+    return ss.str();
+}
+
+std::string CThinBlockStats::MempoolLimiterBytesSavedToString()
+{
+    static const char *units[] = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
+    int i = 0;
+    double size = (double)CThinBlockStats::nMempoolLimiterBytesSaved();
+    while (size > 1000) {
+	size /= 1000;
+	i++;
+    }
+
+    std::ostringstream ss;
+    ss << std::fixed << std::setprecision(2);
+    ss << "Thinblock mempool limiting has saved " << size << units[i] << " of bandwidth";
     return ss.str();
 }

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -4,6 +4,7 @@
 
 #include "thinblock.h"
 #include "utiltime.h"
+#include "unlimited.h"
 #include <sstream>
 #include <iomanip>
 
@@ -132,25 +133,31 @@ void CThinBlockStats::UpdateOutBound(uint64_t nThinBlockSize, uint64_t nOriginal
 
 void CThinBlockStats::UpdateResponseTime(double nResponseTime)
 {
-    CThinBlockStats::mapThinBlockResponseTime[GetTimeMillis()] = nResponseTime;
+    // only update stats if IBD is complete
+    if (IsChainNearlySyncd() && IsThinBlocksEnabled()) {
+        CThinBlockStats::mapThinBlockResponseTime[GetTimeMillis()] = nResponseTime;
 
-    // Delete any entries that are more than 24 hours old
-    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
-    for (std::map<int64_t, double>::iterator mi = CThinBlockStats::mapThinBlockResponseTime.begin(); mi != CThinBlockStats::mapThinBlockResponseTime.end(); ++mi) {
-        if ((*mi).first < nTimeCutoff)
-            CThinBlockStats::mapThinBlockResponseTime.erase(mi);
+        // Delete any entries that are more than 24 hours old
+        int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+        for (std::map<int64_t, double>::iterator mi = CThinBlockStats::mapThinBlockResponseTime.begin(); mi != CThinBlockStats::mapThinBlockResponseTime.end(); ++mi) {
+            if ((*mi).first < nTimeCutoff)
+                CThinBlockStats::mapThinBlockResponseTime.erase(mi);
+        }
     }
 }
 
 void CThinBlockStats::UpdateValidationTime(double nValidationTime)
 {
-    CThinBlockStats::mapThinBlockValidationTime[GetTimeMillis()] = nValidationTime;
+    // only update stats if IBD is complete
+    if (IsChainNearlySyncd() && IsThinBlocksEnabled()) {
+        CThinBlockStats::mapThinBlockValidationTime[GetTimeMillis()] = nValidationTime;
 
-    // Delete any entries that are more than 24 hours old
-    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
-    for (std::map<int64_t, double>::iterator mi = CThinBlockStats::mapThinBlockValidationTime.begin(); mi != CThinBlockStats::mapThinBlockValidationTime.end(); ++mi) {
-        if ((*mi).first < nTimeCutoff)
-            CThinBlockStats::mapThinBlockValidationTime.erase(mi);
+        // Delete any entries that are more than 24 hours old
+        int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+        for (std::map<int64_t, double>::iterator mi = CThinBlockStats::mapThinBlockValidationTime.begin(); mi != CThinBlockStats::mapThinBlockValidationTime.end(); ++mi) {
+            if ((*mi).first < nTimeCutoff)
+                CThinBlockStats::mapThinBlockValidationTime.erase(mi);
+        }
     }
 }
 

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -221,6 +221,13 @@ std::string CThinBlockStats::ToString()
 // Calculate the xthin percentage compression over the last 24 hours
 std::string CThinBlockStats::InBoundPercentToString()
 {
+    // Delete any entries that are more than 24 hours old
+    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+    for (std::map<int64_t, std::pair<uint64_t, uint64_t> >::iterator mi = CThinBlockStats::mapThinBlocksInBound.begin(); mi != CThinBlockStats::mapThinBlocksInBound.end(); ++mi) {
+        if ((*mi).first < nTimeCutoff)
+            CThinBlockStats::mapThinBlocksInBound.erase(mi);
+    }
+
     double nCompressionRate = 0;
     uint64_t nThinSizeTotal = 0;
     uint64_t nOriginalSizeTotal = 0;
@@ -241,6 +248,13 @@ std::string CThinBlockStats::InBoundPercentToString()
 // Calculate the xthin percentage compression over the last 24 hours
 std::string CThinBlockStats::OutBoundPercentToString()
 {
+    // Delete any entries that are more than 24 hours old
+    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+    for (std::map<int64_t, std::pair<uint64_t, uint64_t> >::iterator mi = CThinBlockStats::mapThinBlocksOutBound.begin(); mi != CThinBlockStats::mapThinBlocksOutBound.end(); ++mi) {
+        if ((*mi).first < nTimeCutoff)
+            CThinBlockStats::mapThinBlocksOutBound.erase(mi);
+    }
+
     double nCompressionRate = 0;
     uint64_t nThinSizeTotal = 0;
     uint64_t nOriginalSizeTotal = 0;
@@ -261,6 +275,13 @@ std::string CThinBlockStats::OutBoundPercentToString()
 // Calculate the average inbound xthin bloom filter size
 std::string CThinBlockStats::InBoundBloomFiltersToString()
 {
+    // Delete any entries that are more than 24 hours old
+    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+    for (std::map<int64_t, uint64_t>::iterator mi = CThinBlockStats::mapBloomFiltersInBound.begin(); mi != CThinBlockStats::mapBloomFiltersInBound.end(); ++mi) {
+        if ((*mi).first < nTimeCutoff)
+            CThinBlockStats::mapBloomFiltersInBound.erase(mi);
+    }
+
     uint64_t nInBoundBloomFilters = 0;
     uint64_t nInBoundBloomFilterSize = 0;
     double avgBloomSize = 0;
@@ -287,6 +308,13 @@ std::string CThinBlockStats::InBoundBloomFiltersToString()
 // Calculate the average inbound xthin bloom filter size
 std::string CThinBlockStats::OutBoundBloomFiltersToString()
 {
+    // Delete any entries that are more than 24 hours old
+    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+    for (std::map<int64_t, uint64_t>::iterator mi = CThinBlockStats::mapBloomFiltersOutBound.begin(); mi != CThinBlockStats::mapBloomFiltersOutBound.end(); ++mi) {
+        if ((*mi).first < nTimeCutoff)
+            CThinBlockStats::mapBloomFiltersOutBound.erase(mi);
+    }
+
     uint64_t nOutBoundBloomFilters = 0;
     uint64_t nOutBoundBloomFilterSize = 0;
     double avgBloomSize = 0;
@@ -372,6 +400,13 @@ std::string CThinBlockStats::ValidationTimeToString()
 // Calculate the xthin percentage compression over the last 24 hours
 std::string CThinBlockStats::ReRequestedTxToString()
 {
+    // Delete any entries that are more than 24 hours old
+    int64_t nTimeCutoff = GetTimeMillis() - 60*60*24*1000;
+    for (std::map<int64_t, int>::iterator mi = CThinBlockStats::mapThinBlocksInBoundReRequestedTx.begin(); mi != CThinBlockStats::mapThinBlocksInBoundReRequestedTx.end(); ++mi) {
+        if ((*mi).first < nTimeCutoff)
+            CThinBlockStats::mapThinBlocksInBoundReRequestedTx.erase(mi);
+    }
+
     double nReRequestRate = 0;
     uint64_t nTotalReRequests = 0;
     uint64_t nTotalReRequestedTxs = 0;

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -109,6 +109,7 @@ private:
 	static CStatHistory<uint64_t> nThinSize;
 	static CStatHistory<uint64_t> nBlocks;
 	static CStatHistory<uint64_t> nMempoolLimiterBytesSaved;
+	static CStatHistory<uint64_t> nTotalBloomFilterBytes;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksInBound;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksOutBound;
         static std::map<int64_t, uint64_t> mapBloomFiltersOutBound;

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -110,13 +110,19 @@ private:
 	static CStatHistory<uint64_t> nBlocks;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksInBound;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksOutBound;
+        static std::map<int64_t, double> mapThinBlockResponseTime;
+        static std::map<int64_t, double> mapThinBlockValidationTime;
 
 public:
 	static void UpdateInBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
 	static void UpdateOutBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
+	static void UpdateResponseTime(double nResponseTime);
+	static void UpdateValidationTime(double nValidationTime);
 	static std::string ToString();
         static std::string InBoundPercentToString();
         static std::string OutBoundPercentToString();
+        static std::string ResponseTimeToString();
+        static std::string ValidationTimeToString();
 };
 
 

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -11,7 +11,6 @@
 #include "bloom.h"
 #include "stat.h"
 
-#include <vector>
 
 class CThinBlock
 {
@@ -109,9 +108,15 @@ private:
 	static CStatHistory<uint64_t> nOriginalSize;
 	static CStatHistory<uint64_t> nThinSize;
 	static CStatHistory<uint64_t> nBlocks;
+        static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksInBound;
+        static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksOutBound;
+
 public:
-	static void Update(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
+	static void UpdateInBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
+	static void UpdateOutBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
 	static std::string ToString();
+        static std::string InBoundPercentToString();
+        static std::string OutBoundPercentToString();
 };
 
 

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -108,6 +108,7 @@ private:
 	static CStatHistory<uint64_t> nOriginalSize;
 	static CStatHistory<uint64_t> nThinSize;
 	static CStatHistory<uint64_t> nBlocks;
+	static CStatHistory<uint64_t> nMempoolLimiterBytesSaved;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksInBound;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksOutBound;
         static std::map<int64_t, uint64_t> mapBloomFiltersOutBound;
@@ -115,7 +116,7 @@ private:
         static std::map<int64_t, double> mapThinBlockResponseTime;
         static std::map<int64_t, double> mapThinBlockValidationTime;
         static std::map<int64_t, int> mapThinBlocksInBoundReRequestedTx;
-
+ 
 public:
 	static void UpdateInBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
 	static void UpdateOutBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
@@ -124,6 +125,7 @@ public:
 	static void UpdateResponseTime(double nResponseTime);
 	static void UpdateValidationTime(double nValidationTime);
 	static void UpdateInBoundReRequestedTx(int nReRequestedTx);
+        static void UpdateMempoolLimiterBytesSaved(unsigned int nBytesSaved);
 	static std::string ToString();
         static std::string InBoundPercentToString();
         static std::string OutBoundPercentToString();
@@ -132,6 +134,7 @@ public:
         static std::string ResponseTimeToString();
         static std::string ValidationTimeToString();
         static std::string ReRequestedTxToString();
+        static std::string MempoolLimiterBytesSavedToString();
 };
 
 

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -110,19 +110,28 @@ private:
 	static CStatHistory<uint64_t> nBlocks;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksInBound;
         static std::map<int64_t, std::pair<uint64_t, uint64_t> > mapThinBlocksOutBound;
+        static std::map<int64_t, uint64_t> mapBloomFiltersOutBound;
+        static std::map<int64_t, uint64_t> mapBloomFiltersInBound;
         static std::map<int64_t, double> mapThinBlockResponseTime;
         static std::map<int64_t, double> mapThinBlockValidationTime;
+        static std::map<int64_t, int> mapThinBlocksInBoundReRequestedTx;
 
 public:
 	static void UpdateInBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
 	static void UpdateOutBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
+        static void UpdateOutBoundBloomFilter(uint64_t nBloomFilterSize);
+        static void UpdateInBoundBloomFilter(uint64_t nBloomFilterSize);
 	static void UpdateResponseTime(double nResponseTime);
 	static void UpdateValidationTime(double nValidationTime);
+	static void UpdateInBoundReRequestedTx(int nReRequestedTx);
 	static std::string ToString();
         static std::string InBoundPercentToString();
         static std::string OutBoundPercentToString();
+        static std::string InBoundBloomFiltersToString();
+        static std::string OutBoundBloomFiltersToString();
         static std::string ResponseTimeToString();
         static std::string ValidationTimeToString();
+        static std::string ReRequestedTxToString();
 };
 
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -604,14 +604,7 @@ void ClearThinBlockTimer(uint256 hash)
 
 bool IsThinBlocksEnabled() 
 {
-    bool fThinblocksEnabled = GetBoolArg("-use-thinblocks", true);
-
-    // Enabling the XTHIN service should really be in init.cpp but because
-    // we want to avoid possile future merge conflicts with Core we can enable
-    // it here as it has little performance impact.
-    if (fThinblocksEnabled)
-        nLocalServices |= NODE_XTHIN;
-    return fThinblocksEnabled;
+    return GetBoolArg("-use-thinblocks", true);
 }
 
 bool IsChainNearlySyncd() 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -607,6 +607,27 @@ bool IsThinBlocksEnabled()
     return GetBoolArg("-use-thinblocks", true);
 }
 
+bool CanThinBlockBeDownloaded(CNode* pto)
+{
+    if (pto->ThinBlockCapable() && !GetBoolArg("-connect-thinblock-force", false))
+        return true;
+    else if (pto->ThinBlockCapable() && GetBoolArg("-connect-thinblock-force", false)) {
+        // If connect-thinblock-force is true then we have to check that this node is in fact a connect-thinblock node.
+
+        // When -connect-thinblock-force is true we will only download thinblocks from a peer or peers that
+        // are using -connect-thinblock=<ip>.  This is an undocumented setting used for setting up performance testing
+        // of thinblocks, such as, going over the GFC and needing to have thinblocks always come from the same peer or 
+        // group of peers.  Also, this is a one way street.  Thinblocks will flow ONLY from the remote peer to the peer
+        // that has invoked -connect-thinblock.
+
+        // Check if this node is also a connect-thinblock node
+        BOOST_FOREACH(const std::string& strAddrNode, mapMultiArgs["-connect-thinblock"])
+            if (pto->addrName == strAddrNode)
+                return true;
+    }
+    return false;
+}
+
 bool IsChainNearlySyncd() 
 {
     LOCK(cs_main);

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -652,12 +652,12 @@ void BuildSeededBloomFilter(CBloomFilter& filterMemPool, std::vector<uint256>& v
     // by including a full blocks worth of high priority tx's we cover every scenario.  And when we
     // go on to add the high fee tx's there will be an intersection between the two which then makes 
     // the total number of tx's that go into the bloom filter smaller than just the sum of the two.  
-    uint64_t nBlockPrioritySize = nLargestBlockSeen * 1.15;
+    uint64_t nBlockPrioritySize = nLargestBlockSeen * 1.5;
 
     // Largest projected block size used to add the high fee transactions.  We multiply it by an
     // additional factor to take into account that miners may have slighty different policies when selecting
     // high fee tx's from the pool.
-    uint64_t nBlockMaxProjectedSize = nLargestBlockSeen * 1.35;
+    uint64_t nBlockMaxProjectedSize = nLargestBlockSeen * 1.5;
 
     vector<TxCoinAgePriority> vPriority;
     TxCoinAgePriorityCompare pricomparer;
@@ -786,12 +786,13 @@ void BuildSeededBloomFilter(CBloomFilter& filterMemPool, std::vector<uint256>& v
     static int64_t nStartGrowth = GetTime();
 
     // Tuning knobs for the false positive growth algorithm
-    static uint8_t nHoursToGrow = 24; // number of hours until maximum growth for false positive rate
+    static uint8_t nHoursToGrow = 72; // number of hours until maximum growth for false positive rate
     //static double nGrowthCoefficient = 0.7676; // use for nMinFalsePositive = 0.0001 and nMaxFalsePositive = 0.01 for 6 hour growth period
     //static double nGrowthCoefficient = 0.8831; // use for nMinFalsePositive = 0.0001 and nMaxFalsePositive = 0.02 for 6 hour growth period
-    static double nGrowthCoefficient = 0.1921; // use for nMinFalsePositive = 0.0001 and nMaxFalsePositive = 0.01 for 24 hour growth period
+    //static double nGrowthCoefficient = 0.1921; // use for nMinFalsePositive = 0.0001 and nMaxFalsePositive = 0.01 for 24 hour growth period
+    static double nGrowthCoefficient = 0.0544; // use for nMinFalsePositive = 0.0001 and nMaxFalsePositive = 0.005 for 72 hour growth period
     static double nMinFalsePositive = 0.0001; // starting value for false positive 
-    static double nMaxFalsePositive = 0.01; // maximum false positive rate at end of decay
+    static double nMaxFalsePositive = 0.005; // maximum false positive rate at end of decay
     // TODO: automatically calculate the nGrowthCoefficient from nHoursToGrow, nMinFalsePositve and nMaxFalsePositive
 
     // Count up all the transactions that we'll be putting into the filter, removing any duplicates

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -688,8 +688,10 @@ void HandleBlockMessage(CNode *pfrom, const string &strCommand, CBlock &block, c
     else 
         nLargestBlockSeen = std::max(nSizeBlock, nLargestBlockSeen);
 
+    double nValidationTime = (double)(GetTimeMicros() - startTime) / 1000000.0;
     LogPrint("thin", "Processed Block %s in %.2f seconds\n", inv.hash.ToString(), (double)(GetTimeMicros() - startTime) / 1000000.0);
-    
+    CThinBlockStats::UpdateValidationTime(nValidationTime);
+
     // When we request a thinblock we may get back a regular block if it is smaller than a thinblock
     // Therefore we have to remove the thinblock in flight if it exists and we also need to check that 
     // the block didn't arrive from some other peer.  This code ALSO cleans up the thin block that

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -643,7 +643,9 @@ void BuildSeededBloomFilter(CBloomFilter& filterMemPool, std::vector<uint256>& v
          filterMemPool.insert(vMemPoolHashes[i]);
     for (uint64_t i = 0; i < vOrphanHashes.size(); i++)
          filterMemPool.insert(vOrphanHashes[i]);
-    LogPrint("thin", "Created bloom filter: %d bytes\n",::GetSerializeSize(filterMemPool, SER_NETWORK, PROTOCOL_VERSION));
+    uint64_t nSizeFilter = ::GetSerializeSize(filterMemPool, SER_NETWORK, PROTOCOL_VERSION);
+    LogPrint("thin", "Created bloom filter: %d bytes\n", nSizeFilter);
+    CThinBlockStats::UpdateOutBoundBloomFilter(nSizeFilter);
 }
 
 void LoadFilter(CNode *pfrom, CBloomFilter *filter)
@@ -660,6 +662,7 @@ void LoadFilter(CNode *pfrom, CBloomFilter *filter)
     }
     uint64_t nSizeFilter = ::GetSerializeSize(*pfrom->pThinBlockFilter, SER_NETWORK, PROTOCOL_VERSION);
     LogPrint("thin", "Thinblock Bloom filter size: %d\n", nSizeFilter);
+    CThinBlockStats::UpdateInBoundBloomFilter(nSizeFilter);
 }
 
 void HandleBlockMessage(CNode *pfrom, const string &strCommand, CBlock &block, const CInv &inv)

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -11,9 +11,11 @@
 #include "leakybucket.h"
 #include "main.h"
 #include "net.h"
+#include "policy/policy.h"
 #include "primitives/block.h"
 #include "rpcserver.h"
 #include "thinblock.h"
+#include "timedata.h"
 #include "tinyformat.h"
 #include "txmempool.h"
 #include "unlimited.h"
@@ -28,6 +30,7 @@
 #include <iomanip>
 #include <boost/thread.hpp>
 #include <inttypes.h>
+#include <queue>
 
 using namespace std;
 
@@ -638,27 +641,190 @@ bool IsChainNearlySyncd()
 
 void BuildSeededBloomFilter(CBloomFilter& filterMemPool, std::vector<uint256>& vOrphanHashes, uint256 hash)
 {
-    LogPrint("thin", "Starting creation of bloom filter\n");
+    int64_t nStartTimer= GetTimeMillis();
     seed_insecure_rand();
-    double nBloomPoolSize = (double)mempool.mapTx.size();
-    if (nBloomPoolSize > MAX_BLOOM_FILTER_SIZE / 1.8)
-        nBloomPoolSize = MAX_BLOOM_FILTER_SIZE / 1.8;
-    double nBloomDecay = 1.5 - (nBloomPoolSize * 1.8 / MAX_BLOOM_FILTER_SIZE);  // We should never go below 0.5 as we will start seeing re-requests for tx's
-    int nElements = std::max((int)(((int)mempool.mapTx.size() + (int)vOrphanHashes.size()) * nBloomDecay), 1); // Must make sure nElements is greater than zero or will assert
-    double nFPRate = .001 + (((double)nElements * 1.8 / MAX_BLOOM_FILTER_SIZE) * .004); // The false positive rate in percent decays as the mempool grows
-    filterMemPool = CBloomFilter(nElements, nFPRate, insecure_rand(), BLOOM_UPDATE_ALL);
-    LogPrint("thin", "Bloom multiplier: %f FPrate: %f Num elements in bloom filter: %d num mempool entries: %d\n", nBloomDecay, nFPRate, nElements, (int)mempool.mapTx.size());
+    std::set<uint256> setHighScoreMemPoolHashes;
+    std::set<uint256> setPriorityMemPoolHashes;
 
-    // Seed the filter with the transactions in the memory pool
-    LOCK(cs_main);
-    std::vector<uint256> vMemPoolHashes;
-    mempool.queryHashes(vMemPoolHashes);
-    for (uint64_t i = 0; i < vMemPoolHashes.size(); i++)
-         filterMemPool.insert(vMemPoolHashes[i]);
-    for (uint64_t i = 0; i < vOrphanHashes.size(); i++)
-         filterMemPool.insert(vOrphanHashes[i]);
+    // How much of the block should be dedicated to high-priority transactions.
+    // Logically this should be the same size as the DEFAULT_BLOCK_PRIORITY_SIZE however,
+    // we can't be sure that a miner won't decide to mine more high priority txs and therefore
+    // by including a full blocks worth of high priority tx's we cover every scenario.  And when we
+    // go on to add the high fee tx's there will be an intersection between the two which then makes 
+    // the total number of tx's that go into the bloom filter smaller than just the sum of the two.  
+    uint64_t nBlockPrioritySize = nLargestBlockSeen * 1.15;
+
+    // Largest projected block size used to add the high fee transactions.  We multiply it by an
+    // additional factor to take into account that miners may have slighty different policies when selecting
+    // high fee tx's from the pool.
+    uint64_t nBlockMaxProjectedSize = nLargestBlockSeen * 1.35;
+
+    vector<TxCoinAgePriority> vPriority;
+    TxCoinAgePriorityCompare pricomparer;
+    {
+        LOCK2(cs_main, mempool.cs);
+        CBlockIndex* pindexPrev = chainActive.Tip();
+        const int nHeight = pindexPrev->nHeight + 1;
+        const int64_t nMedianTimePast = pindexPrev->GetMedianTimePast();
+
+        int64_t nLockTimeCutoff = (STANDARD_LOCKTIME_VERIFY_FLAGS & LOCKTIME_MEDIAN_TIME_PAST)
+                                ? nMedianTimePast
+                                : GetAdjustedTime();
+
+        // Create a sorted list of transactions and their updated priorities.  This will be used to fill
+        // the mempoolhashes with the expected priority area of the next block.  We will multiply this by
+        // a factor of ? to account for any differences between the "Miners".
+        vPriority.reserve(mempool.mapTx.size());
+        for (CTxMemPool::indexed_transaction_set::iterator mi = mempool.mapTx.begin();
+             mi != mempool.mapTx.end(); mi++)
+        {
+            double dPriority = mi->GetPriority(nHeight);
+            CAmount dummy;
+            mempool.ApplyDeltas(mi->GetTx().GetHash(), dPriority, dummy);
+            vPriority.push_back(TxCoinAgePriority(dPriority, mi));
+        }
+        std::make_heap(vPriority.begin(), vPriority.end(), pricomparer);
+
+        uint64_t nPrioritySize = 0;
+        CTxMemPool::txiter iter;
+        for (uint64_t i = 0; i < vPriority.size(); i++)
+        {
+            nPrioritySize += vPriority[i].second->GetTxSize();
+            if (nPrioritySize > nBlockPrioritySize)
+                break;
+            setPriorityMemPoolHashes.insert(vPriority[i].second->GetTx().GetHash());
+
+            // Add children.  We don't need to look for parents here since they will all be parents.
+            iter = mempool.mapTx.project<0>(vPriority[i].second);
+            BOOST_FOREACH(CTxMemPool::txiter child, mempool.GetMemPoolChildren(iter))
+            {
+                uint256 childHash = child->GetTx().GetHash();
+                if (!setPriorityMemPoolHashes.count(childHash)) {
+                    setPriorityMemPoolHashes.insert(childHash);
+                    nPrioritySize += child->GetTxSize();
+                    LogPrint("bloom", "add priority child %s with fee %d modified fee %d size %d clearatentry %d priority %f\n", 
+                                       child->GetTx().GetHash().ToString(), child->GetFee(), child->GetModifiedFee(), 
+                                       child->GetTxSize(), child->WasClearAtEntry(), child->GetPriority(nHeight));
+                }
+            }            
+        }
+
+        // Create a list of high score transactions. We will multiply this by
+        // a factor of ? to account for any differences between the way Miners include tx's
+        CTxMemPool::indexed_transaction_set::nth_index<3>::type::iterator mi = mempool.mapTx.get<3>().begin();
+        uint64_t nBlockSize = 0;
+        while (mi != mempool.mapTx.get<3>().end())
+        {
+            CTransaction tx = mi->GetTx();
+
+            if (!IsFinalTx(tx, nHeight, nLockTimeCutoff)) {
+                LogPrint("bloom", "tx %s is not final\n", tx.GetHash().ToString());
+                mi++;
+                continue;
+            }
+
+            // If this tx is not accounted for already in the priority set then continue and add
+            // it to the high score set if it can be and also add any parents or children.  Also add
+            // children and parents to the priority set tx's if they have any.
+            iter = mempool.mapTx.project<0>(mi);
+            if (!setHighScoreMemPoolHashes.count(tx.GetHash()))
+            {
+                LogPrint("bloom", "next tx is %s blocksize %d fee %d modified fee %d size %d clearatentry %d priority %f\n", 
+                                   mi->GetTx().GetHash().ToString(), nBlockSize, mi->GetFee(), mi->GetModifiedFee(), mi->GetTxSize(), 
+                                   mi->WasClearAtEntry(), mi->GetPriority(nHeight));
+
+                // add tx to the set: we don't know if this is a parent or child yet.
+                setHighScoreMemPoolHashes.insert(tx.GetHash());
+
+                // Add any parent tx's
+                bool fChild = false;
+                BOOST_FOREACH(CTxMemPool::txiter parent, mempool.GetMemPoolParents(iter))
+                {
+                    fChild = true;
+                    uint256 parentHash = parent->GetTx().GetHash();
+                    if (!setHighScoreMemPoolHashes.count(parentHash)) {
+                        setHighScoreMemPoolHashes.insert(parentHash);
+                        LogPrint("bloom", "add high score parent %s with blocksize %d fee %d modified fee %d size %d clearatentry %d priority %f\n", 
+                                           parent->GetTx().GetHash().ToString(), nBlockSize, parent->GetFee(), parent->GetModifiedFee(), 
+                                           parent->GetTxSize(), parent->WasClearAtEntry(), parent->GetPriority(nHeight));
+                    }
+                }
+
+                // Now add any children tx's.
+                bool fHasChildren = false;
+                BOOST_FOREACH(CTxMemPool::txiter child, mempool.GetMemPoolChildren(iter))
+                {
+                    fHasChildren = true;
+                    uint256 childHash = child->GetTx().GetHash();
+                    if (!setHighScoreMemPoolHashes.count(childHash)) {
+                        setHighScoreMemPoolHashes.insert(childHash);
+                        LogPrint("bloom", "add high score child %s with blocksize %d fee %d modified fee %d size %d clearatentry %d priority %f\n", 
+                                           child->GetTx().GetHash().ToString(), nBlockSize, child->GetFee(), child->GetModifiedFee(), 
+                                           child->GetTxSize(), child->WasClearAtEntry(), child->GetPriority(nHeight));
+                    }
+                }
+
+                // If a tx with no parents and no children, then we increment this block size.  
+                // We don't want to add parents and children to the size because for tx's with many children, miners may not mine them
+                // as they are not as profitable but we still have to add their hash to the bloom filter in case they do.
+                if (!fChild && !fHasChildren)
+                    nBlockSize += mi->GetTxSize();
+            }
+
+            if (nBlockSize >  nBlockMaxProjectedSize)
+                break;
+
+            mi++;
+        }
+    }
+    LogPrint("thin", "Bloom Filter Targeting completed in:%d (ms)\n", GetTimeMillis() - nStartTimer);
+    nStartTimer= GetTimeMillis(); // reset the timer
+
+    // We set the beginning of our growth algortithm to the time we request our first xthin.  We do this here
+    // rather than setting up a global variable in init.cpp.  This has more to do with potential merge conflicts
+    // with BU than any other technical reason.
+    static int64_t nStartGrowth = GetTime();
+
+    // Tuning knobs for the false positive growth algorithm
+    static uint8_t nHoursToGrow = 24; // number of hours until maximum growth for false positive rate
+    //static double nGrowthCoefficient = 0.7676; // use for nMinFalsePositive = 0.0001 and nMaxFalsePositive = 0.01 for 6 hour growth period
+    //static double nGrowthCoefficient = 0.8831; // use for nMinFalsePositive = 0.0001 and nMaxFalsePositive = 0.02 for 6 hour growth period
+    static double nGrowthCoefficient = 0.1921; // use for nMinFalsePositive = 0.0001 and nMaxFalsePositive = 0.01 for 24 hour growth period
+    static double nMinFalsePositive = 0.0001; // starting value for false positive 
+    static double nMaxFalsePositive = 0.01; // maximum false positive rate at end of decay
+    // TODO: automatically calculate the nGrowthCoefficient from nHoursToGrow, nMinFalsePositve and nMaxFalsePositive
+
+    // Count up all the transactions that we'll be putting into the filter, removing any duplicates
+    BOOST_FOREACH(uint256 txHash, setHighScoreMemPoolHashes)
+        if (setPriorityMemPoolHashes.count(txHash))
+            setPriorityMemPoolHashes.erase(txHash);
+
+    unsigned int nSelectedTxHashes = setHighScoreMemPoolHashes.size() + vOrphanHashes.size() + setPriorityMemPoolHashes.size();
+    unsigned int nElements = std::max(nSelectedTxHashes, (unsigned int)1); // Must make sure nElements is greater than zero or will assert
+
+    // Calculate the new False Positive rate.  
+    // We increase the false positive rate as time increases, starting at nMinFalsePositive and with growth governed by nGrowthCoefficient,
+    // using the simple exponential growth function as follows:
+    // y = (starting or minimum fprate: nMinFalsePositive) * e ^ (time in hours from start * nGrowthCoefficient)
+    int64_t nTimePassed = GetTime() - nStartGrowth;
+    double nFPRate = nMinFalsePositive * exp (((double)(nTimePassed) / 3600) * nGrowthCoefficient);
+    if (nTimePassed > nHoursToGrow * 3600)
+        nFPRate = nMaxFalsePositive;
+
+    filterMemPool = CBloomFilter(nElements, nFPRate, insecure_rand(), BLOOM_UPDATE_ALL);
+    LogPrint("thin", "FPrate: %f Num elements in bloom filter:%d high priority txs:%d high fee txs:%d orphans:%d total txs in mempool:%d\n", 
+              nFPRate, nElements, setPriorityMemPoolHashes.size(), 
+              setHighScoreMemPoolHashes.size(), vOrphanHashes.size(), mempool.mapTx.size());
+
+    // Add the selected tx hashes to the bloom filter
+    BOOST_FOREACH(uint256 txHash, setPriorityMemPoolHashes)
+        filterMemPool.insert(txHash);
+    BOOST_FOREACH(uint256 txHash, setHighScoreMemPoolHashes)
+        filterMemPool.insert(txHash);
+    BOOST_FOREACH(uint256 txHash, vOrphanHashes)
+        filterMemPool.insert(txHash);
     uint64_t nSizeFilter = ::GetSerializeSize(filterMemPool, SER_NETWORK, PROTOCOL_VERSION);
-    LogPrint("thin", "Created bloom filter: %d bytes\n", nSizeFilter);
+    LogPrint("thin", "Created bloom filter: %d bytes for block: %s in:%d (ms)\n", nSizeFilter, hash.ToString(), GetTimeMillis() - nStartTimer);
     CThinBlockStats::UpdateOutBoundBloomFilter(nSizeFilter);
 }
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -688,12 +688,17 @@ void HandleBlockMessage(CNode *pfrom, const string &strCommand, CBlock &block, c
             Misbehaving(pfrom->GetId(), nDoS);
         }
     }
-    else 
+    else {
         nLargestBlockSeen = std::max(nSizeBlock, nLargestBlockSeen);
 
-    double nValidationTime = (double)(GetTimeMicros() - startTime) / 1000000.0;
-    LogPrint("thin", "Processed Block %s in %.2f seconds\n", inv.hash.ToString(), (double)(GetTimeMicros() - startTime) / 1000000.0);
-    CThinBlockStats::UpdateValidationTime(nValidationTime);
+        double nValidationTime = (double)(GetTimeMicros() - startTime) / 1000000.0;
+        if (strCommand != NetMsgType::BLOCK) {
+            LogPrint("thin", "Processed ThinBlock %s in %.2f seconds\n", inv.hash.ToString(), (double)(GetTimeMicros() - startTime) / 1000000.0);
+            CThinBlockStats::UpdateValidationTime(nValidationTime);
+        }
+        else
+            LogPrint("thin", "Processed Regular Block %s in %.2f seconds\n", inv.hash.ToString(), (double)(GetTimeMicros() - startTime) / 1000000.0);
+    }
 
     // When we request a thinblock we may get back a regular block if it is smaller than a thinblock
     // Therefore we have to remove the thinblock in flight if it exists and we also need to check that 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -622,7 +622,7 @@ bool IsChainNearlySyncd()
     return true;
 }
 
-void BuildSeededBloomFilter(CBloomFilter& filterMemPool, std::vector<uint256>& vOrphanHashes)
+void BuildSeededBloomFilter(CBloomFilter& filterMemPool, std::vector<uint256>& vOrphanHashes, uint256 hash)
 {
     LogPrint("thin", "Starting creation of bloom filter\n");
     seed_insecure_rand();

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -791,6 +791,7 @@ void SendXThinBlock(CBlock &block, CNode* pfrom, const CInv &inv)
             int nSizeThinBlock = ::GetSerializeSize(xThinBlock, SER_NETWORK, PROTOCOL_VERSION);
             if (nSizeThinBlock < nSizeBlock) {
                 pfrom->PushMessage(NetMsgType::THINBLOCK, thinBlock);
+                CThinBlockStats::UpdateOutBound(nSizeThinBlock, nSizeBlock);
                 LogPrint("thin", "TX HASH COLLISION: Sent thinblock - size: %d vs block size: %d => tx hashes: %d transactions: %d  peerid=%d\n", nSizeThinBlock, nSizeBlock, xThinBlock.vTxHashes.size(), xThinBlock.vMissingTx.size(), pfrom->id);
             }
             else {
@@ -803,6 +804,7 @@ void SendXThinBlock(CBlock &block, CNode* pfrom, const CInv &inv)
             // Only send a thinblock if smaller than a regular block
             int nSizeThinBlock = ::GetSerializeSize(xThinBlock, SER_NETWORK, PROTOCOL_VERSION);
             if (nSizeThinBlock < nSizeBlock) {
+                CThinBlockStats::UpdateOutBound(nSizeThinBlock, nSizeBlock);
                 pfrom->PushMessage(NetMsgType::XTHINBLOCK, xThinBlock);
                 LogPrint("thin", "Sent xthinblock - size: %d vs block size: %d => tx hashes: %d transactions: %d  peerid=%d\n", nSizeThinBlock, nSizeBlock, xThinBlock.vTxHashes.size(), xThinBlock.vMissingTx.size(), pfrom->id);
             }
@@ -818,6 +820,7 @@ void SendXThinBlock(CBlock &block, CNode* pfrom, const CInv &inv)
         int nSizeBlock = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
         int nSizeThinBlock = ::GetSerializeSize(thinBlock, SER_NETWORK, PROTOCOL_VERSION);
         if (nSizeThinBlock < nSizeBlock) { // Only send a thinblock if smaller than a regular block
+            CThinBlockStats::UpdateOutBound(nSizeThinBlock, nSizeBlock);
             pfrom->PushMessage(NetMsgType::THINBLOCK, thinBlock);
             LogPrint("thin", "Sent thinblock - size: %d vs block size: %d => tx hashes: %d transactions: %d  peerid=%d\n", nSizeThinBlock, nSizeBlock, thinBlock.vTxHashes.size(), thinBlock.vMissingTx.size(), pfrom->id);
         }

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -107,6 +107,7 @@ extern bool HaveThinblockNodes();
 extern bool CheckThinblockTimer(uint256 hash);
 extern void ClearThinblockTimer(uint256 hash);
 extern bool IsThinBlocksEnabled();
+extern bool CanThinBlockBeDownloaded(CNode* pto);
 extern bool IsChainNearlySyncd();
 extern void BuildSeededBloomFilter(CBloomFilter& memPoolFilter, std::vector<uint256>& vOrphanHashes, uint256 hash);
 extern void LoadFilter(CNode *pfrom, CBloomFilter *filter);

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -108,7 +108,7 @@ extern bool CheckThinblockTimer(uint256 hash);
 extern void ClearThinblockTimer(uint256 hash);
 extern bool IsThinBlocksEnabled();
 extern bool IsChainNearlySyncd();
-extern void BuildSeededBloomFilter(CBloomFilter& memPoolFilter, std::vector<uint256>& vOrphanHashes);
+extern void BuildSeededBloomFilter(CBloomFilter& memPoolFilter, std::vector<uint256>& vOrphanHashes, uint256 hash);
 extern void LoadFilter(CNode *pfrom, CBloomFilter *filter);
 extern void HandleBlockMessage(CNode *pfrom, const std::string &strCommand, CBlock &block, const CInv &inv);
 extern void ConnectToThinBlockNodes();

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -40,7 +40,7 @@ extern std::string minerComment;  // An arbitrary field that miners can change t
 /** The default value for -minrelaytxfee */
 static const char DEFAULT_MINLIMITERTXFEE[] = "0.0";
 /** The default value for -maxrelaytxfee */
-static const char DEFAULT_MAXLIMITERTXFEE[] = "5.0";
+static const char DEFAULT_MAXLIMITERTXFEE[] = "3.0";
 /** The number of block heights to gradually choke spam transactions over */
 static const unsigned int MAX_BLOCK_SIZE_MULTIPLIER = 3;
 /** The minimum value possible for -limitfreerelay when rate limiting */


### PR DESCRIPTION
Creating the Xthin request Bloom Filter by targeting the most likely to be mined transactions in the memory pool rather than using every tx in the mempool.  This allows anyone to run a mempool as large as they like while keeping the average bloom filter size down to between 2 and 3 KB.
