### PR TITLE
Reformat unlimited.h

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -15,7 +15,7 @@ BreakBeforeBinaryOperators: false
 BreakBeforeBraces: Allman
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: false
-ColumnLimit:     0
+ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
@@ -39,6 +39,7 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
+ReflowComments: true
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -4,8 +4,11 @@
 #pragma once
 #ifndef REQUEST_MANAGER_H
 #define REQUEST_MANAGER_H
+
 #include "net.h"
 #include "stat.h"
+
+class CNode;
 extern unsigned int MIN_TX_REQUEST_RETRY_INTERVAL;  // When should I request a tx from someone else (in microseconds). cmdline/bitcoin.conf: -txretryinterval
 extern unsigned int MIN_BLK_REQUEST_RETRY_INTERVAL;  // When should I request a block from someone else (in microseconds). cmdline/bitcoin.conf: -blkretryinterval
 

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -25,13 +25,15 @@
 enum {
     TYPICAL_BLOCK_SIZE = 200000,   // used for initial buffer size
     DEFAULT_MAX_GENERATED_BLOCK_SIZE = 1000000,  // default for the maximum size of mined blocks
-    DEFAULT_EXCESSIVE_ACCEPT_DEPTH = 12,  // Default is 12 to make it very expensive for a minority hash power to get lucky, and potentially drive a block that the rest of the network sees as "excessive" onto the blockchain.
+    // Default is 12 to make it very expensive for a minority hash power to get lucky, and potentially drive a block that the rest of the network sees as "excessive" onto the blockchain.
+    DEFAULT_EXCESSIVE_ACCEPT_DEPTH = 12,
     DEFAULT_EXCESSIVE_BLOCK_SIZE = 16000000,
     DEFAULT_MAX_MESSAGE_SIZE_MULTIPLIER = 16,    // Allowed messages lengths will be this * the excessive block size
     DEFAULT_COINBASE_RESERVE_SIZE = 1000,
     MAX_COINBASE_SCRIPTSIG_SIZE = 100,
     EXCESSIVE_BLOCK_CHAIN_RESET = 6*24,  // After 1 day of non-excessive blocks, reset the checker
-    DEFAULT_CHECKPOINT_DAYS = 30,  // Default for the number of days in the past we check scripts during initial block download
+    // Default for the number of days in the past we check scripts during initial block download
+    DEFAULT_CHECKPOINT_DAYS = 30,
 };
 
 class CBlock;
@@ -50,7 +52,8 @@ extern unsigned int maxMessageSizeMultiplier;
 /** BU Default maximum number of Outbound connections to simultaneously allow*/
 extern int nMaxOutConnections;
 
-extern std::vector<std::string> BUComments;  // BU005: Strings specific to the config of this client that should be communicated to other clients
+// BU005: Strings specific to the config of this client that should be communicated to other clients
+extern std::vector<std::string> BUComments;
 extern std::string minerComment;  // An arbitrary field that miners can change to annotate their blocks
 
 // BU - Xtreme Thinblocks Auto Mempool Limiter - begin section

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -6,32 +6,34 @@
 #ifndef BITCOIN_UNLIMITED_H
 #define BITCOIN_UNLIMITED_H
 
-#include "tweak.h"
+#include "chain.h"
+#include "checkqueue.h"
+#include "coins.h"
+#include "consensus/params.h"
+#include "consensus/validation.h"
 #include "leakybucket.h"
 #include "net.h"
-#include "stat.h"
-#include "thinblock.h"
-#include "chain.h"
-#include "coins.h"
-#include "consensus/validation.h"
-#include "consensus/params.h"
 #include "requestManager.h"
 #include "script/script_error.h"
-#include "checkqueue.h"
+#include "stat.h"
+#include "thinblock.h"
+#include "tweak.h"
+#include <boost/thread.hpp>
 #include <univalue.h>
 #include <vector>
-#include <boost/thread.hpp>
 
