### PR TITLE
Updates for PV:  Boost Scope Guard for PV.SetLocks

### DIFF
--- a/qa/rpc-tests/getblocktemplate_longpoll.py
+++ b/qa/rpc-tests/getblocktemplate_longpoll.py
@@ -30,6 +30,7 @@ class GetBlockTemplateLPTest(BitcoinTestFramework):
     def run_test(self):
         print("Warning: this test will take about 70 seconds in the best case. Be patient.")
         self.nodes[0].generate(10)
+        self.sync_all()
         templat = self.nodes[0].getblocktemplate()
         longpollid = templat['longpollid']
         # longpollid should not change between successive invocations if nothing else happens

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -267,7 +267,7 @@ class TestManager(object):
                 elif ((c.cb.bestblockhash == blockhash) != outcome):
                     print("Node ", c.addr, " has best block ", hex(c.cb.bestblockhash), ". Expecting ", hex(blockhash), outcome)
                     print("Quick   RPC returns", c.rpc.getbestblockhash())
-                    time.sleep(5) #wait the requestmanager re-request interval to see if the block shows up
+                    time.sleep(5.5) #wait the requestmanager re-request interval to see if the block shows up
                     print("Delayed RPC returns", c.rpc.getbestblockhash())
 
                     rpcblock =  c.rpc.getbestblockhash()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2580,9 +2580,11 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     /*********************************************************************************************
      If in PV, unlock cs_main here so we have no contention when we're checking inputs and scripts
      *********************************************************************************************/
-    if (fParallel) cs_main.unlock();
+    if (fParallel) LEAVE_CRITICAL_SECTION(cs_main);
 
+    // Begin Section for Boost Scope Guard
     {
+
     // Scope guard to make sure cs_main is set and resources released if we encounter an exception.
     BOOST_SCOPE_EXIT(&PV, &fParallel)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,7 @@
 #include <boost/filesystem/fstream.hpp>
 #include <boost/math/distributions/poisson.hpp>
 #include <boost/thread.hpp>
+#include <boost/scope_exit.hpp>
 
 using namespace std;
 
@@ -2581,6 +2582,14 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
      *********************************************************************************************/
     if (fParallel) cs_main.unlock();
 
+    {
+    // Scope guard to make sure cs_main is set and resources released if we encounter an exception.
+    BOOST_SCOPE_EXIT(&PV, &fParallel)
+    {
+        PV.SetLocks(fParallel);
+    } BOOST_SCOPE_EXIT_END
+
+
     // Start checking Inputs
     bool inOrphanCache;
     bool inVerifiedCache;
@@ -2604,7 +2613,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 // If we were validating at the same time as another block and the other block wins the validation race
                 // and updates the UTXO first, then we may end up here with missing inputs.  Therefore we checke to see
                 // if the chainwork has advanced or if we recieved a quit and if so return without DOSing the node.
-                PV.SetLocks(fParallel);
                 if (PV.ChainWorkHasChanged(nStartingChainWork) || PV.QuitReceived(this_id, fParallel)) {
                     return false;
                 }
@@ -2621,7 +2629,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
             }
 
             if (!SequenceLocks(tx, nLockTimeFlags, &prevheights, *pindex)) {
-                PV.SetLocks(fParallel);
                 return state.DoS(100, error("%s: contains a non-BIP68-final transaction", __func__),
                                  REJECT_INVALID, "bad-txns-nonfinal");
             }
@@ -2658,7 +2665,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                     std::vector<CScriptCheck> vChecks;
                     bool fCacheResults = fJustCheck; /* Don't cache results if we're actually connecting blocks (still consult the cache, though) */
                     if (!CheckInputs(tx, state, viewTempCache, fScriptChecks, flags, fCacheResults, &resourceTracker, nScriptCheckThreads ? &vChecks : NULL)) {
-                        PV.SetLocks(fParallel);
                         return error("ConnectBlock(): CheckInputs on %s failed with %s", 
                                               tx.GetHash().ToString(), FormatStateMessage(state));
                     }
@@ -2680,7 +2686,6 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         pos.nTxOffset += ::GetSerializeSize(tx, SER_DISK, CLIENT_VERSION);
 
         if (PV.QuitReceived(this_id, fParallel)) {
-            PV.SetLocks(fParallel);
             return false;
         }
     }
@@ -2691,24 +2696,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     LogPrint("parallel", "Waiting for script threads to finish\n");
     if (!control.Wait()) {
         // if we end up here then the signature verification failed and we must re-lock cs_main before returning.
-        PV.SetLocks(fParallel);
         return state.DoS(100, false);
     }
     if (PV.QuitReceived(this_id, fParallel)) {
-        PV.SetLocks(fParallel);
         return false;
-    }
-
-
-    /*****************************************************************************************************************
-     *                         Start update of UTXO, if this block wins the validation race                          *
-     *****************************************************************************************************************/
-    // If in PV mode and we win the race then we lock everyone out before updating the UTXO and terminating any
-    // competing threads.
-    if (fParallel) cs_main.lock();
-    // Last check for chain work just in case the thread manages to get here before being terminated.
-    if (PV.ChainWorkHasChanged(nStartingChainWork) || PV.QuitReceived(this_id, fParallel)) {
-        return false; // no need to lock cs_main before returning as it should already be locked.
     }
 
     CAmount blockReward = nFees + GetBlockSubsidy(pindex->nHeight, chainparams.GetConsensus());
@@ -2720,6 +2711,19 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
     if (fJustCheck)
         return true;
+
+
+    /*****************************************************************************************************************
+     *                         Start update of UTXO, if this block wins the validation race                          *
+     *****************************************************************************************************************/
+    // If in PV mode and we win the race then we lock everyone out by taking cs_main but before updating the UTXO and 
+    // terminating any competing threads.
+    } // cs_main is re-aquired automatically as we go out of scope from the BOOST scope guard
+
+    // Last check for chain work just in case the thread manages to get here before being terminated.
+    if (PV.ChainWorkHasChanged(nStartingChainWork) || PV.QuitReceived(this_id, fParallel)) {
+        return false; // no need to lock cs_main before returning as it should already be locked.
+    }
 
     // Quit any competing threads may be validating which have the same previous block before updating the UTXO.
     PV.QuitCompetingThreads(block.GetBlockHeader().hashPrevBlock); 

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -309,7 +309,7 @@ void CParallelValidation::SetLocks(const bool fParallel)
     if (fParallel)
     {
         // cs_main must be re-locked before returning from ConnectBlock()
-        cs_main.lock();
+        ENTER_CRITICAL_SECTION(cs_main);
         boost::thread::id this_id(boost::this_thread::get_id()); 
         LOCK(cs_blockvalidationthread);
         if (mapBlockValidationThreads.count(this_id))


### PR DESCRIPTION
Using a scope guard here helps to make this more maintainable as we don't have to worry about errors or exceptions with regard to re-aquiring cs_main before returning from connectblock().

Also, using ENTER and LEAVE Critical section since that keeps the lockstack up to date.

And a Timing fix, for getblocktemplate_longpoll