### PR TITLE
Don't allow re-requested Blocks and Txns until the chain is syncd

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1638,6 +1638,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     CValidationState state;
     if (!ActivateBestChain(state, chainparams))
         strErrors << "Failed to connect best block";
+    IsChainNearlySyncdInit(); // BUIP010 XTHIN: initialize fIsChainNearlySyncd
 
     std::vector<boost::filesystem::path> vImportFiles;
     if (mapArgs.count("-loadblock"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5472,6 +5472,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         }
 
         CheckBlockIndex(chainparams.GetConsensus());
+
+        IsChainNearlySyncdInit(); // BUIP010 XTHIN
     }
 
     // BUIP010 Xtreme Thinblocks: begin section

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -117,6 +117,8 @@ extern void ClearThinblockTimer(uint256 hash);
 extern bool IsThinBlocksEnabled();
 extern bool CanThinBlockBeDownloaded(CNode* pto);
 extern bool IsChainNearlySyncd();
+extern void IsChainNearlySyncdInit();
+extern bool fIsChainNearlySyncd;
 extern void BuildSeededBloomFilter(CBloomFilter& memPoolFilter, std::vector<uint256>& vOrphanHashes, uint256 hash);
 extern void LoadFilter(CNode *pfrom, CBloomFilter *filter);
 extern void HandleBlockMessage(CNode *pfrom, const std::string &strCommand, CBlock &block, const CInv &inv);
@@ -131,7 +133,6 @@ extern void HandleExpeditedRequest(CDataStream& vRecv,CNode* pfrom);
 extern bool IsRecentlyExpeditedAndStore(const uint256& hash);
 
 extern std::map<uint256, uint64_t> mapThinBlockTimer;
-
 
 // statistics
 void UpdateSendStats(CNode* pfrom, const char* strCommand, int msgSize, int64_t nTime);


### PR DESCRIPTION
IsChainNearlySyncd() determines when re-requests can be made.  Also
fIsChainNearlySyncd is now used and updated during startup and whenever
a header is received.  This reduces the reliance on cs_main locks and
is more efficient.
