### PR TITLE
Update UI banned list

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1728,6 +1728,19 @@ void DumpAddresses()
     LogPrint("net", "Flushed %d addresses to peers.dat  %dms\n", addrman.size(), GetTimeMillis() - nStart);
 }
 
+void DumpBanlist()
+{
+    int64_t nStart = GetTimeMillis();
+
+    CBanDB bandb;
+    banmap_t banmap;
+    CNode::GetBanned(banmap);
+    bandb.Write(banmap);
+
+    LogPrint("net", "Flushed %d banned node ips/subnets to banlist.dat  %dms\n",
+             banmap.size(), GetTimeMillis() - nStart);
+}
+
 void DumpData()
 {
     DumpAddresses();
@@ -2979,21 +2992,6 @@ bool CBanDB::Read(banmap_t& banSet)
     }
     
     return true;
-}
-
-void DumpBanlist()
-{
-    int64_t nStart = GetTimeMillis();
-
-    CNode::SweepBanned(); //clean unused entries (if bantime has expired)
-
-    CBanDB bandb;
-    banmap_t banmap;
-    CNode::GetBanned(banmap);
-    bandb.Write(banmap);
-
-    LogPrint("net", "Flushed %d banned node ips/subnets to banlist.dat  %dms\n",
-             banmap.size(), GetTimeMillis() - nStart);
 }
 
 int64_t PoissonNextSend(int64_t nNow, int average_interval_seconds) {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -508,6 +508,7 @@ void CNode::ClearBanned()
     LOCK(cs_setBanned);
     setBanned.clear();
     setBannedIsDirty = true;
+    uiInterface.BannedListChanged();
 }
 
 bool CNode::IsBanned(CNetAddr ip)
@@ -563,6 +564,7 @@ void CNode::Ban(const CSubNet& subNet, const BanReason &banReason, int64_t banti
         setBanned[subNet] = banEntry;
 
     setBannedIsDirty = true;
+    uiInterface.BannedListChanged();
 }
 
 bool CNode::Unban(const CNetAddr &addr) {
@@ -575,6 +577,9 @@ bool CNode::Unban(const CSubNet &subNet) {
     if (setBanned.erase(subNet))
     {
         setBannedIsDirty = true;
+
+        SweepBanned();
+        uiInterface.BannedListChanged();
         return true;
     }
     return false;
@@ -583,6 +588,7 @@ bool CNode::Unban(const CSubNet &subNet) {
 void CNode::GetBanned(banmap_t &banMap)
 {
     LOCK(cs_setBanned);
+    SweepBanned();
     banMap = setBanned; //create a thread safe copy
 }
 

--- a/src/net.h
+++ b/src/net.h
@@ -844,7 +844,6 @@ public:
     bool Read(banmap_t& banSet);
 };
 
-void DumpBanlist();
 
 /** Return a timestamp in the future (in microseconds) for exponentially distributed events. */
 int64_t PoissonNextSend(int64_t nNow, int average_interval_seconds);

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -142,11 +142,6 @@ void ClientModel::updateTimer1()
 
 void ClientModel::updateTimer2()
 {
-    // Use sweep in instead of dump so that we're not writing to disk every
-    // time the timer is triggered.  If/When the client shuts down the banned
-    // list will get updated.
-    CNode::SweepBanned();
-
     uiInterface.BannedListChanged();
 }
 

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -92,7 +92,8 @@ private:
     PeerTableModel *peerTableModel;
     BanTableModel *banTableModel;
 
-    QTimer *pollTimer;
+    QTimer *pollTimer1;
+    QTimer *pollTimer2;
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
@@ -113,7 +114,8 @@ Q_SIGNALS:
     void showProgress(const QString &title, int nProgress);
 
 public Q_SLOTS:
-    void updateTimer();
+    void updateTimer1();
+    void updateTimer2();
     void updateNumConnections(int numConnections);
     void updateAlert(const QString &hash, int status);
     void updateBanlist();

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -7,7 +7,8 @@
 #define BITCOIN_QT_GUICONSTANTS_H
 
 /* Milliseconds between model updates */
-static const int MODEL_UPDATE_DELAY = 250;
+static const int MODEL_UPDATE_DELAY1 = 250;
+static const int MODEL_UPDATE_DELAY2 = 5000;
 
 /* AskPassphraseDialog -- Maximum passphrase length */
 static const int MAX_PASSPHRASE_SIZE = 1024;

--- a/src/qt/peertablemodel.cpp
+++ b/src/qt/peertablemodel.cpp
@@ -123,7 +123,7 @@ PeerTableModel::PeerTableModel(ClientModel *parent) :
     // set up timer for auto refresh
     timer = new QTimer();
     connect(timer, SIGNAL(timeout()), SLOT(refresh()));
-    timer->setInterval(MODEL_UPDATE_DELAY);
+    timer->setInterval(MODEL_UPDATE_DELAY1);
 
     // load initial data
     refresh();

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -838,7 +838,6 @@ void RPCConsole::disconnectSelectedNode()
     }
 
     // Find the node, disconnect it and clear the selected node
-    //if (CNode *bannedNode = FindNode(strNode.toStdString())) {
     if (bannedNode) {
         bannedNode->fDisconnect = true;
         //BU: Remember to release the reference we took on bannedNode to protect from use-after-free
@@ -867,7 +866,6 @@ void RPCConsole::banSelectedNode(int bantime)
     }
 
     // Find possible nodes, ban it and clear the selected node
-    //if (CNode *bannedNode = FindNode(strNode.toStdString())) {
     if (bannedNode) {
         std::string nStr = strNode.toStdString();
         std::string addr;
@@ -878,10 +876,8 @@ void RPCConsole::banSelectedNode(int bantime)
         bannedNode->fDisconnect = true;
         //BU: Remember to release the reference we took on bannedNode to protect from use-after-free
         bannedNode->Release();
-        DumpBanlist();
 
         clearSelectedNode();
-        clientModel->getBanTableModel()->refresh();
     }
 }
 
@@ -897,8 +893,6 @@ void RPCConsole::unbanSelectedNode()
     if (possibleSubnet.IsValid())
     {
         CNode::Unban(possibleSubnet);
-        DumpBanlist();
-        clientModel->getBanTableModel()->refresh();
     }
 }
 

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -46,7 +46,7 @@ WalletModel::WalletModel(const PlatformStyle *platformStyle, CWallet *wallet, Op
     // This timer will be fired repeatedly to update the balance
     pollTimer = new QTimer(this);
     connect(pollTimer, SIGNAL(timeout()), this, SLOT(pollBalanceChanged()));
-    pollTimer->start(MODEL_UPDATE_DELAY);
+    pollTimer->start(MODEL_UPDATE_DELAY1);
 
     subscribeToCoreSignals();
 }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -584,9 +584,6 @@ UniValue setban(const UniValue& params, bool fHelp)
             throw JSONRPCError(RPC_MISC_ERROR, "Error: Unban failed");
     }
 
-    DumpBanlist(); //store banlist to disk
-    uiInterface.BannedListChanged();
-
     return NullUniValue;
 }
 
@@ -632,8 +629,5 @@ UniValue clearbanned(const UniValue& params, bool fHelp)
                             );
 
     CNode::ClearBanned();
-    DumpBanlist(); //store banlist to disk
-    uiInterface.BannedListChanged();
-
     return NullUniValue;
 }


### PR DESCRIPTION
When a ban/unban happens internally (not through RPC) we need
to refresh the ban list in the UI.  Previous to this we
were only doing it if the ban was set through RPC only.