### PR TITLE
Miner backport

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -209,10 +209,10 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
             std::make_heap(vecPriority.begin(), vecPriority.end(), pricomparer);
         }
 
-        CTxMemPool::indexed_transaction_set::nth_index<3>::type::iterator mi = mempool.mapTx.get<3>().begin();
+        CTxMemPool::indexed_transaction_set::index<mining_score>::type::iterator mi = mempool.mapTx.get<mining_score>().begin();
         CTxMemPool::txiter iter;
 
-        while (mi != mempool.mapTx.get<3>().end() || !clearedTxs.empty())
+        while (mi != mempool.mapTx.get<mining_score>().end() || !clearedTxs.empty())
         {
             bool priorityTx = false;
             if (fPriorityBlock && !vecPriority.empty()) { // add a tx from priority queue to fill the blockprioritysize

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -74,60 +74,319 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
     return nNewTime - nOldTime;
 }
 
-CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& scriptPubKeyIn,bool blockstreamCoreCompatible);
+BlockAssembler::BlockAssembler(const CChainParams& _chainparams)
+    : chainparams(_chainparams)
+{
+    // Largest block you're willing to create:
+    nBlockMaxSize = maxGeneratedBlock;
+    // Core:
+    //nBlockMaxSize = GetArg("-blockmaxsize", DEFAULT_BLOCK_MAX_SIZE);
+    // Limit to between 1K and MAX_BLOCK_SIZE-1K for sanity:
+    //nBlockMaxSize = std::max((unsigned int)1000, std::min((unsigned int)(MAX_BLOCK_SIZE-1000), nBlockMaxSize));
 
-CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& scriptPubKeyIn)
+    // Minimum block size you want to create; block will be filled with free transactions
+    // until there are no more or the block reaches this size:
+    nBlockMinSize = GetArg("-blockminsize", DEFAULT_BLOCK_MIN_SIZE);
+    nBlockMinSize = std::min(nBlockMaxSize, nBlockMinSize);
+}
+
+void BlockAssembler::resetBlock(const CScript& scriptPubKeyIn)
+{
+    inBlock.clear();
+
+    nBlockSize = reserveBlockSize(scriptPubKeyIn);  // Core: 1000
+    nBlockSigOps = 100;  // Reserve 100 sigops for miners to use in their coinbase transaction
+
+    // These counters do not include coinbase tx
+    nBlockTx = 0;
+    nFees = 0;
+
+    lastFewTxs = 0;
+    blockFinished = false;
+}
+
+uint64_t BlockAssembler::reserveBlockSize(const CScript& scriptPubKeyIn)
+{
+    CBlockHeader h;
+    uint64_t nHeaderSize, nCoinbaseSize;
+
+    // BU add the proper block size quantity to the actual size
+    nHeaderSize = h.GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
+    assert(nHeaderSize == 80);  // BU always 80 bytes
+    nHeaderSize += 5;  // tx count varint - 5 bytes is enough for 4 billion txs; 3 bytes for 65535 txs
+
+    // This serializes with output value, a fixed-length 8 byte field, of zero and height, a serialized CScript
+    // signed integer taking up 4 bytes for heights 32768-8388607 (around the year 2167) after which it will use 5.
+    nCoinbaseSize = coinbaseTx(scriptPubKeyIn, 400000, 0).GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
+    // BU005 END
+
+    // BU Miners take the block we give them, wipe away our coinbase and add their own.
+    // So if their reserve choice is bigger then our coinbase then use that.
+    return nHeaderSize + std::max(nCoinbaseSize, coinbaseReserve.value);
+}
+
+CMutableTransaction BlockAssembler::coinbaseTx(const CScript& scriptPubKeyIn, int nHeight, CAmount nValue)
+{
+    CMutableTransaction tx;
+
+    tx.vin.resize(1);
+    tx.vin[0].prevout.SetNull();
+    tx.vout.resize(1);
+    tx.vout[0].scriptPubKey = scriptPubKeyIn;
+    tx.vout[0].nValue = nValue;
+    tx.vin[0].scriptSig = CScript() << nHeight << OP_0;
+
+    // BU005 add block size settings to the coinbase
+    std::string cbmsg = FormatCoinbaseMessage(BUComments, minerComment);
+    const char* cbcstr = cbmsg.c_str();
+    vector<unsigned char> vec(cbcstr, cbcstr+cbmsg.size());
+    COINBASE_FLAGS = CScript() << vec;
+    // Chop off any extra data in the COINBASE_FLAGS so the sig does not exceed the max.
+    // we can do this because the coinbase is not a "real" script...
+    if (tx.vin[0].scriptSig.size() + COINBASE_FLAGS.size() > MAX_COINBASE_SCRIPTSIG_SIZE)
+      {
+        COINBASE_FLAGS.resize(MAX_COINBASE_SCRIPTSIG_SIZE - tx.vin[0].scriptSig.size());
+      }
+    tx.vin[0].scriptSig = tx.vin[0].scriptSig + COINBASE_FLAGS;
+
+    return tx;
+}
+
+CBlockTemplate* BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn)
 {
   CBlockTemplate* tmpl = NULL;
-  if (maxGeneratedBlock >  BLOCKSTREAM_CORE_MAX_BLOCK_SIZE)
-    tmpl = CreateNewBlock(chainparams, scriptPubKeyIn, false);
-  
-  if ((!tmpl) || (tmpl->block.nBlockSize <= BLOCKSTREAM_CORE_MAX_BLOCK_SIZE))  // If the block is too small we need to drop back to the 1MB ruleset
+  if (maxGeneratedBlock > BLOCKSTREAM_CORE_MAX_BLOCK_SIZE)
+    tmpl = CreateNewBlock(scriptPubKeyIn, false);
+
+  // If the block is too small we need to drop back to the 1MB ruleset
+  if ((!tmpl) || (tmpl->block.nBlockSize <= BLOCKSTREAM_CORE_MAX_BLOCK_SIZE))
     {
-      tmpl = CreateNewBlock(chainparams, scriptPubKeyIn, true);
+      tmpl = CreateNewBlock(scriptPubKeyIn, true);
     }
 
   return tmpl;
 }
 
-CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& scriptPubKeyIn,bool blockstreamCoreCompatible)
+CBlockTemplate* BlockAssembler::CreateNewBlock(const CScript& scriptPubKeyIn, bool blockstreamCoreCompatible)
 {
-    // Create new block
-    std::unique_ptr<CBlockTemplate> pblocktemplate(new CBlockTemplate());
+    resetBlock(scriptPubKeyIn);
+
+    pblocktemplate.reset(new CBlockTemplate());
     if(!pblocktemplate.get())
         return NULL;
-    CBlock *pblock = &pblocktemplate->block; // pointer for convenience
-
-    // Create coinbase tx
-    CMutableTransaction txNew;
-    txNew.vin.resize(1);
-    txNew.vin[0].prevout.SetNull();
-    txNew.vout.resize(1);
-    txNew.vout[0].scriptPubKey = scriptPubKeyIn;
+    pblock = &pblocktemplate->block; // pointer for convenience
 
     // Add dummy coinbase tx as first transaction
     pblock->vtx.push_back(CTransaction());
     pblocktemplate->vTxFees.push_back(-1); // updated at end
     pblocktemplate->vTxSigOps.push_back(-1); // updated at end
 
-    // Largest block you're willing to create:
-    //unsigned int nBlockMaxSize = GetArg("-blockmaxsize", DEFAULT_BLOCK_MAX_SIZE);
-    // Limit to betweeen 1K and MAX_BLOCK_SIZE-1K for sanity:
-    uint64_t nBlockMaxSize = maxGeneratedBlock; // std::max((unsigned int)1000, std::min((unsigned int)(maxGeneratedBlock-1000), nBlockMaxSize));
+    LOCK2(cs_main, mempool.cs);
+    CBlockIndex* pindexPrev = chainActive.Tip();
+    nHeight = pindexPrev->nHeight + 1;
 
+    pblock->nTime = GetAdjustedTime();
+    pblock->nVersion = UnlimitedComputeBlockVersion(pindexPrev, chainparams.GetConsensus(), pblock->nTime);
+    // -regtest only: allow overriding block.nVersion with
+    // -blockversion=N to test forking scenarios
+    if (chainparams.MineBlocksOnDemand())
+        pblock->nVersion = GetArg("-blockversion", pblock->nVersion);
+
+    const int64_t nMedianTimePast = pindexPrev->GetMedianTimePast();
+
+    nLockTimeCutoff = (STANDARD_LOCKTIME_VERIFY_FLAGS & LOCKTIME_MEDIAN_TIME_PAST)
+                       ? nMedianTimePast
+                       : pblock->GetBlockTime();
+
+    addPriorityTxs();
+    addScoreTxs();
+
+    nLastBlockTx = nBlockTx;
+    nLastBlockSize = nBlockSize;
+    LogPrintf("CreateNewBlock(): total size %u txs: %u fees: %ld sigops %d\n", nBlockSize, nBlockTx, nFees, nBlockSigOps);
+
+    // Create coinbase transaction.
+    pblock->vtx[0] = coinbaseTx(scriptPubKeyIn, nHeight, nFees + GetBlockSubsidy(nHeight, chainparams.GetConsensus()));
+    pblocktemplate->vTxFees[0] = -nFees;
+
+    // Fill in header
+    pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
+    UpdateTime(pblock, chainparams.GetConsensus(), pindexPrev);
+    pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus());
+    pblock->nNonce         = 0;
+    pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(pblock->vtx[0]);
+
+    CValidationState state;
+    if (blockstreamCoreCompatible)
+      {
+        if (!TestConservativeBlockValidity(state, chainparams, *pblock, pindexPrev, false, false)) {
+          throw std::runtime_error(strprintf("%s: TestConservativeBlockValidity failed: %s", __func__, FormatStateMessage(state)));
+        }
+      }
+    else
+      {
+        if (!TestBlockValidity(state, chainparams, *pblock, pindexPrev, false, false))
+          {
+            throw std::runtime_error(strprintf("%s: TestBlockValidity failed: %s", __func__, FormatStateMessage(state)));
+          }
+      }
+    if (pblock->fExcessive)
+      {
+        throw std::runtime_error(strprintf("%s: Excessive block generated: %s", __func__, FormatStateMessage(state)));
+      }
+
+    return pblocktemplate.release();
+}
+
+bool BlockAssembler::isStillDependent(CTxMemPool::txiter iter)
+{
+    BOOST_FOREACH(CTxMemPool::txiter parent, mempool.GetMemPoolParents(iter))
+    {
+        if (!inBlock.count(parent)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool BlockAssembler::TestForBlock(CTxMemPool::txiter iter)
+{
+    uint64_t nTxSize = iter->GetTxSize();
+
+    if (nBlockSize + nTxSize > nBlockMaxSize) {
+        // If the block is so close to full that no more txs will fit
+        // or if we've tried more than 50 times to fill remaining space
+        // then flag that the block is finished
+        if (nBlockSize >  nBlockMaxSize - 100 || lastFewTxs > 50) {
+             blockFinished = true;
+             return false;
+        }
+        // Once we're within 1000 bytes of a full block, only look at 50 more txs
+        // to try to fill the remaining space.
+        if (nBlockSize > nBlockMaxSize - 1000) {
+            lastFewTxs++;
+        }
+        return false;
+    }
+
+    uint64_t nTxSigOps = iter->GetSigOpCount();
+    if (nBlockSize + nTxSize <= BLOCKSTREAM_CORE_MAX_BLOCK_SIZE) // Enforce the "old" sigops for <= 1MB blocks
+      {
+        // BU: be conservative about what is generated
+        if (nBlockSigOps + nTxSigOps >= BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS) {
+          // BU: so a block that is near the sigops limit might be shorter than it could be if
+          // the high sigops tx was backed out and other tx added.
+          if (nBlockSigOps > BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS - 2)
+            blockFinished = true;
+          return false;
+        }
+      }
+    else
+      {
+        uint64_t blockMbSize = 1+((nBlockSize + nTxSize - 1)/1000000);
+        if (nBlockSigOps + nTxSigOps > blockMiningSigopsPerMb.value*blockMbSize)
+          {
+            if (nBlockSigOps >  blockMiningSigopsPerMb.value*blockMbSize - 2)
+              // very close to the limit, so the block is finished.  So a block that is near the sigops limit
+              // might be shorter than it could be if the high sigops tx was backed out and other tx added.
+              blockFinished = true;
+            return false;
+          }
+      }
+
+    // Must check that lock times are still valid
+    // This can be removed once MTP is always enforced
+    // as long as reorgs keep the mempool consistent.
+    if (!IsFinalTx(iter->GetTx(), nHeight, nLockTimeCutoff))
+        return false;
+
+    return true;
+}
+
+void BlockAssembler::AddToBlock(CTxMemPool::txiter iter)
+{
+    pblock->vtx.push_back(iter->GetTx());
+    pblocktemplate->vTxFees.push_back(iter->GetFee());
+    pblocktemplate->vTxSigOps.push_back(iter->GetSigOpCount());
+    nBlockSize += iter->GetTxSize();
+    ++nBlockTx;
+    nBlockSigOps += iter->GetSigOpCount();
+    nFees += iter->GetFee();
+    inBlock.insert(iter);
+
+    bool fPrintPriority = GetBoolArg("-printpriority", DEFAULT_PRINTPRIORITY);
+    if (fPrintPriority) {
+        double dPriority = iter->GetPriority(nHeight);
+        CAmount dummy;
+        mempool.ApplyDeltas(iter->GetTx().GetHash(), dPriority, dummy);
+        LogPrintf("priority %.1f fee %s txid %s\n",
+                  dPriority,
+                  CFeeRate(iter->GetModifiedFee(), iter->GetTxSize()).ToString(),
+                  iter->GetTx().GetHash().ToString());
+    }
+}
+
+void BlockAssembler::addScoreTxs()
+{
+    std::priority_queue<CTxMemPool::txiter, std::vector<CTxMemPool::txiter>, ScoreCompare> clearedTxs;
+    CTxMemPool::setEntries waitSet;
+    CTxMemPool::indexed_transaction_set::index<mining_score>::type::iterator mi = mempool.mapTx.get<mining_score>().begin();
+    CTxMemPool::txiter iter;
+    while (!blockFinished && (mi != mempool.mapTx.get<mining_score>().end() || !clearedTxs.empty()))
+    {
+        // If no txs that were previously postponed are available to try
+        // again, then try the next highest score tx
+        if (clearedTxs.empty()) {
+            iter = mempool.mapTx.project<0>(mi);
+            mi++;
+        }
+        // If a previously postponed tx is available to try again, then it
+        // has higher score than all untried so far txs
+        else {
+            iter = clearedTxs.top();
+            clearedTxs.pop();
+        }
+
+        // If tx is dependent on other mempool txs which haven't yet been included
+        // then put it in the waitSet
+        if (isStillDependent(iter)) {
+            waitSet.insert(iter);
+            continue;
+        }
+
+        // If the fee rate is below the min fee rate for mining, then we're done
+        // adding txs based on score (fee rate)
+        if (iter->GetModifiedFee() < ::minRelayTxFee.GetFee(iter->GetTxSize()) && nBlockSize >= nBlockMinSize) {
+            return;
+        }
+
+        // If this tx fits in the block add it, otherwise keep looping
+        if (TestForBlock(iter)) {
+            AddToBlock(iter);
+
+            // This tx was successfully added, so
+            // add transactions that depend on this one to the priority queue to try again
+            BOOST_FOREACH(CTxMemPool::txiter child, mempool.GetMemPoolChildren(iter))
+            {
+                if (waitSet.count(child)) {
+                    clearedTxs.push(child);
+                    waitSet.erase(child);
+                }
+            }
+        }
+    }
+}
+
+void BlockAssembler::addPriorityTxs()
+{
     // How much of the block should be dedicated to high-priority transactions,
     // included regardless of the fees they pay
     uint64_t nBlockPrioritySize = GetArg("-blockprioritysize", DEFAULT_BLOCK_PRIORITY_SIZE);
     nBlockPrioritySize = std::min(nBlockMaxSize, nBlockPrioritySize);
 
-    // Minimum block size you want to create; block will be filled with free transactions
-    // until there are no more or the block reaches this size:
-    uint64_t nBlockMinSize = GetArg("-blockminsize", DEFAULT_BLOCK_MIN_SIZE);
-    nBlockMinSize = std::min(nBlockMaxSize, nBlockMinSize);
-
-    // Collect memory pool transactions into the block
-    CTxMemPool::setEntries inBlock;
-    CTxMemPool::setEntries waitSet;
+    if (nBlockPrioritySize == 0) {
+        return;
+    }
 
     // This vector will be sorted into a priority queue:
     vector<TxCoinAgePriority> vecPriority;
@@ -136,259 +395,60 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
     typedef std::map<CTxMemPool::txiter, double, CTxMemPool::CompareIteratorByHash>::iterator waitPriIter;
     double actualPriority = -1;
 
-    std::priority_queue<CTxMemPool::txiter, std::vector<CTxMemPool::txiter>, ScoreCompare> clearedTxs;
-    bool fPrintPriority = GetBoolArg("-printpriority", DEFAULT_PRINTPRIORITY);
-    uint64_t nBlockSize = 0;  // BU add the proper block size quantity to the actual size
+    vecPriority.reserve(mempool.mapTx.size());
+    for (CTxMemPool::indexed_transaction_set::iterator mi = mempool.mapTx.begin();
+         mi != mempool.mapTx.end(); ++mi)
     {
-      CBlockHeader h;
-      nBlockSize += h.GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
+        double dPriority = mi->GetPriority(nHeight);
+        CAmount dummy;
+        mempool.ApplyDeltas(mi->GetTx().GetHash(), dPriority, dummy);
+        vecPriority.push_back(TxCoinAgePriority(dPriority, mi));
     }
-    assert(nBlockSize == 80);  // BU block header is always 80 bytes
+    std::make_heap(vecPriority.begin(), vecPriority.end(), pricomparer);
 
+    CTxMemPool::txiter iter;
+    while (!vecPriority.empty() && !blockFinished) { // add a tx from priority queue to fill the blockprioritysize
+        iter = vecPriority.front().second;
+        actualPriority = vecPriority.front().first;
+        std::pop_heap(vecPriority.begin(), vecPriority.end(), pricomparer);
+        vecPriority.pop_back();
 
-    unsigned int nCoinbaseSize=0;
-    // Compute coinbase transaction WITHOUT FEES just to get its size.  We will recompute this at the end when we know the fees.
-    {
-      txNew.vout[0].nValue = 0;  // Will be fixed below, but we need to adjust the size for a possible 9 byte varint
-      txNew.vin[0].scriptSig = CScript() << ((int) 0) << CScriptNum(0);  // block height will be fixed below, but we need to adjust the size for a possible 9 byte varint
-
-      // BU005 add block size settings to the coinbase
-      std::string cbmsg = FormatCoinbaseMessage(BUComments, minerComment);
-      const char* cbcstr = cbmsg.c_str();
-      vector<unsigned char> vec(cbcstr, cbcstr+cbmsg.size());
-      COINBASE_FLAGS = CScript() << vec;
-      // Chop off any extra data in the COINBASE_FLAGS so the sig does not exceed the max.  
-      // we can do this because the coinbase is not a "real" script...
-      if (txNew.vin[0].scriptSig.size() + COINBASE_FLAGS.size() > MAX_COINBASE_SCRIPTSIG_SIZE)
-        {
-          COINBASE_FLAGS.resize(MAX_COINBASE_SCRIPTSIG_SIZE - txNew.vin[0].scriptSig.size());
-        }
-      txNew.vin[0].scriptSig = txNew.vin[0].scriptSig + COINBASE_FLAGS;
-      nCoinbaseSize = txNew.GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION) + 16;  // This code serialized the transaction but the 2 zeros above (nValue and block height) got encoded into 2 bytes, yet these are varints so there is a possible 16 more bytes 
-      // BU005 END
-    }
-    
-    nBlockSize += std::max(nCoinbaseSize,(unsigned int) coinbaseReserve.value);  // BU Miners take the block we give them, wipe away our coinbase and add their own.  So if their reserve choice is bigger then our coinbase then use that.
-    
-    uint64_t nBlockTx = 0;
-    unsigned int nBlockSigOps = 100;  // Reserve 100 sigops for miners to use in their coinbase transaction
-    int lastFewTxs = 0;
-    CAmount nFees = 0;
-
-    {
-        LOCK2(cs_main, mempool.cs);
-        CBlockIndex* pindexPrev = chainActive.Tip();
-        const int nHeight = pindexPrev->nHeight + 1;
-        // Fill in header
-        pblock->hashPrevBlock  = pindexPrev->GetBlockHash();
-        pblock->nBits          = GetNextWorkRequired(pindexPrev, pblock, chainparams.GetConsensus());        
-        pblock->nTime          = GetAdjustedTime();
-        const int64_t nMedianTimePast = pindexPrev->GetMedianTimePast();
-
-        pblock->nVersion = UnlimitedComputeBlockVersion(pindexPrev, chainparams.GetConsensus(),pblock->nTime);
-        // -regtest only: allow overriding block.nVersion with
-        // -blockversion=N to test forking scenarios
-        if (chainparams.MineBlocksOnDemand())
-            pblock->nVersion = GetArg("-blockversion", pblock->nVersion);
-
-        int64_t nLockTimeCutoff = (STANDARD_LOCKTIME_VERIFY_FLAGS & LOCKTIME_MEDIAN_TIME_PAST)
-                                ? nMedianTimePast
-                                : pblock->GetBlockTime();
-
-        bool fPriorityBlock = nBlockPrioritySize > 0;
-        if (fPriorityBlock) {
-            vecPriority.reserve(mempool.mapTx.size());
-            for (CTxMemPool::indexed_transaction_set::iterator mi = mempool.mapTx.begin();
-                 mi != mempool.mapTx.end(); ++mi)
-            {
-                double dPriority = mi->GetPriority(nHeight);
-                CAmount dummy;
-                mempool.ApplyDeltas(mi->GetTx().GetHash(), dPriority, dummy);
-                vecPriority.push_back(TxCoinAgePriority(dPriority, mi));
-            }
-            std::make_heap(vecPriority.begin(), vecPriority.end(), pricomparer);
+        // If tx already in block, skip
+        if (inBlock.count(iter)) {
+            assert(false); // shouldn't happen for priority txs
+            continue;
         }
 
-        CTxMemPool::indexed_transaction_set::index<mining_score>::type::iterator mi = mempool.mapTx.get<mining_score>().begin();
-        CTxMemPool::txiter iter;
+        // If tx is dependent on other mempool txs which haven't yet been included
+        // then put it in the waitSet
+        if (isStillDependent(iter)) {
+            waitPriMap.insert(std::make_pair(iter, actualPriority));
+            continue;
+        }
 
-        while (mi != mempool.mapTx.get<mining_score>().end() || !clearedTxs.empty())
-        {
-            bool priorityTx = false;
-            if (fPriorityBlock && !vecPriority.empty()) { // add a tx from priority queue to fill the blockprioritysize
-                priorityTx = true;
-                iter = vecPriority.front().second;
-                actualPriority = vecPriority.front().first;
-                std::pop_heap(vecPriority.begin(), vecPriority.end(), pricomparer);
-                vecPriority.pop_back();
-            }
-            else if (clearedTxs.empty()) { // add tx with next highest score
-                iter = mempool.mapTx.project<0>(mi);
-                mi++;
-            }
-            else {  // try to add a previously postponed child tx
-                iter = clearedTxs.top();
-                clearedTxs.pop();
+        // If this tx fits in the block add it, otherwise keep looping
+        if (TestForBlock(iter)) {
+            AddToBlock(iter);
+
+            // If now that this txs is added we've surpassed our desired priority size
+            // or have dropped below the AllowFreeThreshold, then we're done adding priority txs
+            if (nBlockSize + iter->GetTxSize() >= nBlockPrioritySize || !AllowFree(actualPriority)) {
+                return;
             }
 
-            if (inBlock.count(iter))
-                continue; // could have been added to the priorityBlock
-
-            const CTransaction& tx = iter->GetTx();
-
-            bool fOrphan = false;
-            BOOST_FOREACH(CTxMemPool::txiter parent, mempool.GetMemPoolParents(iter))
-            {
-                if (!inBlock.count(parent)) {
-                    fOrphan = true;
-                    break;
-                }
-            }
-            if (fOrphan) {
-                if (priorityTx)
-                    waitPriMap.insert(std::make_pair(iter,actualPriority));
-                else
-                    waitSet.insert(iter);
-                continue;
-            }
-
-            unsigned int nTxSize = iter->GetTxSize();            
-            if (fPriorityBlock &&
-                (nBlockSize + nTxSize >= nBlockPrioritySize || !AllowFree(actualPriority))) {
-                fPriorityBlock = false;
-                waitPriMap.clear();
-            }
-            if (!priorityTx &&
-                (iter->GetModifiedFee() < ::minRelayTxFee.GetFee(nTxSize) && nBlockSize >= nBlockMinSize)) {
-                break;
-            }
-            if (nBlockSize + nTxSize >= nBlockMaxSize) {
-                if (nBlockSize >  nBlockMaxSize - 100 || lastFewTxs > 50) {
-                    break;
-                }
-                // Once we're within 1000 bytes of a full block, only look at 50 more txs
-                // to try to fill the remaining space.
-                if (nBlockSize > nBlockMaxSize - 1000) {
-                    lastFewTxs++;
-                }
-                continue;
-            }
-
-            if (!IsFinalTx(tx, nHeight, nLockTimeCutoff))
-                continue;
-
-            unsigned int nTxSigOps = iter->GetSigOpCount();
-            if (nBlockSize + nTxSize <= BLOCKSTREAM_CORE_MAX_BLOCK_SIZE) // Enforce the "old" sigops for <= 1MB blocks
-              {      
-                if (nBlockSigOps + nTxSigOps >= BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS) {  // BU: be conservative about what is generated
-                  if (nBlockSigOps > BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS - 2) {  // BU: so a block that is near the sigops limit might be shorter than it could be if the high sigops tx was backed out and other tx added.
-                      break;
-                  }
-                  continue;
-                }
-              }
-            else if (nBlockSize + nTxSize > BLOCKSTREAM_CORE_MAX_BLOCK_SIZE)
-              {
-                uint64_t blockMbSize = 1+((nBlockSize + nTxSize - 1)/1000000);
-                if (nBlockSigOps + nTxSigOps > blockMiningSigopsPerMb.value*blockMbSize)
-                  {
-                  if (nBlockSigOps >  blockMiningSigopsPerMb.value*blockMbSize - 2)
-                    {
-                    break;  // very close to the limit, so the block is finished.  So a block that is near the sigops limit might be shorter than it could be if the high sigops tx was backed out and other tx added.
-                    }
-                  continue;  // find another TX
-                  }
-              }
-
-            CAmount nTxFees = iter->GetFee();
-            // Added
-            pblock->vtx.push_back(tx);
-            pblocktemplate->vTxFees.push_back(nTxFees);
-            pblocktemplate->vTxSigOps.push_back(nTxSigOps);
-            nBlockSize += nTxSize;
-            ++nBlockTx;
-            nBlockSigOps += nTxSigOps;
-            nFees += nTxFees;
-
-            if (fPrintPriority)
-            {
-                double dPriority = iter->GetPriority(nHeight);
-                CAmount dummy;
-                mempool.ApplyDeltas(tx.GetHash(), dPriority, dummy);
-                LogPrintf("priority %.1f fee %s txid %s\n",
-                          dPriority , CFeeRate(iter->GetModifiedFee(), nTxSize).ToString(), tx.GetHash().ToString());
-            }
-
-            inBlock.insert(iter);
-
-            // Add transactions that depend on this one to the priority queue
+            // This tx was successfully added, so
+            // add transactions that depend on this one to the priority queue to try again
             BOOST_FOREACH(CTxMemPool::txiter child, mempool.GetMemPoolChildren(iter))
             {
-                if (fPriorityBlock) {
-                    waitPriIter wpiter = waitPriMap.find(child);
-                    if (wpiter != waitPriMap.end()) {
-                        vecPriority.push_back(TxCoinAgePriority(wpiter->second,child));
-                        std::push_heap(vecPriority.begin(), vecPriority.end(), pricomparer);
-                        waitPriMap.erase(wpiter);
-                    }
-                }
-                else {
-                    if (waitSet.count(child)) {
-                        clearedTxs.push(child);
-                        waitSet.erase(child);
-                    }
+                waitPriIter wpiter = waitPriMap.find(child);
+                if (wpiter != waitPriMap.end()) {
+                    vecPriority.push_back(TxCoinAgePriority(wpiter->second,child));
+                    std::push_heap(vecPriority.begin(), vecPriority.end(), pricomparer);
+                    waitPriMap.erase(wpiter);
                 }
             }
         }
-        nLastBlockTx = nBlockTx;
-        nLastBlockSize = nBlockSize;
-        LogPrintf("CreateNewBlock(): total size %u txs: %u fees: %ld sigops %d\n", nBlockSize, nBlockTx, nFees, nBlockSigOps);
-
-        // Compute final coinbase transaction.
-        txNew.vout[0].nValue = nFees + GetBlockSubsidy(nHeight, chainparams.GetConsensus());
-        txNew.vin[0].scriptSig = CScript() << nHeight << CScriptNum(0);
-
-        // BU005 add block size settings to the coinbase
-        std::string cbmsg = FormatCoinbaseMessage(BUComments, minerComment);
-        const char* cbcstr = cbmsg.c_str();
-        vector<unsigned char> vec(cbcstr, cbcstr+cbmsg.size());
-        COINBASE_FLAGS = CScript() << vec;
-        // Chop off any extra data in the COINBASE_FLAGS so the sig does not exceed the max.  
-        // we can do this because the coinbase is not a "real" script...
-        if (txNew.vin[0].scriptSig.size() + COINBASE_FLAGS.size() > MAX_COINBASE_SCRIPTSIG_SIZE)
-          {
-          COINBASE_FLAGS.resize(MAX_COINBASE_SCRIPTSIG_SIZE - txNew.vin[0].scriptSig.size());
-          }
-        txNew.vin[0].scriptSig = txNew.vin[0].scriptSig + COINBASE_FLAGS;
-        // BU005 END
-        
-        pblock->vtx[0] = txNew;
-        pblocktemplate->vTxFees[0] = -nFees;
-        UpdateTime(pblock, chainparams.GetConsensus(), pindexPrev);
-        pblock->nNonce         = 0;
-        pblocktemplate->vTxSigOps[0] = GetLegacySigOpCount(pblock->vtx[0]);
-
-        CValidationState state;
-        if (blockstreamCoreCompatible)
-          {
-            if (!TestConservativeBlockValidity(state, chainparams, *pblock, pindexPrev, false, false)) {
-              throw std::runtime_error(strprintf("%s: TestBlockValidity failed: %s", __func__, FormatStateMessage(state)));
-            }
-          }
-        else
-          {
-            if (!TestBlockValidity(state, chainparams, *pblock, pindexPrev, false, false))
-              {
-                throw std::runtime_error(strprintf("%s: TestBlockValidity failed: %s", __func__, FormatStateMessage(state)));
-              }
-          }
-        if (pblock->fExcessive)
-          {
-            throw std::runtime_error(strprintf("%s: Excessive block generated: %s", __func__, FormatStateMessage(state)));
-          }           
     }
-
-    return pblocktemplate.release();
 }
 
 void IncrementExtraNonce(CBlock* pblock, unsigned int& nExtraNonce)
@@ -403,7 +463,7 @@ void IncrementExtraNonce(CBlock* pblock, unsigned int& nExtraNonce)
     ++nExtraNonce;
     unsigned int nHeight = pblock->GetHeight(); // Height first in coinbase required for block.version=2
     CMutableTransaction txCoinbase(pblock->vtx[0]);
- 
+
     CScript script = (CScript() << nHeight << CScriptNum(nExtraNonce));
     if (script.size() + COINBASE_FLAGS.size() > MAX_COINBASE_SCRIPTSIG_SIZE)
       {
@@ -415,4 +475,3 @@ void IncrementExtraNonce(CBlock* pblock, unsigned int& nExtraNonce)
     pblock->vtx[0] = txCoinbase;
     pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);
 }
-

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -437,7 +437,7 @@ void BlockAssembler::addPriorityTxs()
 
             // If now that this txs is added we've surpassed our desired priority size
             // or have dropped below the AllowFreeThreshold, then we're done adding priority txs
-            if (nBlockSize + iter->GetTxSize() >= nBlockPrioritySize || !AllowFree(actualPriority)) {
+            if (nBlockSize >= nBlockPrioritySize || !AllowFree(actualPriority)) {
                 return;
             }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -347,6 +347,11 @@ void BlockAssembler::addScoreTxs()
             clearedTxs.pop();
         }
 
+        // If tx already in block, skip  (added by addPriorityTxs)
+        if (inBlock.count(iter)) {
+            continue;
+        }
+
         // If tx is dependent on other mempool txs which haven't yet been included
         // then put it in the waitSet
         if (isStillDependent(iter)) {

--- a/src/miner.h
+++ b/src/miner.h
@@ -8,14 +8,17 @@
 #define BITCOIN_MINER_H
 
 #include "primitives/block.h"
+#include "txmempool.h"
 
 #include <stdint.h>
+#include <memory>
 
 class CBlockIndex;
 class CChainParams;
 class CReserveKey;
 class CScript;
 class CWallet;
+
 namespace Consensus { struct Params; };
 
 static const bool DEFAULT_PRINTPRIORITY = false;
@@ -28,7 +31,64 @@ struct CBlockTemplate
 };
 
 /** Generate a new block, without valid proof-of-work */
-CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& scriptPubKeyIn);
+class BlockAssembler
+{
+private:
+    // The constructed block template
+    std::unique_ptr<CBlockTemplate> pblocktemplate;
+    // A convenience pointer that always refers to the CBlock in pblocktemplate
+    CBlock* pblock;
+
+    // Configuration parameters for the block size
+    uint64_t nBlockMaxSize, nBlockMinSize;
+
+    // Information on the current status of the block
+    uint64_t nBlockSize;
+    uint64_t nBlockTx;
+    unsigned int nBlockSigOps;
+    CAmount nFees;
+    CTxMemPool::setEntries inBlock;
+
+    // Chain context for the block
+    int nHeight;
+    int64_t nLockTimeCutoff;
+    const CChainParams& chainparams;
+
+    // Variables used for addScoreTxs and addPriorityTxs
+    int lastFewTxs;
+    bool blockFinished;
+
+public:
+    BlockAssembler(const CChainParams& chainparams);
+    /** Construct a new block template with coinbase to scriptPubKeyIn */
+    CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn);
+
+private:
+    // utility functions
+    /** Clear the block's state and prepare for assembling a new block */
+    void resetBlock(const CScript& scriptPubKeyIn);
+    /** Add a tx to the block */
+    void AddToBlock(CTxMemPool::txiter iter);
+
+    // Methods for how to add transactions to a block.
+    /** Add transactions based on modified feerate */
+    void addScoreTxs();
+    /** Add transactions based on tx "priority" */
+    void addPriorityTxs();
+
+    // helper function for addScoreTxs and addPriorityTxs
+    /** Test if tx will still "fit" in the block */
+    bool TestForBlock(CTxMemPool::txiter iter);
+    /** Test if tx still has unconfirmed parents not yet in block */
+    bool isStillDependent(CTxMemPool::txiter iter);
+    /** Bytes to reserve for coinbase and block header */
+    uint64_t reserveBlockSize(const CScript& scriptPubKeyIn);
+    /** Internal method to construct a new block template */
+    CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, bool blockstreamCoreCompatible);
+    /** Constructs a coinbase transaction */
+    CMutableTransaction coinbaseTx(const CScript& scriptPubKeyIn, int nHeight, CAmount nValue);
+  };
+
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, unsigned int& nExtraNonce);
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);

--- a/src/miner.h
+++ b/src/miner.h
@@ -37,7 +37,7 @@ private:
     // The constructed block template
     std::unique_ptr<CBlockTemplate> pblocktemplate;
     // A convenience pointer that always refers to the CBlock in pblocktemplate
-    CBlock* pblock;
+    CBlock *pblock;
 
     // Configuration parameters for the block size
     uint64_t nBlockMaxSize, nBlockMinSize;
@@ -52,21 +52,21 @@ private:
     // Chain context for the block
     int nHeight;
     int64_t nLockTimeCutoff;
-    const CChainParams& chainparams;
+    const CChainParams &chainparams;
 
     // Variables used for addScoreTxs and addPriorityTxs
     int lastFewTxs;
     bool blockFinished;
 
 public:
-    BlockAssembler(const CChainParams& chainparams);
+    BlockAssembler(const CChainParams &chainparams);
     /** Construct a new block template with coinbase to scriptPubKeyIn */
-    CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn);
+    CBlockTemplate *CreateNewBlock(const CScript &scriptPubKeyIn);
 
 private:
     // utility functions
     /** Clear the block's state and prepare for assembling a new block */
