### PR TITLE
Get build working on Mac

### DIFF
--- a/build-aux/m4/ax_cxx_compile_stdcxx.m4
+++ b/build-aux/m4/ax_cxx_compile_stdcxx.m4
@@ -9,9 +9,9 @@
 # DESCRIPTION
 #
 #   Check for baseline language coverage in the compiler for the specified
-#   version of the C++ standard.  If necessary, add switches to CXX and
-#   CXXCPP to enable support.  VERSION may be '11' (for the C++11 standard)
-#   or '14' (for the C++14 standard).
+#   version of the C++ standard.  If necessary, add switches to CXXFLAGS to
+#   enable support.  VERSION may be '11' (for the C++11 standard) or '14'
+#   (for the C++14 standard).
 #
 #   The second argument, if specified, indicates whether you insist on an
 #   extended mode (e.g. -std=gnu++11) or a strict conformance mode (e.g.
@@ -39,7 +39,7 @@
 #   and this notice are preserved.  This file is offered as-is, without any
 #   warranty.
 
-#serial 4
+#serial 1
 
 dnl  This macro is based on the code from the AX_CXX_COMPILE_STDCXX_11 macro
 dnl  (serial version number 13).
@@ -74,17 +74,14 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
       cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
       AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
                      $cachevar,
-        [ac_save_CXX="$CXX"
-         CXX="$CXX $switch"
+        [ac_save_CXXFLAGS="$CXXFLAGS"
+         CXXFLAGS="$CXXFLAGS $switch"
          AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
           [eval $cachevar=yes],
           [eval $cachevar=no])
-         CXX="$ac_save_CXX"])
+         CXXFLAGS="$ac_save_CXXFLAGS"])
       if eval test x\$$cachevar = xyes; then
-        CXX="$CXX $switch"
-        if test -n "$CXXCPP" ; then
-          CXXCPP="$CXXCPP $switch"
-        fi
+        CXXFLAGS="$CXXFLAGS $switch"
         ac_success=yes
         break
       fi
@@ -100,17 +97,14 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
       cachevar=AS_TR_SH([ax_cv_cxx_compile_cxx$1_$switch])
       AC_CACHE_CHECK(whether $CXX supports C++$1 features with $switch,
                      $cachevar,
-        [ac_save_CXX="$CXX"
-         CXX="$CXX $switch"
+        [ac_save_CXXFLAGS="$CXXFLAGS"
+         CXXFLAGS="$CXXFLAGS $switch"
          AC_COMPILE_IFELSE([AC_LANG_SOURCE([_AX_CXX_COMPILE_STDCXX_testbody_$1])],
           [eval $cachevar=yes],
           [eval $cachevar=no])
-         CXX="$ac_save_CXX"])
+         CXXFLAGS="$ac_save_CXXFLAGS"])
       if eval test x\$$cachevar = xyes; then
-        CXX="$CXX $switch"
-        if test -n "$CXXCPP" ; then
-          CXXCPP="$CXXCPP $switch"
-        fi
+        CXXFLAGS="$CXXFLAGS $switch"
         ac_success=yes
         break
       fi
@@ -121,16 +115,18 @@ AC_DEFUN([AX_CXX_COMPILE_STDCXX], [dnl
     if test x$ac_success = xno; then
       AC_MSG_ERROR([*** A compiler with support for C++$1 language features is required.])
     fi
-  fi
-  if test x$ac_success = xno; then
-    HAVE_CXX$1=0
-    AC_MSG_NOTICE([No compiler with C++$1 support was found])
   else
-    HAVE_CXX$1=1
-    AC_DEFINE(HAVE_CXX$1,1,
-              [define if the compiler supports basic C++$1 syntax])
+    if test x$ac_success = xno; then
+      HAVE_CXX$1=0
+      AC_MSG_NOTICE([No compiler with C++$1 support was found])
+    else
+      HAVE_CXX$1=1
+      AC_DEFINE(HAVE_CXX$1,1,
+                [define if the compiler supports basic C++$1 syntax])
+    fi
+
+    AC_SUBST(HAVE_CXX$1)
   fi
-  AC_SUBST(HAVE_CXX$1)
 ])
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -332,6 +332,9 @@ case $host in
            AC_PATH_TOOL([INSTALLNAMETOOL], [install_name_tool], install_name_tool)
            AC_PATH_TOOL([OTOOL], [otool], otool)
            AC_PATH_PROGS([GENISOIMAGE], [genisoimage mkisofs],genisoimage)