-enum {
-    TYPICAL_BLOCK_SIZE = 200000,   // used for initial buffer size
-    DEFAULT_MAX_GENERATED_BLOCK_SIZE = 1000000,  // default for the maximum size of mined blocks
-    // Default is 12 to make it very expensive for a minority hash power to get lucky, and potentially drive a block that the rest of the network sees as "excessive" onto the blockchain.
+enum
+{
+    TYPICAL_BLOCK_SIZE = 200000,                // used for initial buffer size
+    DEFAULT_MAX_GENERATED_BLOCK_SIZE = 1000000, // default for the maximum size of mined blocks
+    // Default is 12 to make it very expensive for a minority hash power to get lucky, and potentially drive a block
+    // that the rest of the network sees as "excessive" onto the blockchain.
     DEFAULT_EXCESSIVE_ACCEPT_DEPTH = 12,
     DEFAULT_EXCESSIVE_BLOCK_SIZE = 16000000,
-    DEFAULT_MAX_MESSAGE_SIZE_MULTIPLIER = 16,    // Allowed messages lengths will be this * the excessive block size
+    DEFAULT_MAX_MESSAGE_SIZE_MULTIPLIER = 16, // Allowed messages lengths will be this * the excessive block size
     DEFAULT_COINBASE_RESERVE_SIZE = 1000,
     MAX_COINBASE_SCRIPTSIG_SIZE = 100,
-    EXCESSIVE_BLOCK_CHAIN_RESET = 6*24,  // After 1 day of non-excessive blocks, reset the checker
+    EXCESSIVE_BLOCK_CHAIN_RESET = 6 * 24, // After 1 day of non-excessive blocks, reset the checker
     // Default for the number of days in the past we check scripts during initial block download
     DEFAULT_CHECKPOINT_DAYS = 30,
 };
@@ -44,7 +46,7 @@ class CNode;
 class CChainParams;
 
 
-extern uint32_t blockVersion;  // Overrides the mined block version if non-zero
+extern uint32_t blockVersion; // Overrides the mined block version if non-zero
 extern uint64_t maxGeneratedBlock;
 extern unsigned int excessiveBlockSize;
 extern unsigned int excessiveAcceptDepth;
@@ -54,7 +56,7 @@ extern int nMaxOutConnections;
 
 // BU005: Strings specific to the config of this client that should be communicated to other clients
 extern std::vector<std::string> BUComments;
-extern std::string minerComment;  // An arbitrary field that miners can change to annotate their blocks
+extern std::string minerComment; // An arbitrary field that miners can change to annotate their blocks
 
 // BU - Xtreme Thinblocks Auto Mempool Limiter - begin section
 /** The default value for -minrelaytxfee */
@@ -74,7 +76,7 @@ extern CTweak<uint64_t> checkScriptDays;
 // bool InitWarning(const std::string &str);
 
 // Replace Core's ComputeBlockVersion
-int32_t UnlimitedComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params,uint32_t nTime);
+int32_t UnlimitedComputeBlockVersion(const CBlockIndex* pindexPrev, const Consensus::Params& params, uint32_t nTime);
 
 // This API finds a near match to the specified IP address, for example you can
 // leave the port off and it will find the first match to the IP.
