### PR TITLE
Use the correct repo in git clone command

### DIFF
--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -40,7 +40,7 @@ NOTE: Building with Qt4 is still supported, however, could result in a broken UI
 
 1. Clone the GitHub tree to get the source code and go into the directory.
 
-        git clone https://github.com/bitcoin/bitcoin.git
+        git clone https://github.com/BitcoinUnlimited/BitcoinUnlimited.git
         cd bitcoin
 
 2.  Build bitcoin-core:
@@ -81,7 +81,7 @@ You can ignore this section if you are building `bitcoind` for your own use.
 
 bitcoind/bitcoin-cli binaries are not included in the Bitcoin-Qt.app bundle.
 
-If you are building `bitcoind` or `Bitcoin Unlimited` for others, your build machine should be set up
+If you are building `bitcoind` or `bitcoin-qt` for others, your build machine should be set up
 as follows for maximum compatibility:
 
 All dependencies should be compiled with these flags:


### PR DESCRIPTION
Refer to Bitcoin Unlimited git repository and while
at it use bitcoin-qt rather than BitcoinUnlimited to
as the name of the GUI binary.
