### PR TITLE
ehancements to connection slot mitigation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6627,7 +6627,7 @@ bool SendMessages(CNode* pto)
                 //      giving us useful data.  We give them 10 minutes to be useful but then choke off their inventory.  This
                 //      prevents fake peers from connecting and listening to our inventory while providing no value to the network.
                 //      However we will still send them block inventory in the case they are a pruned node or wallet waiting for block
-                //      announcements.
+                //      announcements, therefore we have to check each inv in pto->vInventoryToSend.
                 if (inv.type == MSG_TX && pto->nActivityBytes == 0 && (GetTime() - pto->nTimeConnected) > 120) {
                     LogPrint("evict", "choking off tx inventory for %s time connected %d\n", pto->addr.ToString(), GetTime() - pto->nTimeConnected);
                     continue;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6623,6 +6623,16 @@ bool SendMessages(CNode* pto)
                 if (inv.type == MSG_TX && pto->filterInventoryKnown.contains(inv.hash))
                     continue;
 
+                // BU - here we only want to forward message inventory if our peer has actually been requesting useful data or
+                //      giving us useful data.  We give them 10 minutes to be useful but then choke off their inventory.  This
+                //      prevents fake peers from connecting and listening to our inventory while providing no value to the network.
+                //      However we will still send them block inventory in the case they are a pruned node or wallet waiting for block
+                //      announcements.
+                if (inv.type == MSG_TX && pto->nActivityBytes == 0 && (GetTime() - pto->nTimeConnected) > 120) {
+                    LogPrint("evict", "choking off tx inventory for %s time connected %d\n", pto->addr.ToString(), GetTime() - pto->nTimeConnected);
+                    continue;
+                }
+
                 // trickle out tx inv to protect privacy
                 if (inv.type == MSG_TX && !fSendTrickle)
                 {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1153,10 +1153,11 @@ static void AcceptConnection(const ListenSocket& hListenSocket) {
         mapInboundConnectionTracker[ipAddress].nLastConnectionTime = GetTime();
 
         LogPrint("evict", "Number of Connection attempts is %f for %s\n", nConnections, addr.ToString());
-        if (nConnections > 4) {
+        if (nConnections > 4 && !whitelisted) {
             int nHoursToBan = 4;
             CNode::Ban((CNetAddr)addr, BanReasonNodeMisbehaving, nHoursToBan*60*60);
             LogPrintf("Banning %s for %d hours: Too many connection attempts - connection dropped\n", addr.ToString(), nHoursToBan);
+            CloseSocket(hSocket);
             return;
         }
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -939,7 +939,7 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
         LOCK(cs_vNodes);
 
         static int64_t nLastTime = GetTime();
-        BOOST_FOREACH(CNode *node, vNodes
+        BOOST_FOREACH(CNode *node, vNodes)
         {
             // Decay the activity bytes for each node over a period of 2 hours.  This gradually de-prioritizes a connection 
             // that was once active but has gone stale for some reason and allows lower priority active nodes to climb the ladder.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -11,7 +11,7 @@
 
 #include "addrman.h"
 #include "chainparams.h"
-#include "clientversion.h"n
+#include "clientversion.h"
 #include "consensus/consensus.h"
 #include "crypto/common.h"
 #include "hash.h"
@@ -1000,34 +1000,37 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
 
 //    if (vEvictionCandidates.empty()) return false;
 
+// *** BU - we do not need to deprioritize based on netgroup and it can have unwanted repercussions for xpedited network setup
+//          as well as testing setups.
     // Identify the network group with the most connections and youngest member.
     // (vEvictionCandidates is sorted by reverse connect time)
-    std::sort(vEvictionCandidates.begin(), vEvictionCandidates.end(), ReverseCompareNodeTimeConnected);
-    std::vector<unsigned char> naMostConnections;
-    unsigned int nMostConnections = 0;
-    int64_t nMostConnectionsTime = 0;
-    std::map<std::vector<unsigned char>, std::vector<CNodeRef> > mapAddrCounts;
-    BOOST_FOREACH(const CNodeRef &node, vEvictionCandidates) {
-        mapAddrCounts[node->addr.GetGroup()].push_back(node);
-        int64_t grouptime = mapAddrCounts[node->addr.GetGroup()][0]->nTimeConnected;
-        size_t groupsize = mapAddrCounts[node->addr.GetGroup()].size();
+//    std::sort(vEvictionCandidates.begin(), vEvictionCandidates.end(), ReverseCompareNodeTimeConnected);
+//    std::vector<unsigned char> naMostConnections;
+//    unsigned int nMostConnections = 0;
+//    int64_t nMostConnectionsTime = 0;
+//    std::map<std::vector<unsigned char>, std::vector<CNodeRef> > mapAddrCounts;
+//    BOOST_FOREACH(const CNodeRef &node, vEvictionCandidates) {
+//        mapAddrCounts[node->addr.GetGroup()].push_back(node);
+//        int64_t grouptime = mapAddrCounts[node->addr.GetGroup()][0]->nTimeConnected;
+//        size_t groupsize = mapAddrCounts[node->addr.GetGroup()].size();
 
-        if (groupsize > nMostConnections || (groupsize == nMostConnections && grouptime > nMostConnectionsTime)) {
-            nMostConnections = groupsize;
-            nMostConnectionsTime = grouptime;
-            naMostConnections = node->addr.GetGroup();
-        }
-    }
+//        if (groupsize > nMostConnections || (groupsize == nMostConnections && grouptime > nMostConnectionsTime)) {
+//            nMostConnections = groupsize;
+//            nMostConnectionsTime = grouptime;
+//            naMostConnections = node->addr.GetGroup();
+//        }
+//    }
 
     // Reduce to the network group with the most connections
-    vEvictionCandidates = mapAddrCounts[naMostConnections];
+//    vEvictionCandidates = mapAddrCounts[naMostConnections];
 
     // Do not disconnect peers if there is only one unprotected connection from their network group.
-    if (vEvictionCandidates.size() > 1) {
-        // Disconnect from the network group with the most connections
-        vEvictionCandidates[0]->fDisconnect = true;
-        return true;
-    }
+//    if (vEvictionCandidates.size() > 1) {
+//        // Disconnect from the network group with the most connections
+//        vEvictionCandidates[0]->fDisconnect = true;
+//        return true;
+//    }
+// *** BU end section
 
     // If we get here then we prioritize connections based on activity.  The least active incoming peer is
     // de-prioritized based on bytes in and bytes out.  A whitelisted peer will always get a connection and there is

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -164,6 +164,10 @@ extern std::map<uint256, uint64_t> mapThinBlockTimer;
 
 // BUIP010 Xtreme Thinblocks: end
 
+// BU  Connection Slot mitigation - used to determine how many connection attempts over time
+extern std::map<CNetAddr, std::pair<double, int64_t> > mapInboundConnectionTracker;
+extern CCriticalSection cs_mapInboundConnectionTracker;
+
 // statistics
 void UpdateSendStats(CNode* pfrom, const char* strCommand, int msgSize, int64_t nTime);
 

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -164,8 +164,16 @@ extern std::map<uint256, uint64_t> mapThinBlockTimer;
 
 // BUIP010 Xtreme Thinblocks: end
 
-// BU  Connection Slot mitigation - used to determine how many connection attempts over time
-extern std::map<CNetAddr, std::pair<double, int64_t> > mapInboundConnectionTracker;
+// Connection Slot mitigation - used to track connection attempts and evictions
+struct ConnectionHistory
+{
+    double nConnections;      // number of connection attempts made within 1 minute
+    int64_t nLastConnectionTime;  // the time the last connection attempt was made
+
+    double nEvictions;        // number of times a connection was de-prioritized and disconnected in last 30 minutes
+    int64_t nLastEvictionTime;    // the time the last eviction occurred.
+};
+extern std::map<CNetAddr, ConnectionHistory > mapInboundConnectionTracker;
 extern CCriticalSection cs_mapInboundConnectionTracker;
 
 // statistics


### PR DESCRIPTION
Added the ability to screen heavy hitters and also eviction candidates.   Heavy hitters are nodes that come in and make repeated connections within a short period (we do have the right now).  60 seconds is used in this case and any nodes doing more than 4 connections in the timeframe will get a 1 hour ban.  Similarly we have nodes that are not useful and get evicted frequently...these are nodes that typically just listen to INV 's.  If we get more than 15 to 30 evictions in a 30 minute period then we give them a 4 hour ban (we also have some of these right now).  Both these cases are far enough out to the extremes that the bitnodes crawlers remain unaffected.  

The tracking map and struct forms a foundations to a more robuts DOSmanager.  I"d like to eventually put everything in a DOSman.cpp  where we can track all kinds of node activity and persist it between startups.
