### PR TITLE
Don't allow orphans larger than the MAX_STANDARD_TX_SIZE

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -711,12 +711,12 @@ bool AddOrphanTx(const CTransaction& tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(c
     //      orphan cache is limited to only 5000 entries by default. Only 500MB of memory could be consumed
     //      if there were some kind of orphan memory exhaustion attack.
     //      Dropping any tx means they need to be included in the thin block when it it mined, which is inefficient.
-    //unsigned int sz = tx.GetSerializeSize(SER_NETWORK, CTransaction::CURRENT_VERSION);
-    //if (sz > 5000)
-    //{
-    //    LogPrint("mempool", "ignoring large orphan tx (size: %u, hash: %s)\n", sz, hash.ToString());
-    //    return false;
-    //}
+    unsigned int sz = tx.GetSerializeSize(SER_NETWORK, CTransaction::CURRENT_VERSION);
+    if (sz > MAX_STANDARD_TX_SIZE)
+    {
+        LogPrint("mempool", "ignoring large orphan tx (size: %u, hash: %s)\n", sz, hash.ToString());
+        return false;
+    }
     // BU - Xtreme Thinblocks - end section
 
     mapOrphanTransactions[hash].tx = tx;

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -127,7 +127,8 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vout.resize(1);
         tx.vout[0].nValue = 1*CENT;
         tx.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
-
+      
+        LOCK(cs_orphancache);
         AddOrphanTx(tx, i);
     }
 
@@ -145,6 +146,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         tx.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
         SignSignature(keystore, txPrev, tx, 0);
 
+        LOCK(cs_orphancache);
         AddOrphanTx(tx, i);
     }
 
@@ -169,6 +171,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         for (unsigned int j = 1; j < tx.vin.size(); j++)
             tx.vin[j].scriptSig = tx.vin[0].scriptSig;
 
+        LOCK(cs_orphancache);
         BOOST_CHECK(AddOrphanTx(tx, i));  // BU, we keep orphans up to the configured memory limit to help xthin compression so this should succeed whereas it fails in other clients
     }
 
@@ -176,11 +179,13 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
     for (NodeId i = 0; i < 3; i++)
     {
         size_t sizeBefore = mapOrphanTransactions.size();
+        LOCK(cs_orphancache);
         EraseOrphansFor(i);
         BOOST_CHECK(mapOrphanTransactions.size() < sizeBefore);
     }
 
     // Test LimitOrphanTxSize() function:
+    LOCK(cs_orphancache);
     LimitOrphanTxSize(40);
     BOOST_CHECK(mapOrphanTransactions.size() <= 40);
     LimitOrphanTxSize(10);


### PR DESCRIPTION
This is a more comprehensive fix for the orphan DOS test failure.  It also helps to prevent any possible attack vector using over sized orphans.
