### PR TITLE
[Trival] - Update remote node UI display to show "WITNESS" instead of "UNKNOWN".

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -290,6 +290,11 @@ enum {
     // but no longer do as of protocol version 70011 (= NO_BLOOM_VERSION)
     NODE_BLOOM = (1 << 2),
 
+    // Indicates that a node can be asked for blocks and transactions including
+    // witness data.
+    // BU: Bitcoin Unlimitd does not support this (added to display connected node services correctly)
+    NODE_WITNESS = (1 << 3),
+
     // BUIP010 - Xtreme Thinblocks - begin section
     // NODE_XTHIN means the node supports Xtreme Thinblocks
     // If this is turned off then the node will not service xthin requests nor  

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -910,6 +910,9 @@ QString formatServicesStr(quint64 mask)
             case NODE_BLOOM:
                 strList.append("BLOOM");
                 break;
+            case NODE_WITNESS:
+                strList.append("WITNESS");
+                break;
             case NODE_XTHIN:
                 strList.append("XTHIN");
                 break;


### PR DESCRIPTION
This is a minor usability fix such that remote nodes connected to a BU node show all services they offer by name, instead of showing "UNKNOWN" for the "WITNESS" service bit.

Credit where due: this is a sub-set of a cherry-pick from b8a97498 in bitcoin/bitcoin repo.