### PR TITLE
Usability enhancements for rpc-tests.py: listing, better option handling, summary of test results

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -11,11 +11,17 @@ This module calls down into individual test cases via subprocess. It will
 forward all unrecognized arguments onto the individual test scripts, other
 than:
 
+    - `-h` or '--help': print help about all options
     - `-extended`: run the "extended" test suite in addition to the basic one.
+    - `-extended-only`: run ONLY the "extended" test suite
+    - `-list`: only list the test scripts, do not run. Works in combination
+      with '-extended' and '-extended-only' too, to print subsets.
     - `-win`: signal that this is running in a Windows environment, and we
       should run the tests.
     - `--coverage`: this generates a basic coverage report for the RPC
       interface.
+
+For more detailed help on options, run with '--help'.
 
 For a description of arguments recognized by test scripts, see
 `qa/pull-tester/test_framework/test_framework.py:BitcoinTestFramework.main`.
@@ -47,8 +53,39 @@ ENABLE_COVERAGE=0
 
 #Create a set to store arguments and create the passOn string
 opts = set()
+double_opts = set()  # BU: added for checking validity of -- opts
 passOn = ""
 p = re.compile("^--")
+# some of the single-dash options applicable only to this runner script
+# are also allowed in double-dash format (but are not passed on to the
+# test scripts themselves)
+private_single_opts = ('-h',
+                       '-help',
+                       '-list',
+                       '-extended',
+                       '-extended-only',
+                       '-only-extended',
+                       '-win')
+private_double_opts = ('--list',
+                       '--extended',
+                       '--extended-only',
+                       '--only-extended',
+                       '--win')
+test_script_opts = ('--tracerpc',
+                    '--help',
+                    '--noshutdown',
+                    '--nocleanup',
+                    '--srcdir',
+                    '--tmpdir',
+                    '--coveragedir',
+                    '--randomseed',
+                    '--testbinary',
+                    '--refbinary')
+
+def option_passed(option_without_dashes):
+    """check if option was specified in single-dash or double-dash format"""
+    return ('-' + option_without_dashes in opts
+            or '--' + option_without_dashes in double_opts)
 
 bold = ("","")
 if (os.name == 'posix'):
@@ -57,10 +94,34 @@ if (os.name == 'posix'):
 for arg in sys.argv[1:]:
     if arg == '--coverage':
         ENABLE_COVERAGE = 1
-    elif (p.match(arg) or arg == "-h"):
-        passOn += " " + arg
+    elif (p.match(arg) or arg in ('-h', '-help')):
+        if arg not in private_double_opts:
+            if arg == '-help' or arg == '-h':
+                pass_arg = '--help'
+            else:
+                pass_arg = arg
+            passOn += " " + pass_arg
+        # add it to double_opts only for validation
+        double_opts.add(arg)
     else:
+        # this is for single-dash options only
+        # they are interpreted only by this script
         opts.add(arg)
+
+# check for unrecognized options
+bad_opts_found = []
+bad_opt_str="Unrecognized option: %s"
+for o in opts | double_opts:
+    if o.startswith('--'):
+        if o not in test_script_opts + private_double_opts:
+            print bad_opt_str % o
+            bad_opts_found.append(o)
+    elif o.startswith('-'):
+        if o not in private_single_opts:
+            print bad_opt_str % o
+            bad_opts_found.append(o)
+            print "Run with -h to get help on usage."
+            sys.exit(1)
 
 #Set env vars
 buildDir = BUILDDIR
@@ -70,7 +131,7 @@ if "BITCOINCLI" not in os.environ:
     os.environ["BITCOINCLI"] = buildDir + '/src/bitcoin-cli' + EXEEXT
 
 #Disable Windows tests by default
-if EXEEXT == ".exe" and "-win" not in opts:
+if EXEEXT == ".exe" and not option_passed('win'):
     print "Win tests currently disabled.  Use -win option to enable"
     sys.exit(0)
 
@@ -142,12 +203,40 @@ if ENABLE_ZMQ == 1:
     testScripts.append(RpcTest('zmq_test'))
 
 
