### PR TITLE
fix a coredump in bitcoin-qt when run with `-chain_nol`

### DIFF
--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -51,5 +51,6 @@ static const int MAX_URI_LENGTH = 255;
 #define QAPP_ORG_DOMAIN "bitcoin.org"
 #define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
 #define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
+#define QAPP_APP_NAME_NOLNET "Bitcoin-Qt-nolimit"   // BU
 
 #endif // BITCOIN_QT_GUICONSTANTS_H

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -18,6 +18,7 @@ static const struct {
 } network_styles[] = {
     {"main", QAPP_APP_NAME_DEFAULT, 0, 0, ""},
     {"test", QAPP_APP_NAME_TESTNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[testnet]")},
+    {"nol", QAPP_APP_NAME_NOLNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[nolimit]")},   // BU
     {"regtest", QAPP_APP_NAME_TESTNET, 160, 30, "[regtest]"}
 };
 static const unsigned network_styles_count = sizeof(network_styles)/sizeof(*network_styles);


### PR DESCRIPTION
A missing netstyle for 'nol' network leads to coredump when starting bitcoin-qt with `-chain_nol` parameter.

Error message without this PR fix:
```
$ src/qt/bitcoin-qt -chain_nol
bitcoin-qt: qt/bitcoin.cpp:624: int main(int, char**): Assertion `!networkStyle.isNull()' failed.
Aborted (core dumped)
```