### PR TITLE
Fix for rare data.size() assertion

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -830,8 +830,10 @@ int SocketSendData(CNode* pnode)
     }
 
     if (it == pnode->vSendMsg.end()) {
-        assert(pnode->nSendOffset == 0);
-        assert(pnode->nSendSize == 0);
+        if (pnode->nSendOffset != 0 || pnode->nSendSize !=  0)
+            LogPrintf("ERROR: One or more values were not Zero - nSendOffset was %d nSendSize was %d\n", pnode->nSendOffset, pnode->nSendSize);
+        //assert(pnode->nSendOffset == 0);
+        //assert(pnode->nSendSize == 0);
     }
     pnode->vSendMsg.erase(pnode->vSendMsg.begin(), it);
     return progress;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -784,7 +784,12 @@ int SocketSendData(CNode* pnode)
 
     while (it != pnode->vSendMsg.end()) {
         const CSerializeData& data = *it;
-        assert(data.size() > pnode->nSendOffset);
+        if (data.size() <= 0) {
+            it++;
+            LogPrintf("ERROR:  Trying to send message but data size was %d nSendOffset was %d nSendSize was %d\n", data.size(), pnode->nSendOffset, pnode->nSendSize);
+            continue;
+        }
+        //assert(data.size() > pnode->nSendOffset);
 
         int amt2Send = min((int64_t)(data.size() - pnode->nSendOffset), sendShaper.available(SEND_SHAPER_MIN_FRAG));
         if (amt2Send == 0)

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -314,7 +314,6 @@ int CUnknownObj::NextSource()
 void RequestBlock(CNode* pfrom, CInv obj)
 {
   const CChainParams& chainParams = Params();
-  LOCK(pfrom->cs_vSend);
 
   // First request the headers preceding the announced block. In the normal fully-synced
   // case where a new block is announced that succeeds the current tip (no reorganization),


### PR DESCRIPTION
On very rare occasions it has been seen that we have a data.size()
of what is beleived to be a Zero which is causing an assertion in the
netcode when we send a message.

```
    assert(data.size() > pnode->nSendOffset);
```
