### PR TITLE
Fix walletbackup.py failure in Python 3.5+

### DIFF
--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -143,6 +143,11 @@ class AuthServiceProxy(object):
                 return self._get_response()
             else:
                 raise
+          except BrokenPipeError:
+            # Python 3.5+ raises this instead of BadStatusLine when the connection was reset
+            self.__conn.close()
+            self.__conn.request(method, path, postdata, headers)
+            return self._get_response()
 
     def __call__(self, *args):
         AuthServiceProxy.__id_count += 1

--- a/qa/rpc-tests/test_framework/coverage.py
+++ b/qa/rpc-tests/test_framework/coverage.py
@@ -46,14 +46,7 @@ class AuthServiceProxyWrapper(object):
         called to a file.
 
         """
-        while 1:
-            try:
-                return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
-                break
-            except BrokenPipeError as e: # BU handle connection drops
-                print("Connection broken: ", str(e))
-                self.auth_service_proxy_instance.reconnect()
-            
+        return_val = self.auth_service_proxy_instance.__call__(*args, **kwargs)
         rpc_method = self.auth_service_proxy_instance._service_name
 
         if self.coverage_logfile:


### PR DESCRIPTION
This fixes two RPC tests for me, and eliminates some spurious output while running the test suite.