### PR TITLE
Cleanup thinblocks in flight on socket disconnect

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2507,9 +2507,13 @@ CNode::~CNode()
 
     if (pfilter)
         delete pfilter;
+
     // BUIP010 - Xtreme Thinblocks - begin section
     if (pThinBlockFilter)
         delete pThinBlockFilter;
+    mapThinBlocksInFlight.clear();
+    thinBlockWaitingForTxns = -1;
+    thinBlock.SetNull();
     // BUIP010 - Xtreme Thinblocks - end section
 
     GetNodeSignals().FinalizeNode(GetId());


### PR DESCRIPTION
Because we use SO_REUSEADDR and vNodes when a socket disonnects and reconnects
the data from the previous connection will still be intact and we
need to do a reset when the socket is destroyed otherwise we may
end up waiting for an XTHIN when the other peer no longer knows we've made
the request.
