### PR TITLE
[WIP] ensure a newly connected node has properly sync'd headers

### DIFF
--- a/qa/rpc-tests/mempool_reorg.py
+++ b/qa/rpc-tests/mempool_reorg.py
@@ -82,6 +82,7 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
         for node in self.nodes:
             node.invalidateblock(last_block[0])
+        self.sync_all()
         assert_equal(set(self.nodes[0].getrawmempool()), {spend_101_id, spend_102_1_id, spend_103_1_id})
 
         # Use invalidateblock to re-org back and make all those coinbase spends

--- a/src/main.h
+++ b/src/main.h
@@ -115,6 +115,8 @@ static const int64_t BLOCK_DOWNLOAD_TIMEOUT_BASE = 1000000;
 static const int64_t BLOCK_DOWNLOAD_TIMEOUT_PER_PEER = 500000;
 /** Timeout in secs for the initial sync. If we don't receive the first batch of headers */
 static const uint8_t INITIAL_HEADERS_TIMEOUT = 30;
+/** Timeout in secs for the secondary download of headers after the first headers are received */
+static const uint8_t HEADERS_DOWNLOAD_TIMEOUT = 5;
 
 static const unsigned int DEFAULT_LIMITFREERELAY = 15;
 static const bool DEFAULT_RELAYPRIORITY = true;


### PR DESCRIPTION
Two additional measures to prevent sybil nodes from taking advantage of our node during initial sync. These are the last items I believe that are needed to prevent any of these types of attacks and builds on the work done in PR #356

-  Make sure that the sync height the node advertises is the actual
    height that we get when they connect.  If they are falsely advertising their
    sync height then we will disconnect and ban them.

-  Also, If a node trickles us headers during initial sync then give them a DOS

    A possible attacker could connect to our node during initial sync and
    trickle us the headers causing a much delayed sync, possibly increasing
    sync time by many days.  By giving them a DOS 20 for each infraction
    they will quickly be disconnected after a few downloads and allow
    another peer to be used to download the initial headers instead.

-  Still WIP as I'm working on unit tests for this and need PR406 merged first.