### PR TITLE
Stop allowing txns with less than 150000000 in priority a passthrough

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1378,7 +1378,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
         LogPrint("mempool",
                  "MempoolBytes:%d  LimitFreeRelay:%.5g  FeeCutOff:%.4g  FeesSatoshiPerByte:%.4g  TxBytes:%d  TxFees:%d\n",
                   poolBytes, nFreeLimit, ((double)::minRelayTxFee.GetFee(nSize)) / nSize, ((double)nFees) / nSize, nSize, nFees);
-        if (fLimitFree && nFees < ::minRelayTxFee.GetFee(nSize) && !fSpendsCoinbase && dPriority < 150000000)
+        if (fLimitFree && nFees < ::minRelayTxFee.GetFee(nSize) && !fSpendsCoinbase)
         {
             static double dFreeCount;
 


### PR DESCRIPTION
This feature was intended to allow high priority txns to always propagate
however there are issues with this as highlighted in issue #125

1) This feature is a magic number which is not a good idea to begin with
2) txns that have been floating around without getting mined for long periods of
   time end up rising in priority and avoiding getting rate limited which the
   consequence that our mempools are filling up much faster with un-mineable txns.