+           AC_PATH_PROGS([RSVG_CONVERT], [rsvg-convert rsvg],rsvg-convert)
+           AC_PATH_PROGS([IMAGEMAGICK_CONVERT], [convert],convert)
+           AC_PATH_PROGS([TIFFCP], [tiffcp],tiffcp)
 
            dnl libtool will try to strip the static lib, which is a problem for
            dnl cross-builds because strip attempts to call a hard-coded ld,

--- a/doc/README_osx.md
+++ b/doc/README_osx.md
@@ -1,21 +1,19 @@
 Deterministic OS X Dmg Notes.
 
 Working OS X DMGs are created in Linux by combining a recent clang,
-the Apple's binutils (ld, ar, etc), and DMG authoring tools.
+the Apple binutils (ld, ar, etc) and DMG authoring tools.
 
 Apple uses clang extensively for development and has upstreamed the necessary
 functionality so that a vanilla clang can take advantage. It supports the use
 of -F, -target, -mmacosx-version-min, and --sysroot, which are all necessary
-when building for OS X. A pre-compiled version of 3.2 is used because it was not
-available in the Precise repositories at the time this work was started. In the
-future, it can be switched to use system packages instead.
+when building for OS X.
 
 Apple's version of binutils (called cctools) contains lots of functionality
 missing in the FSF's binutils. In addition to extra linker options for
 frameworks and sysroots, several other tools are needed as well such as
 install_name_tool, lipo, and nmedit. These do not build under linux, so they
 have been patched to do so. The work here was used as a starting point:
