### PR TITLE
Remove declaration of ClearThinblockTimer from unlimited.h

### DIFF
--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -159,7 +159,6 @@ extern CCriticalSection cs_ischainnearlysyncd;
 extern bool HaveConnectThinblockNodes();
 extern bool HaveThinblockNodes();
 extern bool CheckThinblockTimer(uint256 hash);
-extern void ClearThinblockTimer(uint256 hash);
 extern bool IsThinBlocksEnabled();
 extern bool CanThinBlockBeDownloaded(CNode* pto);
 extern bool IsChainNearlySyncd();


### PR DESCRIPTION
Such function is spelled wrongly (in unlimited.cpp the name
ClearThinBlockTimer()) and more to the point is not used
anywhere but in unlimited.cpp.