### PR TITLE
Subject coinbase spends to -limitfreerelay

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1417,7 +1417,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
         LogPrint("mempool",
                  "MempoolBytes:%d  LimitFreeRelay:%.5g  FeeCutOff:%.4g  FeesSatoshiPerByte:%.4g  TxBytes:%d  TxFees:%d\n",
                   poolBytes, nFreeLimit, ((double)::minRelayTxFee.GetFee(nSize)) / nSize, ((double)nFees) / nSize, nSize, nFees);
-        if (fLimitFree && nFees < ::minRelayTxFee.GetFee(nSize) && !fSpendsCoinbase)
+        if (fLimitFree && nFees < ::minRelayTxFee.GetFee(nSize))
         {
             static double dFreeCount;
 


### PR DESCRIPTION
Previously we were forwarding all coinbase spends however this may
not be desireable by some users who want/need to completely prevent all
traffic below a certain fee rate by setting their -limitfreerelay=0.

This came up in issue 125 where one users business model depends on completely
eliminating traffic below a certain fee threshold.