### PR TITLE
[WIP] Clear all send and receive queues when node disconnects

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -473,9 +473,21 @@ void CNode::CloseSocketDisconnect()
     }
 
     // in case this fails, we'll empty the recv buffer when the CNode is deleted
-    TRY_LOCK(cs_vRecvMsg, lockRecv);
-    if (lockRecv)
-        vRecvMsg.clear();
+    // in case this fails, we'll empty the recv buffer when the CNode is deleted
+    {
+        TRY_LOCK(cs_vRecvMsg, lock);
+        if (lock) {
+            vRecvMsg.clear();
+            vRecvGetData.clear();
+        }
+    }
+
+    {
+        TRY_LOCK(cs_vSend, lock);
+        if (lock) {
+            vSendMsg.clear();
+        }
+    }
 }
 
 void CNode::PushVersion()

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -472,22 +472,23 @@ void CNode::CloseSocketDisconnect()
         CloseSocket(hSocket);
     }
 
-    // in case this fails, we'll empty the recv buffer when the CNode is deleted
-    // in case this fails, we'll empty the recv buffer when the CNode is deleted
+    // In case these fail, we'll empty the buffers when the CNode is deleted
+    // We have to use try locks because of the potential for a deadlock.
     {
-        TRY_LOCK(cs_vRecvMsg, lock);
-        if (lock) {
+        TRY_LOCK(cs_vRecvMsg, lockrecv);
+        if (lockrecv) {
             vRecvMsg.clear();
             vRecvGetData.clear();
         }
     }
-
+/*
     {
-        TRY_LOCK(cs_vSend, lock);
-        if (lock) {
+        TRY_LOCK(cs_vSend, locksend);
+        if (locksend) {
             vSendMsg.clear();
         }
     }
+*/
 }
 
 void CNode::PushVersion()


### PR DESCRIPTION
Previously we were only clearing vRecvMsg however there are
two other queues vSendMsg and vRecvGetData which need to be cleared
as well.  A TRY_LOCK is used because of the potential for deadlock
although not likely because at this point there should be no other
contention.