### PR TITLE
Harmonize unit test suite names with filenames

### DIFF
--- a/src/test/alert_tests.cpp
+++ b/src/test/alert_tests.cpp
@@ -114,7 +114,7 @@ struct ReadAlerts : public TestingSetup
     std::vector<CAlert> alerts;
 };
 
-BOOST_FIXTURE_TEST_SUITE(Alert_tests, ReadAlerts)
+BOOST_FIXTURE_TEST_SUITE(alert_tests, ReadAlerts)  // BU harmonize suite name with filename
 
 
 BOOST_AUTO_TEST_CASE(AlertApplies)

--- a/src/test/checkblock_tests.cpp
+++ b/src/test/checkblock_tests.cpp
@@ -38,7 +38,7 @@ bool read_block(const std::string& filename, CBlock& block)
     return true;
 }
 
-BOOST_FIXTURE_TEST_SUITE(CheckBlock_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(checkblock_tests, BasicTestingSetup)  // BU harmonize suite name with filename
 
 
 BOOST_AUTO_TEST_CASE(TestBlock)

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -14,7 +14,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(PrevectorTests, TestingSetup)
+BOOST_FIXTURE_TEST_SUITE(prevector_tests, TestingSetup)  // BU harmonize suite name with filename
 
 template<unsigned int N, typename T>
 class prevector_tester {

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -16,7 +16,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_AUTO_TEST_SUITE(tx_validationcache_tests)
+BOOST_AUTO_TEST_SUITE(txvalidationcache_tests)  // BU harmonize suite name with filename
 
 static bool
 ToMemPool(CMutableTransaction& tx)


### PR DESCRIPTION
This is a minor correction to test suite names which did not follow the convention stated in src/test/README.md:

> The file naming convention is "<source_filename>_tests.cpp" and such files should wrap their tests in a test suite called "<source_filename>_tests".

Following this convention makes it easy to iterate over a set of unit tests just based on some filename pattern, e.g.run through them in default alphabetical sort order:

`$ ls src/test/*_tests.cpp | sort | sed 's/\.cpp//' | while read f; do X=$(basename $f) ; echo $X: ; src/test/test_bitcoin --run_test=$X; done`
