### PR TITLE
add test_classes.py to EXTRA_DIST, for builds set up using distdir target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -216,7 +216,7 @@ endif
 
 dist_noinst_SCRIPTS = autogen.sh
 
-EXTRA_DIST = $(top_srcdir)/share/genbuild.sh qa/pull-tester/rpc-tests.py qa/rpc-tests $(DIST_DOCS) $(WINDOWS_PACKAGING) $(OSX_PACKAGING) $(BIN_CHECKS)
+EXTRA_DIST = $(top_srcdir)/share/genbuild.sh qa/pull-tester/rpc-tests.py qa/pull-tester/test_classes.py qa/rpc-tests $(DIST_DOCS) $(WINDOWS_PACKAGING) $(OSX_PACKAGING) $(BIN_CHECKS)
 
 CLEANFILES = $(OSX_DMG) $(BITCOIN_WIN_INSTALLER)
 


### PR DESCRIPTION
This should fix Travis builds which fail after PR150 merge due to missing test_classes.py in the build folder created by `make distdir PACKAGE=bitcoin VERSION=$HOST` .