-    void resetBlock(const CScript& scriptPubKeyIn);
+    void resetBlock(const CScript &scriptPubKeyIn);
     /** Add a tx to the block */
     void AddToBlock(CTxMemPool::txiter iter);
 
@@ -82,12 +82,12 @@ private:
     /** Test if tx still has unconfirmed parents not yet in block */
     bool isStillDependent(CTxMemPool::txiter iter);
     /** Bytes to reserve for coinbase and block header */
-    uint64_t reserveBlockSize(const CScript& scriptPubKeyIn);
+    uint64_t reserveBlockSize(const CScript &scriptPubKeyIn);
     /** Internal method to construct a new block template */
-    CBlockTemplate* CreateNewBlock(const CScript& scriptPubKeyIn, bool blockstreamCoreCompatible);
+    CBlockTemplate *CreateNewBlock(const CScript &scriptPubKeyIn, bool blockstreamCoreCompatible);
     /** Constructs a coinbase transaction */
-    CMutableTransaction coinbaseTx(const CScript& scriptPubKeyIn, int nHeight, CAmount nValue);
-  };
+    CMutableTransaction coinbaseTx(const CScript &scriptPubKeyIn, int nHeight, CAmount nValue);
+};
 
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, unsigned int& nExtraNonce);

--- a/src/miner.h
+++ b/src/miner.h
@@ -34,10 +34,7 @@ struct CBlockTemplate
 class BlockAssembler
 {
 private:
-    // The constructed block template
-    std::unique_ptr<CBlockTemplate> pblocktemplate;
-    // A convenience pointer that always refers to the CBlock in pblocktemplate
-    CBlock *pblock;
+    const CChainParams &chainparams;
 
     // Configuration parameters for the block size
     uint64_t nBlockMaxSize, nBlockMinSize;
@@ -52,7 +49,6 @@ private:
     // Chain context for the block
     int nHeight;
     int64_t nLockTimeCutoff;
-    const CChainParams &chainparams;
 
     // Variables used for addScoreTxs and addPriorityTxs
     int lastFewTxs;
@@ -68,13 +64,13 @@ private:
     /** Clear the block's state and prepare for assembling a new block */
     void resetBlock(const CScript &scriptPubKeyIn);
     /** Add a tx to the block */
-    void AddToBlock(CTxMemPool::txiter iter);
+    void AddToBlock(CBlockTemplate *, CTxMemPool::txiter iter);
 
     // Methods for how to add transactions to a block.
     /** Add transactions based on modified feerate */
-    void addScoreTxs();
+    void addScoreTxs(CBlockTemplate *);
     /** Add transactions based on tx "priority" */
-    void addPriorityTxs();
+    void addPriorityTxs(CBlockTemplate *);
 
     // helper function for addScoreTxs and addPriorityTxs
     /** Test if tx will still "fit" in the block */

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -114,7 +114,7 @@ UniValue generateBlocks(boost::shared_ptr<CReserveScript> coinbaseScript, int nG
     UniValue blockHashes(UniValue::VARR);
     while (nHeight < nHeightEnd)
     {
-        std::unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(Params(), coinbaseScript->reserveScript));
+        std::unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(Params()).CreateNewBlock(coinbaseScript->reserveScript));
         if (!pblocktemplate.get())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Couldn't create new block");
         CBlock *pblock = &pblocktemplate->block;
@@ -546,7 +546,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
             pblocktemplate = NULL;
         }
         CScript scriptDummy = CScript() << OP_TRUE;
