### PR TITLE
Remove Block Stalling code

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -290,7 +290,6 @@ struct CNodeState {
     //! Were the first headers requested in a sync received
     bool fFirstHeadersReceived;
     //! Since when we're stalling block download progress (in microseconds), or 0.
-    int64_t nStallingSince;
     std::list<QueuedBlock> vBlocksInFlight;
     //! When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.
     int64_t nDownloadingSince;
@@ -310,7 +309,7 @@ struct CNodeState {
         pindexLastCommonBlock = NULL;
         pindexBestHeaderSent = NULL;
         fSyncStarted = false;
-        nStallingSince = 0;
+        // nStallingSince = 0; // BU: no longer used
         nDownloadingSince = 0;
         nBlocksInFlight = 0;
         nBlocksInFlightValidHeaders = 0;
@@ -454,7 +453,7 @@ bool MarkBlockAsReceived(const uint256& hash) {
         }
         state->vBlocksInFlight.erase(itInFlight->second.second);
         state->nBlocksInFlight--;
-        state->nStallingSince = 0;
+        // state->nStallingSince = 0; // BU: no longer used
         mapBlocksInFlight.erase(itInFlight);
         return true;
     }
@@ -6954,6 +6953,7 @@ bool SendMessages(CNode* pto)
         if (!vInv.empty())
             pto->PushMessage(NetMsgType::INV, vInv);
 
+        /* BU: no longer used
         // Detect whether we're stalling
         nNow = GetTimeMicros();
         if (!pto->fDisconnect && state.nStallingSince && state.nStallingSince < nNow - 1000000 * BLOCK_STALLING_TIMEOUT) {
@@ -6963,6 +6963,8 @@ bool SendMessages(CNode* pto)
             LogPrintf("Peer=%d is stalling block download, disconnecting\n", pto->id);
             pto->fDisconnect = true;
         }
+        */
+
         // In case there is a block that has been in flight from this peer for 2 + 0.5 * N times the block interval
         // (with N the number of peers from which we're downloading validated blocks), disconnect due to timeout.
         // We compensate for other peers to prevent killing off peers due to our own downstream link
@@ -7045,12 +7047,14 @@ bool SendMessages(CNode* pto)
                 }
                 // BUIP010 Xtreme Thinblocks: end section
             }
+            /* BU: no longer used
             if (state.nBlocksInFlight == 0 && staller != -1) {
                 if (State(staller)->nStallingSince == 0) {
                     State(staller)->nStallingSince = nNow;
                     LogPrint("net", "Stall started peer=%d\n", staller);
                 }
             }
+            */
         }
 
         //

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -289,7 +289,7 @@ struct CNodeState {
     int64_t fSyncStartTime;
     //! Were the first headers requested in a sync received
     bool fFirstHeadersReceived;
-    //! Since when we're stalling block download progress (in microseconds), or 0.
+
     std::list<QueuedBlock> vBlocksInFlight;
     //! When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.
     int64_t nDownloadingSince;
@@ -309,7 +309,6 @@ struct CNodeState {
         pindexLastCommonBlock = NULL;
         pindexBestHeaderSent = NULL;
         fSyncStarted = false;
-        // nStallingSince = 0; // BU: no longer used
         nDownloadingSince = 0;
         nBlocksInFlight = 0;
         nBlocksInFlightValidHeaders = 0;
@@ -453,7 +452,6 @@ bool MarkBlockAsReceived(const uint256& hash) {
         }
         state->vBlocksInFlight.erase(itInFlight->second.second);
         state->nBlocksInFlight--;
-        // state->nStallingSince = 0; // BU: no longer used
         mapBlocksInFlight.erase(itInFlight);
         return true;
     }
@@ -6953,18 +6951,6 @@ bool SendMessages(CNode* pto)
         if (!vInv.empty())
             pto->PushMessage(NetMsgType::INV, vInv);
 
-        /* BU: no longer used
-        // Detect whether we're stalling
-        nNow = GetTimeMicros();
-        if (!pto->fDisconnect && state.nStallingSince && state.nStallingSince < nNow - 1000000 * BLOCK_STALLING_TIMEOUT) {
-            // Stalling only triggers when the block download window cannot move. During normal steady state,
-            // the download window should be much larger than the to-be-downloaded set of blocks, so disconnection
-            // should only happen during initial block download.
-            LogPrintf("Peer=%d is stalling block download, disconnecting\n", pto->id);
-            pto->fDisconnect = true;
-        }
-        */
-
         // In case there is a block that has been in flight from this peer for 2 + 0.5 * N times the block interval
         // (with N the number of peers from which we're downloading validated blocks), disconnect due to timeout.
         // We compensate for other peers to prevent killing off peers due to our own downstream link
@@ -7047,14 +7033,6 @@ bool SendMessages(CNode* pto)
                 }
                 // BUIP010 Xtreme Thinblocks: end section
             }
-            /* BU: no longer used
-            if (state.nBlocksInFlight == 0 && staller != -1) {
-                if (State(staller)->nStallingSince == 0) {
-                    State(staller)->nStallingSince = nNow;
-                    LogPrint("net", "Stall started peer=%d\n", staller);
-                }
-            }
-            */
         }
 
         //

--- a/src/main.h
+++ b/src/main.h
@@ -86,8 +86,7 @@ static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 /** Number of blocks that can be requested at any given time from a single peer. */
 //static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
 /** Timeout in seconds during which a peer must stall block download progress before being disconnected. */
-//static const unsigned int BLOCK_STALLING_TIMEOUT = 2;
-static const unsigned int BLOCK_STALLING_TIMEOUT = 60; // BU: request manager handles block timeouts at 30 seconds
+//static const unsigned int BLOCK_STALLING_TIMEOUT = 2;  // BU: no longer used  
 /** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends
  *  less than this number, we reached its tip. Changing this value is a protocol upgrade. */
 static const unsigned int MAX_HEADERS_RESULTS = 2000;

--- a/src/main.h
+++ b/src/main.h
@@ -85,8 +85,6 @@ static const int MAX_SCRIPTCHECK_THREADS = 16;
 static const int DEFAULT_SCRIPTCHECK_THREADS = 0;
 /** Number of blocks that can be requested at any given time from a single peer. */
 //static const int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
-/** Timeout in seconds during which a peer must stall block download progress before being disconnected. */
-//static const unsigned int BLOCK_STALLING_TIMEOUT = 2;  // BU: no longer used  
 /** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends
  *  less than this number, we reached its tip. Changing this value is a protocol upgrade. */
 static const unsigned int MAX_HEADERS_RESULTS = 2000;


### PR DESCRIPTION
Block stalling detection is no longer required since
the introduction of the Request Manager.