### PR TITLE
Put lock on flag fischainnearlysyncd

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -48,6 +48,9 @@ set<uint256> setPreVerifiedTxHash;
 set<uint256> setUnVerifiedOrphanTxHash;
 CCriticalSection cs_xval;
 
+bool fIsChainNearlySyncd;
+CCriticalSection cs_ischainnearlysyncd;
+
 uint64_t maxGeneratedBlock = DEFAULT_MAX_GENERATED_BLOCK_SIZE;
 unsigned int excessiveBlockSize = DEFAULT_EXCESSIVE_BLOCK_SIZE;
 unsigned int excessiveAcceptDepth = DEFAULT_EXCESSIVE_ACCEPT_DEPTH;
@@ -128,7 +131,6 @@ std::vector<CNode*> xpeditedTxn; // (256,(CNode*)NULL);
 
 // BUIP010 Xtreme Thinblocks Variables
 std::map<uint256, uint64_t> mapThinBlockTimer;
-bool fIsChainNearlySyncd;
 
 //! The largest block size that we have seen since startup
 uint64_t nLargestBlockSeen=BLOCKSTREAM_CORE_MAX_BLOCK_SIZE; // BU - Xtreme Thinblocks

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -39,9 +39,7 @@ using namespace std;
 
 extern CTxMemPool mempool; // from main.cpp
 
-
 bool IsTrafficShapingEnabled();
-
 
 std::string ExcessiveBlockValidator(const unsigned int& value,unsigned int* item,bool validate)
 {
@@ -1124,7 +1122,7 @@ bool CanThinBlockBeDownloaded(CNode* pto)
 // This way we avoid having to lock cs_main so often which tends to be a bottleneck.
 void IsChainNearlySyncdInit() 
 {
-    LOCK(cs_main);
+    LOCK2(cs_main, cs_ischainnearlysyncd);
     if (!pindexBestHeader) fIsChainNearlySyncd = false;  // Not nearly synced if we don't have any blocks!
     else
       {
@@ -1136,6 +1134,7 @@ void IsChainNearlySyncdInit()
 }
 bool IsChainNearlySyncd()
 {
+    LOCK(cs_ischainnearlysyncd);
     return fIsChainNearlySyncd;
 }
 

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -153,6 +153,9 @@ extern std::set<uint256> setUnVerifiedOrphanTxHash;
 extern CCriticalSection cs_xval;
 // Xpress Validation: end
 
+extern bool fIsChainNearlySyncd;
+extern CCriticalSection cs_ischainnearlysyncd;
+
 extern bool HaveConnectThinblockNodes();
 extern bool HaveThinblockNodes();
 extern bool CheckThinblockTimer(uint256 hash);


### PR DESCRIPTION
I don't believe this is really needed until PV comes in but I don't think it hurts to add it now.  (Without this in PV this will definitely cause crashes).

I took fischainnearlysyncd out of globals.cpp because it's only locally needed in unlimited.cpp.
