### PR TITLE
BIP100: Dynamic max block size by miner vote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,7 +105,8 @@ linux-build
 win32-build
 qa/pull-tester/run-bitcoind-for-test.sh
 qa/pull-tester/tests_config.py
-qa/pull-tester/cache/*
+qa/pull-tester/cache
+qa/pull-tester/cache_bigblock
 qa/pull-tester/test.*/*
 qa/tmp
 cache/

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -213,6 +213,7 @@ testScriptsExt = [ RpcTest(t) for t in [
     'bip65-cltv',
     'bip65-cltv-p2p',
     'bip68-sequence',
+    'bip100-sizelimit',
     'bipdersig-p2p',
     'bipdersig',
     'getblocktemplate_longpoll',
@@ -249,6 +250,7 @@ def show_wrapper_options():
     print("  -f / -force-enable / --force-enable\n" + \
           "                        attempt to run disabled/skipped tests")
     print("  -h / -help / --help   print this help")
+
 
 def runtests():
     global passOn

--- a/qa/rpc-tests/.gitignore
+++ b/qa/rpc-tests/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 cache
+cache_bigblock

--- a/qa/rpc-tests/bip100-sizelimit.py
+++ b/qa/rpc-tests/bip100-sizelimit.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test mining and broadcast of larger-than-1MB-blocks
+#
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+from decimal import Decimal
+
+CACHE_DIR = "cache_bigblock"
+
+class BigBlockTest(BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+
+        if not os.path.isdir(os.path.join(CACHE_DIR, "node0")):
+            print("Creating initial chain. This will be cached for future runs.")
+
+            for i in range(4):
+                initialize_datadir(CACHE_DIR, i) # Overwrite port/rpcport in bitcoin.conf
+
+            # Node 0 creates 8MB blocks that vote for increase to 8MB
+            # Node 1 creates empty blocks that vote for 8MB
+            # Node 2 creates empty blocks that vote for 2MB
+            # Node 3 creates empty blocks that do not vote for increase
+            self.nodes = []
+            # Use node0 to mine blocks for input splitting
+            self.nodes.append(start_node(0, CACHE_DIR, ["-blockmaxsize=8000000", "-bip100=1", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
+            self.nodes.append(start_node(1, CACHE_DIR, ["-blockmaxsize=1000", "-bip100=1", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
+            self.nodes.append(start_node(2, CACHE_DIR, ["-blockmaxsize=1000", "-bip100=1", "-maxblocksizevote=1", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
+            self.nodes.append(start_node(3, CACHE_DIR, ["-blockmaxsize=1000", "-bip100=1", "-maxblocksizevote=2", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
+
+            connect_nodes_bi(self.nodes, 0, 1)
+            connect_nodes_bi(self.nodes, 1, 2)
+            connect_nodes_bi(self.nodes, 2, 3)
+            connect_nodes_bi(self.nodes, 3, 0)
+
+            self.is_network_split = False
+
+            # Create a 2012-block chain in a 75% ratio for increase (genesis block votes for 1MB)
+            # Make sure they are not already sorted correctly
+            blocks = []
+            blocks.append(self.nodes[1].generate(503))
+            assert(self.sync_blocks(self.nodes[1:3]))
+            blocks.append(self.nodes[2].generate(502)) # <--- genesis is 503rd vote for 1MB
+            assert(self.sync_blocks(self.nodes[2:4]))
+            blocks.append(self.nodes[3].generate(503))
+            assert(self.sync_blocks(self.nodes[1:4]))
+            blocks.append(self.nodes[1].generate(503))
+            assert(self.sync_blocks(self.nodes))
+
+            tx_file = open(os.path.join(CACHE_DIR, "txdata"), "w")
+
+            # Create a lot of tansaction data ready to be mined
+            fee = Decimal('.00005')
+            used = set()
+            print("Creating transaction data")
+            for i in range(0,25):
+                inputs = []
+                outputs = {}
+                limit = 0
+                utxos = self.nodes[3].listunspent(0)
+                for utxo in utxos:
+                    if not utxo["txid"]+str(utxo["vout"]) in used:
+                        raw_input = {}
+                        raw_input["txid"] = utxo["txid"]
+                        raw_input["vout"] = utxo["vout"]
+                        inputs.append(raw_input)
+                        outputs[self.nodes[3].getnewaddress()] = utxo["amount"] - fee
+                        used.add(utxo["txid"]+str(utxo["vout"]))
+                        limit = limit + 1
+                        if (limit >= 250):
+                            break
+                rawtx = self.nodes[3].createrawtransaction(inputs, outputs)
+                txdata = self.nodes[3].signrawtransaction(rawtx)["hex"]
+                self.nodes[3].sendrawtransaction(txdata)
+                tx_file.write(txdata+"\n")
+            tx_file.close()
+
+            stop_nodes(self.nodes)
+            wait_bitcoinds()
+            self.nodes = []
+            for i in range(4):
+                os.remove(log_filename(CACHE_DIR, i, "db.log"))
+                os.remove(log_filename(CACHE_DIR, i, "peers.dat"))
+                os.remove(log_filename(CACHE_DIR, i, "fee_estimates.dat"))
+
+        for i in range(4):
+            from_dir = os.path.join(CACHE_DIR, "node"+str(i))
+            to_dir = os.path.join(self.options.tmpdir,  "node"+str(i))
+            shutil.copytree(from_dir, to_dir)
+            initialize_datadir(self.options.tmpdir, i) # Overwrite port/rpcport in bitcoin.conf
+
+    def sync_blocks(self, rpc_connections, wait=1, max_wait=60):
+        """
+        Wait until everybody has the same block count
+        """
+        for i in range(0,max_wait):
+            if i > 0: time.sleep(wait)
+            counts = [ x.getblockcount() for x in rpc_connections ]
+            if counts == [ counts[0] ]*len(counts):
+                return True
+        return False
+
+    def setup_network(self):
+        self.nodes = []
+
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-bip100=1", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockmaxsize=1000", "-bip100=1", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockmaxsize=1000", "-bip100=1", "-maxblocksizevote=1", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60))
+        # (We don't restart the node with the huge wallet
+        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes_bi(self.nodes, 1, 2)
+        connect_nodes_bi(self.nodes, 2, 0)
+
+        self.load_mempool(self.nodes[0])
+
+    def load_mempool(self, node):
+        with open(os.path.join(CACHE_DIR, "txdata"), "r") as f:
+            for line in f:
+                node.sendrawtransaction(line.rstrip())
+
+    def TestMineBig(self, expect_big):
+        # Test if node0 will mine a block bigger than legacy MAX_BLOCK_SIZE
+        self.nodes[0].setminingmaxblock(self.nodes[0].getexcessiveblock()["excessiveBlockSize"])
+        b1hash = self.nodes[0].generate(1)[0]
+        b1 = self.nodes[0].getblock(b1hash, True)
+        assert(self.sync_blocks(self.nodes[0:3]))
+
+        if expect_big:
+            assert(b1['size'] > 1000*1000)
+
+            # Have node1 mine on top of the block,
+            # to make sure it goes along with the fork
+            b2hash = self.nodes[1].generate(1)[0]
+            b2 = self.nodes[1].getblock(b2hash, True)
+            assert(b2['previousblockhash'] == b1hash)
+            assert(self.sync_blocks(self.nodes[0:3]))
+
+        else:
+            assert(b1['size'] < 1000*1000)
+
+        # Reset chain to before b1hash:
+        for node in self.nodes[0:3]:
+            node.invalidateblock(b1hash)
+        assert(self.sync_blocks(self.nodes[0:3]))
+
+
+    def run_test(self):
+        # nodes 0 and 1 have mature 50-BTC coinbase transactions.
+
+        print("Testing consensus blocksize increase conditions")
+
+        assert_equal(self.nodes[0].getblockcount(), 2011) # This is a 0-based height
+
+        # Current nMaxBlockSize is still 1MB
+        assert_equal(self.nodes[0].getexcessiveblock()["excessiveBlockSize"], 1000000)
+        self.TestMineBig(False)
+
+        # Create a situation where the 1512th-highest vote is for 2MB
+        self.nodes[2].generate(1)
+        assert(self.sync_blocks(self.nodes[1:3]))
+        ahash = self.nodes[1].generate(3)[2]
+        assert_equal(self.nodes[1].getexcessiveblock()["excessiveBlockSize"], int(1000000 * 1.05))
+        assert(self.sync_blocks(self.nodes[0:2]))
+        self.TestMineBig(True)
+
+        # Shutdown then restart node[0], it should produce a big block.
+        stop_node(self.nodes[0], 0)
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-bip100=1", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60)
+        self.load_mempool(self.nodes[0])
+        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes_bi(self.nodes, 0, 2)
+        assert_equal(self.nodes[0].getexcessiveblock()["excessiveBlockSize"], int(1000000 * 1.05))
+        self.TestMineBig(True)
+
+        # Test re-orgs past the sizechange block
+        stop_node(self.nodes[0], 0)
+        self.nodes[2].invalidateblock(ahash)
+        assert_equal(self.nodes[2].getexcessiveblock()["excessiveBlockSize"], 1000000)
+        self.nodes[2].generate(2)
+        assert_equal(self.nodes[2].getexcessiveblock()["excessiveBlockSize"], 1000000)
+        assert(self.sync_blocks(self.nodes[1:3]))
+
+        # Restart node0, it should re-org onto longer chain,
+        # and refuse to mine a big block:
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-bip100=1", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60)
+        self.load_mempool(self.nodes[0])
+        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes_bi(self.nodes, 0, 2)
+        assert(self.sync_blocks(self.nodes[0:3]))
+        assert_equal(self.nodes[0].getexcessiveblock()["excessiveBlockSize"], 1000000)
+        self.TestMineBig(False)
+
+        # Mine 4 blocks voting for 8MB. Bigger block NOT ok, we are in the next voting period
+        self.nodes[1].generate(4)
+        assert_equal(self.nodes[1].getexcessiveblock()["excessiveBlockSize"], 1000000)
+        assert(self.sync_blocks(self.nodes[0:3]))
+        self.TestMineBig(False)
+
+
+        print("Cached test chain and transactions left in %s"%(CACHE_DIR))
+
+if __name__ == '__main__':
+    BigBlockTest().main()

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -4,6 +4,8 @@ tweak.h
 thinblock.cpp
 thinblock.h
 leakybucket.h
+maxblocksize.cpp
+maxblocksize.h
 parallel.cpp
 parallel.h
 unlimited.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -102,6 +102,7 @@ BITCOIN_CORE_H = \
   dbwrapper.h \
   limitedmap.h \
   main.h \
+  maxblocksize.h \
   memusage.h \
   merkleblock.h \
   miner.h \
@@ -181,6 +182,7 @@ libbitcoin_server_a_SOURCES = \
   init.cpp \
   dbwrapper.cpp \
   main.cpp \
+  maxblocksize.cpp \
   merkleblock.cpp \
   miner.cpp \
   net.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -59,6 +59,7 @@ BITCOIN_TESTS =\
   test/limitedmap_tests.cpp \
   test/dbwrapper_tests.cpp \
   test/main_tests.cpp \
+  test/maxblocksize_tests.cpp \
   test/mempool_tests.cpp \
   test/merkle_tests.cpp \
   test/miner_tests.cpp \

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -117,6 +117,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1462060800; // May 1st, 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
 
+        // BIP100 defined start height and max block size change critical vote position
+        consensus.bip100ActivationHeight = 449568;
+        consensus.nMaxBlockSizeChangePosition = 1512;
+
         /**
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -288,6 +292,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1456790400; // March 1st, 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
 
+        // BIP100 defined start height and max block size change critical vote position
+        consensus.bip100ActivationHeight = 798336;
+        consensus.nMaxBlockSizeChangePosition = 1512;
+
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
@@ -360,6 +368,9 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 999999999999ULL;
+
+        consensus.bip100ActivationHeight = 0;
+        consensus.nMaxBlockSizeChangePosition = 1512;
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -54,6 +54,13 @@ struct Params {
     uint32_t nRuleChangeActivationThreshold;
     uint32_t nMinerConfirmationWindow;
     BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
+    /**
+     * BIP100: One-based position from beginning (end) of the ascending sorted list of max block size
+     * votes in a retarget interval, at which the possible new lower (higher) max block size is read.
+     * 1512 = 75th percentile of 2016
+     */
+    int bip100ActivationHeight;
+    uint32_t nMaxBlockSizeChangePosition;
     /** Proof of work parameters */
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1153,8 +1153,11 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
                         CleanupBlockRevFiles();
                 }
 
-                if (!LoadBlockIndex()) {
+                bool fRebuildRequired = false;
+                if (!LoadBlockIndex(&fRebuildRequired)) {
                     strLoadError = _("Error loading block database");
+                    if (fRebuildRequired)
+                        strLoadError += _(". You need to rebuild the database using -reindex.");
                     break;
                 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include "expedited.h"
 #include "hash.h"
 #include "init.h"
+#include "maxblocksize.h"
 #include "merkleblock.h"
 #include "net.h"
 #include "parallel.h"
@@ -3046,6 +3047,17 @@ void static UpdateTip(CBlockIndex *pindexNew)
     const CChainParams &chainParams = Params();
     chainActive.SetTip(pindexNew);
 
+    if (GetArg("-bip100", 0))
+    {
+        uint64_t nMaxBlockSize = GetNextMaxBlockSize(pindexNew, chainParams.GetConsensus());
+        if (nMaxBlockSize != excessiveBlockSize)
+        {
+            excessiveBlockSize = nMaxBlockSize;
+            maxGeneratedBlock = (maxGeneratedBlock > excessiveBlockSize ? excessiveBlockSize : maxGeneratedBlock);
+            settingsToUserAgentString();
+        }
+    }
+
     // New best block
     nTimeBestReceived = GetTime();
     mempool.AddTransactionsUpdated(1);
@@ -3846,6 +3858,7 @@ bool ReceivedBlockTransactions(const CBlock &block,
     pindexNew->nFile = pos.nFile;
     pindexNew->nDataPos = pos.nPos;
     pindexNew->nUndoPos = 0;
+    pindexNew->nMaxBlockSizeVote = GetMaxBlockSizeVote(block.vtx[0].vin[0].scriptSig, pindexNew->nHeight);
     pindexNew->nStatus |= BLOCK_HAVE_DATA;
     if (block.fExcessive)
         pindexNew->nStatus |= BLOCK_EXCESSIVE;
@@ -3868,6 +3881,7 @@ bool ReceivedBlockTransactions(const CBlock &block,
                 LOCK(cs_nBlockSequenceId);
                 pindex->nSequenceId = nBlockSequenceId++;
             }
+            pindex->nMaxBlockSize = GetNextMaxBlockSize(pindex->pprev, Params().GetConsensus());
             if (chainActive.Tip() == NULL || !setBlockIndexCandidates.value_comp()(pindex, chainActive.Tip()))
             {
                 setBlockIndexCandidates.insert(pindex);
@@ -4666,7 +4680,7 @@ CBlockIndex *InsertBlockIndex(uint256 hash)
     return pindexNew;
 }
 
-bool static LoadBlockIndexDB()
+bool static LoadBlockIndexDB(bool *fRebuildRequired)
 {
     const CChainParams &chainparams = Params();
     if (!pblocktree->LoadBlockIndexGuts())
@@ -4683,8 +4697,11 @@ bool static LoadBlockIndexDB()
         vSortedByHeight.push_back(std::make_pair(pindex->nHeight, pindex));
     }
     std::sort(vSortedByHeight.begin(), vSortedByHeight.end());
-    BOOST_FOREACH (const PAIRTYPE(int, CBlockIndex *) & item, vSortedByHeight)
+    std::vector<std::pair<int, CBlockIndex *> >::iterator firstBIP100Entry = vSortedByHeight.end();
+    for (std::vector<std::pair<int, CBlockIndex *> >::iterator iter = vSortedByHeight.begin();
+         iter != vSortedByHeight.end(); iter++)
     {
+        const PAIRTYPE(int, CBlockIndex *) &item = *iter;
         CBlockIndex *pindex = item.second;
         pindex->nChainWork = (pindex->pprev ? pindex->pprev->nChainWork : 0) + GetBlockProof(*pindex);
         // We can link the chain of blocks for which we've received transactions at some point.
@@ -4718,6 +4735,14 @@ bool static LoadBlockIndexDB()
         if (pindex->IsValid(BLOCK_VALID_TREE) &&
             (pindexBestHeader == NULL || CBlockIndexWorkComparator()(pindexBestHeader, pindex)))
             pindexBestHeader = pindex;
+        if (item.first < chainparams.GetConsensus().bip100ActivationHeight)
+        {
+            pindex->nMaxBlockSize = BLOCKSTREAM_CORE_MAX_BLOCK_SIZE;
+        }
+        else if (firstBIP100Entry == vSortedByHeight.end())
+        {
+            firstBIP100Entry = iter;
+        }
     }
 
     // Load block file info
@@ -4772,6 +4797,43 @@ bool static LoadBlockIndexDB()
     pblocktree->ReadReindexing(fReindexing);
     fReindex |= fReindexing;
 
+    // Set max block size variables in any remaining pre-BIP100 index entries
+    bool fUpdatedEntries = false;
+    for (std::vector<std::pair<int, CBlockIndex *> >::iterator iter = firstBIP100Entry; iter != vSortedByHeight.end();
+         iter++)
+    {
+        const PAIRTYPE(int, CBlockIndex *) &item = *iter;
+        CBlockIndex *pindex = item.second;
+        if (pindex->nSerialVersion < BIP100_DBI_VERSION)
+        {
+            if (!fUpdatedEntries)
+            {
+                uiInterface.InitMessage(_("Updating block index for BIP100..."));
+                fUpdatedEntries = true;
+            }
+            pindex->nSerialVersion = DISK_BLOCK_INDEX_VERSION;
+            if (pindex->nChainTx)
+            {
+                CBlock block;
+                if (ReadBlockFromDisk(block, pindex, chainparams.GetConsensus()))
+                {
+                    pindex->nMaxBlockSizeVote = GetMaxBlockSizeVote(block.vtx[0].vin[0].scriptSig, pindex->nHeight);
+                    pindex->nMaxBlockSize = GetNextMaxBlockSize(pindex->pprev, chainparams.GetConsensus());
+                }
+                else
+                {
+                    // Error: Can't reconstruct vote. Rebuild required.
+                    // This can happen if the blocks were pruned after BIP100
+                    // activation with pre-BIP100 software.
+                    *fRebuildRequired = true;
+                    return false;
+                }
+            }
+            LogPrint("reindex", "%s: Updating block index entry at height %d for BIP100\n", __func__, pindex->nHeight);
+            setDirtyBlockIndex.insert(pindex);
+        }
+    }
+
     // Check whether we have a transaction index
     pblocktree->ReadFlag("txindex", fTxIndex);
     LogPrintf("%s: transaction index %s\n", __func__, fTxIndex ? "enabled" : "disabled");
@@ -4781,6 +4843,17 @@ bool static LoadBlockIndexDB()
     if (it == mapBlockIndex.end())
         return true;
     chainActive.SetTip(it->second);
+
+    if (GetArg("-bip100", 0))
+    {
+        uint64_t nMaxBlockSize = GetNextMaxBlockSize(it->second, chainparams.GetConsensus());
+        if (nMaxBlockSize != excessiveBlockSize)
+        {
+            excessiveBlockSize = nMaxBlockSize;
+            maxGeneratedBlock = (maxGeneratedBlock > excessiveBlockSize ? excessiveBlockSize : maxGeneratedBlock);
+            settingsToUserAgentString();
+        }
+    }
 
     PruneBlockIndexCandidates();
 
@@ -4939,10 +5012,11 @@ void UnloadBlockIndex()
     fHavePruned = false;
 }
 
-bool LoadBlockIndex()
+bool LoadBlockIndex(bool *fRebuildRequired)
 {
+    assert(fRebuildRequired != NULL);
     // Load block index from databases
-    if (!fReindex && !LoadBlockIndexDB())
+    if (!fReindex && !LoadBlockIndexDB(fRebuildRequired))
         return false;
     return true;
 }

--- a/src/main.h
+++ b/src/main.h
@@ -236,7 +236,7 @@ bool LoadExternalBlockFile(const CChainParams &chainparams, FILE *fileIn, CDiskB
 /** Initialize a new block tree database + block data on disk */
 bool InitBlockIndex(const CChainParams &chainparams);
 /** Load the block tree and coins database from disk */
-bool LoadBlockIndex();
+bool LoadBlockIndex(bool *fRebuildRequired);
 /** Unload database information */
 void UnloadBlockIndex();
 /** Process protocol messages received from a given node */

--- a/src/maxblocksize.cpp
+++ b/src/maxblocksize.cpp
@@ -1,0 +1,151 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2017 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "maxblocksize.h"
+
+#include "chain.h"
+#include "util.h"
+#include <boost/lexical_cast.hpp>
+#include <string>
+
+uint64_t GetNextMaxBlockSize(const CBlockIndex *pindexLast, const Consensus::Params &params)
+{
+    // BIP100 not active, return legacy max size
+    if (pindexLast == NULL || pindexLast->nHeight < params.bip100ActivationHeight)
+        return BLOCKSTREAM_CORE_MAX_BLOCK_SIZE;
+
+    uint64_t nMaxBlockSize = pindexLast->nMaxBlockSize;
+
+    // Only change once per difficulty adjustment interval
+    if ((pindexLast->nHeight + 1) % params.DifficultyAdjustmentInterval() != 0)
+    {
+        return nMaxBlockSize;
+    }
+
+    std::vector<uint64_t> votes(params.DifficultyAdjustmentInterval());
+    const CBlockIndex *pindexWalk = pindexLast;
+    for (int64_t i = 0; i < params.DifficultyAdjustmentInterval(); i++)
+    {
+        assert(pindexWalk);
+        assert(pindexWalk->nMaxBlockSize == nMaxBlockSize);
+        votes[i] = pindexWalk->nMaxBlockSizeVote ? pindexWalk->nMaxBlockSizeVote : pindexWalk->nMaxBlockSize;
+        pindexWalk = pindexWalk->pprev;
+    }
+
+    std::sort(votes.begin(), votes.end());
+    uint64_t lowerValue = votes.at(params.nMaxBlockSizeChangePosition - 1);
+    uint64_t raiseValue = votes.at(params.DifficultyAdjustmentInterval() - params.nMaxBlockSizeChangePosition);
+
+    assert(lowerValue >= 1000000); // minimal vote supported is 1MB
+    assert(lowerValue >= raiseValue); // lowerValue comes from a higher sorted position
+
+    uint64_t raiseCap = nMaxBlockSize * 105 / 100;
+    raiseValue = (raiseValue > raiseCap ? raiseCap : raiseValue);
+    if (raiseValue > nMaxBlockSize)
+    {
+        nMaxBlockSize = raiseValue;
+    }
+    else
+    {
+        uint64_t lowerFloor = nMaxBlockSize * 100 / 105;
+        lowerValue = (lowerValue < lowerFloor ? lowerFloor : lowerValue);
+        if (lowerValue < nMaxBlockSize)
+            nMaxBlockSize = lowerValue;
+    }
+
+    if (nMaxBlockSize != pindexLast->nMaxBlockSize)
+    {
+        LogPrintf("GetNextMaxBlockSize RETARGET\n");
+        LogPrintf("Before: %d\n", pindexLast->nMaxBlockSize);
+        LogPrintf("After:  %d\n", nMaxBlockSize);
+    }
+
+    return nMaxBlockSize;
+}
+
+static uint32_t FindVote(const std::string &coinbase)
+{
+    bool eb_vote = false;
+    uint32_t ebVoteMB = 0;
+    std::vector<char> curr;
+    bool bip100vote = false;
+    bool started = false;
+
+    for (char s : coinbase)
+    {
+        if (s == '/')
+        {
+            started = true;
+            // End (or beginning) of a potential vote string.
+
+            if (curr.size() < 2) // Minimum vote string length is 2
+            {
+                bip100vote = false;
+                curr.clear();
+                continue;
+            }
+
+            if (std::string(begin(curr), end(curr)) == "BIP100")
+            {
+                bip100vote = true;
+                curr.clear();
+                continue;
+            }
+
+            // Look for a B vote.
+            if (bip100vote && curr[0] == 'B')
+            {
+                try
+                {
+                    return boost::lexical_cast<uint32_t>(std::string(begin(curr) + 1, end(curr)));
+                }
+                catch (const std::exception &e)
+                {
+                    LogPrintf("Invalid coinbase B-vote: %s\n", e.what());
+                }
+            }
+
+            // Look for a EB vote. Keep it, but continue to look for a BIP100/B vote.
+            if (!eb_vote && curr[0] == 'E' && curr[1] == 'B')
+            {
+                try
+                {
+                    ebVoteMB = boost::lexical_cast<uint32_t>(std::string(begin(curr) + 2, end(curr)));
+                    eb_vote = true;
+                }
+                catch (const std::exception &e)
+                {
+                    LogPrintf("Invalid coinbase EB-vote: %s\n", e.what());
+                }
+            }
+
+            bip100vote = false;
+            curr.clear();
+            continue;
+        }
+        else if (!started)
+            continue;
+        else
+            curr.push_back(s);
+    }
+    return ebVoteMB;
+}
+
+uint64_t GetMaxBlockSizeVote(const CScript &coinbase, int32_t nHeight)
+{
+    // Skip encoded height if found at start of coinbase
+    CScript expect = CScript() << nHeight;
+    int searchStart = coinbase.size() >= expect.size() && std::equal(expect.begin(), expect.end(), coinbase.begin()) ?
+                          expect.size() :
+                          0;
+
+    std::string s(coinbase.begin() + searchStart, coinbase.end());
+
+    if (s.length() < 5) // shortest vote is /EB1/
+        return 0;
+
+
+    return static_cast<uint64_t>(FindVote(s)) * 1000000;
+}

--- a/src/maxblocksize.h
+++ b/src/maxblocksize.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2017 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_MAXBLOCKSIZE_H
+#define BITCOIN_MAXBLOCKSIZE_H
+
+#include "consensus/consensus.h"
+#include "consensus/params.h"
+#include "script/script.h"
+
+#include <stdint.h>
+
+class CBlockHeader;
+class CBlockIndex;
+
+uint64_t GetNextMaxBlockSize(const CBlockIndex *pindexLast, const Consensus::Params &);
+
+uint64_t GetMaxBlockSizeVote(const CScript &coinbase, int32_t nHeight);
+
+#endif // BITCOIN_MAXBLOCKSIZE_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -79,6 +79,8 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.push_back(Pair("bits", strprintf("%08x", blockindex->nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
+    result.push_back(Pair("sizelimit", blockindex->nMaxBlockSize));
+    result.push_back(Pair("sizelimitvote", blockindex->nMaxBlockSizeVote));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
@@ -121,6 +123,8 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("bits", strprintf("%08x", block.nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
+    result.push_back(Pair("sizelimit", blockindex->nMaxBlockSize));
+    result.push_back(Pair("sizelimitvote", blockindex->nMaxBlockSizeVote));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
@@ -325,6 +329,9 @@ UniValue getblockheader(const UniValue& params, bool fHelp)
             "  \"nonce\" : n,           (numeric) The nonce\n"
             "  \"bits\" : \"1d00ffff\", (string) The bits\n"
             "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
+            "  \"chainwork\" : \"0000...1f3\"     (string) Expected number of hashes required to produce the current chain (in hex)\n"
+            "  \"sizelimit\" : n,       (numeric) BIP100 block size limit as of this block (bytes)\n"
+            "  \"sizelimitvote\" : n,   (numeric) This block's size limit vote (bytes)\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\",      (string) The hash of the next block\n"
             "  \"chainwork\" : \"0000...1f3\"     (string) Expected number of hashes required to produce the current chain (in hex)\n"
@@ -390,6 +397,8 @@ UniValue getblock(const UniValue& params, bool fHelp)
             "  \"bits\" : \"1d00ffff\", (string) The bits\n"
             "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
             "  \"chainwork\" : \"xxxx\",  (string) Expected number of hashes required to produce the chain up to this block (in hex)\n"
+            "  \"sizelimit\" : n,       (numeric) BIP100 block size limit as of this block (bytes)\n"
+            "  \"sizelimitvote\" : n,   (numeric) This block's size limit vote (bytes)\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\"       (string) The hash of the next block\n"
             "}\n"
@@ -646,6 +655,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
             "  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n"
             "  \"pruned\": xx,             (boolean) if the blocks are subject to pruning\n"
             "  \"pruneheight\": xxxxxx,    (numeric) lowest-height complete block stored\n"
+            "  \"sizelimit\" : n,          (numeric) BIP100 block size limit as of the last block (bytes)\n"
             "  \"softforks\": [            (array) status of softforks in progress\n"
             "     {\n"
             "        \"id\": \"xxxx\",        (string) name of softfork\n"
@@ -685,6 +695,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("verificationprogress",  Checkpoints::GuessVerificationProgress(Params().Checkpoints(), chainActive.Tip())));
     obj.push_back(Pair("chainwork",             chainActive.Tip()->nChainWork.GetHex()));
     obj.push_back(Pair("pruned",                fPruneMode));
+    obj.push_back(Pair("sizelimit",             chainActive.Tip()->nMaxBlockSize));
 
     const Consensus::Params& consensusParams = Params().GetConsensus();
     CBlockIndex* tip = chainActive.Tip();

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -247,6 +247,7 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
             "  \"pooledtx\": n              (numeric) The size of the mem pool\n"
             "  \"testnet\": true|false      (boolean) If using testnet or not\n"
             "  \"chain\": \"xxxx\",         (string) current network name as defined in BIP70 (main, test, regtest)\n"
+            "  \"sizelimit\" : n,           (numeric) BIP100 block size limit as of the last block (bytes)\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getmininginfo", "")
@@ -267,6 +268,7 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("pooledtx",         (uint64_t)mempool.size()));
     obj.push_back(Pair("testnet",          Params().TestnetToBeDeprecatedFieldRPC()));
     obj.push_back(Pair("chain",            Params().NetworkIDString()));
+    obj.push_back(Pair("sizelimit",        chainActive.Tip()->nMaxBlockSize));
     obj.push_back(Pair("generate",         getgenerate(params, false)));
     return obj;
 }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -63,6 +63,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
             "  \"unlocked_until\": ttt,      (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked\n"
             "  \"paytxfee\": x.xxxx,         (numeric) the transaction fee set in " + CURRENCY_UNIT + "/kB\n"
             "  \"relayfee\": x.xxxx,         (numeric) minimum relay fee for non-free transactions in " + CURRENCY_UNIT + "/kB\n"
+            "  \"sizelimit\" : n,            (numeric) BIP100 block size limit as of the last block (bytes)\n"
             "  \"errors\": \"...\"           (string) any error messages\n"
             "}\n"
             "\nExamples:\n"
@@ -104,6 +105,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("paytxfee",      ValueFromAmount(payTxFee.GetFeePerK())));
 #endif
     obj.push_back(Pair("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK())));
+    obj.push_back(Pair("sizelimit",     chainActive.Tip()->nMaxBlockSize));
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));
     return obj;
 }

--- a/src/test/maxblocksize_tests.cpp
+++ b/src/test/maxblocksize_tests.cpp
@@ -1,0 +1,204 @@
+// Copyright (c) 2017 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+#include "maxblocksize.h"
+#include "chain.h"
+#include "chainparams.h"
+#include <algorithm>
+
+BOOST_AUTO_TEST_SUITE(maxblocksize_tests);
+
+void fillBlockIndex(
+        Consensus::Params& params, std::vector<CBlockIndex>& blockIndexes,
+        bool addVotes, int64_t currMax) {
+
+    int height = params.bip100ActivationHeight;
+    CBlockIndex* prev = nullptr;
+    for (CBlockIndex& index : blockIndexes)
+    {
+        index.nHeight = height++;
+        index.nMaxBlockSize = currMax;
+
+        if (addVotes)
+            index.nMaxBlockSizeVote = std::max(
+                (index.nHeight - params.bip100ActivationHeight) * 1000000, 1000000);
+
+        index.pprev = prev;
+        prev = &index;
+    }
+};
+
+BOOST_AUTO_TEST_CASE(get_next_max_blocksize) {
+    auto params = Params(CBaseChainParams::MAIN).GetConsensus();
+    BOOST_CHECK_EQUAL(1512, params.nMaxBlockSizeChangePosition);
+
+    // Genesis block, legacy block size
+    BOOST_CHECK_EQUAL(BLOCKSTREAM_CORE_MAX_BLOCK_SIZE, GetNextMaxBlockSize(nullptr, params));
+
+    const int64_t interval = params.DifficultyAdjustmentInterval();
+
+    // Not at a difficulty adjustment interval,
+    // should not change max block size.
+    {
+        uint64_t currMax = 42 * 1000000;
+        std::vector<CBlockIndex> blockInterval(interval);
+        fillBlockIndex(params, blockInterval, true, currMax);
+        CBlockIndex index;
+
+        for (auto& b : blockInterval) {
+            if ((b.nHeight + 1) % interval == 0)
+                continue;
+            BOOST_CHECK_EQUAL(currMax,
+                GetNextMaxBlockSize(&b, params));
+
+        }
+    }
+
+    // No block voted. Keep current size.
+    {
+        uint64_t currMax = 2000000;
+        std::vector<CBlockIndex> blockInterval(interval);
+        fillBlockIndex(params, blockInterval, false, currMax);
+
+        BOOST_CHECK_EQUAL(currMax,
+                GetNextMaxBlockSize(&blockInterval.back(), params));
+    }
+
+    // Everyone votes current size. Keep current size.
+    {
+        uint64_t currMax = 2000000;
+        std::vector<CBlockIndex> blockInterval(interval);
+        fillBlockIndex(params, blockInterval, false, currMax);
+
+        for (CBlockIndex& b : blockInterval)
+            b.nMaxBlockSizeVote = currMax;
+
+        BOOST_CHECK_EQUAL(currMax,
+                GetNextMaxBlockSize(&blockInterval.back(), params));
+    }
+
+    // Everyone votes.
+    // Blocks vote (vote# * 1MB)
+    {
+        // Test raise.
+        uint64_t currMax = 2000000;
+        std::vector<CBlockIndex> blockInterval(interval);
+        fillBlockIndex(params, blockInterval, true, currMax);
+        uint64_t newLimit = GetNextMaxBlockSize(&blockInterval.back(), params);
+        BOOST_CHECK_EQUAL(int(currMax * 1.05), newLimit);
+
+        // Test lower.
+        currMax = 1000 * 2000000;
+        fillBlockIndex(params, blockInterval, true, currMax);
+        newLimit = GetNextMaxBlockSize(&blockInterval.back(), params);
+        BOOST_CHECK_EQUAL(int(currMax / 1.05), newLimit);
+    }
+}
+
+std::vector<unsigned char> to_uchar(const std::string& coinbaseStr) {
+    return std::vector<unsigned char>(begin(coinbaseStr), end(coinbaseStr));
+}
+
+// If we have an explicit /B/ vote, we read it and ignore /EB/.
+BOOST_AUTO_TEST_CASE(get_max_blocksize_vote_b) {
+
+    std::vector<unsigned char> vote(to_uchar("/BIP100/B2/EB1/"));
+    int32_t height = 600000;
+
+    // Coinbase as in the internal miner
+    CScript coinbase = CScript() << height << vote << OP_0;
+    BOOST_CHECK_EQUAL(2000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // Coinbase as created with IncrementExtraNonce
+    unsigned int nonce = 1;
+    CScript coinbase_flags;
+    coinbase = (CScript() << height << vote << CScriptNum(nonce)) + coinbase_flags;
+    BOOST_CHECK_EQUAL(2000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // coinbase without height should also work
+    coinbase = (CScript() << vote << CScriptNum(nonce)) + coinbase_flags;
+    BOOST_CHECK_EQUAL(2000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // can't vote twice, only first one counts.
+    coinbase = (CScript() << to_uchar("/BIP100/B4/EB6/BIP100/B8/"));
+    BOOST_CHECK_EQUAL(4000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // B-votes override EB, even though EB is first.
+    coinbase = (CScript() << to_uchar("/EB6/BIP100/B8/"));
+    BOOST_CHECK_EQUAL(8000000, GetMaxBlockSizeVote(coinbase, height));
+}
+
+// If /B/ is not present, we count /EB/ as a vote.
+BOOST_AUTO_TEST_CASE(get_max_blocksize_vote_eb) {
+    std::vector<unsigned char> vote(to_uchar("/some data/EB1/"));
+    int32_t height = 600000;
+
+    CScript coinbase = CScript() << height << vote << OP_0;
+    BOOST_CHECK_EQUAL(1000000, GetMaxBlockSizeVote(coinbase, height));
+
+    unsigned int nonce = 1;
+    CScript coinbase_flags;
+    coinbase = (CScript() << height << vote << CScriptNum(nonce)) + coinbase_flags;
+    BOOST_CHECK_EQUAL(1000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // Example of a Bitcoin Unlimited coinbase string
+    coinbase = CScript() << height << to_uchar("/EB16/AD12/a miner comment");
+    BOOST_CHECK_EQUAL(16000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // can't vote twice, only first one counts.
+    coinbase = (CScript() << to_uchar("some data/EB6/EB8/"));
+    BOOST_CHECK_EQUAL(6000000, GetMaxBlockSizeVote(coinbase, height));
+}
+
+BOOST_AUTO_TEST_CASE(get_max_blocksize_vote_no_vote) {
+    int32_t height = 600000;
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << OP_0, height));
+
+    // votes must begin and end with /
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/EB2"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("EB2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100/B2"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("BIP100/B2/"), height));
+
+    // whitespace is not allowed
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/ EB2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/EB2 /"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/EB 2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100/B2 /"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100/ B2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100/B 2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100 /B2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/ BIP100/B2/"), height));
+
+    // decimals not supported
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/EB2.2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100/B2.2/"), height));
+
+    // missing mb value
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/BIP100/B/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/EB/"), height));
+
+    // missing BIP100 prefix
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/B2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/BIP100/B/B8/"), height));
+
+    //Explicit zeros and garbage
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/BIP100/B0/BIP100/B2"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/EB0/EB2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/BIP100/Bgarbage/B2/"), height));
+    BOOST_CHECK_EQUAL(2000000, GetMaxBlockSizeVote(CScript() << to_uchar("/EBgarbage/EB2/"), height));
+
+
+    // Test that height is not a part of the vote string.
+    // Encoded height in this test ends with /.
+    // Should not be interpreted as /BIP100/B8/
+    CScript coinbase = CScript() << 47;
+    BOOST_CHECK_EQUAL('/', coinbase.back());
+    std::vector<unsigned char> vote = to_uchar("BIP100/B8/");
+    coinbase.insert(coinbase.end(), vote.begin(), vote.end()); // insert instead of << to avoid size being prepended
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(coinbase, 47));
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -14,6 +14,7 @@
 #include "script/standard.h"
 #include "txmempool.h"
 #include "uint256.h"
+#include "unlimited.h"
 #include "util.h"
 #include "utilstrencodings.h"
 
@@ -475,6 +476,37 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         delete tx;
 
     fCheckpointsEnabled = true;
+}
+
+std::string DefaultCoinbaseStr() {
+    const CChainParams& chainparams = Params(CBaseChainParams::MAIN);
+    CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
+    std::unique_ptr<CBlockTemplate> tpl(BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
+    CScript coinbase = tpl->block.vtx.at(0).vin.at(0).scriptSig;
+    return std::string(coinbase.begin(), coinbase.end());
+}
+
+BOOST_AUTO_TEST_CASE(CreateNewBlock_bip100str)
+{
+    LOCK(cs_main);
+
+    excessiveBlockSize = 1000000;
+
+    // No vote defined. Should only contain EB.
+    SoftSetArg("-bip100", "1");
+    settingsToUserAgentString();
+    std::string c = DefaultCoinbaseStr();
+    BOOST_CHECK(c.find("/BIP100/EB1/") != std::string::npos);
+    BOOST_CHECK(c.find("/B1/") == std::string::npos);
+
+    // Vote for 16MB blocks
+    SoftSetArg("-maxblocksizevote", "16");
+    settingsToUserAgentString();
+    c = DefaultCoinbaseStr();
+    BOOST_CHECK(c.find("/BIP100/B16/EB1/") != std::string::npos);
+
+    mapArgs.erase("-bip100");
+    mapArgs.erase("-maxblocksizevote");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -221,6 +221,9 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->nNonce         = diskindex.nNonce;
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
+                pindexNew->nSerialVersion = diskindex.nSerialVersion;
+                pindexNew->nMaxBlockSize  = diskindex.nMaxBlockSize;
+                pindexNew->nMaxBlockSizeVote = diskindex.nMaxBlockSizeVote;
 
                 if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, Params().GetConsensus()))
                     return error("LoadBlockIndex(): CheckProofOfWork failed: %s", pindexNew->ToString());


### PR DESCRIPTION
This is a Bitcoin Unlimited port of the reference implementation of the [BIP100 specification](https://github.com/jgarzik/bip100/blob/master/bip-0100.mediawiki).

As anticipated in [BUIP002 Multi-BIP Scaling Enabler](https://bitco.in/forum/threads/buip002-passed-multi-bip-scaling-enabler.689/), a ``-bip100`` option is added that causes BU to observe rules that coordinate the EB setting among adopting nodes running a BIP100 implementation (Core and XT development versions have been published), as well as using the input of pure EC nodes.

In BIP100 mode, at each difficulty retargeting, miners' block size votes are tallied and EB is automatically moved toward the size that 75% of miners will accept immediately, in 5% change increments.  The first such increase will lead to a hard fork, so miners are advised to signal 1MB until ready, just as with pure EC.  Subsequent increases or decreases will be followed by all BIP100 nodes without disagreement.

The operation of AD is not altered by ``-bip100``, so a low setting of AD still allows the node to override EB (and exit consensus with other BIP100 nodes). 

Full nodes need no configuration to follow the network sizelimit as determined by BIP100. Miners may set their coinbase /B vote using

``-maxblocksizevote=<n> Set vote for maximum block size in megabytes (default: bip100 sizelimit)``

Several RPC's are enhanced to return the bip100 sizelimit as of the current tip, regardless of whether ``-bip100`` is set.

On first run, block index entries starting at the activation height (449568, which was in January 2017) are updated to track miner size votes and sizelimit history. Use -debug=reindex (NOT -reindex) to see the progress of this update.

When ``-bip100`` is set, a BIP100 flag and the precise current network sizelimit are published in the user agent string (and coinbase for miners) as EB.

Built on #385 which helps the operation of the bip100-sizelimit.py test.

Known TODOs: Update Unlimited GUI as anticipated in BUIP002.