### PR TITLE
Net:Fix for addnode bug ref #65

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1042,8 +1042,11 @@ static void AcceptConnection(const ListenSocket& hListenSocket) {
     //   Otherwise we waste inbound connection slots on outbound addnodes that are blocked waiting on the semaphore.
     //2. BUT, if less than nMaxOutConnections in vAddedNodes, open up any of the unreserved
     //   "-addnode" connection slots to the inbound pool to prevent holding presently unneeded outbound connection slots.
-    LOCK(cs_vAddedNodes);
-    int nMaxAddNodeOutbound = std::min((int)vAddedNodes.size(), nMaxOutConnections);
+    int nMaxAddNodeOutbound = nMaxOutConnections;
+    {
+        LOCK(cs_vAddedNodes);
+        nMaxAddNodeOutbound = std::min((int)vAddedNodes.size(), nMaxOutConnections);
+    }
     int nMaxInbound = nMaxConnections - nMaxOutConnections - nMaxAddNodeOutbound;
     //REVISIT: a. This doesn't take into account RPC "addnode <node> onetry" outbound connections as those aren't tracked
     //         b. This also doesn't take into account whether or not the tracked vAddedNodes are valid or connected

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2185,6 +2185,9 @@ CNetCleanup::~CNetCleanup()
         vhListenSocket.clear();
         delete semOutbound;
         semOutbound = NULL;
+        //BU: clean up the "-addnode" semaphore
+        delete semOutboundAddNode;
+        semOutboundAddNode = NULL;
         delete pnodeLocalHost;
         pnodeLocalHost = NULL;
 

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -191,6 +191,8 @@ UniValue addnode(const UniValue& params, bool fHelp)
 
     if (strCommand == "onetry") {
         CAddress addr;
+        //NOTE: Using RPC "addnode <node> onetry" ignores both the "maxconnections"
+        //      and "maxoutconnections" limits and can cause both to be exceeded.
         OpenNetworkConnection(addr, NULL, strNode.c_str());
         return NullUniValue;
     }

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1399,6 +1399,8 @@ void ConnectToThinBlockNodes()
         BOOST_FOREACH(const std::string& strAddr, mapMultiArgs["-connect-thinblock"])
         {
             CAddress addr;
+            //NOTE: Because the only nodes we are connecting to here are the ones the user put in their
+            //      bitcoin.conf/commandline args as "-connect-thinblock", we don't use the semaphore to limit outbound connections
             OpenNetworkConnection(addr, NULL, strAddr.c_str());
             MilliSleep(500);
         }


### PR DESCRIPTION
Marking as WIP pending comments and answers to questions below.

Fixes the following (Issues #65):
1. Specifying less than `maxoutconnections` of `addnode` options in bitcoin.conf or on the command line prevents RPC calls to `addnode <node> add` from being able to connect to more than the total number of originally configured `addnode` connections simultaneously.  In the extreme case, if no `addnode` connections were configured at startup, the user would never be able to successfully connect to any outbound `addnode` nodes as the tracking semaphore was initialized to a count of 0, which would put all grant requests into an eternal wait state.
   TEST SCENARIO: Do not configure any `addnode`s in bitcoin.conf or on the command line, then attempt to add a new outbound connection via `addnode <node> add`.
   REPRODUCTION RESULT: The node will be added to the `vAddedNodes` list and `getpeerinfo` will return that node as being in the list, however it will never attempt to connect to the node as the semaphore grant will never succeed.
   FIX RESULT: The node will be added to the `vAddedNodes` list and `getpeerinfo` will return that node as being in the list.  Additionally, provided `maxoutconnections` has not already been exceeded and the test node is up and accepting connections, the RPC call should succeed at adding an outbound connection to the specified node.
2. Specifying too many `addnode` entries in bitcon.conf or on the command line will cause incoming connections to be limited further than intended.  Only up to `maxoutconnections` concurrent outbound connections are possible, however specifying more than `maxoutconnections` limits the total number of inbound connections based on the total `addnode` options configured in bitcon.conf or on the command line.  In the extreme case, if more `addnode` options are configured than `maxconnections - maxoutconnections`, then all inbound connections will be blocked.
   TEST SCENARIO: Specify maxconnections=12, maxoutconnections=4, and 8 `addnode` connections in bitcoin.conf.
   REPRODUCTION RESULT: You should end up with between 4 and 12 outbound connections, depending on if the configured `addnode` options are valid and can connect.  You also should never get an inbound connection.
   FIX RESULT: You should end up with between 4 and 8 outbound connections, depending on if the configured `addnode` options are valid and can connect.  You should also end up with up to 4 inbound connections.

Remaining Issues/Questions:
1. ISSUE: Both `maxconnections` and `maxoutconnections` can still be violated by use of `connect`, `connect-thinblock`, and RPC calls to `addnode <node> onetry` as none of these outbound connections are tracked.  These outbound connection methods do not check against the maximum connection constraints (no use of semaphores), and the inbound connections are unaware of these connections so also don't take them into account when determining if there is room to accept a new inbound connections.
   Not sure the best fix for this, short of adding tracking for these different types similar to how addnodes works.  Also not sure what the priority on this fix would be.
2. QUESTION: What is the policy on excessive comments? I tend to comment heavily as an aide to my own understanding of the code and general clarification.  Provided the comments are accurate I don't see an issue with keeping them, and I had one commit specifically for clarification comments.
3. QUESTION: What's the policy for determining if the automated tests need to be updated for a given fix?  If updates are needed, what's the procedure there?
4. QUESTION: What is the intended behavior for the number of outbound connections?  Currently `maxoutconnections` is doubled since we are tracking seeded outbound nodes separately from `addnode` configured outbound nodes.  Seems like there should either be separate configuration options for each, or `addnode`s should be given priority over seeded nodes and we only attempt to seed outbound connections if less than `maxoutconnections` are configured as `addnode`s or we have already iterated through the `vAddedNodes` list and less than `maxoutconnections` would connect.
