### PR TITLE
Keep orphan cache trimmed

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -810,7 +810,7 @@ void EraseOrphansByTime() EXCLUSIVE_LOCKS_REQUIRED(cs_orphancache)
     // every time a tx enters the mempool but just once every 5 minutes is good enough.
     if (GetTime() <  nLastOrphanCheck + 5*60)
         return;
-    int64_t nOrphanTxCutoffTime = GetTime() - GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60;
+    int64_t nOrphanTxCutoffTime = GetTime() - GetArg("-orphanpoolexpiry", DEFAULT_ORPHANPOOL_EXPIRY) * 60 * 60;
     map<uint256, COrphanTx>::iterator iter = mapOrphanTransactions.begin();
     while (iter != mapOrphanTransactions.end())
     {

--- a/src/main.h
+++ b/src/main.h
@@ -67,6 +67,8 @@ static const unsigned int DEFAULT_DESCENDANT_LIMIT = 25;
 static const unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT = 101;
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static const unsigned int DEFAULT_MEMPOOL_EXPIRY = 72;
+/** Default for -orphanpoolexpiry, expiration time for orphan pool transactions in hours */
+static const unsigned int DEFAULT_ORPHANPOOL_EXPIRY = 4;
 /** The maximum size of a blk?????.dat file (since 0.8) */
 static const unsigned int MAX_BLOCKFILE_SIZE = 0x8000000; // 128 MiB
 /** The pre-allocation chunk size for blk?????.dat files (since 0.8) */

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -100,6 +100,14 @@ extern CAllScriptCheckQueues allScriptCheckQueues; // Singleton class
 
 class CParallelValidation
 {
+
+private:
+
+    // txn hashes that are in the previous block
+    CCriticalSection cs_previousblock;
+    vector<uint256> vPreviousBlock;
+
+
 public:
     struct CHandleBlockMsgThreads {
         CCheckQueue<CScriptCheck>* pScriptQueue;
@@ -162,6 +170,9 @@ public:
     /* Is there a re-org in progress */
     void IsReorgInProgress(const boost::thread::id this_id, const bool fReorg, const bool fParallel);
     bool IsReorgInProgress();
+
+    /* Clear orphans from the orphan cache that are no longer needed*/
+    void ClearOrphanCache(const CBlock &block);
 
     /* Process a block message */
     void HandleBlockMessage(CNode *pfrom, const std::string &strCommand, const CBlock &block, const CInv &inv);

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -234,19 +234,19 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         EraseOrphansByTime();
         BOOST_CHECK(mapOrphanTransactions.size() == 50);
 
-        // Advance the clock 72 hours
-        SetMockTime(nStartTime+60*60*72);
+        // Advance the clock DEFAULT_ORPHANPOOL_EXPIRY hours
+        SetMockTime(nStartTime+60*60*DEFAULT_ORPHANPOOL_EXPIRY);
         EraseOrphansByTime();
         BOOST_CHECK(mapOrphanTransactions.size() == 50);
 
         /** Test the boundary where orphans should get purged. **/
-        // Advance the clock 72 hours and 4 minutes 59 seconds
-        SetMockTime(nStartTime+60*60*72 + 299);
+        // Advance the clock DEFAULT_ORPHANPOOL_EXPIRY hours plus 4 minutes 59 seconds
+        SetMockTime(nStartTime+60*60*DEFAULT_ORPHANPOOL_EXPIRY + 299);
         EraseOrphansByTime();
         BOOST_CHECK(mapOrphanTransactions.size() == 50);
 
-        // Advance the clock 72 hours and 5 minutes
-        SetMockTime(nStartTime+60*60*72 + 300);
+        // Advance the clock DEFAULT_ORPHANPOOL_EXPIRY hours plus 5 minutes
+        SetMockTime(nStartTime+60*60*DEFAULT_ORPHANPOOL_EXPIRY + 300);
         EraseOrphansByTime();
         BOOST_CHECK(mapOrphanTransactions.size() == 0);
     }

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -423,8 +423,8 @@ std::string UnlimitedCmdLineHelp()
     strUsage += HelpMessageOpt("-parallel=<n>",  strprintf(_("Turn Parallel Block Validation on or off (off: 0, on: 1, default: %d)"), 1));
     strUsage += HelpMessageOpt("-gen", strprintf(_("Generate coins (default: %u)"), DEFAULT_GENERATE));
     strUsage += HelpMessageOpt("-genproclimit=<n>", strprintf(_("Set the number of threads for coin generation if enabled (-1 = all cores, default: %d)"), DEFAULT_GENERATE_THREADS));
+    strUsage += HelpMessageOpt("-ophanpoolexpiry=<n>", strprintf(_("Do not keep transactions in the orphanpool longer than <n> hours (default: %u)"), DEFAULT_ORPHANPOOL_EXPIRY));
     strUsage += TweakCmdLineHelp();
-    strUsage += HelpMessageOpt("-parallel=<n>",  strprintf(_("Turn Parallel Block Validation on or off (off: 0, on: 1, default: %d)"), 1));
     return strUsage;
 }
 


### PR DESCRIPTION
This PR does several things in keeping the orphan cache properly trimmed.

1)  When a block comes in it removes any orphans that are in the cache that are also in the current and previous blocks.  The previous block it turns out is often where orphans come from which a block is processing in PV the utxo hasn't been update but txns are still arriving that end up in the orphan pool which happens most often soon after startup. 

2)  pull child orphans into the mempool if the txns mined in the blocks have children in the orphan pool.  This further keeps the orphan pool trimmed and the mempool up to date.

3)  Time out the orphans after 4 hours rather than use the 72 hour mempool default.  Doing some analysis i found that orphans typically are short lived , if they are ever reclaimed from the pool (item 2 above), and are usually in the orphan pool for just 10 or 20 seconds, however there is a long tail which extends to about 90 minutes.  So by putting the timeout to 4 hours, and making it configurable, we can quickly remove stale orphans which never get used for one reason or another.

NOTE: i removed a duplicate "-parallel" command line option and replaced it with the -orphanpoolexpiry

These 3 items have a significant impact on the orphan pool, keep the mempool up to date, and subsequently keep the xthin bloom filters smaller, lately i've seen by as much as 3KB depending on the backlog.