### PR TITLE
Remove references to LONG_LONG_MAX

### DIFF
--- a/src/leakybucket.h
+++ b/src/leakybucket.h
@@ -12,13 +12,13 @@
 #include <boost/chrono/chrono.hpp>
 
 /** Default value for the maximum amount of data that can be received in a burst */
-static const int64_t DEFAULT_MAX_RECV_BURST = LONG_LONG_MAX;
+static const int64_t DEFAULT_MAX_RECV_BURST = std::numeric_limits<long long>::max();
 /** Default value for the maximum amount of data that can be sent in a burst */
-static const int64_t DEFAULT_MAX_SEND_BURST = LONG_LONG_MAX;
+static const int64_t DEFAULT_MAX_SEND_BURST = std::numeric_limits<long long>::max();
 /** Default value for the average amount of data received per second */
-static const int64_t DEFAULT_AVE_RECV = LONG_LONG_MAX;
+static const int64_t DEFAULT_AVE_RECV = std::numeric_limits<long long>::max();
 /** Default value for the average amount of data sent per second */
-static const int64_t DEFAULT_AVE_SEND = LONG_LONG_MAX;
+static const int64_t DEFAULT_AVE_SEND = std::numeric_limits<long long>::max();
 /** If we have to break the transmission up into chunks, this is the minimum send chunk size */
 static const int64_t SEND_SHAPER_MIN_FRAG = 256;
 /** If we have to break the transmission up into chunks, this is the minimum receive chunk size */
@@ -52,7 +52,7 @@ protected:
     }
 
 public:
