### PR TITLE
Fix for HaveNameProxy

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1750,7 +1750,7 @@ void ThreadOpenAddedConnections()
             BOOST_FOREACH(const std::string& strAddNode, lAddresses) {
                 CAddress addr;
                 CSemaphoreGrant grant(*semOutboundAddNode);
-                OpenNetworkConnection(addr, &grant);
+                OpenNetworkConnection(addr, &grant, strAddNode.c_str());
                 MilliSleep(500);
             }
             // Retry every 15 seconds.  It is important to check often to make sure the Xpedited Relay network 


### PR DESCRIPTION
Missing strAddNode.c_str() statement in OpenNetworkConnection
