### PR TITLE
fix UI issues

### DIFF
--- a/depends/packages/native_ccache.mk
+++ b/depends/packages/native_ccache.mk
@@ -1,6 +1,6 @@
 package=native_ccache
 $(package)_version=3.2.4
-$(package)_download_path=http://samba.org/ftp/ccache
+$(package)_download_path=https://samba.org/ftp/ccache
 $(package)_file_name=ccache-$($(package)_version).tar.bz2
 $(package)_sha256_hash=ffeb967edb549e67da0bd5f44f729a2022de9fdde65dfd80d2a7204d7f75332e
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -241,6 +241,12 @@ namespace {
     int nPeersWithValidatedDownloads = 0;
 } // anon namespace
 
+int GetBlockchainHeight()
+{
+    LOCK(cs_main);
+    return chainActive.Height();
+}
+
 
 //////////////////////////////////////////////////////////////////////////////
 //
@@ -323,12 +329,6 @@ CNodeState *State(NodeId pnode) {
     if (it == mapNodeState.end())
         return NULL;
     return &it->second;
-}
-
-int GetHeight()
-{
-    LOCK(cs_main);
-    return chainActive.Height();
 }
 
 void UpdatePreferredDownload(CNode* node, CNodeState* state)
@@ -673,7 +673,7 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats) {
 
 void RegisterNodeSignals(CNodeSignals& nodeSignals)
 {
-    nodeSignals.GetHeight.connect(&GetHeight);
+    nodeSignals.GetHeight.connect(&GetBlockchainHeight);
     nodeSignals.ProcessMessages.connect(&ProcessMessages);
     nodeSignals.SendMessages.connect(&SendMessages);
     nodeSignals.InitializeNode.connect(&InitializeNode);
@@ -682,7 +682,7 @@ void RegisterNodeSignals(CNodeSignals& nodeSignals)
 
 void UnregisterNodeSignals(CNodeSignals& nodeSignals)
 {
-    nodeSignals.GetHeight.disconnect(&GetHeight);
+    nodeSignals.GetHeight.disconnect(&GetBlockchainHeight);
     nodeSignals.ProcessMessages.disconnect(&ProcessMessages);
     nodeSignals.SendMessages.disconnect(&SendMessages);
     nodeSignals.InitializeNode.disconnect(&InitializeNode);

--- a/src/qt/forms/receivefreezedialog.ui
+++ b/src/qt/forms/receivefreezedialog.ui
@@ -35,7 +35,7 @@
       </size>
      </property>
      <property name="text">
-      <string>WARNING! Freezing coins mean they will be UNSPENDABLE until the release specified below.</string>
+      <string>WARNING! Freezing coins means they will be UNSPENDABLE until the release date or block specified below.</string>
      </property>
      <property name="scaledContents">
       <bool>false</bool>
@@ -80,7 +80,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Freeze by block :</string>
+          <string>Freeze until block :</string>
          </property>
         </widget>
        </item>
@@ -170,7 +170,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Freeze by date and time :</string>
+          <string>Freeze until date and time :</string>
          </property>
         </widget>
        </item>
@@ -192,7 +192,7 @@
           <bool>false</bool>
          </property>
          <property name="toolTip">
-          <string>Specify the future date and time when coins are released from the freeze. Coins are UNSPENDABLE until the freeze date and time.</string>
+          <string>Specify the future date and time when coins are released from the freeze. Coins are UNSPENDABLE until after the freeze date and time.</string>
          </property>
          <property name="inputMethodHints">
           <set>Qt::ImhDate|Qt::ImhTime</set>

--- a/src/qt/receivefreezedialog.cpp
+++ b/src/qt/receivefreezedialog.cpp
@@ -16,6 +16,10 @@ ReceiveFreezeDialog::ReceiveFreezeDialog(QWidget *parent) :
 {
     ui->setupUi(this);
 
+    ui->freezeDateTime->setMinimumDateTime(QDateTime::currentDateTime());
+    ui->freezeDateTime->setDisplayFormat("yyyy/MM/dd hh:mm");
+    ui->freezeDateTime->setDateTime(QDateTime::currentDateTime());
+  
     on_resetButton_clicked();
 
     connect(this, SIGNAL(accepted()), parent, SLOT(on_freezeDialog_hide()));
@@ -42,7 +46,8 @@ void ReceiveFreezeDialog::on_freezeDateTime_editingFinished()
 void ReceiveFreezeDialog::on_freezeBlock_editingFinished()
 {
     if (ui->freezeBlock->value() > 0)
-        ui->freezeDateTime->setDateTime(QDateTime::fromMSecsSinceEpoch(0));
+      ui->freezeDateTime->clear();
+    //  ui->freezeDateTime->setDateTime(QDateTime::fromMSecsSinceEpoch(0));
 
     /* limit check */
     std::string freezeText = ui->freezeBlock->text().toStdString();

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -157,6 +157,9 @@ extern void SendExpeditedBlock(const CBlock& block,const CNode* skip=NULL);
 extern void HandleExpeditedRequest(CDataStream& vRecv,CNode* pfrom);
 extern bool IsRecentlyExpeditedAndStore(const uint256& hash);
 
+// Returns the block height of the current active chain tip.
+extern int GetBlockchainHeight();
+
 
 extern CSemaphore*  semOutboundAddNode;
 extern std::vector<CNode*> xpeditedBlk; // Who requested expedited blocks from us


### PR DESCRIPTION

Fixed:

when specifying a date, the calendar starts at Jan, 1970. This makes is very painful to use. We should start it at the current date (and not let it go previous).

In regtest, putting in a date in 1970 actually works, and gave me a block of 626400

In the "Coin Freeze until Block: ", let's make the capitalization consistent with other options. That is, "Coin freeze until block:"

And I'd like to also have the date in there so a user can "gut check" his choices. so I propose: "Coin freeze until block: 500000 (approximately Jan 1, 20XX)"

In the Coin Freeze dialog box: "Freezing coins means": mean -> means, "release" -> "moment", and "Freeze by block" -> "Freeze until block", "Freeze by date and time" -> "Freeze until..."
