### PR TITLE
Request Manager fixes for out of order blocks , thinblocks and regtest workaround

### DIFF
--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -474,13 +474,15 @@ void CRequestManager::SendRequests()
     }
 
     // Get Blocks
-    for (vector<uint256>::iterator sendBlkIter = vBlockRequestOrder.begin(); sendBlkIter != vBlockRequestOrder.end(); sendBlkIter++)
+    sendBlkIter = vBlockRequestOrder.begin();
+    while (sendBlkIter != vBlockRequestOrder.end())
     {
         now = GetTimeMicros();
         OdMap::iterator itemIter = mapBlkInfo.find((*sendBlkIter));
         if (itemIter == mapBlkInfo.end())
             break;
         CUnknownObj& item = itemIter->second;
+        sendBlkIter++;
 
         if (now-item.lastRequestTime > blkReqRetryInterval)  // if never requested then lastRequestTime==0 so this will always be true
         {

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -80,9 +80,7 @@ void CRequestManager::cleanup(OdMap::iterator &itemIt)
     droppedTxns -= (item.outstandingReqs - 1);
     pendingTxns -= 1;
 
-    LOCK(cs_vNodes);
-
-    // remove all the source nodes
+     // remove all the source nodes
     for (CUnknownObj::ObjectSourceList::iterator i = item.availableFrom.begin(); i != item.availableFrom.end(); ++i)
     {
         CNode *node = i->node;
@@ -141,8 +139,8 @@ void CRequestManager::AskFor(const CInv &obj, CNode *from, int priority)
     }
     else if ((obj.type == MSG_BLOCK) || (obj.type == MSG_THINBLOCK) || (obj.type == MSG_XTHINBLOCK))
     {
-        uint256 temp = obj.hash;
-        OdMap::value_type v(temp, CUnknownObj());
+        uint256 hash = obj.hash;
+        OdMap::value_type v(hash, CUnknownObj());
 
         // for blocks we must add to both mapBlkInfo and vBlockRequestOrder
         std::pair<OdMap::iterator,bool> result = mapBlkInfo.insert(v);
@@ -348,7 +346,7 @@ void CUnknownObj::AddSource(CNode *from)
     }
 }
 
-void RequestBlock(CNode *pfrom, CInv obj)
+bool RequestBlock(CNode *pfrom, CInv obj)
 {
     const CChainParams &chainParams = Params();
 
@@ -481,7 +479,7 @@ void CRequestManager::SendRequests()
         OdMap::iterator itemIter = mapBlkInfo.find((*sendBlkIter));
         if (itemIter == mapBlkInfo.end())
             break;
-        CUnknownObj& item = itemIter->second;
+        CUnknownObj &item = itemIter->second;
         sendBlkIter++;
 
         if (now-item.lastRequestTime > blkReqRetryInterval)  // if never requested then lastRequestTime==0 so this will always be true

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -6,6 +6,7 @@
 #define REQUEST_MANAGER_H
 #include "net.h"
 #include "stat.h"
+
 // When should I request a tx from someone else (in microseconds). cmdline/bitcoin.conf: -txretryinterval
 extern unsigned int MIN_TX_REQUEST_RETRY_INTERVAL;
 // When should I request a block from someone else (in microseconds). cmdline/bitcoin.conf: -blkretryinterval
@@ -65,6 +66,12 @@ public:
 class CRequestManager
 {
 protected:
+
+    // keeps track of the order of block requests so we can iterate through
+    // the mapBlkInfo in the order that block INV or HEADERS were received.
+    // This keeps blocks from returning out of order.
+    std::vector<uint256> vBlockRequestOrder;
+
     // map of transactions
     typedef std::map<uint256, CUnknownObj> OdMap;
     OdMap mapTxnInfo;

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -79,7 +79,7 @@ protected:
     CCriticalSection cs_objDownloader; // protects mapTxnInfo and mapBlkInfo
 
     OdMap::iterator sendIter;
-    OdMap::iterator sendBlkIter;
+    std::vector<uint256>::iterator sendBlkIter;
 
     int inFlight;
     // int maxInFlight;


### PR DESCRIPTION
Several items here:

Blocks are now requested in Request manager in the correct order, or rather the order than INV's were received.  This fixes some issues with regression tests and is  more efficient at connecting blocks because they no longer have to be written to disk, then read from disk to be connected.  

If two thinblocks are requested from the same peer, only one will actually be requested but the block source to the second will get deleted. This behavior would cause frequent hangups on regtest and cause block to be re-requested in the future.  Instead we do not delete the block source if we we're unable to actually make the request.

With the two fixes above the "regtest" workaround is no longer needed for the block re-request intterval.