### PR TITLE
Handle a special case for  Parallel Validation

### DIFF
--- a/qa/rpc-tests/parallel.py
+++ b/qa/rpc-tests/parallel.py
@@ -23,9 +23,7 @@ class ParallelTest (BitcoinTestFramework):
         self.nodes.append(start_node(1, self.options.tmpdir, ["-parallel=0", "-rpcservertimeout=0", "-debug", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
         self.nodes.append(start_node(2, self.options.tmpdir, ["-parallel=0", "-rpcservertimeout=0", "-debug", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
         self.nodes.append(start_node(3, self.options.tmpdir, ["-parallel=0", "-rpcservertimeout=0", "-debug", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
-        connect_nodes(self.nodes[0],1)
-        connect_nodes(self.nodes[0],2)
-        connect_nodes(self.nodes[0],3)
+        interconnect_nodes(self.nodes)
         self.is_network_split=False
         self.sync_all()
 
@@ -367,7 +365,7 @@ class ParallelTest (BitcoinTestFramework):
         sync_blocks(self.nodes)
 
 
-        # Mine a block which will cause a reorg.
+        # Mine a block which will cause a reorg back to node0
         print ("Mine another block...")
         self.nodes[0].generate(1)
         sync_blocks(self.nodes)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3053,7 +3053,14 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
 {
     AssertLockHeld(cs_main);
 
-    assert(pindexNew->pprev == chainActive.Tip());
+    // With PV there is a special case where one chain may be in the process of connecting several blocks but then
+    // a second chain also begins to connect blocks and its block beat the first chains block to advance the tip.
+    // As a result pindexNew->prev on the first chain will no longer match the chaintip as the second chain continues
+    // connecting blocks. Therefore we must return "false" rather than "assert" as was previously the case.
+    //assert(pindexNew->pprev == chainActive.Tip());
+    if (pindexNew->pprev != chainActive.Tip())
+        return false;
+
     // Read block from disk.
     int64_t nTime1 = GetTimeMicros();
     CBlock block;


### PR DESCRIPTION
When one chain with several blocks to connect is beaten by  another
chain, also with several blocks to connect we must not issue
an assertion when pindexNew->pprev != chainActive.Tip(). Rather
we want to just return "false" in this case and allow the second chain
to proceed connecting blocks.