@@ -84,33 +86,41 @@ int32_t UnlimitedComputeBlockVersion(const CBlockIndex* pindexPrev, const Consen
 CNode* FindLikelyNode(const std::string& addrName);
 
 // process incoming unsolicited block
-void HandleExpeditedBlock(CDataStream& vRecv,CNode* pfrom);
+void HandleExpeditedBlock(CDataStream& vRecv, CNode* pfrom);
 
 // Convert the BUComments to the string client's "subversion" string
 extern void settingsToUserAgentString();
-// Convert a list of client comments (typically BUcomments) and a custom comment into a string appropriate for the coinbase txn
-// The coinbase size restriction is NOT enforced
-extern std::string FormatCoinbaseMessage(const std::vector<std::string>& comments,const std::string& customComment);  
+// Convert a list of client comments (typically BUcomments) and a custom comment into a string appropriate for the
+// coinbase txn The coinbase size restriction is NOT enforced
+extern std::string FormatCoinbaseMessage(const std::vector<std::string>& comments, const std::string& customComment);
 
 extern void UnlimitedSetup(void);
 extern std::string UnlimitedCmdLineHelp();
 
 // Called whenever a new block is accepted
-extern void UnlimitedAcceptBlock(const CBlock& block, CValidationState& state, CBlockIndex* ppindex, CDiskBlockPos* dbp);
+extern void UnlimitedAcceptBlock(const CBlock& block,
+    CValidationState& state,
+    CBlockIndex* ppindex,
+    CDiskBlockPos* dbp);
 
 extern void UnlimitedLogBlock(const CBlock& block, const std::string& hash, uint64_t receiptTime);
 
 // used during mining
-extern bool TestConservativeBlockValidity(CValidationState& state, const CChainParams& chainparams, const CBlock& block, CBlockIndex* pindexPrev, bool fCheckPOW, bool fCheckMerkleRoot);
+extern bool TestConservativeBlockValidity(CValidationState& state,
+    const CChainParams& chainparams,
+    const CBlock& block,
+    CBlockIndex* pindexPrev,
+    bool fCheckPOW,
+    bool fCheckMerkleRoot);
 
 // Check whether this block is bigger in some metric than we really want to accept
-extern bool CheckExcessive(const CBlock& block, uint64_t blockSize, uint64_t nSigOps, uint64_t nTx,uint64_t largestTx);
+extern bool CheckExcessive(const CBlock& block, uint64_t blockSize, uint64_t nSigOps, uint64_t nTx, uint64_t largestTx);
 
 // Check whether this chain qualifies as excessive.
 extern int isChainExcessive(const CBlockIndex* blk, unsigned int checkDepth = excessiveAcceptDepth);
 
 // Check whether any block N back in this chain is an excessive block
-extern int chainContainsExcessive(const CBlockIndex* blk, unsigned int goBack=0);
+extern int chainContainsExcessive(const CBlockIndex* blk, unsigned int goBack = 0);
 
 //// Internal CPU miner
 
@@ -178,7 +188,7 @@ extern uint64_t LargestBlockSeen(uint64_t nBlockSize = 0);
 
 // Xpress Validation: begin
 // Transactions that have already been accepted into the memory pool do not need to be
-// re-verified and can avoid having to do a second and expensive CheckInputs() when 
+// re-verified and can avoid having to do a second and expensive CheckInputs() when
 // processing a new block.  (Protected by cs_xval)
 extern std::set<uint256> setPreVerifiedTxHash;
 
@@ -189,32 +199,33 @@ extern std::set<uint256> setUnVerifiedOrphanTxHash;
 extern CCriticalSection cs_xval;
 // Xpress Validation: end
 
-extern void LoadFilter(CNode *pfrom, CBloomFilter *filter);
+extern void LoadFilter(CNode* pfrom, CBloomFilter* filter);
 
-extern bool CheckAndRequestExpeditedBlocks(CNode* pfrom);  // Checks to see if the node is configured in bitcoin.conf to be an expedited block source and if so, request them.
-extern void SendExpeditedBlock(CXThinBlock& thinBlock,unsigned char hops, const CNode* skip=NULL);
-extern void SendExpeditedBlock(const CBlock& block,const CNode* skip=NULL);
-extern void HandleExpeditedRequest(CDataStream& vRecv,CNode* pfrom);
+extern bool CheckAndRequestExpeditedBlocks(CNode* pfrom); // Checks to see if the node is configured in bitcoin.conf to
+                                                          // be an expedited block source and if so, request them.
+extern void SendExpeditedBlock(CXThinBlock& thinBlock, unsigned char hops, const CNode* skip = NULL);
+extern void SendExpeditedBlock(const CBlock& block, const CNode* skip = NULL);
+extern void HandleExpeditedRequest(CDataStream& vRecv, CNode* pfrom);
 extern bool IsRecentlyExpeditedAndStore(const uint256& hash);
 
 
-extern CSemaphore*  semOutboundAddNode;
-extern std::vector<CNode*> xpeditedBlk; // Who requested expedited blocks from us
+extern CSemaphore* semOutboundAddNode;
+extern std::vector<CNode*> xpeditedBlk;   // Who requested expedited blocks from us
 extern std::vector<CNode*> xpeditedBlkUp; // Who we requested expedited blocks from
 extern std::vector<CNode*> xpeditedTxn;
-extern CStatHistory<uint64_t > recvAmt; 
-extern CStatHistory<uint64_t > sendAmt; 
+extern CStatHistory<uint64_t> recvAmt;
+extern CStatHistory<uint64_t> sendAmt;
 
 // Connection Slot mitigation - used to track connection attempts and evictions
 struct ConnectionHistory
 {
-    double nConnections;      // number of connection attempts made within 1 minute
-    int64_t nLastConnectionTime;  // the time the last connection attempt was made
+    double nConnections;         // number of connection attempts made within 1 minute
+    int64_t nLastConnectionTime; // the time the last connection attempt was made
 
-    double nEvictions;        // number of times a connection was de-prioritized and disconnected in last 30 minutes
-    int64_t nLastEvictionTime;    // the time the last eviction occurred.
+    double nEvictions;         // number of times a connection was de-prioritized and disconnected in last 30 minutes
+    int64_t nLastEvictionTime; // the time the last eviction occurred.
 };
-extern std::map<CNetAddr, ConnectionHistory > mapInboundConnectionTracker;
+extern std::map<CNetAddr, ConnectionHistory> mapInboundConnectionTracker;
 extern CCriticalSection cs_mapInboundConnectionTracker;
 
 // statistics
@@ -226,10 +237,10 @@ extern CStatHistory<unsigned int> txAdded;
 extern CStatHistory<uint64_t, MinValMax<uint64_t> > poolSize;
 
 // Configuration variable validators
-std::string ExcessiveBlockValidator(const unsigned int& value,unsigned int* item,bool validate);
-std::string OutboundConnectionValidator(const int& value,int* item,bool validate);
-std::string SubverValidator(const std::string& value,std::string* item,bool validate);
-std::string MiningBlockSizeValidator(const uint64_t& value,uint64_t* item,bool validate);
+std::string ExcessiveBlockValidator(const unsigned int& value, unsigned int* item, bool validate);
+std::string OutboundConnectionValidator(const int& value, int* item, bool validate);
+std::string SubverValidator(const std::string& value, std::string* item, bool validate);
+std::string MiningBlockSizeValidator(const uint64_t& value, uint64_t* item, bool validate);
 
 extern CTweak<unsigned int> maxTxSize;
 extern CTweak<uint64_t> blockSigopsPerMb;
@@ -238,15 +249,17 @@ extern CTweak<uint64_t> blockMiningSigopsPerMb;
 
 // Protocol Changes:
 
-enum {
-  EXPEDITED_STOP   = 1,
-  EXPEDITED_BLOCKS = 2,
-  EXPEDITED_TXNS   = 4,
+enum
+{
+    EXPEDITED_STOP = 1,
+    EXPEDITED_BLOCKS = 2,
+    EXPEDITED_TXNS = 4,
 };
 
-enum {
-  EXPEDITED_MSG_HDR   = 1,
-  EXPEDITED_MSG_XTHIN = 2,
+enum
+{
+    EXPEDITED_MSG_HDR = 1,
+    EXPEDITED_MSG_XTHIN = 2,
 };
 
 


### PR DESCRIPTION
This is a reformat of unlimited.h with clang-format.

I will follow up with a .cpp file: unlimited.cpp, so we get a feel for one of each.

If we agree the clang-format is suitable then I will submit PRs for a reformatting of the other BU-specific files as they are not subject to merge conflict concerns.

I added the 120 column limit to .clang-format that was informally agreed in slack discussions