### PR TITLE
scale maxuploadtarget according to EB, adapt (fix) qa test

### DIFF
--- a/doc/reduce-traffic.md
+++ b/doc/reduce-traffic.md
@@ -3,14 +3,33 @@ Reduce Traffic
 
 Some node operators need to deal with bandwidth caps imposed by their ISPs.
 
-By default, bitcoin-core allows up to 125 connections to different peers, 8 of
-which are outbound. You can therefore, have at most 117 inbound connections.
+By default, Bitcoin Unlimited allows up to 125 connections to different peers,
+8 of which are outbound. You can therefore, have at most 117 inbound connections.
 
 The default settings can result in relatively significant traffic consumption.
 
 Ways to reduce traffic:
 
-## 1. Use `-maxuploadtarget=<MiB per day>`
+## 1. Use the traffic shaping options
+
+Bitcoin Unlimited adds traffic shaping which is controlled by the following
+parameters (these can also be regulated in the GUI):
+
+  -receiveburst: The maximum rate that data can be received in kB/s.
+       If there has been a period of lower than average data rates,
+       the client may receive extra data to bring the average back to
+       '-receiveavg' but the data rate will not exceed this parameter.
+
+  -sendburst: The maximum rate that data can be sent in kB/s.
+       If there has been a period of lower than average data rates,
+       the client may send extra data to bring the average back to
+       '-sendavg' but the data rate will not exceed this parameter.
+
+  -receiveavg: The average rate that data can be received in kB/s
+
+  -sendavg: The maximum rate that data can be sent in kB/s
+
+## 2. Use `-maxuploadtarget=<MiB per day>`
 
 A major component of the traffic is caused by serving historic blocks to other nodes
 during the initial blocks download phase (syncing up a new node).
@@ -19,19 +38,18 @@ This is *not* a hard limit; only a threshold to minimize the outbound
 traffic. When the limit is about to be reached, the uploaded data is cut by no
 longer serving historic blocks (blocks older than one week).
 Keep in mind that new nodes require other nodes that are willing to serve
-historic blocks. **The recommended minimum is 144 blocks per day (max. 144MB
-per day)**
+historic blocks. **The recommended minimum is 144 * <excessive block size> per day**
 
 Whitelisted peers will never be disconnected, although their traffic counts for
 calculating the target.
 
-## 2. Disable "listening" (`-listen=0`)
+## 3. Disable "listening" (`-listen=0`)
 
 Disabling listening will result in fewer nodes connected (remember the maximum of 8
 outbound peers). Fewer nodes will result in less traffic usage as you are relaying
 blocks and transactions to fewer nodes.
 
-## 3. Reduce maximum connections (`-maxconnections=<num>`)
+## 4. Reduce maximum connections (`-maxconnections=<num>`)
 
 Reducing the maximum connected nodes to a minimum could be desirable if traffic
 limits are tiny. Keep in mind that bitcoin's trustless model works best if you are

--- a/qa/rpc-tests/maxuploadtarget.py
+++ b/qa/rpc-tests/maxuploadtarget.py
@@ -35,7 +35,7 @@ print "running with -excessiveblocksize = %s bytes" % EXCESSIVE_BLOCKSIZE
 # The formula below works out to the original 30s timeout for the case of
 # 1MB blocks, and scales up sufficiently to allow the test to pass even
 # with 16MB blocks (tested on a reasonably fast machine).
-SYNC_WITH_PING_TIMEOUT = 30 + 20 * int((max(1000000, EXCESSIVE_BLOCKSIZE)-1000000) / 1000000)  # seconds
+SYNC_WITH_PING_TIMEOUT = 60 + 20 * int((max(1000000, EXCESSIVE_BLOCKSIZE)-1000000) / 1000000)  # seconds
 print "sync_with_ping timeout =  %s sec" % SYNC_WITH_PING_TIMEOUT
 
 

