### PR TITLE
use atomic for IsInitialBlockDownload()

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1410,6 +1410,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (!ActivateBestChain(state, chainparams))
         strErrors << "Failed to connect best block";
     IsChainNearlySyncdInit(); // BUIP010 XTHIN: initialize fIsChainNearlySyncd
+    IsInitialBlockDownloadInit();
 
     std::vector<boost::filesystem::path> vImportFiles;
     if (mapArgs.count("-loadblock"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5355,12 +5355,12 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
         uint256 hashStop;
         vRecv >> locator >> hashStop;
 
-        LOCK(cs_main);
         if (IsInitialBlockDownload() && !pfrom->fWhitelisted) {
             LogPrint("net", "Ignoring getheaders from peer=%d because node is in initial block download\n", pfrom->id);
             return true;
         }
 
+        LOCK(cs_main);
         CNodeState *nodestate = State(pfrom->GetId());
         CBlockIndex* pindex = NULL;
         if (locator.IsNull())

--- a/src/main.h
+++ b/src/main.h
@@ -230,8 +230,6 @@ bool SendMessages(CNode* pto);
 void ThreadScriptCheck();
 /** Try to detect Partition (network isolation) attacks against us */
 void PartitionCheck(bool (*initialDownloadCheck)(), CCriticalSection& cs, const CBlockIndex *const &bestHeader, int64_t nPowTargetSpacing);
-/** Check whether we are doing an initial block download (synchronizing from disk or network) */
-bool IsInitialBlockDownload();
 /** Format a string that describes several potential problems detected by the core.
  * strFor can have three values:
  * - "rpc": get critical warnings, which should put the client in safe mode if non-empty

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -5,12 +5,13 @@
 #include "chain.h"
 #include "clientversion.h"
 #include "chainparams.h"
-#include "miner.h"
+#include "checkpoints.h"
 #include "consensus/consensus.h"
 #include "consensus/params.h"
 #include "consensus/validation.h"
 #include "leakybucket.h"
 #include "main.h"
+#include "miner.h"
 #include "net.h"
 #include "policy/policy.h"
 #include "primitives/block.h"
@@ -41,6 +42,7 @@ using namespace std;
 extern CTxMemPool mempool; // from main.cpp
 static atomic<uint64_t> nLargestBlockSeen{BLOCKSTREAM_CORE_MAX_BLOCK_SIZE}; // track the largest block we've seen
 static atomic<bool> fIsChainNearlySyncd{false};
+static atomic<bool> fIsInitialBlockDownload{false};
 
 bool IsTrafficShapingEnabled();
 
@@ -1067,6 +1069,43 @@ UniValue settrafficshaping(const UniValue& params, bool fHelp)
     }
 
     return NullUniValue;
+}
+
+// fIsInitialBlockDownload is updated only during startup and whenever we receive a header.
+// This way we avoid having to lock cs_main so often which tends to be a bottleneck.
+void IsInitialBlockDownloadInit()
+{
+    const CChainParams& chainParams = Params();
+    LOCK(cs_main);
+    if (!pindexBestHeader) {
+        // Not nearly synced if we don't have any blocks!
+        fIsInitialBlockDownload.store(true);
+        return;
+    }
+    if (fImporting || fReindex) {
+        fIsInitialBlockDownload.store(true);
+        return;
+    }
+    if (fCheckpointsEnabled && chainActive.Height() < Checkpoints::GetTotalBlocksEstimate(chainParams.Checkpoints())) {
+        fIsInitialBlockDownload.store(true);
+        return;
+    }
+    static bool lockIBDState = false;
+    if (lockIBDState) {
+        fIsInitialBlockDownload.store(false);
+        return;
+    }
+    bool state = (chainActive.Height() < pindexBestHeader->nHeight - 24 * 6 ||
+            pindexBestHeader->GetBlockTime() < GetTime() - chainParams.MaxTipAge());
+    if (!state)
+        lockIBDState = true;
+    fIsInitialBlockDownload.store(state);
+    return;
+}
+
+bool IsInitialBlockDownload()
+{
+    return fIsInitialBlockDownload.load();
 }
 
 

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -144,6 +144,11 @@ extern CLeakyBucket sendShaper;
 // Test to determine if traffic shaping is enabled
 extern bool IsTrafficShapingEnabled();
 
+// Check whether we are doing an initial block download (synchronizing from disk or network)
+extern bool IsInitialBlockDownload();
+extern void IsInitialBlockDownloadInit();
+
+// Check whether we are nearly sync'd.  Used primarily to determine whether an xthin can be retrieved.
 extern bool IsChainNearlySyncd();
 extern void IsChainNearlySyncdInit();
 extern uint64_t LargestBlockSeen(uint64_t nBlockSize = 0);


### PR DESCRIPTION
use the same approach we used for IsChainNearlySyncd by setting an atomic bool every time a header or block is processed.  

This approach also further reduces the contention on cs_main.