### PR TITLE
Fix regression tests.  Headers not getting downloaded.

### DIFF
--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -316,7 +316,9 @@ void RequestBlock(CNode* pfrom, CInv obj)
   // time the block arrives, the header chain leading up to it is already validated. Not
   // doing this will result in the received block being rejected as an orphan in case it is
   // not a direct successor.
-  if (IsChainNearlySyncd()) // only download headers if we're not doing IBD.  The IBD process will take care of it's own headers.
+  //  NOTE: only download headers if we're not doing IBD.  The IBD process will take care of it's own headers.
+  //        Also, we need to always download headers for "regtest". TODO: we need to redesign how IBD is initiated here.
+  if (IsChainNearlySyncd() || chainParams.NetworkIDString() == "regtest")
   {
     LogPrint("net", "getheaders (%d) %s to peer=%d\n", pindexBestHeader->nHeight, obj.hash.ToString(), pfrom->id);  
     pfrom->PushMessage(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexBestHeader), obj.hash);


### PR DESCRIPTION
When we run regression tests we mine many blocks quickly
which causes a backlog of  blocks however IBD doesn't get
initiated here because there are no txns coming through.
Therefore when in regest mode we will explicity download
the header before requesting the block.
