### PR TITLE
Fix deb package build

### DIFF
--- a/contrib/debian/control
+++ b/contrib/debian/control
@@ -2,7 +2,7 @@ Source: bitcoinunlimited
 Section: utils
 Priority: optional
 Maintainer: Andrew Stone <g.andrew.stone@gmail.com>
-Uploaders: Micah Anderson <micah@debian.org>
+Uploaders: Andrea Suisani <sickpig@gmail.com>
 Build-Depends: debhelper,
  devscripts,
  automake,
@@ -11,6 +11,7 @@ Build-Depends: debhelper,
  libboost-system-dev (>> 1.35) | libboost-system1.35-dev,
  libdb4.8++-dev,
  libssl-dev,
+ libevent-dev,
  pkg-config,
  libminiupnpc8-dev | libminiupnpc-dev (>> 1.6),
  libboost-filesystem-dev (>> 1.35) | libboost-filesystem1.35-dev,
@@ -40,7 +41,7 @@ Description: peer-to-peer network based digital currency - daemon
  This package provides the daemon, bitcoind, and the CLI tool
  bitcoin-cli to interact with the daemon.
 
-Package: bitcoinunlimited-qt
+Package: bitcoin-qt
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: peer-to-peer network based digital currency - Qt GUI

--- a/contrib/debian/rules
+++ b/contrib/debian/rules
@@ -18,7 +18,7 @@ override_dh_auto_clean:
 # Yea, autogen should be run on the source archive, but I like doing git archive
 override_dh_auto_configure:
 	./autogen.sh
-	./configure
+	./configure --without-miniupnpc --with-gui=qt4
 
 override_dh_auto_test:
 	make check


### PR DESCRIPTION
- add libevent-dev to the list of bitcoind dependencies
- s/bitcoinunlimited-qt/bitcoin-qt/
- add --with-gui=qt4 to the rules file, without this the configure
  won't detect the qt4 library and as result won't build bitcoin-qt
