### PR TITLE
add contrib script to remove trailing whitespace from files

### DIFF
--- a/contrib/devtools/remove-trailing-space.py
+++ b/contrib/devtools/remove-trailing-space.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+'''
+This tool removes trailing whitespace from files passed on command line.
+
+Usage:  remove_trailing_space.py [filepath ...]
+
+Limitations:
+- makes no backups of modified files
+- modifies in place
+- does not care what files you pass to it
+- assumes it can keep the entire stripped file in memory
+
+Always use only on files that are under version control!
+
+Copyright (c) 2017 The Bitcoin Unlimited developers
+Distributed under the MIT software license, see the accompanying
+file COPYING or http://www.opensource.org/licenses/mit-license.php.
+'''
+
+import sys
+
+
+if __name__ == "__main__":
+    for filename in sys.argv[1:]:
+        lines = []
+        # open file in universal newline mode, then
+        # read it in, strip off trailing whitespace
+        with open(filename, mode='U') as f:
+            for line in f.readlines():
+                lines.append(line.rstrip())
+
+        # overwrite with stripped content
+        with open(filename, mode='w') as f:
+            f.seek(0)
+            for line in lines:
+                f.write(line + '\n')

--- a/contrib/devtools/remove-trailing-space.py
+++ b/contrib/devtools/remove-trailing-space.py
@@ -2,7 +2,7 @@
 '''
 This tool removes trailing whitespace from files passed on command line.
 
-Usage:  remove_trailing_space.py [filepath ...]
+Usage:  remove-trailing-space.py [filepath ...]
 
 Limitations:
 - makes no backups of modified files

--- a/contrib/devtools/remove_trailing_space.py
+++ b/contrib/devtools/remove_trailing_space.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+'''
+This tool removes trailing whitespace from files passed on command line.
+
+Usage:  remove_trailing_space.py [filepath ...]
+
+Limitations:
+- makes no backups of modified files
+- modifies in place
+- does not care what files you pass to it
+- assumes it can keep the entire stripped file in memory
+
+Always use only on files that are under version control!
+
+Copyright (c) 2017 The Bitcoin Unlimited developers
+Distributed under the MIT software license, see the accompanying
+file COPYING or http://www.opensource.org/licenses/mit-license.php.
+'''
+
+import sys
+
+
+if __name__ == "__main__":
+    for filename in sys.argv[1:]:
+        lines = []
+        # open file in universal newline mode, then
+        # read it in, strip off trailing whitespace
+        with open(filename, mode='U') as f:
+            for line in f.readlines():
+                lines.append(line.rstrip())
+
+        # overwrite with stripped content
+        with open(filename, mode='w') as f:
+            f.seek(0)
+            for line in lines:
+                f.write(line + '\n')


### PR DESCRIPTION
This Python script removes trailing whitespace from files passed on command line (for those times when you forgot to set up your editor / IDE to do this automatically for you :)

Usage:  remove-trailing-space.py [filepath ...]

Limitations:
- makes no backups of modified files
- modifies in place
- does not care what files you pass to it
- assumes it can keep the entire stripped file in memory

Always use only on files that are under version control!

---

I ran this on the `release` HEAD src folder on my Linux box using

`$ find src -path src/leveldb -prune -o \( -name \*.cpp -o -name \*.h -o -name \*.sh -o -name \*.py \)  -exec remove_trailing_space.py {} \;`

The above command modified 83 files, but probably still excludes some sources that probably would need to be captured for a full run (there is a lone Java file in there, and some HTML / CSS / YAML / Makefiles etc).

The result still builds ok for me.

I'm not going to submit a PR for the removal of the existing whitespace at this time due to possible conflicts with other PRs. At a suitable time, perhaps the BitcoinUnlimitedJanitor can use it to run a general cleanup.

EDIT: changed name of script