-    CLeakyBucket(int64_t maxp, int64_t fillp, int64_t startLevel = LONG_LONG_MAX) : max(maxp), fill(fillp)
+    CLeakyBucket(int64_t maxp, int64_t fillp, int64_t startLevel = std::numeric_limits<long long>::max()) : max(maxp), fill(fillp)
     {
         lastFill = clock.now();
         // set the initial level to either what is specified by the user or to the maximum
@@ -63,8 +63,8 @@ public:
     // use "set" to restart
     void disable(void)
     {
-        fill = LONG_LONG_MAX;
-        max = LONG_LONG_MAX;
+        fill = std::numeric_limits<long long>::max();
+        max = std::numeric_limits<long long>::max();
     }
 
     // Access the values in this bucket
@@ -91,8 +91,8 @@ public:
     // Return the # tokens available if that amount is larger than the cutoff, otherwise return 0
     int64_t available(int64_t cutoff = 0)
     {
-        if (fill == LONG_LONG_MAX)
-            return LONG_LONG_MAX; // shaping is off
+        if (fill == std::numeric_limits<long long>::max())
+            return std::numeric_limits<long long>::max(); // shaping is off
         fillIt();
         return (level > cutoff) ? level : 0;
     }
@@ -100,7 +100,7 @@ public:
     // Try to use amt tokens.  Returns TRUE if the tokens were consumed, false otherwise
     bool try_leak(int64_t amt)
     {
-        if (fill == LONG_LONG_MAX)
+        if (fill == std::numeric_limits<long long>::max())
             return true; // leaky bucket is turned off.
         assert(amt >= 0);
         fillIt();
@@ -114,7 +114,7 @@ public:
     // This function reduces the level in the bucket by amt, even if that makes the level negative, and returns true if the level is >= 0.  This function is useful in a situation like data receipt (with soft limits) where you are not certain how many bytes will be received until after you have received them.
     bool leak(int64_t amt)
     {
-        if (fill == LONG_LONG_MAX)
+        if (fill == std::numeric_limits<long long>::max())
             return true; // leaky bucket is turned off.
         fillIt();
         level -= amt;

--- a/src/qt/unlimiteddialog.cpp
+++ b/src/qt/unlimiteddialog.cpp
@@ -54,7 +54,7 @@ UnlimitedDialog::UnlimitedDialog(QWidget* parent,UnlimitedModel* mdl):
 
     int64_t max, ave;
     sendShaper.get(&max, &ave);
-    int64_t longMax = LONG_LONG_MAX;
+    int64_t longMax = std::numeric_limits<long long>::max();
     bool enabled = (ave != longMax);
     ui.sendShapingEnable->setChecked(enabled);
     ui.sendBurstSlider->setRange(0, 1000); // The slider is just for convenience so setting their ranges to what is commonly chosen
@@ -91,7 +91,7 @@ UnlimitedDialog::UnlimitedDialog(QWidget* parent,UnlimitedModel* mdl):
     }
 
     receiveShaper.get(&max, &ave);
-    enabled = (ave != LONG_LONG_MAX);
+    enabled = (ave != std::numeric_limits<long long>::max());
     ui.recvShapingEnable->setChecked(enabled);
     if (enabled) {
         ui.recvBurstEdit->setText(QString(boost::lexical_cast<std::string>(max / 1024).c_str()));

--- a/src/qt/unlimitedmodel.cpp
+++ b/src/qt/unlimitedmodel.cpp
@@ -70,8 +70,8 @@ void UnlimitedModel::Init()
     int64_t burstKB = settings.value("nReceiveBurst").toLongLong();
     int64_t aveKB = settings.value("nReceiveAve").toLongLong();
 
-    std::string avg = QString::number(inUse ? aveKB : LONG_LONG_MAX).toStdString();
-    std::string burst = QString::number(inUse ? burstKB : LONG_LONG_MAX).toStdString();
+    std::string avg = QString::number(inUse ? aveKB : std::numeric_limits<long long>::max()).toStdString();
+    std::string burst = QString::number(inUse ? burstKB : std::numeric_limits<long long>::max()).toStdString();
 
     if (!SoftSetArg("-receiveavg", avg))
         addOverriddenOption("-receiveavg");
@@ -82,8 +82,8 @@ void UnlimitedModel::Init()
     burstKB = settings.value("nSendBurst").toLongLong();
     aveKB = settings.value("nSendAve").toLongLong();
 
-    avg = boost::lexical_cast<std::string>(inUse ? aveKB : LONG_LONG_MAX);
-    burst = boost::lexical_cast<std::string>(inUse ? burstKB : LONG_LONG_MAX);
+    avg = boost::lexical_cast<std::string>(inUse ? aveKB : std::numeric_limits<long long>::max());
+    burst = boost::lexical_cast<std::string>(inUse ? burstKB : std::numeric_limits<long long>::max());
 
     if (!SoftSetArg("-sendavg", avg))
         addOverriddenOption("-sendavg");

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -581,16 +581,16 @@ void UnlimitedSetup(void)
     //  Init network shapers
     int64_t rb = GetArg("-receiveburst", DEFAULT_MAX_RECV_BURST);
     // parameter is in KBytes/sec, leaky bucket is in bytes/sec.  But if it is "off" then don't multiply
-    if (rb != LONG_LONG_MAX)
+    if (rb != std::numeric_limits<long long>::max())
         rb *= 1024;
     int64_t ra = GetArg("-receiveavg", DEFAULT_MAX_RECV_BURST);
-    if (ra != LONG_LONG_MAX)
+    if (ra != std::numeric_limits<long long>::max())
         ra *= 1024;
     int64_t sb = GetArg("-sendburst", DEFAULT_MAX_RECV_BURST);
-    if (sb != LONG_LONG_MAX)
+    if (sb != std::numeric_limits<long long>::max())
         sb *= 1024;
     int64_t sa = GetArg("-sendavg", DEFAULT_MAX_RECV_BURST);
-    if (sa != LONG_LONG_MAX)
+    if (sa != std::numeric_limits<long long>::max())
         sa *= 1024;
 
     receiveShaper.set(rb, ra);
@@ -937,11 +937,11 @@ bool IsTrafficShapingEnabled()
     int64_t max, avg;
 
     sendShaper.get(&max, &avg);
-    if (avg != LONG_LONG_MAX || max != LONG_LONG_MAX)
+    if (avg != std::numeric_limits<long long>::max() || max != std::numeric_limits<long long>::max())
         return true;
 
     receiveShaper.get(&max, &avg);
-    if (avg != LONG_LONG_MAX || max != LONG_LONG_MAX)
+    if (avg != std::numeric_limits<long long>::max() || max != std::numeric_limits<long long>::max())
         return true;
 
     return false;
@@ -973,12 +973,12 @@ UniValue gettrafficshaping(const UniValue& params, bool fHelp)
     UniValue ret(UniValue::VOBJ);
     int64_t max, avg;
     sendShaper.get(&max, &avg);
-    if (avg != LONG_LONG_MAX || max != LONG_LONG_MAX) {
+    if (avg != std::numeric_limits<long long>::max() || max != std::numeric_limits<long long>::max()) {
         ret.push_back(Pair("sendBurst", max / 1024));
         ret.push_back(Pair("sendAve", avg / 1024));
     }
     receiveShaper.get(&max, &avg);
-    if (avg != LONG_LONG_MAX || max != LONG_LONG_MAX) {
+    if (avg != std::numeric_limits<long long>::max() || max != std::numeric_limits<long long>::max()) {
         ret.push_back(Pair("recvBurst", max / 1024));
         ret.push_back(Pair("recvAve", avg / 1024));
     }


### PR DESCRIPTION
This is extracted from the C++11 failed patch. this part is relatively harmless, so should be merged already.