### PR TITLE
Ensure that we connect to at least a few XTHIN capable nodes.

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -188,7 +188,10 @@ CTweakRef<int> maxOutConnectionsTweak("net.maxOutboundConnections",
     "Maximum number of outbound connections",
     &nMaxOutConnections,
     &OutboundConnectionValidator);
-CTweakRef<int> maxConnectionsTweak("net.maxConnections", "Maximum number of connections connections", &nMaxConnections);
+CTweakRef<int> maxConnectionsTweak("net.maxConnections", "Maximum number of connections", &nMaxConnections);
+CTweakRef<int> minXthinNodesTweak("net.minXthinNodes",
+    "Minimum number of outbound xthin capable nodes to connect to",
+    &nMinXthinNodes);
 // When should I request a tx from someone else (in microseconds). cmdline/bitcoin.conf: -txretryinterval
 CTweakRef<unsigned int> triTweak("net.txRetryInterval",
     "How long to wait in microseconds before requesting a transaction from another source",

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -88,6 +88,8 @@ uint64_t nLocalHostNonce = 0;
 static std::vector<ListenSocket> vhListenSocket;
 extern CAddrMan addrman;
 int nMaxConnections = DEFAULT_MAX_PEER_CONNECTIONS;
+int nMinXthinNodes = MIN_XTHIN_NODES;
+
 bool fAddressesInitialized = false;
 std::string strSubVersion;
 
@@ -1782,7 +1784,7 @@ void ThreadOpenConnections()
             }
             // Disconnect a node that is not XTHIN capable if all outbound slots are full and we
             // have not yet connected to enough XTHIN nodes.
-            int nMinXthinNodes = GetArg("-min-xthin-nodes", MIN_XTHIN_NODES);
+            nMinXthinNodes = GetArg("-min-xthin-nodes", MIN_XTHIN_NODES);
             if (nOutbound >= nMaxOutConnections &&
                 nThinBlockCapable <= min(nMinXthinNodes, nMaxOutConnections) &&
                 nDisconnects < MAX_DISCONNECTS && IsThinBlocksEnabled() && IsChainNearlySyncd())

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1748,12 +1748,81 @@ void ThreadOpenConnections()
 
     // Initiate network connections
     int64_t nStart = GetTime();