-
+def show_wrapper_options():
+    """ print command line options specific to wrapper """
+    print "Wrapper options:"
+    print
+    print "  -extended/--extended  run the extended set of tests"
+    print "  -only-extended / -extended-only\n" + \
+          "  --only-extended / --extended-only\n" + \
+          "                        run ONLY the extended tests"
+    print "  -list / --list        only list test names"
+    print "  -win / --win          signal running on Windows and run those tests"
+    print "  -h / -help / --help   print this help"
 
 def runtests():
+    global passOn
     coverage = None
+    execution_time = {}
+    test_passed = {}
+    test_failure_info = {}
+    disabled = 0
+    skipped = 0
 
-    run_only_extended = '-only-extended' in opts
+    run_only_extended = option_passed('only-extended') or option_passed('extended-only')
+
+    if option_passed('list'):
+        if run_only_extended:
+            for t in testScriptsExt:
+                print t
+        else:
+            for t in testScripts:
+                print t
+            if option_passed('extended'):
+                for t in testScriptsExt:
+                    print t
+        sys.exit(0)
 
     if ENABLE_COVERAGE:
         coverage = RPCCoverage()
@@ -155,62 +244,110 @@ def runtests():
 
     if(ENABLE_WALLET == 1 and ENABLE_UTILS == 1 and ENABLE_BITCOIND == 1):
         rpcTestDir = buildDir + '/qa/rpc-tests/'
-        run_extended = ('-extended' in opts) or run_only_extended
+        run_extended = option_passed('extended') or run_only_extended
         cov_flag = coverage.flag if coverage else ''
         flags = " --srcdir %s/src %s %s" % (buildDir, cov_flag, passOn)
 
         #Run Tests
+        p = re.compile(" -h| --help| -help")
         for i in range(len(testScripts)):
+            scriptname=re.sub(".py$", "", str(testScripts[i]).split(' ')[0])
+            fullscriptcmd=str(testScripts[i])
             if ((len(opts) == 0
-                    or (len(opts) == 1 and "-win" in opts )
-                    or run_extended
-                    or str(testScripts[i]) in opts
-                    or re.sub(".py$", "", str(testScripts[i])) in opts )
+                    or p.match(passOn)
+                    or option_passed('extended')
+                    or option_passed('win')
+                    or scriptname in opts
+                    or (scriptname + '.py') in opts )
                 and not run_only_extended):
 
                 if testScripts[i].is_disabled():
                     print("Disabled testscript %s%s%s (reason: %s)" % (bold[1], testScripts[i], bold[0], testScripts[i].reason))
+                    disabled += 1
                 elif testScripts[i].is_skipped():
                     print("Skipping testscript %s%s%s on this platform (reason: %s)" % (bold[1], testScripts[i], bold[0], testScripts[i].reason))
+                    skipped += 1
                 else:
-                    # not disabled or skipped - execute test
+                    # not disabled or skipped - execute test (or print help if requested)
+
+                    # print the wrapper-specific help options
+                    if p.match(passOn):
+                        show_wrapper_options()
+
+                    if bad_opts_found:
+                        if not ' --help' in passOn:
+                            passOn += ' --help'
 
                     print("Running testscript %s%s%s ..." % (bold[1], testScripts[i], bold[0]))
                     time0 = time.time()
-                    subprocess.check_call(
-                        rpcTestDir + repr(testScripts[i]) + flags, shell=True)
-                    print("Duration: %s s\n" % (int(time.time() - time0)))
+                    test_passed[fullscriptcmd] = False
+                    try:
+                        subprocess.check_call(
+                            rpcTestDir + repr(testScripts[i]) + flags, shell=True)
+                        test_passed[fullscriptcmd] = True
+                    except subprocess.CalledProcessError as e:
+                        test_failure_info[fullscriptcmd] = e
+                        #print "CalledProcessError for test %s: %s" % (scriptname, e)
 
-                    # exit if help is called so we print just one set of
-                    # instructions
-                    p = re.compile(" -h| --help")
+                    # exit if help was called
                     if p.match(passOn):
                         sys.exit(0)
+                    else:
+                        execution_time[fullscriptcmd] = int(time.time() - time0)
+                        print "Duration: %s s\n" % execution_time[fullscriptcmd]
 
         # Run Extended Tests
         for i in range(len(testScriptsExt)):
