### PR TITLE
Show number of Orphans in the Information UI

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -95,6 +95,12 @@ long ClientModel::getMempoolSize() const
     return mempool.size();
 }
 
+long ClientModel::getOrphanPoolSize() const
+{
+    LOCK(cs_orphancache);
+    return mapOrphanTransactions.size();
+}
+
 size_t ClientModel::getMempoolDynamicUsage() const
 {
     return mempool.DynamicMemoryUsage();
@@ -123,6 +129,7 @@ void ClientModel::updateTimer()
     // no locking required at this point
     // the following calls will aquire the required lock
     Q_EMIT mempoolSizeChanged(getMempoolSize(), getMempoolDynamicUsage());
+    Q_EMIT orphanPoolSizeChanged(getOrphanPoolSize());
     Q_EMIT bytesChanged(getTotalBytesRecv(), getTotalBytesSent());
     Q_EMIT transactionsPerSecondChanged(getTransactionsPerSecond()); // BU:
 }

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -56,6 +56,10 @@ public:
 
     //! Return number of transactions in the mempool
     long getMempoolSize() const;
+
+    //! Return number of transactions in the orphan pool
+    long getOrphanPoolSize() const;
+
     //! Return the dynamic memory usage of the mempool
     size_t getMempoolDynamicUsage() const;
     
@@ -97,6 +101,7 @@ Q_SIGNALS:
     void numConnectionsChanged(int count);
     void numBlocksChanged(int count, const QDateTime& blockDate, double nVerificationProgress);
     void mempoolSizeChanged(long count, size_t mempoolSizeInBytes);
+    void orphanPoolSizeChanged(long count);
     void alertsChanged(const QString &warnings);
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);
     void transactionsPerSecondChanged(double tansactionsPerSecond);  // BU:

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -339,14 +339,14 @@
         </widget>
        </item>
        <item row="15" column="0">
-        <widget class="QLabel" name="labelMemoryUsage">
+        <widget class="QLabel" name="labelNumberOfOrphanTransactions">
          <property name="text">
-          <string>Memory usage</string>
+          <string>Transactions in Orphan pool</string>
          </property>
         </widget>
        </item>
        <item row="15" column="1">
-        <widget class="QLabel" name="mempoolSize">
+        <widget class="QLabel" name="orphanPoolNumberTxs">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
@@ -362,13 +362,36 @@
         </widget>
        </item>
        <item row="16" column="0">
+        <widget class="QLabel" name="labelMemoryUsage">
+         <property name="text">
+          <string>Memory usage</string>
+         </property>
+        </widget>
+       </item>
+       <item row="16" column="1">
+        <widget class="QLabel" name="mempoolSize">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="0">
         <widget class="QLabel" name="labelTransactionsPerSecond">
          <property name="text">
           <string>Transactions per second</string>
          </property>
         </widget>
        </item>
-       <item row="16" column="1">
+       <item row="17" column="1">
         <widget class="QLabel" name="transactionsPerSecond">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -385,7 +408,7 @@
         </widget>
        </item>
 
-       <item row="17" column="2" rowspan="3">
+       <item row="18" column="2" rowspan="3">
         <layout class="QVBoxLayout" name="verticalLayoutDebugButton">
          <property name="spacing">
           <number>3</number>
@@ -425,7 +448,7 @@
          </item>
         </layout>
        </item>
-       <item row="18" column="0">
+       <item row="19" column="0">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -344,8 +344,7 @@ void RPCConsole::setClientModel(ClientModel *model)
         connect(model, SIGNAL(bytesChanged(quint64,quint64)), this, SLOT(updateTrafficStats(quint64, quint64)));
 
         connect(model, SIGNAL(mempoolSizeChanged(long,size_t)), this, SLOT(setMempoolSize(long,size_t)));
-
-        // BU:
+        connect(model, SIGNAL(orphanPoolSizeChanged(long)), this, SLOT(setOrphanPoolSize(long)));
         connect(model, SIGNAL(transactionsPerSecondChanged(double)), this, SLOT(setTransactionsPerSecond(double)));
 
         // set up peer table
@@ -542,7 +541,11 @@ void RPCConsole::setMempoolSize(long numberOfTxs, size_t dynUsage)
         ui->mempoolSize->setText(QString::number(dynUsage/1000000.0, 'f', 2) + " MB");
 }
 
-// BU: begin
+void RPCConsole::setOrphanPoolSize(long numberOfTxs)
+{
+    ui->orphanPoolNumberTxs->setText(QString::number(numberOfTxs));
+}
+
 void RPCConsole::setTransactionsPerSecond(double nTxPerSec)
 {
     if (nTxPerSec < 100)
@@ -550,7 +553,6 @@ void RPCConsole::setTransactionsPerSecond(double nTxPerSec)
     else
         ui->transactionsPerSecond->setText(QString::number((uint64_t)nTxPerSec));
 }
-// BU: end
 
 void RPCConsole::on_lineEdit_returnPressed()
 {

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -87,7 +87,9 @@ public Q_SLOTS:
     void setNumBlocks(int count, const QDateTime& blockDate, double nVerificationProgress);
     /** Set size (number of transactions and memory usage) of the mempool in the UI */
     void setMempoolSize(long numberOfTxs, size_t dynUsage);
-    /** BU: Set tx's per second in the UI */
+    /** Set number of transactions in ophan pool in the UI */
+    void setOrphanPoolSize(long numberOfTxs);
+    /** Set tx's per second in the UI */
     void setTransactionsPerSecond(double nTxPerSec);
     /** Go forward or back in history */
     void browseHistory(int offset);


### PR DESCRIPTION
It's a good idea to be able to see and also study the orphan
cache size as time goes by.  It would be good information to
have to start adjusting the size of the orphan cache timeout
which is currently tied to the transaction timeout.  In the future
we could decouple this so that orhpans could be purged more quickly
from the cache rather than waiting the standard 72 hours.  Having
the abililty to see the cache size in action will be helpful in
arriving at a good default value.