### PR TITLE
Updating Chinese translations

### DIFF
--- a/src/qt/locale/bitcoin_zh_CN.ts
+++ b/src/qt/locale/bitcoin_zh_CN.ts
@@ -169,7 +169,7 @@
     </message>
     <message>
         <source>Bitcoin Unlimited will close now to finish the encryption process. Remember that encrypting your wallet cannot fully protect your bitcoins from being stolen by malware infecting your computer.</source>
-        <translation>比特币核心现在将关闭以完成加密过程。请记住，在您的计算机被恶意软件感染的情况下，加密不能完全保护您的比特币免于被盗。</translation>
+        <translation>比特币无限现在将关闭以完成加密过程。请记住，在您的计算机被恶意软件感染的情况下，加密不能完全保护您的比特币免于被盗。</translation>
     </message>
     <message>
         <source>IMPORTANT: Any previous backups you have made of your wallet file should be replaced with the newly generated, encrypted wallet file. For security reasons, previous backups of the unencrypted wallet file will become useless as soon as you start using the new, encrypted wallet.</source>
@@ -307,7 +307,7 @@
     </message>
     <message>
         <source>Bitcoin Unlimited client</source>
-        <translation>比特币核心钱包客户端</translation>
+        <translation>比特币无限钱包客户端</translation>
     </message>
     <message>
         <source>Importing blocks from disk...</source>
@@ -359,7 +359,7 @@
     </message>
     <message>
         <source>Show information about Bitcoin Unlimited</source>
-        <translation>显示有关比特币核心钱包信息</translation>
+        <translation>显示有关比特币无限钱包信息</translation>
     </message>
     <message>
         <source>&amp;Show / Hide</source>
@@ -399,7 +399,7 @@
     </message>
     <message>
         <source>Bitcoin Unlimited</source>
-        <translation>比特币核心</translation>
+        <translation>比特币无限</translation>
     </message>
     <message>
         <source>Request payments (generates QR codes and bitcoin: URIs)</source>
@@ -407,11 +407,11 @@
     </message>
     <message>
         <source>&amp;About Bitcoin Unlimited</source>
-        <translation>关于比特币核心(&amp;A)</translation>
+        <translation>关于比特币无限(&amp;A)</translation>
     </message>
     <message>
         <source>Modify configuration options for Bitcoin Unlimited</source>
-        <translation>修改比特币核心的配置选项</translation>
+        <translation>修改比特币无限的配置选项</translation>
     </message>
     <message>
         <source>Show the list of used sending addresses and labels</source>
@@ -431,7 +431,7 @@
     </message>
     <message>
         <source>Show the Bitcoin Unlimited help message to get a list with possible Bitcoin command-line options</source>
-        <translation>显示比特币核心 程序帮助信息，获取可用的命令行选项 </translation>
+        <translation>显示比特币无限 程序帮助信息，获取可用的命令行选项 </translation>
     </message>
     <message numerus="yes">
         <source>%n active connection(s) to Bitcoin network</source>
@@ -856,7 +856,7 @@
     <name>HelpMessageDialog</name>
     <message>
         <source>Bitcoin Unlimited</source>
-        <translation>比特币核心</translation>
+        <translation>比特币无限</translation>
     </message>
     <message>
         <source>version</source>
@@ -868,7 +868,7 @@
     </message>
     <message>
         <source>About Bitcoin Unlimited</source>
-        <translation>关于比特币核心</translation>
+        <translation>关于比特币无限</translation>
     </message>
     <message>
         <source>Command-line options</source>
@@ -919,15 +919,15 @@
     </message>
     <message>
         <source>Welcome to Bitcoin Unlimited.</source>
-        <translation>欢迎使用 比特币核心 程序。</translation>
+        <translation>欢迎使用 比特币无限 程序。</translation>
     </message>
     <message>
         <source>As this is the first time the program is launched, you can choose where Bitcoin Unlimited will store its data.</source>
-        <translation>由于这是第一次运行 比特币核心 程序，您可以选择数据存储目录。</translation>
+        <translation>由于这是第一次运行 比特币无限 程序，您可以选择数据存储目录。</translation>
     </message>
     <message>
         <source>Bitcoin Unlimited will download and store a copy of the Bitcoin block chain. At least %1GB of data will be stored in this directory, and it will grow over time. The wallet will also be stored in this directory.</source>
-        <translation>比特币核心 程序会下载储存一份数据块链(blockchain)。至少需要 %1 GB的存储空间，随着时间推移会需要更多的存储空间。钱包文件也储存在该目录。</translation>
+        <translation>比特币无限 程序会下载储存一份数据块链(blockchain)。至少需要 %1 GB的存储空间，随着时间推移会需要更多的存储空间。钱包文件也储存在该目录。</translation>
     </message>
     <message>
         <source>Use the default data directory</source>
@@ -939,7 +939,7 @@
     </message>
     <message>
         <source>Bitcoin Unlimited</source>
-        <translation>比特币核心</translation>
+        <translation>比特币无限</translation>
     </message>
     <message>
         <source>Error: Specified data directory "%1" cannot be created.</source>
@@ -1021,7 +1021,7 @@
     </message>
     <message>
         <source>The user interface language can be set here. This setting will take effect after restarting Bitcoin Unlimited.</source>
-        <translation>可以在这里设置用户界面语言。此设置将在重新启动比特币核心后生效。</translation>
+        <translation>可以在这里设置用户界面语言。此设置将在重新启动比特币无限后生效。</translation>
     </message>
     <message>
         <source>Third party URLs (e.g. a block explorer) that appear in the transactions tab as context menu items. %s in the URL is replaced by transaction hash. Multiple URLs are separated by vertical bar |.</source>
