### PR TITLE
Do not check scripts unless blocks are less than 30 days old

### DIFF
--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -56,6 +56,10 @@ static const unsigned int MAX_BLOCK_SIZE_MULTIPLIER = 3;
 static const unsigned int DEFAULT_MIN_LIMITFREERELAY = 1;
 // BU - Xtreme Thinblocks Auto Mempool Limiter - end section
 
+// The number of days in the past we check scripts during initial block download
+static const uint8_t DEFAULT_CHECKPOINT_DAYS = 30;
+
+
 // print out a configuration warning during initialization
 // bool InitWarning(const std::string &str);
 


### PR DESCRIPTION
Thanks to Tom Zander and Tom Harding.  This PR is based on their
commits for their respective projcts.

This PR will end the need for the constant updating each release for new checkpoint data.

We still allow one to force the checking of scripts by the use
of fCheckpointsEnabled however in general we only will check the
signatures for the last 30 days of blocks. All other block checks
are still performed for all blocks.