### PR TITLE
Release Branch - Comptool fix for the requestmanager re-request interval

### DIFF
--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -249,6 +249,7 @@ class TestManager(object):
     # with the expected outcome (if given)
     def check_results(self, blockhash, outcome):
         with mininode_lock:
+
             for c in self.connections:
                 if outcome is None:
                     if c.cb.bestblockhash != self.connections[0].cb.bestblockhash:
@@ -267,10 +268,17 @@ class TestManager(object):
                 elif ((c.cb.bestblockhash == blockhash) != outcome):
                     print("Node ", c.addr, " has best block ", hex(c.cb.bestblockhash), ". Expecting ", hex(blockhash), outcome)
                     print("Quick   RPC returns", c.rpc.getbestblockhash())
-                    time.sleep(5)
+                    time.sleep(5) #wait the requestmanager re-request interval to see if the block shows up
                     print("Delayed RPC returns", c.rpc.getbestblockhash())
+                    rpcblock =  c.rpc.getbestblockhash()
+                    block = hex(blockhash)[2:]
+                    #print(" returns", rpcblock)
+                    #print(" returns", block)
+                    if rpcblock == block:
+                        return True
+                    else:
 		    # pdb.set_trace()
-                    return False
+                        return False
             return True
 
     # Either check that the mempools all agree with each other, or that

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -270,10 +270,12 @@ class TestManager(object):
                     print("Quick   RPC returns", c.rpc.getbestblockhash())
                     time.sleep(5) #wait the requestmanager re-request interval to see if the block shows up
                     print("Delayed RPC returns", c.rpc.getbestblockhash())
+
                     rpcblock =  c.rpc.getbestblockhash()
                     block = hex(blockhash)[2:]
-                    #print(" returns", rpcblock)
-                    #print(" returns", block)
+                    #sometimes a leading zero or two are missing from the blockhash. Replace these.
+                    while (len(block) < 64):
+                        block = '0' + block
                     if rpcblock == block:
                         return True
                     else:


### PR DESCRIPTION
When a block doesn't show up right away the request manager
will wait 5 seconds (on mainnet it is 30 seconds) before
re-requesting a block.  If that should happen during a test
we need to check whether the block was successfully re-requested
and if so mark the test as passed.  Previously we were waiting
for the 5 seconds but then returning with a False if the correct
block showed up when it should be True.