@@ -1049,15 +1049,15 @@
     </message>
     <message>
         <source>Automatically start Bitcoin Unlimited after logging in to the system.</source>
-        <translation>登录到系统后自动启动比特币核心。</translation>
+        <translation>登录到系统后自动启动比特币无限。</translation>
     </message>
     <message>
         <source>&amp;Start Bitcoin Unlimited on system login</source>
-        <translation>系统登录时启动比特币核心(&amp;S)</translation>
+        <translation>系统登录时启动比特币无限(&amp;S)</translation>
     </message>
     <message>
         <source>(0 = auto, &lt;0 = leave that many cores free)</source>
-        <translation>(0 = 自动, &lt;0 = 离开很多免费的核心)</translation>
+        <translation>(0 = 自动, &lt;0 = 预留此数量的核心)</translation>
     </message>
     <message>
         <source>W&amp;allet</source>
@@ -1519,7 +1519,7 @@
     </message>
     <message>
         <source>Open the Bitcoin Unlimited debug log file from the current data directory. This can take a few seconds for large log files.</source>
-        <translation>从当前的数据目录打开比特币核心调试日志文件。对于较大的日志文件，这可能需要几秒钟。</translation>
+        <translation>从当前的数据目录打开比特币无限调试日志文件。对于较大的日志文件，这可能需要几秒钟。</translation>
     </message>
     <message>
         <source>Received</source>
@@ -1675,7 +1675,7 @@
     </message>
     <message>
         <source>Welcome to the Bitcoin Unlimited RPC console.</source>
-        <translation>欢迎使用 比特币核心 RPC 控制台。</translation>
+        <translation>欢迎使用 比特币无限 RPC 控制台。</translation>
     </message>
     <message>
         <source>Use up and down arrows to navigate history, and &lt;b&gt;Ctrl-L&lt;/b&gt; to clear screen.</source>
@@ -2261,7 +2261,7 @@
     <name>ShutdownWindow</name>
     <message>
         <source>Bitcoin Unlimited is shutting down...</source>
-        <translation>比特币核心正在关机...</translation>
+        <translation>比特币无限正在关机...</translation>
     </message>
     <message>
         <source>Do not shut down the computer until this window disappears.</source>
@@ -2411,7 +2411,7 @@
     <name>SplashScreen</name>
     <message>
         <source>Bitcoin Unlimited</source>
-        <translation>比特币核心</translation>
+        <translation>比特币无限</translation>
     </message>
     <message>
         <source>The Bitcoin Unlimited developers</source>
@@ -2990,7 +2990,7 @@
     </message>
     <message>
         <source>Set the number of script verification threads (%u to %d, 0 = auto, &lt;0 = leave that many cores free, default: %d)</source>
-        <translation>设置脚本验证的程序 (%u 到 %d, 0 = 自动, &lt;0 = 保留自由的核心, 默认值: %d)</translation>
+        <translation>设置脚本验证的程序 (%u 到 %d, 0 = 自动, &lt;0 = 预留此数量的核心, 默认值: %d)</translation>
     </message>
     <message>
         <source>The block database contains a block which appears to be from the future. This may be due to your computer's date and time being set incorrectly. Only rebuild the block database if you are sure that your computer's date and time are correct</source>
@@ -3002,7 +3002,7 @@
     </message>
     <message>
         <source>Unable to bind to %s on this computer. Bitcoin Unlimited is probably already running.</source>
-        <translation>无法 %s的绑定到电脑上，比特币核心钱包可能已经在运行。</translation>
+        <translation>无法 %s的绑定到电脑上，比特币无限钱包可能已经在运行。</translation>
     </message>
     <message>
         <source>Use UPnP to map the listening port (default: 1 when listening and no -proxy)</source>
@@ -3206,7 +3206,7 @@
     </message>
     <message>
         <source>Cannot obtain a lock on data directory %s. Bitcoin Unlimited is probably already running.</source>
-        <translation>无法获取数据目录的 %s. 比特币核心钱包可能已经在运行.</translation>
+        <translation>无法获取数据目录的 %s. 比特币无限钱包可能已经在运行.</translation>
     </message>
     <message>
         <source>Create new files with system default permissions, instead of umask 077 (only effective with disabled wallet functionality)</source>
@@ -3294,7 +3294,7 @@
     </message>
     <message>
         <source>Error loading wallet.dat: Wallet requires newer version of Bitcoin Unlimited</source>
-        <translation>加载wallet.dat错误：需要新版的比特币核心钱包</translation>
+        <translation>加载wallet.dat错误：需要新版的比特币无限钱包</translation>
     </message>
     <message>
         <source>Error reading from database, shutting down.</source>
@@ -3414,7 +3414,7 @@
     </message>
     <message>
         <source>Wallet needed to be rewritten: restart Bitcoin Unlimited to complete</source>
-        <translation>钱包需要被改写：重新启动核心钱包来完成</translation>
+        <translation>钱包需要被改写：重新启动比特币无限钱包来完成</translation>
     </message>
     <message>
         <source>Warning</source>


### PR DESCRIPTION
The translation “比特币核心”（Bitcoin Core in Chinese） are now all changed to
“比特币无限” (Bitcoin Unlimited in Chinese). The translation of “leave that
many cores free” was wrong about the word "free", its translation now
changed to "预留" （leave the space free）instead of previously"自由"(freedom)