### PR TITLE
Do not queue jump GET_XTHIN in test environments

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -740,7 +740,10 @@ bool CNode::ReceiveMsgBytes(const char* pch, unsigned int nBytes)
                 nActivityBytes += msg.hdr.nMessageSize;
 
                 // BU: furthermore, if the message is a priority message then move from the back to the front of the deque
-                if (strCommand == NetMsgType::GET_XTHIN || 
+                // NOTE: for GET_XTHIN we don't jump the queue on test environments because the GET_XTHIN can get ahead of 
+                // a previous GET_XTHIN/HEADER requests and result in a DOS if the block returns out of order and with no headers
+                // in the block index or the setblockindexcandidates.
+                if ((strCommand == NetMsgType::GET_XTHIN && Params().NetworkIDString() == "main") || 
                     strCommand == NetMsgType::XTHINBLOCK || 
                     strCommand == NetMsgType::THINBLOCK || 
                     strCommand == NetMsgType::XBLOCKTX || 


### PR DESCRIPTION
When mining large numbers of blocks and then syncing them to many
nodes it sometimes happens that a GET_XTHIN request can jump
ahead of another GET_XTHIN request or HEADER request resulting in blocks
showing up out of order and with no headers connected in the block index.
This results in a small DOS(10) and a subsequent node disconnect if this
happens 10 times during a regression test run.