### PR TITLE
[qa] add capability to disable/skip tests and have them show up as such in the log

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -162,8 +162,8 @@ def runtests():
             if (len(opts) == 0
                     or (len(opts) == 1 and "-win" in opts )
                     or run_extended
-                    or testScripts[i] in opts
-                    or re.sub(".py$", "", testScripts[i]) in opts ):
+                    or str(testScripts[i]) in opts
+                    or re.sub(".py$", "", str(testScripts[i])) in opts ):
 
                 if testScripts[i].is_disabled():
                     print("Disabled testscript %s%s%s (reason: %s)" % (bold[1], testScripts[i], bold[0], testScripts[i].reason))
@@ -186,7 +186,7 @@ def runtests():
 
         # Run Extended Tests
         for i in range(len(testScriptsExt)):
-            if (run_extended or testScriptsExt[i] in opts
+            if (run_extended or str(testScriptsExt[i]) in opts
                     or re.sub(".py$", "", str(testScriptsExt[i])) in opts):
 
                 if testScriptsExt[i].is_disabled():

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -76,7 +76,7 @@ if EXEEXT == ".exe" and "-win" not in opts:
 
 #Tests
 testScripts = [ RpcTest(t) for t in [
-    Skip('bip68-112-113-p2p', "linux", "because we don't like Linux"),
+    'bip68-112-113-p2p',
     'wallet',
     'excessive',
     'listtransactions',

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -31,6 +31,7 @@ import tempfile
 import re
 
 from tests_config import *
+from test_classes import RpcTest, Disabled, Skip
 
 #If imported values are not defined then set to zero (or disabled)
 if not vars().has_key('ENABLE_WALLET'):
@@ -74,70 +75,73 @@ if EXEEXT == ".exe" and "-win" not in opts:
     sys.exit(0)
 
 #Tests
-testScripts = [
-    'bip68-112-113-p2p.py',
-    'wallet.py',
-    'excessive.py',
-    'listtransactions.py',
-    'receivedby.py',
-    'mempool_resurrect_test.py',
-    'txn_doublespend.py --mineblock',
-    'txn_clone.py',
-    'getchaintips.py',
-    'rawtransactions.py',
-    'rest.py',
-    'mempool_spendcoinbase.py',
-    'mempool_reorg.py',
-#    'mempool_limit.py',  # mempool priority changes causes create_lots_of_big_transactions to fail
-    'httpbasics.py',
-    'multi_rpc.py',
-    'zapwallettxes.py',
-    'proxy_test.py',
-    'merkle_blocks.py',
-    'fundrawtransaction.py',
-    'signrawtransactions.py',
-    'walletbackup.py',
-    'nodehandling.py',
-    'reindex.py',
-    'decodescript.py',
-#    'p2p-fullblocktest.py',
-    'blockchain.py',
-    'disablewallet.py',
-#    'sendheaders.py',   # BU requests INVs not headers -- in the future we may add support for headers, at least by treating them like INVs
-    'keypool.py',
-#    'prioritise_transaction.py',
-#    'invalidblockrequest.py',
-    'invalidtxrequest.py',
-    'abandonconflict.py',
-    'p2p-versionbits-warning.py',
-]
+testScripts = [ RpcTest(t) for t in [
+    Skip('bip68-112-113-p2p', "linux", "because we don't like Linux"),
+    'wallet',
+    'excessive',
+    'listtransactions',
+    'receivedby',
+    'mempool_resurrect_test',
+    'txn_doublespend --mineblock',
+    'txn_clone',
+    'getchaintips',
+    'rawtransactions',
+    'rest',
+    'mempool_spendcoinbase',
+    'mempool_reorg',
+    Disabled('mempool_limit', "mempool priority changes causes create_lots_of_big_transactions to fail"),
+    'httpbasics',
+    'multi_rpc',
+    'zapwallettxes',
+    'proxy_test',
+    'merkle_blocks',
+    'fundrawtransaction',
+    'signrawtransactions',
+    'walletbackup',
+    'nodehandling',
+    'reindex',
+    'decodescript',
+    Disabled('p2p-fullblocktest', "TODO"),
+    'blockchain',
+    'disablewallet',
+    Disabled('sendheaders', "BU requests INVs not headers -- in the future we may add support for headers, at least by treating them like INVs)"),
+    'keypool',
+    Disabled('prioritise_transaction', "TODO"),
+    Disabled('invalidblockrequest', "TODO"),
+    'invalidtxrequest',
+    'abandonconflict',
+    'p2p-versionbits-warning'
+    ,
+] ]
 
-testScriptsExt = [
-    'bip9-softforks.py',
-    'bip65-cltv.py',
-    'bip65-cltv-p2p.py',
-#    'bip68-sequence.py',
-    'bipdersig-p2p.py',
-    'bipdersig.py',
-    'getblocktemplate_longpoll.py',
-    'getblocktemplate_proposals.py',
-    'txn_doublespend.py',
-    'txn_clone.py --mineblock',
-#    'pruning.py',  # too much disk
-    'forknotify.py',
-    'invalidateblock.py',
-#    'rpcbind_test.py', #temporary, bug in libevent, see #6655
-    'smartfees.py',
-    'maxblocksinflight.py',
-    'p2p-acceptblock.py',
-    'mempool_packages.py',
-    'maxuploadtarget.py',
-#    'replace-by-fee.py', # disabled while Replace By Fee is disabled in code
-]
+testScriptsExt = [ RpcTest(t) for t in [
+    'bip9-softforks',
+    'bip65-cltv',
+    'bip65-cltv-p2p',
+    Disabled('bip68-sequence', "TODO"),
+    'bipdersig-p2p',
+    'bipdersig',
+    'getblocktemplate_longpoll',
+    'getblocktemplate_proposals',
+    'txn_doublespend',
+    'txn_clone --mineblock',
+    Disabled('pruning', "too much disk"),
+    'forknotify',
+    'invalidateblock',
+    Disabled('rpcbind_test', "temporary, bug in libevent, see #6655"),
+    'smartfees',
+    'maxblocksinflight',
+    'p2p-acceptblock',
+    'mempool_packages',
+    'maxuploadtarget',
+    Disabled('replace-by-fee', "disabled while Replace By Fee is disabled in code")
+] ]
 
 #Enable ZMQ tests
 if ENABLE_ZMQ == 1:
-    testScripts.append('zmq_test.py')
+    testScripts.append(RpcTest('zmq_test'))
+
+
 
 
 def runtests():
@@ -161,30 +165,43 @@ def runtests():
                     or testScripts[i] in opts
                     or re.sub(".py$", "", testScripts[i]) in opts ):
 
-                print("Running testscript %s%s%s ..." % (bold[1], testScripts[i], bold[0]))
-                time0 = time.time()
-                subprocess.check_call(
-                    rpcTestDir + testScripts[i] + flags, shell=True)
-                print("Duration: %s s\n" % (int(time.time() - time0)))
+                if testScripts[i].is_disabled():
+                    print("Disabled testscript %s%s%s (reason: %s)" % (bold[1], testScripts[i], bold[0], testScripts[i].reason))
+                elif testScripts[i].is_skipped():
+                    print("Skipping testscript %s%s%s on this platform (reason: %s)" % (bold[1], testScripts[i], bold[0], testScripts[i].reason))
+                else:
+                    # not disabled or skipped - execute test
 
-                # exit if help is called so we print just one set of
-                # instructions
-                p = re.compile(" -h| --help")
-                if p.match(passOn):
-                    sys.exit(0)
+                    print("Running testscript %s%s%s ..." % (bold[1], testScripts[i], bold[0]))
+                    time0 = time.time()
+                    subprocess.check_call(
+                        rpcTestDir + repr(testScripts[i]) + flags, shell=True)
+                    print("Duration: %s s\n" % (int(time.time() - time0)))
+
+                    # exit if help is called so we print just one set of
+                    # instructions
+                    p = re.compile(" -h| --help")
+                    if p.match(passOn):
+                        sys.exit(0)
 
         # Run Extended Tests
         for i in range(len(testScriptsExt)):
             if (run_extended or testScriptsExt[i] in opts
-                    or re.sub(".py$", "", testScriptsExt[i]) in opts):
+                    or re.sub(".py$", "", str(testScriptsExt[i])) in opts):
 
-                print(
-                    "Running 2nd level testscript "
-                    + "%s%s%s ..." % (bold[1], testScriptsExt[i], bold[0]))
-                time0 = time.time()
-                subprocess.check_call(
-                    rpcTestDir + testScriptsExt[i] + flags, shell=True)
-                print("Duration: %s s\n" % (int(time.time() - time0)))
+                if testScriptsExt[i].is_disabled():
+                    print("Disabled testscript %s%s%s (reason: %s)" % (bold[1], testScriptsExt[i], bold[0], testScriptsExt[i].reason))
+                elif testScripts[i].is_skipped():
+                    print("Skipping testscript %s%s%s on this platform (reason: %s)" % (bold[1], testScriptsExt[i], bold[0], testScriptsExt[i].reason))
+                else:
+                    # not disabled or skipped - execute test
+                    print(
+                        "Running 2nd level testscript "
+                        + "%s%s%s ..." % (bold[1], testScriptsExt[i], bold[0]))
+                    time0 = time.time()
+                    subprocess.check_call(
+                        rpcTestDir + str(testScriptsExt[i]) + flags, shell=True)
+                    print("Duration: %s s\n" % (int(time.time() - time0)))
 
         if coverage:
             coverage.report_rpc_coverage()

--- a/qa/pull-tester/test_classes.py
+++ b/qa/pull-tester/test_classes.py
@@ -1,0 +1,128 @@
+# Copyright (c) 2016 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""
+RpcTest class and help functions which create Disabled/Skipped tests
+
+>>> sometest=RpcTest("name")
+>>> repr(sometest)
+'name.py'
+>>> sometest.is_disabled()
+False
+>>> sometest.reason is None
+True
+>>> sometest.skip_platforms
+[]
+>>> disabled_test=Disabled("foo", "foo does not work right now")
+>>> disabled_test.is_disabled()
+True
+>>> disabled_test.reason
+'foo does not work right now'
+>>> disabled_test.skip_platforms
+[]
+>>> skipped_test=Skip("bar", "", "bar is skipped on all platforms because all matches empty string")
+>>> skipped_test.is_skipped()
+True
+>>> unskipped_test=Skip("baz", "NoSuchPlatform", "baz is not skipped since there is no such platform")
+>>> unskipped_test.is_skipped()
+False
+"""
+
+import platform
+
+
+# collect as much platform info as we want people to be able to filter
+# against for skipped tests
+# platform.node() is not included because too easy to get an accidental match
+# against a computer's name.
+_PLATFORM_INFO =  [ platform.machine(),
+                    platform.platform(),
+                    platform.platform(aliased=1),
+                    platform.platform(terse=1),
+                    platform.system(),
+                    ','.join(platform.architecture()),
+                    ','.join(platform.uname()),
+                  ]
+
+
+class RpcTest(object):
+    ''' Convenience class for RCP tests and disabled/skipped tests '''
+    def __init__(self, obj):
+        if isinstance(obj, RpcTest):
+            self.name = obj.name
+            self.args = obj.args
+            self.disabled = obj.disabled
+            self.reason = obj.reason
+            self.skip_platforms = obj.skip_platforms
+        else:
+            words = str(obj).split(" ")  # need to split args
+            self.name = words[0]
+            if len(words) > 1:
+                self.args = words[1:]
+            else:
+                self.args = []
+            self.disabled = False
+            self.reason = None
+            self.skip_platforms = []
+
+    def is_disabled(self):
+        ''' returns True if test is explicitly disabled (completely) '''
+        return self.disabled
+
+    def is_skipped(self):
+        ''' returns True if test would skip on this platform '''
+        skip = False
+        for platform_to_skip in self.skip_platforms:
+            for pi in _PLATFORM_INFO:
+                if platform_to_skip.lower() in pi.lower().split(','):
+                    skip = True
+                    break;
+        return skip
+
+    def disable(self, reason):
+        ''' set test to explicitly disabled (completely) '''
+        self.disabled = True
+        self.reason = reason
+
+    def skip(self, platforms, reason):
+        ''' set test to skip on certain platforms '''
+        self.reason = reason
+        if isinstance(platforms, tuple) or isinstance(platforms, list):
+            for i in platforms:
+                self.skip_platforms.append(i)
+        else:
+                self.skip_platforms.append(platforms)
+
+    def __repr__(self):
+        retval = self.name + '.py'
+        if self.args:
+            retval = " ".join([retval, ] + self.args)
+        return retval
+
+    def __str__(self):
+        return repr(self)
+
+
+def Disabled(test_name, reason):
+    ''' create a disabled test '''
+    assert reason, "disabling a test requires a reason!"
+    rpctest = RpcTest(test_name)
+    rpctest.disable(reason)
+    return rpctest
+
+
+def Skip(test_name, platforms, reason):
+    ''' create a test which is skipped on certain platforms.
+        The 'platforms' parameter can be a string or tuple/list of strings
+        which are matched against platform identifiers obtained when
+        the test is executed.
+    '''
+    assert reason, "skipping a test on some platforms requires a reason!"
+    rpctest = RpcTest(test_name)
+    rpctest.skip(platforms, reason)
+    return rpctest
+
+
+if __name__ == "__main__":
+    import doctest
+    doctest.testmod()


### PR DESCRIPTION
Most test frameworks allow to skip tests on certain platforms if they are inapplicable or skip them wholesale.

This patch introduces this ability for the qa tests, which in the past had sometimes been disabled by commenting them out. This leads to the test not being executed at all, and sometimes people lose awareness that those disabled tests even exist.

Also, the reason for disabling tests was not always specified.

Now, the Disabled() and Skip() constructors can be used to mark tests as completely disabled, or to be skipped if the platform they're being run on matches certain keywords.

In both cases, a reason for disabling/selectively skipping the test needs to be specified, and will be output in the test run log together with the information that the test is disabled or skipped on the platform.

This will hopefully contribute to keeping awareness of temporarily disabled tests up, and motivate contributors  to look at fixing those tests permanently, if the test should be made to pass.