### PR TITLE
Use separate mutex for transactions per second

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1024,6 +1024,8 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<uint256>* pvNoSpendsRe
 // BU: begin
 void CTxMemPool::UpdateTransactionsPerSecond()
 {
+    boost::mutex::scoped_lock lock(cs_txPerSec);
+
     static int64_t nLastTime = GetTime();
     double nSecondsToAverage = 60; // Length of time in seconds to smooth the tx rate over
     int64_t nNow = GetTime();

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -18,6 +18,8 @@
 #undef foreach
 #include "boost/multi_index_container.hpp"
 #include "boost/multi_index/ordered_index.hpp"
+#include <boost/thread/locks.hpp>
+#include <boost/thread/mutex.hpp>
 
 class CAutoFile;
 class CBlockIndex;
@@ -376,6 +378,7 @@ private:
 
     void trackPackageRemoved(const CFeeRate& rate);
 
+    boost::mutex cs_txPerSec;
     double nTxPerSec; //BU: tx's per second accepted into the mempool
 
 public:
@@ -556,7 +559,7 @@ public:
     // BU: begin
     double TransactionsPerSecond()
     {
-        LOCK(cs);
+        boost::mutex::scoped_lock lock(cs_txPerSec);
         return nTxPerSec;
     }
     // BU: end


### PR DESCRIPTION
We want to be able update transactions per second from mulitple threads
in the future so we can enable multi-threaded transactions.  Also we
want to reduce the contention on mempool.cs which is locked frequently
when we update txns per second on the UI.