### PR TITLE
Revert AD "sticky gate" 

### DIFF
--- a/qa/rpc-tests/excessive.py
+++ b/qa/rpc-tests/excessive.py
@@ -29,12 +29,12 @@ class ExcessiveBlockTest (BitcoinTestFramework):
             n.generate(1)
             self.sync_all()
           self.nodes[0].generate(100)
-	  self.sync_all()
+          self.sync_all()
         
  	# Set the accept depth at 1, 2, and 3 and watch each nodes resist the chain for that long
-        self.nodes[1].setminingmaxblock(1000, 1)
-        self.nodes[2].setminingmaxblock(1000, 2)
-        self.nodes[3].setminingmaxblock(1000, 3)
+        self.nodes[1].setminingmaxblock(1000)
+        self.nodes[2].setminingmaxblock(1000)
+        self.nodes[3].setminingmaxblock(1000)
 
         self.nodes[1].setexcessiveblock(1000, 1)
         self.nodes[2].setexcessiveblock(1000, 2)
@@ -46,77 +46,67 @@ class ExcessiveBlockTest (BitcoinTestFramework):
         self.nodes[0].generate(1)
         time.sleep(2) #give blocks a chance to fully propagate
         counts = [ x.getblockcount() for x in self.nodes ]
-        assert_equal(counts, [201,200,200,200])  
+        assert_equal(counts, [201,200,200,200])
 
         self.nodes[0].generate(1)
         time.sleep(2) #give blocks a chance to fully propagate
         sync_blocks(self.nodes[0:2])
         counts = [ x.getblockcount() for x in self.nodes ]
-        assert_equal(counts, [202,202,200,200])  
+        assert_equal(counts, [202,202,200,200])
 
         self.nodes[0].generate(1)
         time.sleep(2) #give blocks a chance to fully propagate
         sync_blocks(self.nodes[0:3])
         counts = [ x.getblockcount() for x in self.nodes ]
-        assert_equal(counts, [203,203,203,200])  
+        assert_equal(counts, [203,203,203,200])
 
         self.nodes[0].generate(1)
         time.sleep(2) #give blocks a chance to fully propagate
         self.sync_all()
         counts = [ x.getblockcount() for x in self.nodes ]
-        assert_equal(counts, [204,204,204,204])  
+        assert_equal(counts, [204,204,204,204])
 
-        # Now generate another excessive block, but all nodes should snap right to it because they have an older excessive block
+        # Mine 4 excessive blocks back-to-back.
         for i in range(0,20):
           self.nodes[0].sendtoaddress(addr, 1.0)
         self.nodes[0].generate(1)
-        self.sync_all()
-        counts = [ x.getblockcount() for x in self.nodes ]
-        assert_equal(counts, [205,205,205,205])  
-      
-        self.nodes[0].generate(6*24)  # Now generate a day's worth of small blocks which should re-enable the node's reluctance to accept a large block
-        self.sync_all()
+        for i in range(0,20):
+          self.nodes[0].sendtoaddress(addr, 1.0)
+        self.nodes[0].generate(1)
+        for i in range(0,20):
+          self.nodes[0].sendtoaddress(addr, 1.0)
+        self.nodes[0].generate(1)
         for i in range(0,20):
           self.nodes[0].sendtoaddress(addr, 1.0)
         self.nodes[0].generate(1)
         time.sleep(2) #give blocks a chance to fully propagate
         counts = [ x.getblockcount() for x in self.nodes ]
-        assert_equal(counts, [350,349,349,349])  
+        assert_equal(counts, [208,204,204,204])
 
-        for i in range(0,20):
-          self.nodes[0].sendtoaddress(addr, 1.0)
+        # Mine empty blocks and watch nodes begin to accept the chain
         self.nodes[0].generate(1)
         time.sleep(2) #give blocks a chance to fully propagate
         sync_blocks(self.nodes[0:2])
         counts = [ x.getblockcount() for x in self.nodes ]
-        assert_equal(counts, [351,351,350,350])  
+        assert_equal(counts, [209,209,204,204])
 
-        for i in range(0,20):
-          self.nodes[0].sendtoaddress(addr, 1.0)
         self.nodes[0].generate(1)
         time.sleep(2) #give blocks a chance to fully propagate
         sync_blocks(self.nodes[0:3])
         counts = [ x.getblockcount() for x in self.nodes ]
-        assert_equal(counts, [352,352,352,351])  
+        assert_equal(counts, [210,210,210,204])
 
+        # Another EB. Node 3 is still on block 204.
         for i in range(0,20):
           self.nodes[0].sendtoaddress(addr, 1.0)
         self.nodes[0].generate(1)
