### PR TITLE
Update CalculateMemPoolAncestors: Remove +1 as per BU: Fix use after free bug

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -233,7 +233,8 @@ bool CTxMemPool::CalculateMemPoolAncestors(const CTxMemPoolEntry &entry, setEntr
             if (setAncestors.count(phash) == 0) {
                 parentHashes.insert(phash);
             }
-            if (parentHashes.size() + setAncestors.size() + 1 > limitAncestorCount) {
+            // removed +1 from test below as per BU: Fix use after free bug
+            if (parentHashes.size() + setAncestors.size() > limitAncestorCount) {
                 errString = strprintf("too many unconfirmed ancestors [limit: %u]", limitAncestorCount);
                 return false;
             }


### PR DESCRIPTION
Testing mempool_packages.py is failing on the 23 iteration at self.chain_transaction. The test expects it to reach 25 (MAX_ANCESTORS) this leads to txmempool.cpp:237 which returns false because  "too many unconfirmed ancestors [limit: 25]" where 2 + 23 + 1 > 25
so the test expects that parentHashes.size() will be 0 when its actually 2

txmempool.cpp:242 says: parentHashes.erase(stageit);  // BU: Fix use after free bug by moving this last

line:236: if (parentHashes.size() + setAncestors.size() + 1 > limitAncestorCount) {

the +1 is a bug because when the line:242 parentHashes.erase was moved last for BU the +1 should have also been removed. So when you move the erase() downward like was done for `// BU: Fix use after free bug by moving this last`then in the BOOST_FOREACH loop stageit is still counted as part of parentHashes, and therefore the `+ 1` is no longer needed

the test passes with that modification (81 secs)
