### PR TITLE
Don't allow undefined setminingmaxblock parameter

### DIFF
--- a/qa/rpc-tests/excessive.py
+++ b/qa/rpc-tests/excessive.py
@@ -32,9 +32,9 @@ class ExcessiveBlockTest (BitcoinTestFramework):
 	  self.sync_all()
         
  	# Set the accept depth at 1, 2, and 3 and watch each nodes resist the chain for that long
-        self.nodes[1].setminingmaxblock(1000, 1)
-        self.nodes[2].setminingmaxblock(1000, 2)
-        self.nodes[3].setminingmaxblock(1000, 3)
+        self.nodes[1].setminingmaxblock(1000)
+        self.nodes[2].setminingmaxblock(1000)
+        self.nodes[3].setminingmaxblock(1000)
 
         self.nodes[1].setexcessiveblock(1000, 1)
         self.nodes[2].setexcessiveblock(1000, 2)

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -812,7 +812,7 @@ UniValue getminingmaxblock(const UniValue& params, bool fHelp)
 
 UniValue setminingmaxblock(const UniValue& params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
+    if (fHelp || params.size() != 1)
         throw runtime_error(
             "setminingmaxblock blocksize\n"
             "\nSet the maximum number of bytes to include in a generated (mined) block.  This command does not turn generation on/off.\n"


### PR DESCRIPTION
The setminingmaxblock API requires exactly 1 parameter. Don't allow an extra one.