### PR TITLE
Fix heap-use-after-free error that sometimes happens when running the nodehandling.py test.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -391,6 +391,21 @@ CNode* FindNode(const CService& addr)
     return NULL;
 }
 
+int DisconnectSubNetNodes(const CSubNet& subNet)
+{
+    int nDisconnected = 0;
+    LOCK(cs_vNodes);
+    BOOST_FOREACH(CNode* pnode, vNodes)
+        if (subNet.Match((CNetAddr)pnode->addr)) {
+            pnode->fDisconnect = true;
+            nDisconnected++;
+        }
+
+    //return the number of nodes in this subnet marked for disconnection
+    return nDisconnected;
+}
+
+
 CNode* ConnectNode(CAddress addrConnect, const char* pszDest)
 {
     if (pszDest == NULL) {

--- a/src/net.h
+++ b/src/net.h
@@ -96,6 +96,7 @@ CNode* FindNode(const CNetAddr& ip);
 CNode* FindNode(const CSubNet& subNet);
 CNode* FindNode(const std::string& addrName);
 CNode* FindNode(const CService& ip);
+int DisconnectSubNetNodes(const CSubNet& subNet);
 CNode* ConnectNode(CAddress addrConnect, const char* pszDest = NULL);
 bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant* grantOutbound = NULL, const char* strDest = NULL, bool fOneShot = false);
 void MapPort(bool fUseUPnP);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -821,9 +821,24 @@ void RPCConsole::disconnectSelectedNode()
 {
     // Get currently selected peer address
     QString strNode = GUIUtil::getEntryData(ui->peerWidget, 0, PeerTableModel::Address);
+
+    //BU: Enforce cs_vNodes lock held external to FindNode function calls to prevent use-after-free errors
+    CNode* bannedNode = NULL;
+    {
+        LOCK(cs_vNodes);
+        bannedNode = FindNode(strNode.toStdString());
+
+        //BU: Since we are making UI update calls below, we want to protect bannedNode from deletion
+        //    while still being able to release the lock on cs_vNodes to not block on a UI update
+        if (bannedNode) bannedNode->AddRef();
+    }
+
     // Find the node, disconnect it and clear the selected node
-    if (CNode *bannedNode = FindNode(strNode.toStdString())) {
+    //if (CNode *bannedNode = FindNode(strNode.toStdString())) {
+    if (bannedNode) {
         bannedNode->fDisconnect = true;
+        //BU: Remember to release the reference we took on bannedNode to protect from use-after-free
+        bannedNode->Release();
         clearSelectedNode();
     }
 }
@@ -835,8 +850,21 @@ void RPCConsole::banSelectedNode(int bantime)
 
     // Get currently selected peer address
     QString strNode = GUIUtil::getEntryData(ui->peerWidget, 0, PeerTableModel::Address);
+
+    //BU: Enforce cs_vNodes lock held external to FindNode function calls to prevent use-after-free errors
+    CNode* bannedNode = NULL;
+    {
+        LOCK(cs_vNodes);
+        bannedNode = FindNode(strNode.toStdString());
+
+        //BU: Since we are making UI update calls below, we want to protect bannedNode from deletion
+        //    while still being able to release the lock on cs_vNodes to not block on a UI update
+        if (bannedNode) bannedNode->AddRef();
+    }
+
     // Find possible nodes, ban it and clear the selected node
-    if (CNode *bannedNode = FindNode(strNode.toStdString())) {
+    //if (CNode *bannedNode = FindNode(strNode.toStdString())) {
+    if (bannedNode) {
         std::string nStr = strNode.toStdString();
         std::string addr;
         int port = 0;
@@ -844,6 +872,8 @@ void RPCConsole::banSelectedNode(int bantime)
 
         CNode::Ban(CNetAddr(addr), BanReasonManuallyAdded, bantime);
         bannedNode->fDisconnect = true;
+        //BU: Remember to release the reference we took on bannedNode to protect from use-after-free
+        bannedNode->Release();
         DumpBanlist();
 
         clearSelectedNode();

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -240,7 +240,7 @@ UniValue disconnectnode(const UniValue& params, bool fHelp)
             + HelpExampleRpc("disconnectnode", "\"192.168.0.6:8333\"")
         );
 
-    //BU: Add lock on cs_vNodes here to prevent the pNode returned from potentially being deleted before setting fDisconnect
+    //BU: Add lock on cs_vNodes as FindNode now requries it to prevent potential use-after-free errors
     LOCK(cs_vNodes);
     CNode* pNode = FindNode(params[0].get_str());
     if (pNode == NULL)

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -240,6 +240,8 @@ UniValue disconnectnode(const UniValue& params, bool fHelp)
             + HelpExampleRpc("disconnectnode", "\"192.168.0.6:8333\"")
         );
 
+    //BU: Add lock on cs_vNodes here to prevent the pNode returned from potentially being deleted before setting fDisconnect
+    LOCK(cs_vNodes);
     CNode* pNode = FindNode(params[0].get_str());
     if (pNode == NULL)
         throw JSONRPCError(RPC_CLIENT_NODE_NOT_CONNECTED, "Node not found in connected nodes");
@@ -571,8 +573,10 @@ UniValue setban(const UniValue& params, bool fHelp)
         isSubnet ? CNode::Ban(subNet, BanReasonManuallyAdded, banTime, absolute) : CNode::Ban(netAddr, BanReasonManuallyAdded, banTime, absolute);
 
         //disconnect possible nodes
-        while(CNode *bannedNode = (isSubnet ? FindNode(subNet) : FindNode(netAddr)))
-            bannedNode->fDisconnect = true;
+        if (!isSubnet) subNet = CSubNet(netAddr);
+        DisconnectSubNetNodes(subNet);//BU: Since we need to mark any nodes in subNet for disconnect, atomically mark all nodes at once
+        //while(CNode *bannedNode = (isSubnet ? FindNode(subNet) : FindNode(netAddr)))
+        //    bannedNode->fDisconnect = true;
     }
     else if(strCommand == "remove")
     {


### PR DESCRIPTION
When running the `nodehandling.py` test with the latest 0.12.1bu branch (6ec0f08) , about 1/3 of the time a heap-use-after-free occurs.  This error is only apparent when using the `-fsanitize=address,undefined` compile option, which is intended to catch these types of errors, as this error does not cause a core dump or prevent the test from passing (usually occurs during node shutdown procedure) when executed without compiling with the `fsantize` flags.  This is likely because the instrumentation provided by compiling with the `fsantize` flags causes all program execution to run slower, which allows `FindNode` to return a `CNode` pointer, which then gets freed by `ThreadSocketHandler` prior to the rpc call using the pointer to set the `fDisconnect` flag on the returned `CNode` pointer, which is now invalid due to the free operation.

In particular, when running the `nodehandling.py` test this error can occur with calls to the `setban` and `disconectnode` rpc calls.  These calls have been modified to set the `fDisconnect` flag in a thread safe manner via helper functions which obtain a `cs_vNodes` lock.  Calls to the new functions protected by `cs_vNodes` lock are only made from within `rpcnet.cpp`.

1. Commit 1 is purely formatting in rpcnet.cpp to update the file to conform to the clang standards as defined in doc/developer-notes.md.
2. Commit 2 is updating `ThreadSocketHandler` to protect a couple of calls on the `vNodes` vector which were not protected by `cs_vNodes`.  This includes protecting the one place where CNodes are freed that wasn't already protected by a lock on `cs_vNodes`.
3. Commit 3 uses the new functions which set `fDisconnect` on `CNodes` in a thread safe manner behind a lock on `cs_vNodes`.

Example error output in attached file.
[nodehandling.txt](https://github.com/BitcoinUnlimited/BitcoinUnlimited/files/561011/nodehandling.txt)