-        pblocktemplate = CreateNewBlock(Params(), scriptDummy);
+        pblocktemplate = BlockAssembler(Params()).CreateNewBlock(scriptDummy);
         if (!pblocktemplate)
             throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
 

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -103,13 +103,13 @@ BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
     removed.clear();
 }
 
-template<int index>
+template<typename name>
 void CheckSort(CTxMemPool &pool, std::vector<std::string> &sortedOrder)
 {
     BOOST_CHECK_EQUAL(pool.size(), sortedOrder.size());
-    typename CTxMemPool::indexed_transaction_set::nth_index<index>::type::iterator it = pool.mapTx.get<index>().begin();
+    typename CTxMemPool::indexed_transaction_set::index<name>::type::iterator it = pool.mapTx.get<name>().begin();
     int count=0;
-    for (; it != pool.mapTx.get<index>().end(); ++it, ++count) {
+    for (; it != pool.mapTx.get<name>().end(); ++it, ++count) {
         BOOST_CHECK_EQUAL(it->GetTx().GetHash().ToString(), sortedOrder[count]);
     }
 }
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     sortedOrder[2] = tx1.GetHash().ToString(); // 10000
     sortedOrder[3] = tx4.GetHash().ToString(); // 15000
     sortedOrder[4] = tx2.GetHash().ToString(); // 20000
-    CheckSort<1>(pool, sortedOrder);
+    CheckSort<descendant_score>(pool, sortedOrder);
 
     /* low fee but with high fee child */
     /* tx6 -> tx7 -> tx8, tx9 -> tx10 */
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     BOOST_CHECK_EQUAL(pool.size(), 6);
     // Check that at this point, tx6 is sorted low
     sortedOrder.insert(sortedOrder.begin(), tx6.GetHash().ToString());
-    CheckSort<1>(pool, sortedOrder);
+    CheckSort<descendant_score>(pool, sortedOrder);
 
     CTxMemPool::setEntries setAncestors;
     setAncestors.insert(pool.mapTx.find(tx6.GetHash()));
@@ -203,7 +203,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     sortedOrder.erase(sortedOrder.begin());
     sortedOrder.push_back(tx6.GetHash().ToString());
     sortedOrder.push_back(tx7.GetHash().ToString());
-    CheckSort<1>(pool, sortedOrder);
+    CheckSort<descendant_score>(pool, sortedOrder);
 
     /* low fee child of tx7 */
     CMutableTransaction tx8 = CMutableTransaction();
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
 
     // Now tx8 should be sorted low, but tx6/tx both high
     sortedOrder.insert(sortedOrder.begin(), tx8.GetHash().ToString());
-    CheckSort<1>(pool, sortedOrder);
+    CheckSort<descendant_score>(pool, sortedOrder);
 
     /* low fee child of tx7 */
     CMutableTransaction tx9 = CMutableTransaction();
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     // tx9 should be sorted low
     BOOST_CHECK_EQUAL(pool.size(), 9);
     sortedOrder.insert(sortedOrder.begin(), tx9.GetHash().ToString());
-    CheckSort<1>(pool, sortedOrder);
+    CheckSort<descendant_score>(pool, sortedOrder);
 
     std::vector<std::string> snapshotOrder = sortedOrder;
 
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     sortedOrder.insert(sortedOrder.begin()+5, tx9.GetHash().ToString());
     sortedOrder.insert(sortedOrder.begin()+6, tx8.GetHash().ToString());
     sortedOrder.insert(sortedOrder.begin()+7, tx10.GetHash().ToString()); // tx10 is just before tx6
-    CheckSort<1>(pool, sortedOrder);
+    CheckSort<descendant_score>(pool, sortedOrder);
 
     // there should be 10 transactions in the mempool
     BOOST_CHECK_EQUAL(pool.size(), 10);
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
     // Now try removing tx10 and verify the sort order returns to normal
     std::list<CTransaction> removed;
     pool.remove(pool.mapTx.find(tx10.GetHash())->GetTx(), removed, true);
-    CheckSort<1>(pool, snapshotOrder);
+    CheckSort<descendant_score>(pool, snapshotOrder);
 
     pool.remove(pool.mapTx.find(tx9.GetHash())->GetTx(), removed, true);
     pool.remove(pool.mapTx.find(tx8.GetHash())->GetTx(), removed, true);
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(MempoolIndexingTest)
         sortedOrder.push_back(tx3.GetHash().ToString());
         sortedOrder.push_back(tx6.GetHash().ToString());
     }
