### PR TITLE
PV: release the scriptqueue from one thread only

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -217,6 +217,7 @@ CStatHistory<uint64_t > recvAmt;
 CStatHistory<uint64_t > sendAmt; 
 CStatHistory<uint64_t> nTxValidationTime("txValidationTime", STAT_OP_MAX | STAT_INDIVIDUAL);
 CStatHistory<uint64_t> nBlockValidationTime("blockValidationTime", STAT_OP_MAX | STAT_INDIVIDUAL);
+CCriticalSection cs_blockvalidationtime;
 
 CThinBlockData thindata; // Singleton class
 

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -173,10 +173,6 @@ void CParallelValidation::QuitCompetingThreads(const uint256& prevBlockHash)
                 LogPrint("parallel", "interrupting a thread with blockhash %s and previous blockhash %s\n", 
                           (*mi).second.hash.ToString(), prevBlockHash.ToString());
             }
-            // Clear the scriptqueue before returning so that we can grab it again if we have another block to process
-            // using this same thread.
-            else if ((*mi).first == this_id)
-                mapBlockValidationThreads[this_id].pScriptQueue = NULL;
         }
     }
 }
@@ -423,9 +419,6 @@ void CParallelValidation::HandleBlockMessage(CNode *pfrom, const string &strComm
                                (*miLargestBlock).second.hash.ToString(), (*miLargestBlock).second.hashPrevBlock.ToString());
                     }
                 }
-                else
-                    assert("No grant possible, but no validation threads are running!");
-
             } // We must not hold the lock here because we could be waiting for a grant, below.
 
             // wait for semaphore grant

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -463,7 +463,6 @@ void HandleBlockMessageThread(CNode *pfrom, const string &strCommand, const CBlo
     // conditions in AcceptBlock().
     bool forceProcessing = pfrom->fWhitelisted && !IsInitialBlockDownload();
     const CChainParams& chainparams = Params();
-    pfrom->firstBlock += 1;
     if (PV.Enabled()) {
         ProcessNewBlock(state, chainparams, pfrom, &block, forceProcessing, NULL, true);
     }
@@ -512,6 +511,7 @@ void HandleBlockMessageThread(CNode *pfrom, const string &strCommand, const CBlo
                 if (pnode->mapThinBlocksInFlight.size() > 0)
                     nTotalThinBlocksInFlight++;
             }
+            pfrom->firstBlock += 1; // update statistics, requires cs_vNodes
         }
 
         // When we no longer have any thinblocks in flight then clear the set


### PR DESCRIPTION
Previously we were releasing the queue in two places and from
potentially two different threads which was causing an intermittent
crash.  We only need to set the pScriptQueue = NULL in SetLocks()
which is called when the boost scope guard is triggered in
connectblock().