### PR TITLE
[QT] Bugfix: ensure tray icon menu is not empty

### DIFF
--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -545,6 +545,9 @@ void BitcoinGUI::createTrayIcon(const NetworkStyle *networkStyle)
     QString toolTip = tr("Bitcoin Unlimited client") + " " + networkStyle->getTitleAddText();
     trayIcon->setToolTip(toolTip);
     trayIcon->setIcon(networkStyle->getTrayAndWindowIcon());
+
+    trayIconMenu = new QMenu(this);
+    trayIcon->setContextMenu(trayIconMenu);
     trayIcon->show();
 #endif
 
@@ -554,12 +557,9 @@ void BitcoinGUI::createTrayIcon(const NetworkStyle *networkStyle)
 void BitcoinGUI::createTrayIconMenu()
 {
 #ifndef Q_OS_MAC
-    // return if trayIcon is unset (only on non-Mac OSes)
-    if (!trayIcon)
+    // return if trayIcon or trayIconMenu is unset (only on non-Mac OSes)
+    if (!trayIcon || !trayIconMenu)
         return;
-
-    trayIconMenu = new QMenu(this);
-    trayIcon->setContextMenu(trayIconMenu);
 
     connect(trayIcon, SIGNAL(activated(QSystemTrayIcon::ActivationReason)),
             this, SLOT(trayIconActivated(QSystemTrayIcon::ActivationReason)));


### PR DESCRIPTION
I am experiencing a bug in which the tray icon menu does not contain any content. This change resolves this bug by moving the `trayIcon->show()` call to be made after the `trayIcon->setContextMenu(trayIconMenu)` call.