### PR TITLE
Stats: full range for min/max

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sudo apt-get install libqt4-dev libprotobuf-dev protobuf-compiler libqrencode-de
 sudo apt-get install software-properties-common
 
 ## this not needed if your wallet will use the new
-## format, ot if you're not going to use a wallet at all
+## format, or if you're not going to use a wallet at all
 sudo add-apt-repository ppa:bitcoin-unlimited/bu-ppa
 sudo apt-get update
 sudo apt-get install libdb4.8-dev libdb4.8++-dev

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -205,7 +205,7 @@ CTweak<uint64_t> checkScriptDays("blockchain.checkScriptDays","The number of day
 
 CRequestManager requester;  // after the maps nodes and tweaks
 
-CStatHistory<unsigned int, MinValMax<unsigned int> > txAdded; //"memPool/txAdded");
+CStatHistory<unsigned int> txAdded; //"memPool/txAdded");
 CStatHistory<uint64_t, MinValMax<uint64_t> > poolSize; // "memPool/size",STAT_OP_AVE);
 CStatHistory<uint64_t > recvAmt; 
 CStatHistory<uint64_t > sendAmt; 

--- a/src/stat.h
+++ b/src/stat.h
@@ -483,10 +483,10 @@ public:
   // happens when results are moved from a faster series to a slower one.
   MinValMax& operator+=(const MinValMax& rhs)
     {
-      //if (rhs.max > max) max=rhs.max;
-      //if (rhs.min < min) min=rhs.min;
-      max += rhs.max;
-      min += rhs.min;
+      if (rhs.max > max) max=rhs.max;
+      if (rhs.min < min) min=rhs.min;
+//      max += rhs.max;
+//      min += rhs.min;
       val += rhs.val;
       samples += rhs.samples;
       return *this;
@@ -501,8 +501,8 @@ public:
   MinValMax& operator/=(const NUM& rhs)
     {
       val /= rhs;
-      min /= rhs;
-      max /= rhs;
+//      min /= rhs;
+//      max /= rhs;
       return *this;
     }
    

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -185,7 +185,7 @@ void UpdateSendStats(CNode* pfrom, const char* strCommand, int msgSize, int64_t 
 
 void UpdateRecvStats(CNode* pfrom, const std::string& strCommand, int msgSize, int64_t nTimeReceived);
 // txn mempool statistics
-extern CStatHistory<unsigned int, MinValMax<unsigned int> > txAdded;
+extern CStatHistory<unsigned int> txAdded;
 extern CStatHistory<uint64_t, MinValMax<uint64_t> > poolSize;
 
 // Configuration variable validators


### PR DESCRIPTION
This PR contains a few trivial changes to make the stats more intuitive. 

Specifically:

- 'getstat memPool/size' will now have the min and max of the full interval range
- 'getstat memPool/txAdded' will no longer have a min or max since they are not relevant to this stat.