+            scriptname = re.sub(".py$", "", str(testScriptsExt[i]).split(' ')[0])
+            fullscriptcmd=str(testScriptsExt[i])
             if (run_extended or str(testScriptsExt[i]) in opts
                     or re.sub(".py$", "", str(testScriptsExt[i])) in opts):
 
                 if testScriptsExt[i].is_disabled():
                     print("Disabled testscript %s%s%s (reason: %s)" % (bold[1], testScriptsExt[i], bold[0], testScriptsExt[i].reason))
+                    disabled += 1
                 elif testScripts[i].is_skipped():
                     print("Skipping testscript %s%s%s on this platform (reason: %s)" % (bold[1], testScriptsExt[i], bold[0], testScriptsExt[i].reason))
-                else:
-                    # not disabled or skipped - execute test
+                    skipped += 1
+                elif fullscriptcmd not in execution_time.keys():
+                    # not disabled, skipped or already executed - run test
                     print(
                         "Running 2nd level testscript "
                         + "%s%s%s ..." % (bold[1], testScriptsExt[i], bold[0]))
                     time0 = time.time()
-                    subprocess.check_call(
-                        rpcTestDir + str(testScriptsExt[i]) + flags, shell=True)
-                    print("Duration: %s s\n" % (int(time.time() - time0)))
+                    test_passed[fullscriptcmd] = False
+                    try:
+                        subprocess.check_call(
+                            rpcTestDir + repr(testScriptsExt[i]) + flags, shell=True)
+                        test_passed[fullscriptcmd] = True
+                    except subprocess.CalledProcessError as e:
+                        test_failure_info[fullscriptcmd] = e
+                        #print "CalledProcessError for test %s: %s" % (scriptname, e)
+                    execution_time[fullscriptcmd] = int(time.time() - time0)
+                    print "Duration: %s s\n" % execution_time[fullscriptcmd]
+                else:
+                    print "Skipping extended test name %s - already executed in regular\n" % scriptname
 
         if coverage:
             coverage.report_rpc_coverage()
 
             print("Cleaning up coverage data")
             coverage.cleanup()
+
+        # show some overall results and aggregates
+        print
+        print "%-50s  Status    Time (s)" % "Test"
+        print '-' * 70
+        for k in sorted(execution_time.keys()):
+            print "%-50s  %-6s    %7s" % (k, "PASS" if test_passed[k] else "FAILED", execution_time[k])
+        print '-' * 70
+        print "%-44s  Total time (s): %7s" % (" ", sum(execution_time.values()))
+
+        print
+        print "%d test(s) passed / %d test(s) failed / %d test(s) executed" % (test_passed.values().count(True),
+                                                                   test_passed.values().count(False),
+                                                                   len(test_passed))
+        print "%d test(s) disabled / %d test(s) skipped due to platform" % (disabled, skipped)
 
     else:
         print "No rpc tests to run. Wallet, utils, and bitcoind must all be enabled"

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -78,6 +78,7 @@ test_script_opts = ('--tracerpc',
                     '--srcdir',
                     '--tmpdir',
                     '--coveragedir',
+                    '--mineblock',
                     '--randomseed',
                     '--testbinary',
                     '--refbinary')
@@ -221,8 +222,8 @@ def runtests():
     execution_time = {}
     test_passed = {}
     test_failure_info = {}
-    disabled = 0
-    skipped = 0
+    disabled = []
+    skipped = []
 
     run_only_extended = option_passed('only-extended') or option_passed('extended-only')
 
@@ -263,10 +264,10 @@ def runtests():
 
                 if testScripts[i].is_disabled():
                     print("Disabled testscript %s%s%s (reason: %s)" % (bold[1], testScripts[i], bold[0], testScripts[i].reason))
-                    disabled += 1
+                    disabled.append(str(testScripts[i]))
                 elif testScripts[i].is_skipped():
                     print("Skipping testscript %s%s%s on this platform (reason: %s)" % (bold[1], testScripts[i], bold[0], testScripts[i].reason))
-                    skipped += 1
+                    skipped.append(str(testScripts[i]))
                 else:
                     # not disabled or skipped - execute test (or print help if requested)
 
@@ -305,10 +306,10 @@ def runtests():
 
                 if testScriptsExt[i].is_disabled():
                     print("Disabled testscript %s%s%s (reason: %s)" % (bold[1], testScriptsExt[i], bold[0], testScriptsExt[i].reason))
