### PR TITLE
Use https to download ccache.

### DIFF
--- a/depends/packages/native_ccache.mk
+++ b/depends/packages/native_ccache.mk
@@ -1,6 +1,6 @@
 package=native_ccache
 $(package)_version=3.2.4
-$(package)_download_path=http://samba.org/ftp/ccache
+$(package)_download_path=https://samba.org/ftp/ccache
 $(package)_file_name=ccache-$($(package)_version).tar.bz2
 $(package)_sha256_hash=ffeb967edb549e67da0bd5f44f729a2022de9fdde65dfd80d2a7204d7f75332e
 


### PR DESCRIPTION
samba.org doesn't serve it from http anymore. We need to use https.