-        self.sync_all()
+        time.sleep(2) #give blocks a chance to fully propagate
         counts = [ x.getblockcount() for x in self.nodes ]
-        assert_equal(counts, [353,353,353,353])  
+        assert_equal(counts, [211,210,210,204])
 
-        for i in range(0,20):
-          self.nodes[0].sendtoaddress(addr, 1.0)
-        self.nodes[0].generate(1)
-        self.sync_all()
-        counts = [ x.getblockcount() for x in self.nodes ]
-        assert_equal(counts, [354,354,354,354])  
-
-        self.nodes[0].generate(6*24 + 10)  # Now generate a day's worth of small blocks which should re-enable the node's reluctance to accept a large block + 10 because we have to get beyond all the node's accept depths
+        self.nodes[0].generate(4)  # Reset AD windows
         self.sync_all()
 
-        counts = [ x.getblockcount() for x in self.nodes ]
         self.nodes[1].setminingmaxblock(100000)  # not sure how big the txns will be but smaller than this 
         self.nodes[1].setexcessiveblock(100000, 1)  # not sure how big the txns will be but smaller than this 
         for i in range(0,40):
@@ -126,13 +116,14 @@ class ExcessiveBlockTest (BitcoinTestFramework):
         time.sleep(2) #give blocks a chance to fully propagate
         sync_blocks(self.nodes[0:2])
         counts = [ x.getblockcount() for x in self.nodes ]
-        assert_equal(counts, [509,509,508,508])  
-      
+        assert_equal(counts, [216,216,215,215])
 
         print "Random test"
         random.seed(1)
         for i in range(0,2):
           print "round ", i,
+          self.nodes[0].generate(11)  # Reset AD windows
+          self.sync_all()
           for n in self.nodes:
             size = random.randint(1,1000)*1000
             n.setminingmaxblock(size)

