### PR TITLE
New configuration parameter: maxoutconnections

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -883,6 +883,9 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     int nBind = std::max((int)mapArgs.count("-bind") + (int)mapArgs.count("-whitebind"), 1);
     int nUserMaxConnections = GetArg("-maxconnections", DEFAULT_MAX_PEER_CONNECTIONS);
     nMaxConnections = std::max(nUserMaxConnections, 0);
+    // make outbound conns modifialbe by the user
+    int nUserMaxOutConnections = GetArg("-maxoutconnections", DEFAULT_MAX_OUTBOUND_CONNECTIONS);
+    nMaxOutConnections = std::max(nUserMaxOutConnections,0);
 
     // Trim requested connection counts, to fit into system limitations
     nMaxConnections = std::max(std::min(nMaxConnections, (int)(FD_SETSIZE - nBind - MIN_CORE_FILEDESCRIPTORS)), 0);
@@ -893,6 +896,11 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     if (nMaxConnections < nUserMaxConnections)
         InitWarning(strprintf(_("Reducing -maxconnections from %d to %d, because of system limitations."), nUserMaxConnections, nMaxConnections));
+
+    if (nMaxConnections < nMaxOutConnections) {
+	InitWarning(strprintf(_("Reducing -maxoutconnections from %d to %d, because higher than max available connections."), nUserMaxOutConnections, nMaxConnections));
+	nMaxOutConnections = nMaxConnections;
+    }
 
     // ********************************************************* Step 3: parameter-to-internal-flags
 

--- a/src/net.h
+++ b/src/net.h
@@ -67,6 +67,8 @@ static const size_t MAPASKFOR_MAX_SZ = MAX_INV_SZ;
 static const size_t SETASKFOR_MAX_SZ = 2 * MAX_INV_SZ;
 /** The maximum number of peer connections to maintain. */
 static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
+/** The maximum numer of outbound peer connections */
+static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 8;
 /** The default for -maxuploadtarget. 0 = Unlimited */
 static const uint64_t DEFAULT_MAX_UPLOAD_TARGET = 0;
 /** Default for blocks only*/
@@ -170,6 +172,8 @@ extern CAddrMan addrman;
 
 /** Maximum number of connections to simultaneously allow (aka connection slots) */
 extern int nMaxConnections;
+/** Default maximum number of Outbound connections to simultaneously allow*/
+extern int nMaxOutConnections;
 
 extern std::vector<CNode*> vNodes;
 extern CCriticalSection cs_vNodes;


### PR DESCRIPTION
Remove the hard coded maximum number of outbound connections.
Add a new parameter to let the operator to set the number of
outbound connections.

newoutconnections default value is 8 and it can't be greater
that maxconnections, if this is the case it will be automatic
decreased to maxconnections. In such cases nodes will establish
only outbound connections.
