### PR TITLE
add block sync polling loop to accomodate test hardware of different capabilities

### DIFF
--- a/contrib/gitian-descriptors/gitian-arm.yml
+++ b/contrib/gitian-descriptors/gitian-arm.yml
@@ -1,5 +1,5 @@
 ---
-name: "BitcoinUnlimited-linux-0.12"
+name: "BitcoinUnlimited-linux-1.0"
 enable_cache: true
 suites:
 - "trusty"

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -1,5 +1,5 @@
 ---
-name: "BitcoinUnlimited-linux-0.12"
+name: "BitcoinUnlimited-linux-1.0"
 enable_cache: true
 suites:
 - "trusty"

--- a/contrib/gitian-descriptors/gitian-osx.yml
+++ b/contrib/gitian-descriptors/gitian-osx.yml
@@ -1,5 +1,5 @@
 ---
-name: "BitcoinUnlimited-osx-0.12.1"
+name: "BitcoinUnlimited-osx-1.0"
 enable_cache: true
 suites:
 - "trusty"

--- a/contrib/gitian-descriptors/gitian-win.yml
+++ b/contrib/gitian-descriptors/gitian-win.yml
@@ -1,5 +1,5 @@
 ---
-name: "BitcoinUnlimited-win-0.12"
+name: "BitcoinUnlimited-win-1.0"
 enable_cache: true
 suites:
 - "trusty"

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -253,7 +253,6 @@ class TestManager(object):
                 if outcome is None:
                     if c.cb.bestblockhash != self.connections[0].cb.bestblockhash:
                         print("Node ", c.addr, " has best block ", hex(c.cb.bestblockhash), ". Expecting ", hex(self.connections[0].cb.bestblockhash))
-                        # pdb.set_trace()
                         return False
                 elif isinstance(outcome, RejectResult): # Check that block was rejected w/ code
                     if c.cb.bestblockhash == blockhash:
@@ -266,9 +265,17 @@ class TestManager(object):
                         return False
                 elif ((c.cb.bestblockhash == blockhash) != outcome):
                     print("Node ", c.addr, " has best block ", hex(c.cb.bestblockhash), ". Expecting ", hex(blockhash), outcome)
-                    print("Quick   RPC returns", c.rpc.getbestblockhash())
-                    time.sleep(5.5) #wait the requestmanager re-request interval to see if the block shows up
-                    print("Delayed RPC returns", c.rpc.getbestblockhash())
+                    hsh = c.rpc.getbestblockhash()
+                    print("Quick   RPC returns", hsh)
+                    t = 0
+                    # give 20 seconds to sync, this is a pretty generous number.  How much time might it take
+                    # an underpowered test node running 4-6 copies of bitcoind to sync them?  
+                    while t < 10 and hsh != hex(blockhash)[2:]:  # hex(blockhash) returns "0x..." whereas hsh does not have the "0x"
+                        t += 1
+                        time.sleep(2) 
+                        hsh = c.rpc.getbestblockhash()
+                    if t == 10:
+                        print("Delayed RPC returns", hsh)
 
                     rpcblock =  c.rpc.getbestblockhash()
                     block = hex(blockhash)[2:]
@@ -278,7 +285,6 @@ class TestManager(object):
                     if rpcblock == block:
                         return True
                     else:
-		    # pdb.set_trace()
                         return False
 
             return True

--- a/qa/rpc-tests/txn_clone.py
+++ b/qa/rpc-tests/txn_clone.py
@@ -163,4 +163,3 @@ class TxnMallTest(BitcoinTestFramework):
 
 if __name__ == '__main__':
     TxnMallTest().main()
-

--- a/qa/rpc-tests/txn_doublespend.py
+++ b/qa/rpc-tests/txn_doublespend.py
@@ -25,6 +25,7 @@ class TxnMallTest(BitcoinTestFramework):
         # All nodes should start with 1,250 BTC:
         starting_balance = 1250
         for i in range(4):
+            print("node ", i," balance ", self.nodes[i].getbalance())
             assert_equal(self.nodes[i].getbalance(), starting_balance)
             self.nodes[i].getnewaddress("")  # bug workaround, coins generated assigned to first getnewaddress!
         

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -118,7 +118,7 @@ void CAddrMan::SwapRandom(unsigned int nRndPos1, unsigned int nRndPos2)
 
 void CAddrMan::Delete(int nId)
 {
-    assert(mapInfo.count(nId) != 0);
+    DbgAssert(mapInfo.count(nId) != 0, return); // already deleted so no-op
     CAddrInfo& info = mapInfo[nId];
     assert(!info.fInTried);
     assert(info.nRefCount == 0);

--- a/src/chain.h
+++ b/src/chain.h
@@ -12,6 +12,7 @@
 #include "pow.h"
 #include "tinyformat.h"
 #include "uint256.h"
+#include "util.h"
 
 #include <vector>
 
@@ -378,6 +379,8 @@ public:
 
     /** Efficiently check whether a block is present in this chain. */
     bool Contains(const CBlockIndex *pindex) const {
+        /* null pointer isn't in this chain but caller should not send in the first place */
+        DbgAssert(pindex, return false);
         return (*this)[pindex->nHeight] == pindex;
     }
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -143,7 +143,7 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
       CBlockHeader h;
       nBlockSize += h.GetSerializeSize(SER_NETWORK, PROTOCOL_VERSION);
     }
-    assert(nBlockSize == 80);  // BU always 80 bytes
+    assert(nBlockSize == 80);  // BU block header is always 80 bytes
 
 
     unsigned int nCoinbaseSize=0;