--- a/src/chain.h
+++ b/src/chain.h
@@ -87,12 +87,15 @@ enum BlockStatus {
     BLOCK_HAVE_DATA          =    8, //! full block available in blk*.dat
     BLOCK_HAVE_UNDO          =   16, //! undo data available in rev*.dat
     BLOCK_HAVE_MASK          =   BLOCK_HAVE_DATA | BLOCK_HAVE_UNDO,
- 
-    BLOCK_EXCESSIVE          =   32, // BU: This block is bigger than what we really want to accept.
 
     BLOCK_FAILED_VALID       =   64, //! stage after last reached validness failed
     BLOCK_FAILED_CHILD       =   128, //! descends from failed block
     BLOCK_FAILED_MASK        =   BLOCK_FAILED_VALID | BLOCK_FAILED_CHILD,
+};
+
+enum ExcessiveStatus {
+    BLOCK_EXCESSIVE          =   1, // BU: This block is bigger than what we really want to accept.
+    BLOCK_EXCESSIVE_CHILD    =   2, // BU: This block has been unlinked as the child of an excessive block
 };
 
 /** The block chain is a tree shaped structure starting with the
@@ -139,6 +142,9 @@ public:
     //! Verification status of this block. See enum BlockStatus
     unsigned int nStatus;
 
+    //! (memory only) Excessive status of this block. See enum ExcessiveStatus
+    unsigned int nExcessiveStatus;
+
     //! block header
     int nVersion;
     uint256 hashMerkleRoot;
@@ -162,6 +168,7 @@ public:
         nTx = 0;
         nChainTx = 0;
         nStatus = 0;
+        nExcessiveStatus = 0;
         nSequenceId = 0;
 
         nVersion       = 0;

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -653,44 +653,21 @@ std::string LicenseInfo()
            "\n";
 }
 
-
-int chainContainsExcessive(const CBlockIndex* blk, unsigned int goBack)
+bool isChainExcessive(const CBlockIndex* blk, unsigned int goBack)
 {
-    if (goBack == 0)
-        goBack = excessiveAcceptDepth+EXCESSIVE_BLOCK_CHAIN_RESET;
-    for (unsigned int i = 0; i < goBack; i++, blk = blk->pprev) 
-    {
-        if (!blk)
-	  break; // we hit the beginning
-        if (blk->nStatus & BLOCK_EXCESSIVE)
-	  return true;
-    }
-    return false;
-}
+    // Headers don't count towards acceptDepth
+    while (blk && !(blk->nStatus & BLOCK_VALID_TRANSACTIONS))
+        blk = blk->pprev;
 
-int isChainExcessive(const CBlockIndex* blk, unsigned int goBack)
-{
     if (goBack == 0)
         goBack = excessiveAcceptDepth;
-    bool recentExcessive = false;
-    bool oldExcessive = false;
     for (unsigned int i = 0; i < goBack; i++, blk = blk->pprev) {
         if (!blk)
-	  break; // we hit the beginning
-        if (blk->nStatus & BLOCK_EXCESSIVE)
-	  recentExcessive = true;
+            return false; // Not excessive if we hit the beginning
+        if (blk->nExcessiveStatus & BLOCK_EXCESSIVE)
+            return true;
     }
- 
-    // Once an excessive block is built upon the chain is not excessive even if more large blocks appear.
-    // So look back to make sure that this is the "first" excessive block for a while
-    for (unsigned int i = 0; i < EXCESSIVE_BLOCK_CHAIN_RESET; i++, blk = blk->pprev) {
-        if (!blk)
-	  break; // we hit the beginning
-        if (blk->nStatus & BLOCK_EXCESSIVE)
-	  oldExcessive = true;
-    }
-
-    return (recentExcessive && !oldExcessive);
+    return false;
 }
 
 bool CheckExcessive(const CBlock& block, uint64_t blockSize, uint64_t nSigOps, uint64_t nTx)

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -22,8 +22,7 @@ enum {
     DEFAULT_EXCESSIVE_ACCEPT_DEPTH = 4,
     DEFAULT_EXCESSIVE_BLOCK_SIZE = 16000000,
     DEFAULT_MAX_MESSAGE_SIZE_MULTIPLIER = 10,
-    MAX_COINBASE_SCRIPTSIG_SIZE = 100,
-    EXCESSIVE_BLOCK_CHAIN_RESET = 6*24,  // After 1 day of non-excessive blocks, reset the checker
+    MAX_COINBASE_SCRIPTSIG_SIZE = 100
 };
 
 class CBlock;
@@ -92,11 +91,8 @@ extern bool TestConservativeBlockValidity(CValidationState& state, const CChainP
 // Check whether this block is bigger in some metric than we really want to accept
 extern bool CheckExcessive(const CBlock& block, uint64_t blockSize, uint64_t nSigOps, uint64_t nTx);
 
-// Check whether this chain qualifies as excessive.
-extern int isChainExcessive(const CBlockIndex* blk, unsigned int checkDepth = excessiveAcceptDepth);
-
 // Check whether any block N back in this chain is an excessive block
-extern int chainContainsExcessive(const CBlockIndex* blk, unsigned int goBack=0);
+extern bool isChainExcessive(const CBlockIndex* blk, unsigned int checkDepth = excessiveAcceptDepth);
 
 // RPC calls
 


### PR DESCRIPTION
Commit 48b712e created a "sticky gate" which, when triggered by an AD event, allows any size block for about one full day. The gate is open while an excessive block as recent as AD + 144 blocks is in the active chain.

This behavior can adversely affect consensus and convergence, and should be reverted until it can be weighed more carefully.  It should be reverted, rather than merely disabled, because not just the numerical values but the behavior itself needs to be debated.

Risk is introduced by the combination of published AD values and the daylong period devoid of blocksize checks, which present attacker a way to disrupt the BU chain.  His challenge is to create an excessive block, followed by AD confirming blocks, before honest BU nodes can create a chain of length AD+1.

If an attacker can succeed in this, he has 144 blocks which are permitted to be any size at all. He then submits as many enormous blocks as possible, to make them a permanent part of the BU chain, straining all BU users, possibly fragmenting the chain and/or pushing some users off the network.

Attacker's likelihood of success during a single attempt to open the sticky gate depends on the hashrate fraction q (of total BU hashrate) that he dedicates to this purpose. The probability of success for AD=5 is as follows (review of this is very welcome):
```
AD=5
q       P[success]
0.05	0.00000580135
0.10	0.000295706
0.15	0.00265686
0.20	0.0116542
0.25	0.0343275
0.30	0.0782248
0.35	0.148684
0.40	0.246502
0.45	0.366877
0.50	0.5
0.55	0.633123
0.60	0.753498
```
Attacker is free to make another attempt, as soon as one attempt fails. 


Two failed assertions in CheckBlockIndex were masked by the sticky gate.  To satisfy the setBlockIndexCandidates assertion, headers without data must not count toward satisfaction of AD, since CheckBlockIndex is called before data arrrives.  The fix is in isChainExcessive. To satisfy the mapBlocksUnlinked assertion, an additional status value BLOCK_EXCESSIVE_CHILD is added to children of an excessive block that are added to the map when a candidate is disqualified. The status is cleared when the blocks are moved out of mapBlocksUnlinked.