### PR TITLE
Fix direct headers announcement to Bitcoin Core nodes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5110,10 +5110,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     {
         LOCK(cs_main);
         // BUIP010 Xtreme Thinblocks: We only do inv/getdata for xthinblocks and so we must have headersfirst turned off
-        if (IsThinBlocksEnabled())
-            State(pfrom->GetId())->fPreferHeaders = false;
-        else
-            State(pfrom->GetId())->fPreferHeaders = true;
+        // However, because nodes never send SENDHEADERS messages when they want xthinblocks, we can safely set fPreferHeaders.
+        State(pfrom->GetId())->fPreferHeaders = true;
     }
 
 


### PR DESCRIPTION
Bitcoin Core will likely stop requesting directly from INV requests soon (well, in the next release in a few months, see https://github.com/bitcoin/bitcoin/pull/8872 for more details on why), however this will add a round-trip in propogation between Bitcoin Unlimited and Bitcoin Core nodes due to a quirk in sendheaders handling in BU.
In reading the XThin code, it seems to me that the check for setting fPreferHeaders is done twice (sendheaders messages are both not sent and not processed if IsThinBlocksEnabled()) , so it should be safe to remove the check in sendheaders receiving, allowing Bitcoin Core nodes to receive headers announcements which they will request for immediately while still allowing XThin nodes to skip sendheaders and receive the inv messages they want to request XThin blocks.

Note that I have not tested this as my usual dev machine is unavailable at the moment.
