### PR TITLE
Use std::atomic for IsChainNearlySyncd()

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -88,9 +88,6 @@ uint64_t CNode::nTotalBytesSent = 0;
 CCriticalSection CNode::cs_totalBytesRecv;
 CCriticalSection CNode::cs_totalBytesSent;
 
-bool fIsChainNearlySyncd;
-CCriticalSection cs_ischainnearlysyncd;
-
 // critical sections from net.cpp
 CCriticalSection cs_setservAddNodeAddresses;
 CCriticalSection cs_vAddedNodes;

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -144,12 +144,8 @@ extern CLeakyBucket sendShaper;
 // Test to determine if traffic shaping is enabled
 extern bool IsTrafficShapingEnabled();
 
-extern bool fIsChainNearlySyncd;
-extern CCriticalSection cs_ischainnearlysyncd;
-
 extern bool IsChainNearlySyncd();
 extern void IsChainNearlySyncdInit();
-extern bool fIsChainNearlySyncd;
 extern uint64_t LargestBlockSeen(uint64_t nBlockSize = 0);
 extern void LoadFilter(CNode *pfrom, CBloomFilter *filter);
 extern void HandleBlockMessage(CNode *pfrom, const std::string &strCommand, CBlock &block, const CInv &inv);


### PR DESCRIPTION
This function gets called frequently  at the time we are looking
for a peer to download an xthin from.  This should give a small
performance boost.