### PR TITLE
Make time formatting consistent in debug UI

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -213,7 +213,8 @@ QString ClientModel::clientName() const
 
 QString ClientModel::formatClientStartupTime() const
 {
-    return QDateTime::fromTime_t(nClientStartupTime).toString();
+    QString time_format = "MMM  d yyyy, HH:mm:ss";
+    return QDateTime::fromTime_t(nClientStartupTime).toString(time_format);
 }
 
 void ClientModel::updateBanlist()

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -529,7 +529,9 @@ void RPCConsole::setNumConnections(int count)
 void RPCConsole::setNumBlocks(int count, const QDateTime& blockDate, double nVerificationProgress)
 {
     ui->numberOfBlocks->setText(QString::number(count));
-    ui->lastBlockTime->setText(blockDate.toString());
+
+    QString time_format = "MMM  d yyyy, HH:mm:ss";
+    ui->lastBlockTime->setText(blockDate.toString(time_format));
 }
 
 void RPCConsole::setMempoolSize(long numberOfTxs, size_t dynUsage)


### PR DESCRIPTION
The startup time as well as Last Block Time have inconsistent
formatting with the Build Date.  This PR makes them all follow
the same format:

Month, day, year, time of day
Feb 5 2017, 10:30:33

rather than

Day of week, Month, day, time of day, year
Sun Feb 5 10:30:33 2017