### PR TITLE
Evict Orphans that are older than -mempoolexpiry

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -86,7 +86,6 @@ CFeeRate minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
 
 CTxMemPool mempool(::minRelayTxFee);
 
-
 map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(cs_main);;
 map<uint256, set<uint256> > mapOrphanTransactionsByPrev GUARDED_BY(cs_main);;
 void EraseOrphansFor(NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(cs_main);
@@ -640,6 +639,7 @@ bool AddOrphanTx(const CTransaction& tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(c
 
     mapOrphanTransactions[hash].tx = tx;
     mapOrphanTransactions[hash].fromPeer = peer;
+    mapOrphanTransactions[hash].nEntryTime = GetTime(); // BU - Xtreme Thinblocks;
     BOOST_FOREACH(const CTxIn& txin, tx.vin)
         mapOrphanTransactionsByPrev[txin.prevout.hash].insert(hash);
 
@@ -681,6 +681,29 @@ void EraseOrphansFor(NodeId peer)
     if (nErased > 0) LogPrint("mempool", "Erased %d orphan tx from peer %d\n", nErased, peer);
 }
 
+// BU - Xtreme Thinblocks: begin
+void EraseOrphansByTime() EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+{
+    // Because we have to iterate through the entire orphan cache which can be large we don't want to check this
+    // every time a tx enters the mempool but just once a minute is good enough.
+    static int64_t nLastOrphanCheck = GetTime();
+    if (GetTime() <  nLastOrphanCheck + 60)
+        return;
+
+    int64_t nOrphanTxCutoffTime = GetTime() - GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60;
+    for (map<uint256, COrphanTx>::iterator mi = mapOrphanTransactions.begin(); mi != mapOrphanTransactions.end(); ++mi)
+    {
+        uint256 txHash = mi->second.tx.GetHash();
+        if (mi->second.nEntryTime < nOrphanTxCutoffTime)
+        {
+            LogPrint("mempool", "Erased old orphan tx %s of age %d seconds\n", txHash.ToString(), GetTime() - mi->second.nEntryTime);
+            EraseOrphanTx(txHash);
+        }
+    }
+
+    nLastOrphanCheck = GetTime();
+}
+// BU - Xtreme Thinblocks: end
 
 unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
@@ -1299,6 +1322,8 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
             if (!pool.exists(hash))
                 return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool full");
         }
+        // BU - Xtreme Thinblocks - trim the orphan pool by entry time and do not allow it to be overidden.
+        EraseOrphansByTime();
     }
 
     SyncWithWallets(tx, NULL);

--- a/src/main.h
+++ b/src/main.h
@@ -542,6 +542,7 @@ static const unsigned int REJECT_CONFLICT = 0x102;
 struct COrphanTx {
     CTransaction tx;
     NodeId fromPeer;
+    int64_t nEntryTime; // BU - Xtreme Thinblocks: used for aging orphans out of the cache
 };
 extern std::map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(cs_main);;
 extern std::map<uint256, std::set<uint256> > mapOrphanTransactionsByPrev GUARDED_BY(cs_main);;


### PR DESCRIPTION
The orphan cache for BU can grow very large over time
and if the parent tx's never show up and also never get mined
then the orphans can remain in the pool permanently.  There is
also an attack vector (although a weak one) that is prevented whereby
an attacker could fill our orphan cache with unmineable tx's and thereby
causing our Xthin bloom filters to get overly large.

This PR evicts the orphans that have aged beyond the -mempoolexpiry limit
or the DEFAULT_MEPOOL_EXPIRY.
