### PR TITLE
Renable the check IsInitialBlockDownload() for txns during IBD

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5267,17 +5267,16 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
                 if (!fAlreadyHave && !fImporting && !fReindex) {  // BU request manager keeps track of all sources so no need for: && !mapBlocksInFlight.count(inv.hash)) {
 		    requester.AskFor(inv, pfrom);
                 }
-                else
-		  {
+                else {
 		    LogPrint("net", "skipping request of block %s.  already have: %d  importing: %d  reindex: %d  isChainNearlySyncd: %d\n",inv.hash.ToString(),fAlreadyHave,fImporting,fReindex,IsChainNearlySyncd());
-		  }
+		}
             }
             else
             {
                 if (fBlocksOnly)
                     LogPrint("net", "transaction (%s) inv sent in violation of protocol peer=%d\n", inv.hash.ToString(), pfrom->id);
-                else if (!fAlreadyHave && !fImporting && !fReindex) // BU removed && !IsInitialBlockDownload())
-                  requester.AskFor(inv,pfrom); // BU manage outgoing requests.  was: pfrom->AskFor(inv);
+                else if (!fAlreadyHave && !fImporting && !fReindex && !IsInitialBlockDownload())
+                    requester.AskFor(inv,pfrom); // BU manage outgoing requests.  was: pfrom->AskFor(inv);
             }
 
             // Track requests for our stuff


### PR DESCRIPTION
We want to ensure we don't unnecessarily download txns during IBD
until the chain is approaching a sync'd state.  This will be more
important as txn rates rise further.

@gandrewstone  I checked through all the regression tests as well as the extended.  they work fine.  I had been incorrect in thinking that core had backed out my old commit. seems the functionality was still there so there was no need to comment out the IsInitialBlockDownload().