### PR TITLE
Release Branch - Renable bip68-sequence.py

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -203,7 +203,7 @@ testScriptsExt = [ RpcTest(t) for t in [
     'bip9-softforks',
     'bip65-cltv',
     'bip65-cltv-p2p',
-    Disabled('bip68-sequence', "TODO"),
+    'bip68-sequence',
     'bipdersig-p2p',
     'bipdersig',
     'getblocktemplate_longpoll',

--- a/qa/rpc-tests/bip68-sequence.py
+++ b/qa/rpc-tests/bip68-sequence.py
@@ -44,8 +44,9 @@ class BIP68Test(BitcoinTestFramework):
         print("Running test sequence-lock-confirmed-inputs")
         self.test_sequence_lock_confirmed_inputs()
 
-        print("Running test sequence-lock-unconfirmed-inputs")
-        self.test_sequence_lock_unconfirmed_inputs()
+        #BU: this test uses prioritisetransaction which has been disabled in BU
+        #print("Running test sequence-lock-unconfirmed-inputs")
+        #self.test_sequence_lock_unconfirmed_inputs()
 
         print("Running test BIP68 not consensus before versionbits activation")
         self.test_bip68_not_consensus()


### PR DESCRIPTION
Most of this test runs just fine.  There is one test that
is now commented out that requires RBF