--- a/qa/rpc-tests/maxuploadtarget.py
+++ b/qa/rpc-tests/maxuploadtarget.py
@@ -20,6 +20,25 @@ if uploadtarget has been reached.
 * Verify that the upload counters are reset after 24 hours.
 '''
 
+# BU: the EB parameter now controls the daily buffer size (the amount of
+#     data that a peer can upload before the user-specified maxuploadtarget
+#     parameter actually takes effect.
+#     EB in this test is set to match the historic size, which resulted in
+#     a daily buffer of 144 * 1MB.
+#     But it is possible to adjust it (pick a multiple of 1MB below) and
+#     tests should pass. This has been tested up to 16MB.
+EXCESSIVE_BLOCKSIZE = 1000000  # bytes
+print "running with -excessiveblocksize = %s bytes" % EXCESSIVE_BLOCKSIZE
+
+# sync_with_ping() timeouts also need to scale with block size
+# (this has been determined empirically)
+# The formula below works out to the original 30s timeout for the case of
+# 1MB blocks, and scales up sufficiently to allow the test to pass even
+# with 16MB blocks (tested on a reasonably fast machine).
+SYNC_WITH_PING_TIMEOUT = 30 + 20 * int((max(1000000, EXCESSIVE_BLOCKSIZE)-1000000) / 1000000)  # seconds
+print "sync_with_ping timeout =  %s sec" % SYNC_WITH_PING_TIMEOUT
+
+
 # TestNode: bare-bones "peer".  Used mostly as a conduit for a test to sending
 # p2p messages to a node, generating the messages in the main testing logic.
 class TestNode(NodeConnCB):
@@ -73,7 +92,7 @@ class TestNode(NodeConnCB):
         self.peer_disconnected = True
 
     # Sync up with the node after delivery of a block
-    def sync_with_ping(self, timeout=30):
+    def sync_with_ping(self, timeout=SYNC_WITH_PING_TIMEOUT):
         def received_pong():
             return (self.last_pong.nonce == self.ping_counter)
         self.connection.send_message(msg_ping(nonce=self.ping_counter))
@@ -95,15 +114,38 @@ class MaxUploadTest(BitcoinTestFramework):
         initialize_chain_clean(self.options.tmpdir, 2)
 
     def setup_network(self):
-        # Start a node with maxuploadtarget of 200 MB (/24h)
+        # Start a node with maxuploadtarget of 200*EB (MB/24h)
+        # some other attributes defined below have been factored out of
+        # other methods in this class.
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-maxuploadtarget=200", "-blockmaxsize=999000"]))
+        # an overhead factor approximates how the traffic with bigger blocks
+        self.overhead_factor_a = 10  # percent
+        print "overhead_factor = %s %%" % self.overhead_factor_a
+        # maxuploadtarget (unit: MiB) was 200 originally, now scale with EB
+        self.maxuploadtarget = int(200 * EXCESSIVE_BLOCKSIZE / 1000000)
+        print "maxuploadtarget = %sMiB" % self.maxuploadtarget
+        self.blockmaxsize = EXCESSIVE_BLOCKSIZE-1000  # EB-1KB
+        print "blockmaxsize = %s bytes" % self.blockmaxsize
+        self.max_bytes_per_day = self.maxuploadtarget * 1024 * 1024
+        print "max_bytes_per_day = %s bytes" % self.max_bytes_per_day
+        self.daily_buffer = 144 * EXCESSIVE_BLOCKSIZE
+        print "daily buffer = %s bytes" % self.daily_buffer
+        self.max_bytes_available = self.max_bytes_per_day - self.daily_buffer
+        print "max_bytes_available = %s bytes" % self.max_bytes_available
+        # roughly how many 66k transactions we need to create a big block
+        self.num_transactions = int(EXCESSIVE_BLOCKSIZE / 66000) - 1
+        print "num txs in big block = %s" % self.num_transactions
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug",
+                                                              "-use-thinblocks=0", # turned off to predict size of transmitted data
+                                                              "-excessiveblocksize=%s" % EXCESSIVE_BLOCKSIZE,
+                                                              "-maxuploadtarget=%s" % self.maxuploadtarget,
+                                                              "-blockmaxsize=%s" % self.blockmaxsize]))
 
-    def mine_full_block(self, node, address):
-        # Want to create a full block
-        # We'll generate a 66k transaction below, and 14 of them is close to the 1MB block limit
-        for j in xrange(14):
-            if len(self.utxo) < 14:
+    def mine_big_block(self, node, address):
+        # Want to create a big block
+        # We'll generate a 66k transaction below
+        for j in xrange(self.num_transactions):
+            if len(self.utxo) < self.num_transactions:
                 self.utxo = node.listunspent()
             inputs=[]
             outputs = {}
@@ -121,18 +163,21 @@ class MaxUploadTest(BitcoinTestFramework):
             # Appears to be ever so slightly faster to sign with SIGHASH_NONE
             signresult = node.signrawtransaction(newtx,None,None,"NONE")
             txid = node.sendrawtransaction(signresult["hex"], True)
-        # Mine a full sized block which will be these transactions we just created
+        # Mine a big sized block which will be these transactions we just created
         node.generate(1)
 
     def run_test(self):
         # Before we connect anything, we first set the time on the node
         # to be in the past, otherwise things break because the CNode
         # time counters can't be reset backward after initialization
+
+        # set 2 weeks in the past
         old_time = int(time.time() - 2*60*60*24*7)
         self.nodes[0].setmocktime(old_time)
 
         # Generate some old blocks
-        self.nodes[0].generate(130)
+        # we scale this by EB
+        self.nodes[0].generate((130 * EXCESSIVE_BLOCKSIZE / 1000000))
 
         # test_nodes[0] will only request old blocks
         # test_nodes[1] will only request new blocks
@@ -151,18 +196,19 @@ class MaxUploadTest(BitcoinTestFramework):
         # Test logic begins here
 
         # Now mine a big block
-        self.mine_full_block(self.nodes[0], self.nodes[0].getnewaddress())
+        self.mine_big_block(self.nodes[0], self.nodes[0].getnewaddress())
 
         # Store the hash; we'll request this later
         big_old_block = self.nodes[0].getbestblockhash()
         old_block_size = self.nodes[0].getblock(big_old_block, True)['size']
+        print "mined big block size = %s bytes" % old_block_size
         big_old_block = int(big_old_block, 16)
 
         # Advance to two days ago
         self.nodes[0].setmocktime(int(time.time()) - 2*60*60*24)
 
         # Mine one more block, so that the prior block looks old
-        self.mine_full_block(self.nodes[0], self.nodes[0].getnewaddress())
+        self.mine_big_block(self.nodes[0], self.nodes[0].getnewaddress())
 
         # We'll be requesting this new block too
         big_new_block = self.nodes[0].getbestblockhash()
@@ -175,26 +221,42 @@ class MaxUploadTest(BitcoinTestFramework):
         getdata_request = msg_getdata()
         getdata_request.inv.append(CInv(2, big_old_block))
 
-        max_bytes_per_day = 200*1024*1024
-        daily_buffer = 144 * 1000000
-        max_bytes_available = max_bytes_per_day - daily_buffer
-        success_count = max_bytes_available / old_block_size
+        # Compute a theoretical amount of blocks that should be transferable
+        # based purely on the size of the big_old_block.
+        # This calculation will be inaccurate due to other protocol
+        # overheads, so a compensation factor is used later on to adjust
+        # for those.
+        successcount = self.max_bytes_available / old_block_size
+        print "successcount = %s" % successcount
+        compensation = int(successcount * (self.overhead_factor_a / 100.0))
+        print "compensation = %s" % compensation
 
         # 144MB will be reserved for relaying new blocks, so expect this to
-        # succeed for ~70 tries.
-        for i in xrange(success_count):
+        # succeed for a certain number tries.
+        for i in xrange(successcount - compensation):
+            #print "data request #%s" % (i+1)
             test_nodes[0].send_message(getdata_request)
             test_nodes[0].sync_with_ping()
             assert_equal(test_nodes[0].block_receive_map[big_old_block], i+1)
 
+        # check that the node has not been disconnected yet
         assert_equal(len(self.nodes[0].getpeerinfo()), 3)
+        print "Peer 0 still connected after downloading old block %d times" % (successcount - compensation)
+
         # At most a couple more tries should succeed (depending on how long 
         # the test has been running so far).
-        for i in xrange(3):
+        i = 1
+        while True:
             test_nodes[0].send_message(getdata_request)
+            test_nodes[0].sync_with_ping()
+            if test_nodes[0].peer_disconnected: break
+            i += 1
+
+        #for i in xrange(3 * compensation):
+        #    test_nodes[0].send_message(getdata_request)
         test_nodes[0].wait_for_disconnect()
         assert_equal(len(self.nodes[0].getpeerinfo()), 2)
-        print "Peer 0 disconnected after downloading old block too many times"
+        print "Peer 0 disconnected after downloading old block %d times" % (successcount - compensation + i)
 
         # Requesting the current block on test_nodes[1] should succeed indefinitely,
         # even when over the max upload target.
@@ -232,7 +294,7 @@ class MaxUploadTest(BitcoinTestFramework):
         #stop and start node 0 with 1MB maxuploadtarget, whitelist 127.0.0.1
         print "Restarting nodes with -whitelist=127.0.0.1"
         stop_node(self.nodes[0], 0)
-        self.nodes[0] = start_node(0, self.options.tmpdir, ["-debug", "-whitelist=127.0.0.1", "-maxuploadtarget=1", "-blockmaxsize=999000"])
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-debug", "-use-thinblocks=0", "-whitelist=127.0.0.1", "-excessiveblocksize=1000000", "-maxuploadtarget=1", "-blockmaxsize=999000"])
 
         #recreate/reconnect 3 test nodes
         test_nodes = []

--- a/qa/rpc-tests/maxuploadtarget.py
+++ b/qa/rpc-tests/maxuploadtarget.py
@@ -32,9 +32,11 @@ print "running with -excessiveblocksize = %s bytes" % EXCESSIVE_BLOCKSIZE
 
 # sync_with_ping() timeouts also need to scale with block size
 # (this has been determined empirically)
-# The formula below works out to the original 30s timeout for the case of
-# 1MB blocks, and scales up sufficiently to allow the test to pass even
-# with 16MB blocks (tested on a reasonably fast machine).
+# The formula below allows a sync timeout to scale up sufficiently to pass
+# even with 16MB blocks (tested on a reasonably fast machine).
+# The baseline has been increased from 30s to 60s which enables the test
+# to pass with 1MB on a slow i686 machine. Raising the baseline timeout
+# does not increase the test duration on faster machines.
 SYNC_WITH_PING_TIMEOUT = 60 + 20 * int((max(1000000, EXCESSIVE_BLOCKSIZE)-1000000) / 1000000)  # seconds
 print "sync_with_ping timeout =  %s sec" % SYNC_WITH_PING_TIMEOUT
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2360,7 +2360,7 @@ void CNode::RecordBytesSent(uint64_t bytes)
 void CNode::SetMaxOutboundTarget(uint64_t limit)
 {
     LOCK(cs_totalBytesSent);
-    uint64_t recommendedMinimum = (nMaxOutboundTimeframe / 600) * BU_MAX_BLOCK_SIZE;
+    uint64_t recommendedMinimum = (nMaxOutboundTimeframe * excessiveBlockSize) / 600;
     nMaxOutboundLimit = limit;
 
     if (limit > 0 && limit < recommendedMinimum)
@@ -2415,7 +2415,7 @@ bool CNode::OutboundTargetReached(bool historicalBlockServingLimit)
     {
         // keep a large enough buffer to at least relay each block once
         uint64_t timeLeftInCycle = GetMaxOutboundTimeLeftInCycle();
-        uint64_t buffer = timeLeftInCycle / 600 * BU_MAX_BLOCK_SIZE;
+        uint64_t buffer = (timeLeftInCycle * excessiveBlockSize) / 600;
         if (buffer >= nMaxOutboundLimit || nMaxOutboundTotalBytesSentInCycle >= nMaxOutboundLimit - buffer)
             return true;
     }


### PR DESCRIPTION
The maxupload daily buffer size was used to allow at least a full day's worth of "full" blocks to be uploaded without triggering the 1-week historical cutoff.

Adapting this to use BU_MAX_BLOCK_SIZE seemed excessive. Using EB is a fair compromise as that is the line drawn by the users to represent what they consider saturated blocks (above that they would probably start looking at upgrading their node capacity).

This patch implements this EB-dependent sizing of the buffer, and adjusts the regression test in a few ways:
- xthin blocks are disabled because the test relies on roughly predictable block transfer volumes
- more flexible compensation is made for protocol overheads other than the getdata requests
- timeouts in the test are scaled with block size

The test has been executed with EXCESSIVE_BLOCKSIZE=16000000 on a not-so-recent desktop PC (6-core AMD), but this PR delivers it in a form compatible with the original (by setting EB=1MB) as this saves on test execution time.

The test framework throws a timeout when 32MB block size is attempted. This seems unrelated to the functionality being tested here, and can be addressed in a separate bugfix.
