### PR TITLE
Remove #pragma once

### DIFF
--- a/src/qt/unlimiteddialog.h
+++ b/src/qt/unlimiteddialog.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2011-2015 The Bitcoin Unlimited developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#pragma once
+
 #ifndef BITCOIN_QT_UNLIMITEDDIALOG_H
 #define BITCOIN_QT_UNLIMITEDDIALOG_H
 

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2017 The Bitcoin Unlimited developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#pragma once
+
 #ifndef REQUEST_MANAGER_H
 #define REQUEST_MANAGER_H
 #include "net.h"

--- a/src/stat.h
+++ b/src/stat.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2017 The Bitcoin Unlimited developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#pragma once
+
 #ifndef STAT_H
 #define STAT_H
 

--- a/src/tweak.h
+++ b/src/tweak.h
@@ -1,7 +1,7 @@
 // Copyright (c) 2016-2017 The Bitcoin Unlimited developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#pragma once
+
 #ifndef TWEAK_H
 #define TWEAK_H
 

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -2,7 +2,7 @@
 // Copyright (c) 2016-2017 The Bitcoin Unlimited developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
-#pragma once
+
 #ifndef BITCOIN_UNLIMITED_H
 #define BITCOIN_UNLIMITED_H
 


### PR DESCRIPTION
#pragma once is an obsolete non-portable directive.  Header guards are used anyway, and perform just as fast (in fact the way #pragma once was being used can actually hinder the multiple-include optimisation).  This patch removes it.