### PR TITLE
Change block request timeout to 5 seconds

### DIFF
--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -30,7 +30,7 @@ using namespace std;
 CRequestManager requester;
 
 unsigned int MIN_REQUEST_RETRY_INTERVAL = 2*1000*1000;  // When should I request an object from someone else (in microseconds)
-unsigned int MIN_BLK_REQUEST_RETRY_INTERVAL = 2*1000*1000;  // When should I request a block from someone else (in microseconds)
+unsigned int MIN_BLK_REQUEST_RETRY_INTERVAL = 5*1000*1000;  // When should I request a block from someone else (in microseconds)
 
 // defined in main.cpp.  should be moved into a utilities file but want to make rebasing easier
 extern bool CanDirectFetch(const Consensus::Params &consensusParams);


### PR DESCRIPTION
The current timeout value of 2 seconds is often too fast and is causing us to download extra blocks when a few seconds wait generally avoids it.  Especially so when connected to node that are far apart as is often the case for BU nodes currently. 