-                    disabled += 1
+                    disabled.append(str(testScriptsExt[i]))
                 elif testScripts[i].is_skipped():
                     print("Skipping testscript %s%s%s on this platform (reason: %s)" % (bold[1], testScriptsExt[i], bold[0], testScriptsExt[i].reason))
-                    skipped += 1
+                    skipped.append(str(testScriptsExt[i]))
                 elif fullscriptcmd not in execution_time.keys():
                     # not disabled, skipped or already executed - run test
                     print(
@@ -340,6 +341,10 @@ def runtests():
         print '-' * 70
         for k in sorted(execution_time.keys()):
             print "%-50s  %-6s    %7s" % (k, "PASS" if test_passed[k] else "FAILED", execution_time[k])
+        for d in disabled:
+            print "%-50s  %-8s" % (d, "DISABLED")
+        for s in skipped:
+            print "%-50s  %-8s" % (s, "SKIPPED")
         print '-' * 70
         print "%-44s  Total time (s): %7s" % (" ", sum(execution_time.values()))
 
@@ -347,7 +352,7 @@ def runtests():
         print "%d test(s) passed / %d test(s) failed / %d test(s) executed" % (test_passed.values().count(True),
                                                                    test_passed.values().count(False),
                                                                    len(test_passed))
-        print "%d test(s) disabled / %d test(s) skipped due to platform" % (disabled, skipped)
+        print "%d test(s) disabled / %d test(s) skipped due to platform" % (len(disabled), len(skipped))
 
     else:
         print "No rpc tests to run. Wallet, utils, and bitcoind must all be enabled"

--- a/qa/pull-tester/test_classes.py
+++ b/qa/pull-tester/test_classes.py
@@ -26,6 +26,9 @@ True
 >>> unskipped_test=Skip("baz", "NoSuchPlatform", "baz is not skipped since there is no such platform")
 >>> unskipped_test.is_skipped()
 False
+>>> testwithargs=RpcTest("name --somearg --anotherarg")
+>>> repr(testwithargs)
+'name.py --somearg --anotherarg'
 """
 
 import platform


### PR DESCRIPTION
This is a cross-port of some rpctests.py test runner enhancements made in the BTCfork project [1].

Overview of changes:

- added a new `-list` option which, when given, only lists tests without executing them. This is useful for filtering a subset of tests without having to dissect the contents of the Python script. The `-list` option can be combined with `-extended` or `-extended-only` to list all tests or just the extended set of tests.
- command line option handling has been made a little more user-friendly by accepting double-hyphen forms as well for the single-hyphen options. Options like `-only-extended` have been given counterparts e.g. `-extended-only` to minimize friction.
- a warning message is printed for unrecognized options
- at the end of the test run, an overview table is printed, similar to what latest versions of the Core client software do. The overview shows executed tests along with their status and time taken, and also prints out aggregate information about the number of passed / failed / disabled / skipped tests. This is intended to facilitate a better overview and "feel" for how tests are affected during development, both in terms of performance and failures.

### Example usages:

Running all tests which have 'bip' in their names:

`qa/pull-tester/rpc-tests.py $(qa/pull-tester/rpc-tests.py -list -extended | grep bip)`

Summary output from the above command:

```
... (output of successful and failed tests skipped)
Disabled testscript bip68-sequence.py (reason: TODO)
... (output of successful and failed tests skipped)

Test                                                Status    Time (s)
----------------------------------------------------------------------
bip65-cltv-p2p.py                                   FAILED         29
bip65-cltv.py                                       PASS           38
bip68-112-113-p2p.py                                PASS          146
bip9-softforks.py                                   FAILED         24
bipdersig-p2p.py                                    FAILED         22
bipdersig.py                                        PASS           38
bip68-sequence.py                                   DISABLED
----------------------------------------------------------------------
                                              Total time (s):     297

3 test(s) passed / 3 test(s) failed / 6 test(s) executed
1 test(s) disabled / 0 test(s) skipped due to platform
```

[1] https://github.com/BTCfork/hardfork_prototype_1_mvf-core/commits/master/qa/pull-tester/rpc-tests.py