### PR TITLE
[qa] comment out replace-by-fee test as long as RBF is commented out

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -132,7 +132,7 @@ testScriptsExt = [
     'p2p-acceptblock.py',
     'mempool_packages.py',
     'maxuploadtarget.py',
-    'replace-by-fee.py',
+#    'replace-by-fee.py', # disabled while Replace By Fee is disabled in code
 ]
 
 #Enable ZMQ tests


### PR DESCRIPTION
Comment out replace-by-fee test as long as RBF is commented out in implementation, so this test isn't unnecessarily executed. 
