### PR TITLE
switch to secondary polltimer2 in UI to reduce number of mempool.cs locks taken

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -135,13 +135,16 @@ void ClientModel::updateTimer1()
     // no locking required at this point
     // the following calls will aquire the required lock
     Q_EMIT mempoolSizeChanged(getMempoolSize(), getMempoolDynamicUsage());
-    Q_EMIT orphanPoolSizeChanged(getOrphanPoolSize());
-    Q_EMIT bytesChanged(getTotalBytesRecv(), getTotalBytesSent());
     Q_EMIT transactionsPerSecondChanged(getTransactionsPerSecond());
 }
 
 void ClientModel::updateTimer2()
 {
+    // no locking required at this point
+    // the following calls will aquire the required lock
+    Q_EMIT orphanPoolSizeChanged(getOrphanPoolSize());
+    Q_EMIT bytesChanged(getTotalBytesRecv(), getTotalBytesSent());
+
     uiInterface.BannedListChanged();
 }
 

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -7,7 +7,7 @@
 #define BITCOIN_QT_GUICONSTANTS_H
 
 /* Milliseconds between model updates */
-static const int MODEL_UPDATE_DELAY1 = 250;
+static const int MODEL_UPDATE_DELAY1 = 500;
 static const int MODEL_UPDATE_DELAY2 = 5000;
 
 /* AskPassphraseDialog -- Maximum passphrase length */


### PR DESCRIPTION
Also modify the polltimer1 trigger to be 500ms rather than 250ms...it provides ample responsiveness and further reduces the number of mempool.cs locks taken.