### PR TITLE
Use a hardcoded seed value for the bloom filter

### DIFF
--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -911,10 +911,10 @@ void SendXThinBlock(CBlock &block, CNode* pfrom, const CInv &inv)
     pfrom->blocksSent += 1;
 }
 
-void BuildSeededBloomFilter(CBloomFilter& filterMemPool, vector<uint256>& vOrphanHashes, uint256 hash)
+void BuildSeededBloomFilter(CBloomFilter& filterMemPool, vector<uint256>& vOrphanHashes, uint256 hash, bool fDeterministic)
 {
     int64_t nStartTimer = GetTimeMillis();
-    seed_insecure_rand();
+    seed_insecure_rand(fDeterministic);
     set<uint256> setHighScoreMemPoolHashes;
     set<uint256> setPriorityMemPoolHashes;
 

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -162,7 +162,7 @@ bool CanThinBlockBeDownloaded(CNode* pto);
 void ConnectToThinBlockNodes();
 void CheckNodeSupportForThinBlocks();
 void SendXThinBlock(CBlock &block, CNode* pfrom, const CInv &inv);
-void BuildSeededBloomFilter(CBloomFilter& memPoolFilter, std::vector<uint256>& vOrphanHashes, uint256 hash);
+void BuildSeededBloomFilter(CBloomFilter& memPoolFilter, std::vector<uint256>& vOrphanHashes, uint256 hash, bool fDeterministic = false);
 
 // Xpress Validation: begin
 // Transactions that have already been accepted into the memory pool do not need to be


### PR DESCRIPTION
When running thinblock_tests.cpp there is occassionally a failure
due to getting a false positive in the bloom filter. Using a hard
coded seed will alwasy give us the same result for the test and
prevent the failures.