### PR TITLE
Reduce bip68-112-113-p2p.py execution time from 30 to 2 min.

### DIFF
--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -222,7 +222,7 @@ class TestManager(object):
                 blockhash in node.block_request_map and node.block_request_map[blockhash]
                 for node in self.test_nodes
             )
-        time.sleep(22)  # The BU xthin preferential thinblock timer will delay sync so we need to wait longer for sync
+        time.sleep(1)  # The BU xthin preferential thinblock timer will delay sync so we need to wait longer for sync
         # --> error if not requested
         if not wait_until(blocks_requested, attempts=20*num_blocks):
             # print [ c.cb.block_request_map for c in self.connections ]


### PR DESCRIPTION
This is a band aid until a proper fix will be found.
To achieve such reduction we simply changed the
time.sleep(22) to sleep(1) in comptool.py
That way we will be able to get full test suite executed 
before travis max exec time limit kicks in. 
