### PR TITLE
[WIP don't merge yet] Dont re-request blocks unless the IsChainNearlSyncd is true

### DIFF
--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -406,7 +406,7 @@ void CRequestManager::SendRequests()
 
       if (now-item.lastRequestTime > MIN_BLK_REQUEST_RETRY_INTERVAL)  // if never requested then lastRequestTime==0 so this will always be true
 	{
-          if (!item.availableFrom.empty())
+          if (!item.availableFrom.empty() && IsChainNearlySyncd())
 	    {
 	      CNodeRequestData next;
               while ((!item.availableFrom.empty())&&(next.node == NULL)) // Go thru the availableFrom list, looking for the first node that isn't disconnected


### PR DESCRIPTION
re requesting blocks during IBD could get us into trouble if the network conditions get slow and we start re requesting full blocks from many sources.
