### PR TITLE
Remove -minrelaytxfee as a config option

### DIFF
--- a/qa/rpc-tests/abandonconflict.py
+++ b/qa/rpc-tests/abandonconflict.py
@@ -13,7 +13,7 @@ class AbandonConflictTest(BitcoinTestFramework):
 
     def setup_network(self):
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minrelaytxfee=0.00001"]))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minlimitertxfee=1.0"]))
         self.nodes.append(start_node(1, self.options.tmpdir, ["-debug","-logtimemicros"]))
         connect_nodes(self.nodes[0], 1)
 
@@ -72,7 +72,7 @@ class AbandonConflictTest(BitcoinTestFramework):
         # TODO: redo with eviction
         # Note had to make sure tx did not have AllowFree priority
         stop_node(self.nodes[0],0)
-        self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minrelaytxfee=0.0001"])
+        self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minlimitertxfee=10.0"])
 
         # Verify txs no longer in mempool
         assert(len(self.nodes[0].getrawmempool()) == 0)
@@ -98,7 +98,7 @@ class AbandonConflictTest(BitcoinTestFramework):
 
         # Verify that even with a low min relay fee, the tx is not reaccepted from wallet on startup once abandoned
         stop_node(self.nodes[0],0)
-        self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minrelaytxfee=0.00001"])
+        self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minlimitertxfee=1.0"])
         assert(len(self.nodes[0].getrawmempool()) == 0)
         assert(self.nodes[0].getbalance() == balance)
 
@@ -118,7 +118,7 @@ class AbandonConflictTest(BitcoinTestFramework):
 
         # Remove using high relay fee again
         stop_node(self.nodes[0],0)
-        self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minrelaytxfee=0.0001"])
+        self.nodes[0]=start_node(0, self.options.tmpdir, ["-debug","-logtimemicros","-minlimitertxfee=10.0"])
         assert(len(self.nodes[0].getrawmempool()) == 0)
         newbalance = self.nodes[0].getbalance()
         assert(newbalance == balance - Decimal("24.9996"))

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -55,9 +55,9 @@ extern std::string minerComment;  // An arbitrary field that miners can change t
 
 // BU - Xtreme Thinblocks Auto Mempool Limiter - begin section
 /** The default value for -minrelaytxfee */
-static const char DEFAULT_MINLIMITERTXFEE[] = "0.0";
+static const char DEFAULT_MINLIMITERTXFEE[] = "0.000";
 /** The default value for -maxrelaytxfee */
-static const char DEFAULT_MAXLIMITERTXFEE[] = "3.0";
+static const char DEFAULT_MAXLIMITERTXFEE[] = "3.000";
 /** The number of block heights to gradually choke spam transactions over */
 static const unsigned int MAX_BLOCK_SIZE_MULTIPLIER = 3;
 /** The minimum value possible for -limitfreerelay when rate limiting */


### PR DESCRIPTION
Although minrelaytxfee is used internally it is no longer a config
option and minlimitertxfee is used in its place.