@@ -410,7 +410,7 @@ void IncrementExtraNonce(CBlock* pblock, unsigned int& nExtraNonce)
 	COINBASE_FLAGS.resize(MAX_COINBASE_SCRIPTSIG_SIZE - script.size());
       }
     txCoinbase.vin[0].scriptSig = script + COINBASE_FLAGS;
-    assert(txCoinbase.vin[0].scriptSig.size() <= 100);
+    assert(txCoinbase.vin[0].scriptSig.size() <= MAX_COINBASE_SCRIPTSIG_SIZE);
 
     pblock->vtx[0] = txCoinbase;
     pblock->hashMerkleRoot = BlockMerkleRoot(*pblock);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1288,7 +1288,8 @@ void ThreadSocketHandler()
                     }
                     if (fDelete) {
                         vNodesDisconnected.remove(pnode);
-                        assert(std::find(vNodes.begin(),vNodes.end(), pnode) == vNodes.end());  // make sure it has been removed
+                        // no need to remove from vNodes. we know pnode has already been removed from vNodes since that
+                        // occurred prior to insertion into vNodesDisconnected
                         delete pnode;
                     }
                 }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -356,6 +356,7 @@ public:
 
     friend bool operator<(const CInv& a, const CInv& b);
 
+    /// returns true if this inv is one of any of the inv types ever used.
     bool IsKnownType() const;
     const char* GetCommand() const;
     std::string ToString() const;

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -137,7 +137,7 @@ void CRequestManager::AskFor(const CInv& obj, CNode* from, int priority)
     }
   else
     {
-      assert(!"TBD");
+      DbgAssert(!"Request manager does not handle objects of this type", return);
     }
 
 }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -459,7 +459,7 @@ void RPCRegisterTimerInterface(RPCTimerInterface *iface)
 void RPCUnregisterTimerInterface(RPCTimerInterface *iface)
 {
     std::vector<RPCTimerInterface*>::iterator i = std::find(timerInterfaces.begin(), timerInterfaces.end(), iface);
-    assert(i != timerInterfaces.end());
+    DbgAssert(i != timerInterfaces.end(), return);  // already removed, so ignore the problem in production
     timerInterfaces.erase(i);
 }
 

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -462,15 +462,6 @@ public:
         return *this;
     }
 
-    CScript& operator<<(const CScript& b)
-    {
-        // I'm not sure if this should push the script or concatenate scripts.
-        // If there's ever a use for pushing a script onto a script, delete this member fn
-        assert(!"Warning: Pushing a CScript onto a CScript with << is probably not intended, use + to concatenate!");
-        return *this;
-    }
-
-
     bool GetOp(iterator& pc, opcodetype& opcodeRet, std::vector<unsigned char>& vchRet)
     {
          // Wrapper so it can be called with either iterator or const_iterator

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -49,6 +49,21 @@ static const unsigned char ParseHex_expected[65] = {
     0xde, 0x5c, 0x38, 0x4d, 0xf7, 0xba, 0x0b, 0x8d, 0x57, 0x8a, 0x4c, 0x70, 0x2b, 0x6b, 0xf1, 0x1d,
     0x5f
 };
+
+BOOST_AUTO_TEST_CASE(util_DbgAssert)
+{
+#ifndef DEBUG_ASSERTION
+    int i=0;
+    bool savedVal = fPrintToConsole;
+    fPrintToConsole = true;
+    DbgAssert(1, i=1);
+    BOOST_CHECK(i == 0);
+    DbgAssert(0, i=1);
+    BOOST_CHECK(i == 1);
+    fPrintToConsole=savedVal;
+#endif    
+}
+
 BOOST_AUTO_TEST_CASE(util_ParseHex)
 {
     std::vector<unsigned char> result;

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -81,7 +81,7 @@ int32_t UnlimitedComputeBlockVersion(const CBlockIndex* pindexPrev, const Consen
 CNode* FindLikelyNode(const std::string& addrName);
 
 // process incoming unsolicited block
-void HandleExpeditedBlock(CDataStream& vRecv,CNode* pfrom);
+bool HandleExpeditedBlock(CDataStream& vRecv,CNode* pfrom);
 
 // Convert the BUComments to the string client's "subversion" string
 extern void settingsToUserAgentString();

--- a/src/util.h
+++ b/src/util.h
@@ -29,6 +29,18 @@
 #include <boost/signals2/signal.hpp>
 #include <boost/thread/exceptions.hpp>
 
+#ifdef DEBUG_ASSERTION
+/// If DEBUG_ASSERTION is enabled this asserts when the predicate is false.
+//  If DEBUG_ASSERTION is disabled and the predicate is false, it executes the execInRelease statements.
+//  Typically, the programmer will error out -- return false, raise an exception, etc in the execInRelease code.
+//  DO NOT USE break or continue inside the DbgAssert!
+#define DbgAssert(pred, execInRelease) assert(pred)
+#else
+#define DbgStringify(x) #x
+#define DbgStringifyIntLiteral(x) DbgStringify(x)
+#define DbgAssert(pred, execInRelease) do { if (!(pred)) { LogPrintStr(std::string(__FILE__ "(" DbgStringifyIntLiteral(__LINE__) "): Debug Assertion failed: \"" #pred "\"\n")); execInRelease; }} while(0)
+#endif
+
 static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGIPS        = true;
 static const bool DEFAULT_LOGTIMESTAMPS = true;


### PR DESCRIPTION
the 5 second sync delay does not take into account the variety of hardware and virtual machines the test infrastructure is run on.  Because of this we get occasional spurious failures in the qa tests.  This polling loop will make the tests run faster and be more tolerant to different hardware platforms.

Also to be merged into "release" branch.