### PR TITLE
Trivial: Update copyright year to 2017

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ define(_CLIENT_VERSION_MINOR, 0)
 define(_CLIENT_VERSION_REVISION, 0)
 define(_CLIENT_VERSION_BUILD, 99)  # version 99 here indicates an unreleased version
 define(_CLIENT_VERSION_IS_RELEASE, true)
-define(_COPYRIGHT_YEAR, 2016)
+define(_COPYRIGHT_YEAR, 2017)
 AC_INIT([Bitcoin Unlimited],[_CLIENT_VERSION_MAJOR._CLIENT_VERSION_MINOR._CLIENT_VERSION_REVISION],[https://github.com/BitcoinUnlimited/BitcoinUnlimited/issues],[bitcoinUnlimited])
 AC_CONFIG_SRCDIR([src/main.cpp])
 AC_CONFIG_HEADERS([src/config/bitcoin-config.h])

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -27,7 +27,7 @@
  * Copyright year (2009-this)
  * Todo: update this when changing our copyright comments in the source
  */
-#define COPYRIGHT_YEAR 2016
+#define COPYRIGHT_YEAR 2017
 
 #endif //HAVE_CONFIG_H
 


### PR DESCRIPTION
Update the copyright year displayed visibly to the user in the client UI and file property info to 2017.  Fixes #272 against the `dev` branch.

NOTE: The update to `configure.ac` has already been applied to `release`, but the update to `clientversion.h` needs to be merged to `release` as well `dev`.