### PR TITLE
Improve BSD build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -364,6 +364,22 @@ case $host in
      TARGET_OS=linux
      LEVELDB_TARGET_FLAGS="-DOS_LINUX"
      ;;
+   *dragonfly*)
+     TARGET_OS=dragonfly
+     LEVELDB_TARGET_FLAGS="-DOS_DRAGONFLYBSD"
+     ;;
+   *freebsd*)
+     TARGET_OS=freebsd
+     LEVELDB_TARGET_FLAGS="-DOS_FREEBSD"
+     ;;
+   *netbsd*)
+     TARGET_OS=netbsd
+     LEVELDB_TARGET_FLAGS="-DOS_NETBSD"
+     ;;
+   *openbsd*)
+     TARGET_OS=openbsd
+     LEVELDB_TARGET_FLAGS="-DOS_OPENBSD"
+     ;;
    *)
      OTHER_OS=`echo ${host_os} | awk '{print toupper($0)}'`
      LEVELDB_TARGET_FLAGS="-DOS_${OTHER_OS}"


### PR DESCRIPTION
At present, BU leveldb builds on no BSD system for several
reasons that boil down to the lack of an OS_XXX macro
definition.  This gets BU building better on those systems.

On my DragonFlyBSD system the build process now fails close
to the end, in Qt, with LibreSSL vs OpenSSL issues (DragonFlyBSD
switched to LibreSSL recently).
I will submit a separate PR for that once I resolve it.