-    CheckSort<3>(pool, sortedOrder);
+    CheckSort<mining_score>(pool, sortedOrder);
 }
 
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
       pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
       BOOST_CHECK(pblocktemplate);
       BOOST_CHECK(pblocktemplate->block.fExcessive == false);
-      BOOST_CHECK(pblocktemplate->block.nBlockSize <= maxGeneratedBlock - 2);
+      BOOST_CHECK(pblocktemplate->block.nBlockSize <= maxGeneratedBlock - 4);
       unsigned int blockSize = pblocktemplate->block.GetSerializeSize(SER_NETWORK, CTransaction::CURRENT_VERSION);
       BOOST_CHECK(blockSize <= maxGeneratedBlock - 4);
       minRoom = std::min(minRoom, maxGeneratedBlock - blockSize);
@@ -227,7 +227,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
       pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
       BOOST_CHECK(pblocktemplate);
       BOOST_CHECK(pblocktemplate->block.fExcessive == false);
-      BOOST_CHECK(pblocktemplate->block.nBlockSize <= maxGeneratedBlock);
+      BOOST_CHECK(pblocktemplate->block.nBlockSize <= maxGeneratedBlock - 2);
       unsigned int blockSize = pblocktemplate->block.GetSerializeSize(SER_NETWORK, CTransaction::CURRENT_VERSION);
       BOOST_CHECK(blockSize <= maxGeneratedBlock - 2);
       minRoom = std::min(minRoom, maxGeneratedBlock - blockSize);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -166,25 +166,28 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         hash = tx.GetHash();
         bool spendsCoinbase = (i == 0) ? true : false; // only first tx spends coinbase
         // If we do set the # of sig ops in the CTxMemPoolEntry, template creation passes