-    while (true) {
+    unsigned int nDisconnects = 0;
+    while (true)
+    {
         ProcessOneShot();
 
         MilliSleep(500);
 
-        CSemaphoreGrant grant(*semOutbound);
+        // Only connect out to one peer per network group (/16 for IPv4).
+        // Do this here so we don't have to critsect vNodes inside mapAddresses critsect.
+        // And also must do this before the semaphore grant so that we don't have to block
+        // if the grants are all taken and we want to disconnect a node in the event that
+        // we don't have enough connections to XTHIN capable nodes yet.
+        int nOutbound = 0;
+        int nThinBlockCapable = 0;
+        set<vector<unsigned char> > setConnected;
+        CNode* ptemp = nullptr;
+        bool fDisconnected = false;
+        {
+            LOCK(cs_vNodes);
+            BOOST_FOREACH (CNode* pnode, vNodes)
+            {
+                if (pnode->fAutoOutbound) // only count outgoing connections.
+                {
+                    setConnected.insert(pnode->addr.GetGroup());
+                    nOutbound++;
+
+                    if (pnode->ThinBlockCapable())
+                        nThinBlockCapable++;
+                    else
+                        ptemp = pnode;
+                }
+            }
+            // Disconnect a node that is not XTHIN capable if all outbound slots are full and we
+            // have not yet connected to enough XTHIN nodes.
+            int nMinXthinNodes = GetArg("-min-xthin-nodes", MIN_XTHIN_NODES);
+            if (nOutbound >= nMaxOutConnections &&
+                nThinBlockCapable <= min(nMinXthinNodes, nMaxOutConnections) &&
+                nDisconnects < MAX_DISCONNECTS && IsThinBlocksEnabled() && IsChainNearlySyncd())
+            {
+                if (ptemp != nullptr)
+                {
+                    ptemp->fDisconnect = true;
+                    fDisconnected = true;
+                    nDisconnects++;
+                }
+            }
+        }
+
+        // If disconnected then wait for disconnection completion
+        if (fDisconnected)
+        {
+            while (true)
+            {
+                MilliSleep(500);
+                {
+                    LOCK(cs_vNodes);
+                    if (find(vNodes.begin(), vNodes.end(), ptemp) == vNodes.end())
+                        break;
+                }
+            }
+        }
+
+        // During IBD we do not actively disconnect and search for XTHIN capable nodes therefore
+        // we need to check occasionally whether IBD is complete, meaning IsChainNearlySynd() returns true.
+        // Therefore we do a try_wait() rather than wait() when aquiring the semaphore. A try_wait() is
+        // indicated by passing "true" to CSemaphore grant().
+        CSemaphoreGrant grant(*semOutbound, true);
+        if (!grant)
+        {
+            // If the try_wait() fails, meaning all grants are currently in use, then we wait for one minute
+            // to check again whether we should disconnect any nodes.  We don't have to check this too often
+            // as this is most relevant during IBD.
+            MilliSleep(60000);
+            continue;
+        }
         boost::this_thread::interruption_point();
 
         // Add seed nodes if DNS seeds are all down (an infrastructure attack?).
@@ -1770,25 +1839,10 @@ void ThreadOpenConnections()
         // Choose an address to connect to based on most recently seen
         //
         CAddress addrConnect;
-
-        // Only connect out to one peer per network group (/16 for IPv4).
-        // Do this here so we don't have to critsect vNodes inside mapAddresses critsect.
-        int nOutbound = 0;
-        set<vector<unsigned char> > setConnected;
-        {
-            LOCK(cs_vNodes);
-            BOOST_FOREACH (CNode* pnode, vNodes) {
-                if (!pnode->fInbound) {
-                    setConnected.insert(pnode->addr.GetGroup());
-                    nOutbound++;
-                }
-            }
-        }
-
         int64_t nANow = GetAdjustedTime();
-
         int nTries = 0;
-        while (true) {
+        while (true)
+        {
             CAddrInfo addr = addrman.Select();
 
             // if we selected an invalid address, restart
@@ -1818,8 +1872,18 @@ void ThreadOpenConnections()
         }
 
         if (addrConnect.IsValid())
+        {
             //Seeded outbound connections track against the original semaphore
-            OpenNetworkConnection(addrConnect, &grant);
+            if (OpenNetworkConnection(addrConnect, &grant))
+            {
+                LOCK(cs_vNodes);
+                CNode* pnode = FindNode((CService)addrConnect);
+                // We need to use a separate outbound flag so as not to differentiate these outbound 
+                // nodes with ones that were added using -addnode -connect-thinblock or -connect.
+                if (pnode)
+                    pnode->fAutoOutbound = true;
+            }
+        }
     }
 }
 
@@ -2621,6 +2685,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     fOneShot = false;
     fClient = false; // set by version message
     fInbound = fInboundIn;
+    fAutoOutbound = false;
     fNetworkNode = false;
     fSuccessfullyConnected = false;
     fDisconnect = false;
@@ -2704,6 +2769,7 @@ CNode::~CNode()
     // We must set this to false on disconnect otherwise we will have trouble reconnecting -addnode nodes
     // if the remote peer restarts.
     fSuccessfullyConnected = false;
+    fAutoOutbound = false;
 
     // BUIP010 - Xtreme Thinblocks - end section
 

--- a/src/net.h
+++ b/src/net.h
@@ -177,7 +177,8 @@ extern CAddrMan addrman;
 
 /** Maximum number of connections to simultaneously allow (aka connection slots) */
 extern int nMaxConnections;
-
+/** The minimum number of xthin nodes to connect to */
+extern int nMinXthinNodes;
 extern std::vector<CNode*> vNodes;
 extern CCriticalSection cs_vNodes;
 extern std::map<CInv, CDataStream> mapRelay;

--- a/src/net.h
+++ b/src/net.h
@@ -70,6 +70,10 @@ static const size_t SETASKFOR_MAX_SZ = 2 * MAX_INV_SZ;
 static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 /** BU: The maximum numer of outbound peer connections */
 static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 8;
+/** BU: The minimum number of xthin nodes to connect */
+static const uint8_t MIN_XTHIN_NODES = 4;
+/** BU: The maximum disconnects while searching for xthin nodes to connect */
+static const unsigned int MAX_DISCONNECTS = 500;
 /** The default for -maxuploadtarget. 0 = Unlimited */
 static const uint64_t DEFAULT_MAX_UPLOAD_TARGET = 0;
 /** Default for blocks only*/
@@ -376,7 +380,8 @@ public:
     bool fOneShot;
     bool fClient;
     bool fInbound;
-    bool fNetworkNode;
+    bool fAutoOutbound; // any outbound node not connected with -addnode, connect-thinblock or -connect
+    bool fNetworkNode; // any outbound node
     bool fSuccessfullyConnected;
     bool fDisconnect;
     // We use fRelayTxes for two purposes -

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -462,6 +462,9 @@ std::string UnlimitedCmdLineHelp()
         HelpMessageOpt("-minlimitertxfee=<amt>", strprintf(_("Fees (in satoshi/byte) smaller than this are considered "
                                                              "zero fee and subject to -limitfreerelay (default: %s)"),
                                                      DEFAULT_MINLIMITERTXFEE));
+    strUsage += HelpMessageOpt(
+        "-min-xthin-nodes=<n>", strprintf(_("Minimum number of xthin nodes to automatically find and connect "
+        "(default: %d)"), 4));
     strUsage += HelpMessageOpt("-maxlimitertxfee=<amt>",
         strprintf(_("Fees (in satoshi/byte) larger than this are always relayed (default: %s)"),
                                    DEFAULT_MAXLIMITERTXFEE));

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -464,7 +464,8 @@ std::string UnlimitedCmdLineHelp()
                                                      DEFAULT_MINLIMITERTXFEE));
     strUsage += HelpMessageOpt(
         "-min-xthin-nodes=<n>", strprintf(_("Minimum number of xthin nodes to automatically find and connect "
-        "(default: %d)"), 4));
+                                            "(default: %d)"),
+                                    4));
     strUsage += HelpMessageOpt("-maxlimitertxfee=<amt>",
         strprintf(_("Fees (in satoshi/byte) larger than this are always relayed (default: %s)"),
                                    DEFAULT_MAXLIMITERTXFEE));


### PR DESCRIPTION
In the past we relied on -addnode or -connect-thinblock to manually
configure connection to XTHIN capable nodes,  or to just rely on luck
in getting a connection.  Here we will actively seek out XTHIN nodes
and maintain at least 4 connections or the minimum number of outbound
connections whichever is less.