### PR TITLE
Removed redundant parameter from mempool.PrioritiseTransaction

### DIFF
--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -298,7 +298,7 @@ UniValue prioritisetransaction(const UniValue& params, bool fHelp)
     uint256 hash = ParseHashStr(params[0].get_str(), "txid");
     CAmount nAmount = params[2].get_int64();
 
-    mempool.PrioritiseTransaction(hash, params[0].get_str(), params[1].get_real(), nAmount);
+    mempool.PrioritiseTransaction(hash, params[1].get_real(), nAmount);
     return true;
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -802,7 +802,7 @@ CTxMemPool::ReadFeeEstimates(CAutoFile& filein)
     return true;
 }
 
-void CTxMemPool::PrioritiseTransaction(const uint256 hash, const string strHash, double dPriorityDelta, const CAmount& nFeeDelta)
+void CTxMemPool::PrioritiseTransaction(const uint256& hash, double dPriorityDelta, const CAmount& nFeeDelta)
 {
     {
         LOCK(cs);
@@ -822,7 +822,7 @@ void CTxMemPool::PrioritiseTransaction(const uint256 hash, const string strHash,
             }
         }
     }
-    LogPrintf("PrioritiseTransaction: %s priority += %f, fee += %d\n", strHash, dPriorityDelta, FormatMoney(nFeeDelta));
+    LogPrintf("PrioritiseTransaction: %s priority += %f, fee += %d\n", hash.ToString(), dPriorityDelta, FormatMoney(nFeeDelta));
 }
 
 void CTxMemPool::ApplyDeltas(const uint256 hash, double &dPriorityDelta, CAmount &nFeeDelta) const

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -477,7 +477,7 @@ public:
     bool HasNoInputsOf(const CTransaction& tx) const;
 
     /** Affect CreateNewBlock prioritisation of transactions */
-    void PrioritiseTransaction(const uint256 hash, const std::string strHash, double dPriorityDelta, const CAmount& nFeeDelta);
+    void PrioritiseTransaction(const uint256& hash, double dPriorityDelta, const CAmount& nFeeDelta);
     void ApplyDeltas(const uint256 hash, double &dPriorityDelta, CAmount &nFeeDelta) const;
     void ClearPrioritisation(const uint256 hash);
 


### PR DESCRIPTION
The string parameter is used only for logging.

The only place where the string form of the hash isn't recalculated is at src/rpc/mining.cpp where it's obtained from the arguments, however, in this case the uint256 hash is then parsed from the given string.

In every other use of the function, the string representation is always calculated from the uint256 hash object (either with ToString() or with GetHash()), so no real benefit on having this redundant parameter.

This also makes the API more consistent with other methods that only receive the uint256 hash parameter.

Cheers

Note: this patch was accepted and merged in Bitcoin-Core
https://github.com/bitcoin/bitcoin/pull/9801