### PR TITLE
Reduce default number of blocks to check at startup

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -170,7 +170,7 @@ extern uint64_t nPruneTarget;
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of chainActive.Tip() will not be pruned. */
 static const unsigned int MIN_BLOCKS_TO_KEEP = 288;
 
-static const signed int DEFAULT_CHECKBLOCKS = MIN_BLOCKS_TO_KEEP;
+static const signed int DEFAULT_CHECKBLOCKS = 6;
 static const unsigned int DEFAULT_CHECKLEVEL = 3;
 
 // Require that user allocate at least 550MB for block & undo files (blk???.dat and rev???.dat)


### PR DESCRIPTION
Hello,

the title is self-explanatory I guess :) bitcoin-core has this as default since 0.13.1
It is nice for desktop users because the software starts much faster with this change.