### PR TITLE
Fix configure error on native Windows MinGW build

### DIFF
--- a/build-aux/m4/ax_boost_base.m4
+++ b/build-aux/m4/ax_boost_base.m4
@@ -170,7 +170,7 @@ if test "x$want_boost" = "xyes"; then
         AC_MSG_RESULT(yes)
     succeeded=yes
     found_system=yes
-        ],[
+        ],[:
         ])
     AC_LANG_POP([C++])
 
@@ -263,7 +263,7 @@ if test "x$want_boost" = "xyes"; then
             AC_MSG_RESULT(yes)
         succeeded=yes
         found_system=yes
-            ],[
+            ],[:
             ])
         AC_LANG_POP([C++])
     fi


### PR DESCRIPTION
After the recent merge of #268 into dev, native Windows MinGW builds fail on the `configure` step with the following error (occurs for both 32-bit and 64-bit tool chains):
```
checking whether the linker accepts -mwindows... yes
checking whether to build Bitcoin GUI... yes (Qt5)
./configure: line 25381: syntax error near unexpected token `fi'
./configure: line 25381: `fi'
make: *** No targets specified and no makefile found.  Stop.
```

I have been able to trace this issue down to a specific change in `ax_boost_base.m4`, and I am able to get `configure` to run correctly if I revert these two lines.  I'm just not certain why the change was made or if reverting it will cause side effects.  I have tested using this change on a Debian system as well as Windows and there didn't seem to be any build issues.  **If someone familiar with autoconf and m4 files could look at this and see if they can see any reason this fix would be problematic.**  I'm just not familiar with autoconf and m4 files myself.

NOTE: In case it helps, the tool chains I'm using are 
32-bit: i686-4.9.2-release-posix-dwarf-rt_v3-rev1
64-bit: x86_64-4.9.2-release-posix-seh-rt_v3-rev1

You can also see the set of build scripts I'm using for compiling natively on Windows in PR #85 