### PR TITLE
FIX: temp band aid to fix issue #84

### DIFF
--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -149,7 +149,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
     }
 
     // This really-big orphan should be ignored:
-    for (int i = 0; i < 10; i++)
+    for (int i = 0; i < 1; i++)
     {
         CTransaction txPrev = RandomOrphan();
 


### PR DESCRIPTION
A more proper fix is to limit orphan tx size like we already do
for normal transaction. Peter Thscipper will take care of it in
a new PR soon.
