### PR TITLE
Remove addInventoryKnown() for blocks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5257,7 +5257,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             const CInv &inv = vInv[nInv];
 
             boost::this_thread::interruption_point();
-            pfrom->AddInventoryKnown(inv);
 
             bool fAlreadyHave = AlreadyHave(inv);
             LogPrint("net", "got inv: %s  %s peer=%d\n", inv.ToString(), fAlreadyHave ? "have" : "new", pfrom->id);
@@ -5274,6 +5273,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             }
             else
             {
+                pfrom->AddInventoryKnown(inv);
                 if (fBlocksOnly)
                     LogPrint("net", "transaction (%s) inv sent in violation of protocol peer=%d\n", inv.hash.ToString(), pfrom->id);
                 else if (!fAlreadyHave && !fImporting && !fReindex) // BU removed && !IsInitialBlockDownload())
@@ -5836,7 +5836,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                     }
                 }
             }
-            pfrom->AddInventoryKnown(inv);
             CXThinBlockTx thinBlockTx(thinRequestBlockTx.blockhash, vTx);
             pfrom->PushMessage(NetMsgType::XBLOCKTX, thinBlockTx);
             pfrom->blocksSent += 1;
@@ -5879,7 +5878,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         if (pfrom->thinBlockWaitingForTxns == 0) {
             // We have all the transactions now that are in this block: try to reassemble and process.
             pfrom->thinBlockWaitingForTxns = -1;
-            pfrom->AddInventoryKnown(inv);
             requester.Received(inv, pfrom, msgSize);
 
             // for compression statistics, we have to add up the size of xthinblock and the re-requested thinBlockTx.
@@ -5923,8 +5921,6 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         CInv inv(MSG_BLOCK, block.GetHash());
         LogPrint("blk", "received block %s peer=%d\n", inv.hash.ToString(), pfrom->id);
         UnlimitedLogBlock(block,inv.hash.ToString(),receiptTime);
-
-        pfrom->AddInventoryKnown(inv);
 
         if (IsChainNearlySyncd()) // BU send the received block out expedited channels quickly
           {

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -113,7 +113,6 @@ bool CThinBlock::process(CNode* pfrom, int nSizeThinBlock, string strCommand)
             // We have all the transactions now that are in this block: try to reassemble and process.
             requester.Received(GetInv(), pfrom, nSizeThinBlock);
             pfrom->thinBlockWaitingForTxns = -1;
-            pfrom->AddInventoryKnown(GetInv());
             int blockSize = pfrom->thinBlock.GetSerializeSize(SER_NETWORK, CBlock::CURRENT_VERSION);
             LogPrint("thin", "Reassembled thin block for %s (%d bytes). Message was %d bytes, compression ratio %3.2f\n",
                      pfrom->thinBlock.GetHash().ToString(),
@@ -349,7 +348,6 @@ bool CXThinBlock::process(CNode* pfrom, int nSizeThinBlock, string strCommand)  
     if (pfrom->thinBlockWaitingForTxns == 0) {
         // We have all the transactions now that are in this block: try to reassemble and process.
         pfrom->thinBlockWaitingForTxns = -1;
-        pfrom->AddInventoryKnown(GetInv());
         int blockSize = pfrom->thinBlock.GetSerializeSize(SER_NETWORK, CBlock::CURRENT_VERSION);
         LogPrint("thin", "Reassembled thin block for %s (%d bytes). Message was %d bytes, compression ratio %3.2f\n",
 	       pfrom->thinBlock.GetHash().ToString(),


### PR DESCRIPTION
There is no value in updating addinventoryknown for blocks
because when we check AlreadyHave() we don't lookup the bloom
filter at all we just go directly to the blockindex for checking
block hashes.