### PR TITLE
[WIP] Bandwidth accounting by message type

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -80,7 +80,11 @@ const static std::string logAllowIncomingMsgCmds[] = {
     "getblocks", "getheaders", "tx", "headers", "block",
     "getaddr", "mempool", "ping", "pong", "alert", "notfound",
     "filterload", "filteradd", "filterclear", "reject",
-    "sendheaders", "verack"};
+    "sendheaders", "verack",
+    // BU
+    "thinblock", "xthinblock", "xblocktx", "get_xblocktx", "get_xthin",
+    "req_xpedited", "Xb", "Xt", "buversion", "buverack",
+};
 
 const static std::string NET_MESSAGE_COMMAND_OTHER = "*other*";
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -79,7 +79,8 @@ const static std::string logAllowIncomingMsgCmds[] = {
     "version", "addr", "inv", "getdata", "merkleblock",
     "getblocks", "getheaders", "tx", "headers", "block",
     "getaddr", "mempool", "ping", "pong", "alert", "notfound",
-    "filterload", "filteradd", "filterclear", "reject"};
+    "filterload", "filteradd", "filterclear", "reject",
+    "sendheaders", "verack"};
 
 const static std::string NET_MESSAGE_COMMAND_OTHER = "*other*";
 

--- a/src/net.h
+++ b/src/net.h
@@ -197,6 +197,7 @@ struct LocalServiceInfo {
 
 extern CCriticalSection cs_mapLocalHost;
 extern std::map<CNetAddr, LocalServiceInfo> mapLocalHost;
+typedef std::map<std::string, uint64_t> mapMsgCmdSize; //command, total bytes
 
 class CNodeStats
 {
@@ -214,7 +215,9 @@ public:
     bool fInbound;
     int nStartingHeight;
     uint64_t nSendBytes;
+    mapMsgCmdSize mapSendBytesPerMsgCmd;
     uint64_t nRecvBytes;
+    mapMsgCmdSize mapRecvBytesPerMsgCmd;
     bool fWhitelisted;
     double dPingTime;
     double dPingWait;
@@ -418,6 +421,9 @@ protected:
     static std::vector<CSubNet> vWhitelistedRange;
     static CCriticalSection cs_vWhitelistedRange;
 
+    mapMsgCmdSize mapSendBytesPerMsgCmd;
+    mapMsgCmdSize mapRecvBytesPerMsgCmd;
+
     // Basic fuzz-testing
     void Fuzz(int nChance); // modifies ssSend
 
@@ -598,7 +604,7 @@ public:
     void AbortMessage() UNLOCK_FUNCTION(cs_vSend);
 
     // TODO: Document the precondition of this function.  Is cs_vSend locked?
-    void EndMessage() UNLOCK_FUNCTION(cs_vSend);
+    void EndMessage(const char* pszCommand) UNLOCK_FUNCTION(cs_vSend);
 
     void PushVersion();
 
@@ -608,7 +614,7 @@ public:
         try
         {
             BeginMessage(pszCommand);
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {
@@ -623,8 +629,10 @@ public:
         try {
             BeginMessage(pszCommand);
             ssSend << a1;
-            EndMessage();
-        } catch (...) {
+            EndMessage(pszCommand);
+        }
+        catch (...)
+        {
             AbortMessage();
             throw;
         }
@@ -636,8 +644,10 @@ public:
         try {
             BeginMessage(pszCommand);
             ssSend << a1 << a2;
-            EndMessage();
-        } catch (...) {
+            EndMessage(pszCommand);
+        }
+        catch (...)
+        {
             AbortMessage();
             throw;
         }
@@ -650,7 +660,7 @@ public:
         {
             BeginMessage(pszCommand);
             ssSend << a1 << a2 << a3;
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {
@@ -665,8 +675,10 @@ public:
         try {
             BeginMessage(pszCommand);
             ssSend << a1 << a2 << a3 << a4;
-            EndMessage();
-        } catch (...) {
+            EndMessage(pszCommand);
+        }
+        catch (...)
+        {
             AbortMessage();
             throw;
         }
@@ -679,7 +691,7 @@ public:
         {
             BeginMessage(pszCommand);
             ssSend << a1 << a2 << a3 << a4 << a5;
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {
@@ -695,7 +707,7 @@ public:
         {
             BeginMessage(pszCommand);
             ssSend << a1 << a2 << a3 << a4 << a5 << a6;
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {
@@ -711,7 +723,7 @@ public:
         {
             BeginMessage(pszCommand);
             ssSend << a1 << a2 << a3 << a4 << a5 << a6 << a7;
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {
@@ -726,8 +738,10 @@ public:
         try {
             BeginMessage(pszCommand);
             ssSend << a1 << a2 << a3 << a4 << a5 << a6 << a7 << a8;
-            EndMessage();
-        } catch (...) {
+            EndMessage(pszCommand);
+        }
+        catch (...)
+        {
             AbortMessage();
             throw;
         }
@@ -740,7 +754,7 @@ public:
         {
             BeginMessage(pszCommand);
             ssSend << a1 << a2 << a3 << a4 << a5 << a6 << a7 << a8 << a9;
-            EndMessage();
+            EndMessage(pszCommand);
         }
         catch (...)
         {

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -113,6 +113,14 @@ UniValue getpeerinfo(const UniValue& params, bool fHelp)
             "       n,                        (numeric) The heights of blocks we're currently asking from this peer\n"
             "       ...\n"
             "    ]\n"
+            "    \"bytessent_per_msg\": {\n"
+            "       \"addr\": n,             (numeric) The total bytes sent aggregated by message type\n"
+            "       ...\n"
+            "    }\n"
+            "    \"bytesrecv_per_msg\": {\n"
+            "       \"addr\": n,             (numeric) The total bytes received aggregated by message type\n"
+            "       ...\n"
+            "    }\n"
             "  }\n"
             "  ,...\n"
             "]\n"
@@ -173,6 +181,20 @@ UniValue getpeerinfo(const UniValue& params, bool fHelp)
             obj.push_back(Pair("inflight", heights));
         }
         obj.push_back(Pair("whitelisted", stats.fWhitelisted));
+
+        UniValue sendPerMsgCmd(UniValue::VOBJ);
+        BOOST_FOREACH(const mapMsgCmdSize::value_type &i, stats.mapSendBytesPerMsgCmd) {
+            if (i.second > 0)
+                sendPerMsgCmd.push_back(Pair(i.first, i.second));
+        }
+        obj.push_back(Pair("bytessent_per_msg", sendPerMsgCmd));
+
+        UniValue recvPerMsgCmd(UniValue::VOBJ);
+        BOOST_FOREACH(const mapMsgCmdSize::value_type &i, stats.mapRecvBytesPerMsgCmd) {
+            if (i.second > 0)
+                recvPerMsgCmd.push_back(Pair(i.first, i.second));
+        }
+        obj.push_back(Pair("bytesrecv_per_msg", recvPerMsgCmd));
 
         ret.push_back(obj);
 	}


### PR DESCRIPTION
A backport of bitcoin#6589 and follow-up bugfix, extended with support for BU message types.

The accounting data is shown in the getpeerinfo console RPC command which is useful for debugging and understanding what is going on on the network.  I have checked this works as intended.