### PR TITLE
Rate Limiting not returning correct status

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1322,9 +1322,8 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
             LogPrint("mempool", "Rate limit dFreeCount: %g => %g\n", dFreeCount, dFreeCount+nSize);
             if ((dFreeCount + nSize) >= (nFreeLimit*10*1000 * nLargestBlockSeen / BLOCKSTREAM_CORE_MAX_BLOCK_SIZE)) {
                 CThinBlockStats::UpdateMempoolLimiterBytesSaved(nSize);
-                return state.DoS(0,
-                       LogPrint("mempool", "AcceptToMemoryPool : free transaction rejected by rate limiter"),
-                       REJECT_INSUFFICIENTFEE, "rate limited free transaction");
+                LogPrint("mempool", "AcceptToMemoryPool : free transaction %s rejected by rate limiter\n", hash.ToString());
+                return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "rate limited free transaction");
             }
             dFreeCount += nSize;
         }


### PR DESCRIPTION
The error message was returning true rather than false and thus all
txn's that were supposed to be rate limited were being accepted into
the mempool and then forwarded on to other nodes.