-https://github.com/mingwandroid/toolchain4
+[mingwandroid/toolchain4](https://github.com/mingwandroid/toolchain4).
 
 In order to build a working toolchain, the following source packages are needed
 from Apple: cctools, dyld, and ld64.
@@ -29,16 +27,19 @@ originally done in toolchain4.
 
 To complicate things further, all builds must target an Apple SDK. These SDKs
 are free to download, but not redistributable.
-To obtain it, register for a developer account, then download the Xcode 6.1.1 dmg:
-https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/xcode_6.1.1/xcode_6.1.1.dmg
+To obtain it, register for a developer account, then download the [Xcode 7.3.1 dmg](https://developer.apple.com/devcenter/download.action?path=/Developer_Tools/Xcode_7.3.1/Xcode_7.3.1.dmg).
 
 This file is several gigabytes in size, but only a single directory inside is
-needed: Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.9.sdk
+needed:
+```
+Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk
+```
 
 Unfortunately, the usual linux tools (7zip, hpmount, loopback mount) are incapable of opening this file.
 To create a tarball suitable for Gitian input, mount the dmg in OS X, then create it with:
-  $ tar -C /Volumes/Xcode/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/ -czf MacOSX10.9.sdk.tar.gz MacOSX10.9.sdk
-
+```
+  $ tar -C /Volumes/Xcode/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/ -czf MacOSX10.11.sdk.tar.gz MacOSX10.11.sdk
+```
 
 The Gitian descriptors build 2 sets of files: Linux tools, then Apple binaries
 which are created using these tools. The build process has been designed to
@@ -48,15 +49,14 @@ fully deterministic and may be freely redistributed.
 genisoimage is used to create the initial DMG. It is not deterministic as-is,
 so it has been patched. A system genisoimage will work fine, but it will not
 be deterministic because the file-order will change between invocations.
-The patch can be seen here:
-https://raw.githubusercontent.com/theuni/osx-cross-depends/master/patches/cdrtools/genisoimage.diff
+The patch can be seen here:  [theuni/osx-cross-depends](https://raw.githubusercontent.com/theuni/osx-cross-depends/master/patches/cdrtools/genisoimage.diff).
 No effort was made to fix this cleanly, so it likely leaks memory badly. But
 it's only used for a single invocation, so that's no real concern.
 
 genisoimage cannot compress DMGs, so afterwards, the 'dmg' tool from the
 libdmg-hfsplus project is used to compress it. There are several bugs in this
 tool and its maintainer has seemingly abandoned the project. It has been forked
-and is available (with fixes) here: https://github.com/theuni/libdmg-hfsplus .
+and is available (with fixes) here: [theuni/libdmg-hfsplus](https://github.com/theuni/libdmg-hfsplus).
 
 The 'dmg' tool has the ability to create DMGs from scratch as well, but this
 functionality is broken. Only the compression feature is currently used.
@@ -78,6 +78,6 @@ build process to remain somewhat deterministic. Here's how it works:
   that have been previously (deterministically) built in order to create a
   final dmg.
 - The Apple keyholder uses this unsigned app to create a detached signature,
-  using the script that is also included there.
+  using the script that is also included there. Detached signatures are available from this [repository](https://github.com/bitcoin-core/bitcoin-detached-sigs).
 - Builders feed the unsigned app + detached signature back into Gitian. It
   uses the pre-built tools to recombine the pieces into a deterministic dmg.

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -16,7 +16,7 @@ Then install [Homebrew](http://brew.sh).
 Dependencies
 ----------------------
 
-    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config homebrew/versions/protobuf260 --c++11 qt5 libevent
+    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config protobuf --c++11 qt5 libevent
 
 In case you want to build the disk image with `make deploy` (.dmg / optional), you need RSVG
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -5,11 +5,13 @@ The built-in one is located in `/Applications/Utilities/Terminal.app`.
 
 Preparation
 -----------
-Download and install [Xcode](https://developer.apple.com/xcode/download).
+Install the OS X command line tools:
 
-Once installed, run `xcode-select --install` to install the OS X command line tools.
+`xcode-select --install`
 
-Install [Homebrew](http://brew.sh).
+When the popup appears, click `Install`.
+
+Then install [Homebrew](http://brew.sh).
 
 Dependencies
 ----------------------

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -1,6 +1,6 @@
 Mac OS X Build Instructions and Notes
 ====================================
-This guide will show you how to build bitcoind (headless client) for OS X.
+This guide will show you how to build Bitcoin Core for OS X.
 
 Notes
 -----
@@ -114,6 +114,16 @@ you can monitor its process by looking at the debug.log file, like this:
 Other commands:
 -------
 
-    ./bitcoind -daemon # to start the bitcoin daemon.
+    ./bitcoind -daemon    # to start the bitcoin daemon.
     ./bitcoin-cli --help  # for a list of command-line options.
     ./bitcoin-cli help    # When the daemon is running, to get a list of RPC commands
+
+Using Qt official installer while building
+------------------------------------------
+
+If you prefer to use the latest Qt installed from the official binary
+installer over the brew version, you have to make several changes to
+the installed tree and its binaries (all these changes are contained
+in the brew version already). The changes needed are described in
+[#7714](https://github.com/bitcoin/bitcoin/issues/7714). We do not
+support building Bitcoin Core this way though.

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -16,7 +16,7 @@ Then install [Homebrew](http://brew.sh).
 Dependencies
 ----------------------
 
-    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config protobuf --c++11 qt5 libevent
+    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config homebrew/versions/protobuf260 --c++11 qt5 libevent
 
 NOTE: Building with Qt4 is still supported, however, could result in a broken UI. Building with Qt5 is recommended.
 

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -90,6 +90,6 @@ Uncheck everything except Qt Creator during the installation process.
 Notes
 -----
 
-* Tested on OS X 10.7 through 10.11 on 64-bit Intel processors only.
+* Tested on OS X 10.8 through 10.12 on 64-bit Intel processors only.
 
 * Building with downloaded Qt binaries is not officially supported. See the notes in [#7714](https://github.com/bitcoin/bitcoin/issues/7714)

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -18,6 +18,10 @@ Dependencies
 
     brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config homebrew/versions/protobuf260 --c++11 qt5 libevent
 
+In case you want to build the disk image with `make deploy` (.dmg / optional), you need RSVG
+
+    brew install librsvg
+
 NOTE: Building with Qt4 is still supported, however, could result in a broken UI. Building with Qt5 is recommended.
 
 Build Bitcoin Core

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -5,18 +5,16 @@ The built-in one is located in `/Applications/Utilities/Terminal.app`.
 
 Preparation
 -----------
-Install the OS X command line tools:
+Download and install [Xcode](https://developer.apple.com/xcode/download).
 
-`xcode-select --install`
+Once installed, run `xcode-select --install` to install the OS X command line tools.
 
-When the popup appears, click `Install`.
-
-Then install [Homebrew](http://brew.sh).
+Install [Homebrew](http://brew.sh).
 
 Dependencies
 ----------------------
 
-    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config homebrew/versions/protobuf260 --c++11 qt5 libevent
+    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config protobuf --c++11 qt5 libevent
 
 NOTE: Building with Qt4 is still supported, however, could result in a broken UI. Building with Qt5 is recommended.
 
@@ -90,6 +88,6 @@ Uncheck everything except Qt Creator during the installation process.
 Notes
 -----
 
-* Tested on OS X 10.8 through 10.12 on 64-bit Intel processors only.
+* Tested on OS X 10.7 through 10.11 on 64-bit Intel processors only.
 
 * Building with downloaded Qt binaries is not officially supported. See the notes in [#7714](https://github.com/bitcoin/bitcoin/issues/7714)

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -1,68 +1,78 @@
 Mac OS X Build Instructions and Notes
 ====================================
-This guide will show you how to build Bitcoin Core for OS X.
-
-Notes
------
-
-* Tested on OS X 10.7 through 10.11 on 64-bit Intel processors only.
-
-* All of the commands should be executed in a Terminal application. The
-built-in one is located in `/Applications/Utilities`.
+The commands in this guide should be executed in a Terminal application.
+The built-in one is located in `/Applications/Utilities/Terminal.app`.
 
 Preparation
 -----------
+Download and install [Xcode](https://developer.apple.com/xcode/download).
 
-You need to install Xcode with all the options checked so that the compiler
-and everything is available in /usr not just /Developer. Xcode should be
-available on your OS X installation media, but if not, you can get the
-current version from https://developer.apple.com/xcode/. If you install
-Xcode 4.3 or later, you'll need to install its command line tools. This can
-be done in `Xcode > Preferences > Downloads > Components` and generally must
-be re-done or updated every time Xcode is updated.
+Once installed, run `xcode-select --install` to install the OS X command line tools.
 
-You will also need to install [Homebrew](http://brew.sh) in order to install library
-dependencies.
+Install [Homebrew](http://brew.sh).
 
-The installation of the actual dependencies is covered in the instructions
-sections below.
-
-Instructions: Homebrew
+Dependencies
 ----------------------
 
-#### Install dependencies using Homebrew
+    brew install automake berkeley-db4 libtool boost --c++11 miniupnpc openssl pkg-config protobuf --c++11 qt5 libevent
 
-    brew install autoconf automake berkeley-db4 libtool boost miniupnpc openssl pkg-config protobuf qt5 libevent
+NOTE: Building with Qt4 is still supported, however, could result in a broken UI. Building with Qt5 is recommended.
 
-NOTE: Building with Qt4 is still supported, however, could result in a broken UI. As such, building with Qt5 is recommended.
+Build Bitcoin Core
+------------------------
 
-### Building `bitcoin`
-
-1. Clone the GitHub tree to get the source code and go into the directory.
+1. Clone the bitcoin source code and cd into `bitcoin`
 
         git clone https://github.com/BitcoinUnlimited/BitcoinUnlimited.git
         cd bitcoin
 
 2.  Build bitcoin-core:
-    This will configure and build the headless bitcoin binaries as well as the gui (if Qt is found).
-    You can disable the gui build by passing `--without-gui` to configure.
+
+    Configure and build the headless bitcoin binaries as well as the GUI (if Qt is found).
+
+    You can disable the GUI build by passing `--without-gui` to configure.
 
         ./autogen.sh
         ./configure
         make
 
-3.  It is also a good idea to build and run the unit tests:
+3.  It is recommended to build and run the unit tests:
 
         make check
 
-4.  (Optional) You can also install bitcoind to your path:
+4.  You can also create a .dmg that contains the .app bundle (optional):
 
-        make install
+        make deploy
 
-Use Qt Creator as IDE
+Running
+-------
+
+Bitcoin Core is now available at `./src/bitcoind`
+
+Before running, it's recommended you create an RPC configuration file.
+
+    echo -e "rpcuser=bitcoinrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
+
+    chmod 600 "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
+
+The first time you run bitcoind, it will start downloading the blockchain. This process could take several hours.
+
+You can monitor the download process by looking at the debug.log file:
+
+    tail -f $HOME/Library/Application\ Support/Bitcoin/debug.log
+
+Other commands:
+-------
+
+    ./src/bitcoind -daemon # Starts the bitcoin daemon.
+    ./src/bitcoin-cli --help # Outputs a list of command-line options.
+    ./src/bitcoin-cli help # Outputs a list of RPC commands when the daemon is running.
+
+Using Qt Creator as IDE
 ------------------------
-You can use Qt Creator as IDE, for debugging and for manipulating forms, etc.
-Download Qt Creator from https://www.qt.io/download/. Download the "community edition" and only install Qt Creator (uncheck the rest during the installation process).
+You can use Qt Creator as an IDE, for bitcoin development.
+Download and install the community edition of [Qt Creator](https://www.qt.io/download/).
+Uncheck everything except Qt Creator during the installation process.
 
 1. Make sure you installed everything through Homebrew mentioned above
 2. Do a proper ./configure --enable-debug
@@ -75,55 +85,9 @@ Download Qt Creator from https://www.qt.io/download/. Download the "community ed
 9. Select LLDB as debugger (you might need to set the path to your installation)
 10. Start debugging with Qt Creator
 
-Creating a release build
-------------------------
-You can ignore this section if you are building `bitcoind` for your own use.
+Notes
+-----
 
-bitcoind/bitcoin-cli binaries are not included in the Bitcoin-Qt.app bundle.
+* Tested on OS X 10.7 through 10.11 on 64-bit Intel processors only.
 
-If you are building `bitcoind` or `bitcoin-qt` for others, your build machine should be set up
-as follows for maximum compatibility:
-
-All dependencies should be compiled with these flags:
-
- -mmacosx-version-min=10.7
- -arch x86_64
- -isysroot $(xcode-select --print-path)/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.7.sdk
-
-Once dependencies are compiled, see [doc/release-process.md](release-process.md) for how the Bitcoin
-bundle is packaged and signed to create the .dmg disk image that is distributed.
-
-Running
--------
-
-It's now available at `./bitcoind`, provided that you are still in the `src`
-directory. We have to first create the RPC configuration file, though.
-
-Run `./bitcoind` to get the filename where it should be put, or just try these
-commands:
-
-    echo -e "rpcuser=bitcoinrpc\nrpcpassword=$(xxd -l 16 -p /dev/urandom)" > "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
-    chmod 600 "/Users/${USER}/Library/Application Support/Bitcoin/bitcoin.conf"
-
-The next time you run it, it will start downloading the blockchain, but it won't
-output anything while it's doing this. This process may take several hours;
-you can monitor its process by looking at the debug.log file, like this:
-
-    tail -f $HOME/Library/Application\ Support/Bitcoin/debug.log
-
-Other commands:
--------
-
-    ./bitcoind -daemon    # to start the bitcoin daemon.
-    ./bitcoin-cli --help  # for a list of command-line options.
-    ./bitcoin-cli help    # When the daemon is running, to get a list of RPC commands
-
-Using Qt official installer while building
-------------------------------------------
-
-If you prefer to use the latest Qt installed from the official binary
-installer over the brew version, you have to make several changes to
-the installed tree and its binaries (all these changes are contained
-in the brew version already). The changes needed are described in
-[#7714](https://github.com/bitcoin/bitcoin/issues/7714). We do not
-support building Bitcoin Core this way though.
+* Building with downloaded Qt binaries is not officially supported. See the notes in [#7714](https://github.com/bitcoin/bitcoin/issues/7714)

--- a/doc/build-osx.md
+++ b/doc/build-osx.md
@@ -24,15 +24,15 @@ In case you want to build the disk image with `make deploy` (.dmg / optional), y
 
 NOTE: Building with Qt4 is still supported, however, could result in a broken UI. Building with Qt5 is recommended.
 
-Build Bitcoin Core
+Build Bitcoin Unlimited
 ------------------------
 
-1. Clone the bitcoin source code and cd into `bitcoin`
+1. Clone the bitcoin source code and cd into `BitcoinUnlimited`
 
         git clone https://github.com/BitcoinUnlimited/BitcoinUnlimited.git
-        cd bitcoin
+        cd BitcoinUnlimited
 
-2.  Build bitcoin-core:
+2.  Build:
 
     Configure and build the headless bitcoin binaries as well as the GUI (if Qt is found).
 
@@ -53,7 +53,7 @@ Build Bitcoin Core
 Running
 -------
 
-Bitcoin Core is now available at `./src/bitcoind`
+Bitcoin Unlimlited is now available at `./src/bitcoind`
 
 Before running, it's recommended you create an RPC configuration file.
 

--- a/src/Makefile.qttest.include
+++ b/src/Makefile.qttest.include
@@ -1,13 +1,16 @@
 bin_PROGRAMS += qt/test/test_bitcoin-qt
 TESTS += qt/test/test_bitcoin-qt
 
-TEST_QT_MOC_CPP = qt/test/moc_uritests.cpp
+TEST_QT_MOC_CPP = \
+  qt/test/moc_compattests.cpp \
+  qt/test/moc_uritests.cpp
 
 if ENABLE_WALLET
 TEST_QT_MOC_CPP += qt/test/moc_paymentservertests.cpp
 endif
 
 TEST_QT_H = \
+  qt/test/compattests.h \
   qt/test/uritests.h \
   qt/test/paymentrequestdata.h \
   qt/test/paymentservertests.h
@@ -16,6 +19,7 @@ qt_test_test_bitcoin_qt_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(BITCOIN_
   $(QT_INCLUDES) $(QT_TEST_INCLUDES) $(PROTOBUF_CFLAGS)
 
 qt_test_test_bitcoin_qt_SOURCES = \
+  qt/test/compattests.cpp \
   qt/test/test_main.cpp \
   qt/test/uritests.cpp \
   $(TEST_QT_H)

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -47,6 +47,7 @@ BITCOIN_TESTS =\
   test/bloom_tests.cpp \
   test/checkblock_tests.cpp \
   test/Checkpoints_tests.cpp \
+  test/bswap_tests.cpp \
   test/coins_tests.cpp \
   test/compress_tests.cpp \
   test/crypto_tests.cpp \

--- a/src/compat/byteswap.h
+++ b/src/compat/byteswap.h
@@ -15,6 +15,23 @@
 #include <byteswap.h>
 #endif
 
+#if defined(__APPLE__)
+
+#if !defined(bswap_16)
+
+// Mac OS X / Darwin features; we include a check for bswap_16 because if it is already defined, protobuf has
+// defined these macros for us already; if it isn't, we do it ourselves. In either case, we get the exact same
+// result regardless which path was taken
+#include <libkern/OSByteOrder.h>
+#define bswap_16(x) OSSwapInt16(x)
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)
+
+#endif // !defined(bswap_16)
+
+#else
+// Non-Mac OS X / non-Darwin
+
 #if HAVE_DECL_BSWAP_16 == 0
 inline uint16_t bswap_16(uint16_t x)
 {
@@ -43,5 +60,7 @@ inline uint64_t bswap_64(uint64_t x)
           | ((x & 0x00000000000000ffull) << 56));
 }
 #endif // HAVE_DECL_BSWAP64
+
+#endif // defined(__APPLE__)
 
 #endif // BITCOIN_COMPAT_BYTESWAP_H

--- a/src/qt/test/compattests.cpp
+++ b/src/qt/test/compattests.cpp
@@ -1,0 +1,23 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "paymentrequestplus.h" // this includes protobuf's port.h which defines its own bswap macos
+
+#include "compattests.h"
+
+#include "compat/byteswap.h"
+
+void CompatTests::bswapTests()
+{
+	// Sibling in bitcoin/src/test/bswap_tests.cpp
+	uint16_t u1 = 0x1234;
+	uint32_t u2 = 0x56789abc;
+	uint64_t u3 = 0xdef0123456789abc;
+	uint16_t e1 = 0x3412;
+	uint32_t e2 = 0xbc9a7856;
+	uint64_t e3 = 0xbc9a78563412f0de;
+	QVERIFY(bswap_16(u1) == e1);
+	QVERIFY(bswap_32(u2) == e2);
+	QVERIFY(bswap_64(u3) == e3);
+}

--- a/src/qt/test/compattests.h
+++ b/src/qt/test/compattests.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TEST_COMPATTESTS_H
+#define BITCOIN_QT_TEST_COMPATTESTS_H
+
+#include <QObject>
+#include <QTest>
+
+class CompatTests : public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void bswapTests();
+};
+
+#endif // BITCOIN_QT_TEST_COMPATTESTS_H

--- a/src/qt/test/test_main.cpp
+++ b/src/qt/test/test_main.cpp
@@ -9,6 +9,7 @@
 
 #include "util.h"
 #include "uritests.h"
+#include "compattests.h"
 
 #ifdef ENABLE_WALLET
 #include "paymentservertests.h"
@@ -49,6 +50,9 @@ int main(int argc, char *argv[])
     if (QTest::qExec(&test2) != 0)
         fInvalid = true;
 #endif
+    CompatTests test4;
+    if (QTest::qExec(&test4) != 0)
+        fInvalid = true;
 
     return fInvalid;
 }

--- a/src/test/bswap_tests.cpp
+++ b/src/test/bswap_tests.cpp
@@ -1,0 +1,26 @@
+// Copyright (c) 2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "compat/byteswap.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(bswap_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(bswap_tests)
+{
+	// Sibling in bitcoin/src/qt/test/compattests.cpp
+	uint16_t u1 = 0x1234;
+	uint32_t u2 = 0x56789abc;
+	uint64_t u3 = 0xdef0123456789abc;
+	uint16_t e1 = 0x3412;
+	uint32_t e2 = 0xbc9a7856;
+	uint64_t e3 = 0xbc9a78563412f0de;
+	BOOST_CHECK(bswap_16(u1) == e1);
+	BOOST_CHECK(bswap_32(u2) == e2);
+	BOOST_CHECK(bswap_64(u3) == e3);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Two build fixes and several doc updates from Core with conflicts resolved.

Not entirely clear how our copies of build-aux/m4/ax_cxx_compiled_stdcxx.m4 got out of sync but I need Core's version that uses CXXFLAGS for the Mac build to work.

Also pulled pertinent doc updates except for release-process.md which was too differrent to sensibly merge, and I suspect our release process is different anyway.

With these changes I can build on Mac Sierra following the instructions.