### PR TITLE
add --randomseed option to Python test framework

### DIFF
--- a/qa/rpc-tests/excessive.py
+++ b/qa/rpc-tests/excessive.py
@@ -130,7 +130,8 @@ class ExcessiveBlockTest (BitcoinTestFramework):
       
 
         print "Random test"
-        random.seed(1)
+        # random seed is initialized by test framework, we print it for reference
+        print "Seed: %s" % self.randomseed
         for i in range(0,2):
           print "round ", i,
           for n in self.nodes:

--- a/qa/rpc-tests/excessive.py
+++ b/qa/rpc-tests/excessive.py
@@ -130,8 +130,7 @@ class ExcessiveBlockTest (BitcoinTestFramework):
       
 
         print "Random test"
-        # random seed is initialized by test framework, we print it for reference
-        print "Seed: %s" % self.randomseed
+        # random seed is initialized and printed by test framework
         for i in range(0,2):
           print "round ", i,
           for n in self.nodes:

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -125,6 +125,7 @@ class BitcoinTestFramework(object):
         else:
             self.randomseed = int(time.time())
         random.seed(self.randomseed)
+        print "Random seed: %s" % self.randomseed
 
         if self.options.trace_rpc:
             import logging

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -9,6 +9,8 @@
 # Add python-bitcoinrpc to module search path:
 import os
 import sys
+import time       # BU added
+import random     # BU added
 
 import shutil
 import tempfile
@@ -111,8 +113,18 @@ class BitcoinTestFramework(object):
                           help="Print out all RPC calls as they are made")
         parser.add_option("--coveragedir", dest="coveragedir",
                           help="Write tested RPC commands into this directory")
+        # BU: added for tests using randomness (e.g. excessive.py)
+        parser.add_option("--randomseed", dest="randomseed",
+                          help="Set RNG seed for tests that use randomness (ignored otherwise)")
         self.add_options(parser)
         (self.options, self.args) = parser.parse_args()
+
+        # BU: initialize RNG seed based on time if no seed specified
+        if self.options.randomseed:
+            self.randomseed = int(self.options.randomseed)
+        else:
+            self.randomseed = int(time.time())
+        random.seed(self.randomseed)
 
         if self.options.trace_rpc:
             import logging


### PR DESCRIPTION
This is added to avoid duplication of random seeding in tests that want to make use of randomness.
The test framework now initializes the RNG based on current time in seconds since the epoch unless --randomseed=X is specified.
If X is specified it is converted to an integer.

The seed used is made accessible through the attribute `self.randomseed` in BitcoinTestFramework.

Tests which use random numbers should print out their seed before doing so.
In this way, if they crash due to random-generated data this increases the chances that it will be possible to reproduce the fault, e.g. like this:
(assuming the `excessive` test crashed with a seed of 12345)

`qa/pull-tester/rpc-tests.py --randomseed=12345 excessive`

The `excessive.py` test has been adapted to print out its seed, which is no longer a fixed number.