### PR TITLE
avoid use of boost copy_file since it has incompatibilities with c++11.

### DIFF
--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -926,20 +926,20 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
                 if (boost::filesystem::is_directory(pathDest))
                     pathDest /= wallet.strWalletFile;
 
-#if 0 // BU copy_file does not work with c++11, due to a link error in many versions of boost
-                try {
-#if BOOST_VERSION >= 104000
-                    boost::filesystem::copy_file(pathSrc, pathDest, boost::filesystem::copy_option::overwrite_if_exists);
-#else
-                    boost::filesystem::copy_file(pathSrc, pathDest);
-#endif
-                    LogPrintf("copied wallet.dat to %s\n", pathDest.string());
-                    return true;
-                } catch (const boost::filesystem::filesystem_error& e) {
-                    LogPrintf("error copying wallet.dat to %s - %s\n", pathDest.string(), e.what());
-                    return false;
-                }
-#else
+// BU copy_file does not work with c++11, due to a link error in many versions of boost.  Return this code to use when the default boost version in most distros fix this bug.
+//                try {
+//#if BOOST_VERSION >= 104000
+//                    boost::filesystem::copy_file(pathSrc, pathDest, boost::filesystem::copy_option::overwrite_if_exists);
+//#else
+//                    boost::filesystem::copy_file(pathSrc, pathDest);
+//#endif
+//                    LogPrintf("copied wallet.dat to %s\n", pathDest.string());
+//                    return true;
+//                } catch (const boost::filesystem::filesystem_error& e) {
+//                    LogPrintf("error copying wallet.dat to %s - %s\n", pathDest.string(), e.what());
+//                    return false;
+//                }
+// Replacement copy code
                 try {
                     ifstream source(pathSrc.string(), ios::binary);
                     ofstream dest(pathDest.string(), ios::binary);
@@ -960,7 +960,7 @@ bool BackupWallet(const CWallet& wallet, const string& strDest)
                     LogPrintf("error copying wallet from %s to %s - %s\n", pathSrc.string(), pathDest.string(), e.what());
                     return false;
                 }
-#endif                
+// end replacement copy code              
             }
         }
         MilliSleep(100);


### PR DESCRIPTION
… in certain versions of boost.  the original code is left commented out so we can put it back when distros advance to compatible boost versions