-        mempool.addUnchecked(hash, entry.Fee(1000000).Time(GetTime()).SpendsCoinbase(spendsCoinbase).SigOps(20).FromTx(tx));
+        mempool.addUnchecked(
+            hash, entry.Fee(1000000).Time(GetTime()).SpendsCoinbase(spendsCoinbase).SigOps(20).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
     BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
     delete pblocktemplate;
 
-    // Now generate lots of full size blocks and verify that none exceed the maxGeneratedBlock value, the mempool has 65k bytes of tx in it so this code will test both saturated and unsaturated blocks.
-    for (unsigned int i = 2000; i <= 80000; i+=2000)
+    // Now generate lots of full size blocks and verify that none exceed the maxGeneratedBlock value, the mempool has
+    // 65k bytes of tx in it so this code will test both saturated and unsaturated blocks.
+    for (unsigned int i = 2000; i <= 80000; i += 2000)
     {
-      maxGeneratedBlock = i;
+        maxGeneratedBlock = i;
 
-      pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
-      BOOST_CHECK(pblocktemplate);
-      BOOST_CHECK(pblocktemplate->block.fExcessive == false);
-      BOOST_CHECK(pblocktemplate->block.nBlockSize <= maxGeneratedBlock);
-      unsigned int blockSize = pblocktemplate->block.GetSerializeSize(SER_NETWORK, CTransaction::CURRENT_VERSION);
-      BOOST_CHECK(blockSize <= maxGeneratedBlock);
-      //printf("%lu %lu <= %lu\n", (long unsigned int) blockSize, (long unsigned int) pblocktemplate->block.nBlockSize, (long unsigned int) maxGeneratedBlock);
-      delete pblocktemplate;
+        pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
+        BOOST_CHECK(pblocktemplate);
+        BOOST_CHECK(pblocktemplate->block.fExcessive == false);
+        BOOST_CHECK(pblocktemplate->block.nBlockSize <= maxGeneratedBlock);
+        unsigned int blockSize = pblocktemplate->block.GetSerializeSize(SER_NETWORK, CTransaction::CURRENT_VERSION);
+        BOOST_CHECK(blockSize <= maxGeneratedBlock);
+        // printf("%lu %lu <= %lu\n", (long unsigned int) blockSize, (long unsigned int)
+        // pblocktemplate->block.nBlockSize, (long unsigned int) maxGeneratedBlock);
+        delete pblocktemplate;
     }
 
     BOOST_CHECK(chainActive.Tip()->nHeight == 110);
@@ -194,20 +197,21 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     coinbaseReserve.value = 0;
     minerComment = "I am a meat popsicle.";
 
-     // Now generate lots of full size blocks and verify that none exceed the maxGeneratedBlock value
-    for (unsigned int i = 2000; i <= 30000; i+=67)
+    // Now generate lots of full size blocks and verify that none exceed the maxGeneratedBlock value
+    for (unsigned int i = 2000; i <= 30000; i += 67)
     {
-      maxGeneratedBlock = i;
+        maxGeneratedBlock = i;
 
-      pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
-      BOOST_CHECK(pblocktemplate);
-      BOOST_CHECK(pblocktemplate->block.fExcessive == false);
-      BOOST_CHECK(pblocktemplate->block.nBlockSize <= maxGeneratedBlock - 4);
-      unsigned int blockSize = pblocktemplate->block.GetSerializeSize(SER_NETWORK, CTransaction::CURRENT_VERSION);
-      BOOST_CHECK(blockSize <= maxGeneratedBlock - 4);
-      minRoom = std::min(minRoom, maxGeneratedBlock - blockSize);
-      //printf("%lu %lu <= %lu\n", (long unsigned int) blockSize, (long unsigned int) pblocktemplate->block.nBlockSize, (long unsigned int) maxGeneratedBlock);
-      delete pblocktemplate;
+        pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
+        BOOST_CHECK(pblocktemplate);
+        BOOST_CHECK(pblocktemplate->block.fExcessive == false);
+        BOOST_CHECK(pblocktemplate->block.nBlockSize <= maxGeneratedBlock - 4);
+        unsigned int blockSize = pblocktemplate->block.GetSerializeSize(SER_NETWORK, CTransaction::CURRENT_VERSION);
+        BOOST_CHECK(blockSize <= maxGeneratedBlock - 4);
+        minRoom = std::min(minRoom, maxGeneratedBlock - blockSize);
+        // printf("%lu %lu <= %lu\n", (long unsigned int) blockSize, (long unsigned int)
+        // pblocktemplate->block.nBlockSize, (long unsigned int) maxGeneratedBlock);
+        delete pblocktemplate;
     }
 
     // Assert we went right up to the limit.  We reserved 4 bytes for height but only use 2 as height is 110.
@@ -215,24 +219,28 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     BOOST_CHECK(minRoom == 4);
 
     minRoom = 1000;
-    std::string testMinerComment("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLM__________");
-     // Now generate lots of full size blocks and verify that none exceed the maxGeneratedBlock value
-    //printf("test mining with different sized miner comments");
-    for (unsigned int i = 2000; i <= 40000; i+=89)
+    std::string testMinerComment("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdefghijklmnopqrstuvw"
+                                 "xyzABCDEFGHIJKLM__________");
+    // Now generate lots of full size blocks and verify that none exceed the maxGeneratedBlock value
+    // printf("test mining with different sized miner comments");
+    for (unsigned int i = 2000; i <= 40000; i += 89)
     {
-      maxGeneratedBlock = i;
-      if ((i%100) > 0) minerComment = testMinerComment.substr(0,i%100);
-      else minerComment = "";
-      //minerComment = testMinerComment.substr(0,i%100);
-      pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
-      BOOST_CHECK(pblocktemplate);
-      BOOST_CHECK(pblocktemplate->block.fExcessive == false);
-      BOOST_CHECK(pblocktemplate->block.nBlockSize <= maxGeneratedBlock - 2);
-      unsigned int blockSize = pblocktemplate->block.GetSerializeSize(SER_NETWORK, CTransaction::CURRENT_VERSION);
-      BOOST_CHECK(blockSize <= maxGeneratedBlock - 2);
-      minRoom = std::min(minRoom, maxGeneratedBlock - blockSize);
-      //printf("%lu %lu (miner comment is %d) <= %lu\n", (long unsigned int) blockSize, (long unsigned int) pblocktemplate->block.nBlockSize, i%100, (long unsigned int) maxGeneratedBlock);
-      delete pblocktemplate;
+        maxGeneratedBlock = i;
+        if ((i % 100) > 0)
+            minerComment = testMinerComment.substr(0, i % 100);
+        else
+            minerComment = "";
+        // minerComment = testMinerComment.substr(0,i%100);
+        pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
+        BOOST_CHECK(pblocktemplate);
+        BOOST_CHECK(pblocktemplate->block.fExcessive == false);
+        BOOST_CHECK(pblocktemplate->block.nBlockSize <= maxGeneratedBlock - 2);
+        unsigned int blockSize = pblocktemplate->block.GetSerializeSize(SER_NETWORK, CTransaction::CURRENT_VERSION);
+        BOOST_CHECK(blockSize <= maxGeneratedBlock - 2);
+        minRoom = std::min(minRoom, maxGeneratedBlock - blockSize);
+        // printf("%lu %lu (miner comment is %d) <= %lu\n", (long unsigned int) blockSize, (long unsigned int)
+        // pblocktemplate->block.nBlockSize, i%100, (long unsigned int) maxGeneratedBlock);
+        delete pblocktemplate;
     }
 
     // Assert we went right up to the limit.  We reserved 4 bytes for height but only use 2 as height is 110.

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -102,7 +102,7 @@ CBlock
 TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>& txns, const CScript& scriptPubKey)
 {
     const CChainParams& chainparams = Params();
-    CBlockTemplate *pblocktemplate = CreateNewBlock(chainparams, scriptPubKey);
+    CBlockTemplate *pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
     CBlock& block = pblocktemplate->block;
 
     // Replace mempool-selected txns with just coinbase plus passed-in txns:

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -884,9 +884,9 @@ void CTxMemPool::RemoveStaged(setEntries &stage) {
 
 int CTxMemPool::Expire(int64_t time) {
     LOCK(cs);
-    indexed_transaction_set::nth_index<2>::type::iterator it = mapTx.get<2>().begin();
+    indexed_transaction_set::index<entry_time>::type::iterator it = mapTx.get<entry_time>().begin();
     setEntries toremove;
-    while (it != mapTx.get<2>().end() && it->GetTime() < time) {
+    while (it != mapTx.get<entry_time>().end() && it->GetTime() < time) {
         toremove.insert(mapTx.project<0>(it));
         it++;
     }
@@ -982,7 +982,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<uint256>* pvNoSpendsRe
     unsigned nTxnRemoved = 0;
     CFeeRate maxFeeRateRemoved(0);
     while (DynamicMemoryUsage() > sizelimit) {
-        indexed_transaction_set::nth_index<1>::type::iterator it = mapTx.get<1>().begin();
+        indexed_transaction_set::index<descendant_score>::type::iterator it = mapTx.get<descendant_score>().begin();
 
         // We set the new mempool min fee to the feerate of the removed set, plus the
         // "minimum reasonable fee rate" (ie some value under which we consider txn

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -267,6 +267,11 @@ public:
     }
 };
 
+// Multi_index tag names
+struct descendant_score {};
+struct entry_time {};
+struct mining_score {};
+
 class CBlockPolicyEstimator;
 
 /** An inpoint - a combination of a transaction and an index n into its vin */
@@ -392,16 +397,19 @@ public:
             boost::multi_index::ordered_unique<mempoolentry_txid>,
             // sorted by fee rate
             boost::multi_index::ordered_non_unique<
+                boost::multi_index::tag<descendant_score>,
                 boost::multi_index::identity<CTxMemPoolEntry>,
                 CompareTxMemPoolEntryByDescendantScore
             >,
             // sorted by entry time
             boost::multi_index::ordered_non_unique<
+                boost::multi_index::tag<entry_time>,
                 boost::multi_index::identity<CTxMemPoolEntry>,
                 CompareTxMemPoolEntryByEntryTime
                 >,
             // sorted by score (for mining prioritization)
             boost::multi_index::ordered_unique<
+                boost::multi_index::tag<mining_score>,
                 boost::multi_index::identity<CTxMemPoolEntry>,
                 CompareTxMemPoolEntryByScore
             >

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -904,7 +904,7 @@ void static BitcoinMiner(const CChainParams &chainparams)
                 pindexPrev = chainActive.Tip();
             }
 
-            unique_ptr<CBlockTemplate> pblocktemplate(CreateNewBlock(chainparams, coinbaseScript->reserveScript));
+            unique_ptr<CBlockTemplate> pblocktemplate(BlockAssembler(chainparams).CreateNewBlock(coinbaseScript->reserveScript));
             if (!pblocktemplate.get())
             {
                 LogPrintf("Error in BitcoinMiner: Keypool ran out, please call keypoolrefill before restarting the "


### PR DESCRIPTION
Ultimate goal here is a backport of CPFP. That depends on various prior changes to miner.cpp/h that we don't have backported to BU yet. This series of commits are backports of 2 Core PRs that take us right up to the point where CPFP related PRs start to go in.

PR bitcoin#7539
PR bitcoin#7598

This is obviously very sensitive code given the recent big block that was generated. I've done my best to preserve existing semantics except for one case. The old code had a 16 byte reserve for extra varints in the coinbase.  I've replaced it; there were 3 incorrect assumptions:

1) The height in the coinbase isn't a varint, it's a script serialized integer, which is a minimum of 2 bytes and currently 4 bytes (for heights of 32768 and higher) and will be 4 bytes for another 150 years.  See BIP34
2) The coinbase output amount isn't a varint, it's always 8 bytes like all txout values.
3) There was no accounting for the txCount varint in the serialized block.  I reserve 5 bytes for 4 billion txs, which should be enough for a while :)  Current full blocks will only be using 3 bytes, but that will bump to 5 once blocks can hold 65536 txs.

The test loops are more fine-grained, and assert that blocks up to and including a tighter limit (because of the reasons above, such as a 2-byte height of 110) are created, but no greater.  Comments are included that explain the limits.  This gives me a high degree of confidence my understanding and implementation is correct.

Nevertheless careful review appreciated @gandrewstone and @ptschip