### PR TITLE
remove MainCleanup and NetCleanup from getting called twice

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -684,9 +684,6 @@ int main(int argc, char *argv[])
         app.handleRunawayException(QString::fromStdString(strMiscWarning));
     }
 
-    NetCleanup();
-    MainCleanup();
-
     return app.getReturnValue();
 }
 #endif // BITCOIN_QT_TEST


### PR DESCRIPTION
On Windows10 this is a problem.  It appears that Netcleanup
and Maincleanup get called on nodeshutdown but also when Qt
exits.  The nodeshutdown completes but then QT wants to finish
and makes the second calls which can't be competed because the node
is already shutdown. Now the process hangs and leaves a partial process
in the tasklist but it isn't obvious to the user because they
can re-start bitcoin-qt without any issues. They will only notice
it if you try to delete the debug.log or look at your tasklist.