### PR TITLE
Fix copyright year and version on release when building natively on Windows (MinGW)

### DIFF
--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -27,7 +27,7 @@
  * Copyright year (2009-this)
  * Todo: update this when changing our copyright comments in the source
  */
-#define COPYRIGHT_YEAR 2016
+#define COPYRIGHT_YEAR 2017
 
 #endif //HAVE_CONFIG_H
 

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -17,7 +17,7 @@
 //! These need to be macros, as clientversion.cpp's and bitcoin*-res.rc's voodoo requires it
 #define CLIENT_VERSION_MAJOR 1
 #define CLIENT_VERSION_MINOR 0
-#define CLIENT_VERSION_REVISION 0
+#define CLIENT_VERSION_REVISION 1
 #define CLIENT_VERSION_BUILD 0
 
 //! Set to true for release, false for prerelease or test build


### PR DESCRIPTION
Trivial: Update copyright year to 2017
(cherry picked from commit 52c6f7314ad59bfe48bee02ac3f0431b02ce3573)