### PR TITLE
do not allow HTTP timeouts to happen in excessive.py

### DIFF
--- a/qa/rpc-tests/excessive.py
+++ b/qa/rpc-tests/excessive.py
@@ -28,7 +28,11 @@ class ExcessiveBlockTest (BitcoinTestFramework):
       BitcoinTestFramework.__init__(self)
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(4, self.options.tmpdir,timewait=60*10)
+        self.nodes = []
+        self.nodes.append(start_node(0,self.options.tmpdir, ["-rpcservertimeout=0"], timewait=60*10))
+        self.nodes.append(start_node(1,self.options.tmpdir, ["-rpcservertimeout=0"], timewait=60*10))
+        self.nodes.append(start_node(2,self.options.tmpdir, ["-rpcservertimeout=0"], timewait=60*10))
+        self.nodes.append(start_node(3,self.options.tmpdir, ["-rpcservertimeout=0"], timewait=60*10))
         interconnect_nodes(self.nodes)
         self.is_network_split=False
         self.sync_all()


### PR DESCRIPTION
We set the http keepalive timeout to zero to prevent a timeout from
happneing while we're waiting for a process to finish and then
we end up trying to request from a connection that no longer exists.
Instead we timout the connections right away so that each time a new
fresh connection is aquired.

This is something that has been coming up lately in very lately in long
running tests.