### PR TITLE
Partially revert b126b10a

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -7,6 +7,9 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
+/** The maximum allowed number of signature check operations in a block (network rule) */
+static const unsigned int MAX_BLOCK_SIGOPS = 1000000/50;
+
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
 static const unsigned int BU_MAX_BLOCK_SIZE = 32000000;  // BU: this constant is deprecated but is still used in a few areas such as allocation of memory.  Removing it is a tradeoff between being perfect and changing more code. TODO: remove this entirely
 static const unsigned int BLOCKSTREAM_CORE_MAX_BLOCK_SIZE = 1000000;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1083,9 +1083,8 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state)
     if (tx.vout.empty())
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-vout-empty");
     // Size limits
-    // BU: size limits removed
-    //if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > MAX_BLOCK_SIZE)
-    //    return state.DoS(100, false, REJECT_INVALID, "bad-txns-oversize");
+    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) > 1000000)
+        return state.DoS(100, false, REJECT_INVALID, "bad-txns-oversize");
 
     // Check for negative or overflow output values
     CAmount nValueOut = 0;
@@ -2529,9 +2528,9 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
         nInputs += tx.vin.size();
         nSigOps += GetLegacySigOpCount(tx);
-        //if (nSigOps > MAX_BLOCK_SIGOPS)
-        //    return state.DoS(100, error("ConnectBlock(): too many sigops"),
-        //                    REJECT_INVALID, "bad-blk-sigops");
+        if (nSigOps > MAX_BLOCK_SIGOPS)
+            return state.DoS(100, error("ConnectBlock(): too many sigops"),
+                            REJECT_INVALID, "bad-blk-sigops");
 
         if (!tx.IsCoinBase())
         {
@@ -2558,9 +2557,9 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 // this is to prevent a "rogue miner" from creating
                 // an incredibly-expensive-to-validate block.
                 nSigOps += GetP2SHSigOpCount(tx, view);
-                //if (nSigOps > MAX_BLOCK_SIGOPS)
-                //    return state.DoS(100, error("ConnectBlock(): too many sigops"),
-                //                     REJECT_INVALID, "bad-blk-sigops");
+                if (nSigOps > MAX_BLOCK_SIGOPS)
+                    return state.DoS(100, error("ConnectBlock(): too many sigops"),
+                                     REJECT_INVALID, "bad-blk-sigops");
             }
 
             nFees += view.GetValueIn(tx)-tx.GetValueOut();


### PR DESCRIPTION
As discussed with solex and others on slack; first step is to get back to being compatible with the Bitcoin protocol rules.

---

The changes made then made sense because BU was meant only for clients
but miners really have to check all limits on all incoming and outgoing
blocks and transactions because we already had a chain-fork on testnet
based on a very similar issue.

This commit restored BU to follow the published protocol rules for
Bitcoin's
- sigop limits
- maximum transaction size
