### PR TITLE
Fix for issues with startup and mutliple monitors on windows.

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -830,15 +830,19 @@ void restoreWindowGeometry(const QString& strSetting, const QSize& defaultSize, 
     QSettings settings;
     QPoint pos = settings.value(strSetting + "Pos").toPoint();
     QSize size = settings.value(strSetting + "Size", defaultSize).toSize();
+    QRect screen = QApplication::desktop()->screenGeometry();
+    QPoint posCenter(
+        abs((screen.width() - size.width()) / 2),
+        abs((screen.height() - size.height()) / 2));
 
-    if (!pos.x() && !pos.y()) {
-        QRect screen = QApplication::desktop()->screenGeometry();
-        pos.setX((screen.width() - size.width()) / 2);
-        pos.setY((screen.height() - size.height()) / 2);
-    }
+    if (!pos.x() && !pos.y())
+        pos = posCenter;
 
     parent->resize(size);
     parent->move(pos);
+
+    if (QApplication::desktop()->screenNumber(parent) == -1)
+        parent->move(posCenter);
 }
 
 void setClipboard(const QString& str)


### PR DESCRIPTION
I noticed a small bug in bitcoin-qt with multiple physical displays. This bug affects me because I use a Windows 10 laptop that sometimes uses a second display. 

I can only reproduce this issue on windows 10. I could not reproduce this issue on Ubuntu 16.04 LTS with dual displays running in a VirtualBox VM.

This is a pull request for a fix for this issue. 

To demonstrate the bug:
1. Install Bitcoin-qt on a system with multiple monitors (i.e. a laptop attached to a second screen). I have only reproduced this issue on windows 10 with ‘extend these displays’ configured.   
2. Start bitcoin-qt and place it on the second screen. 
3. Close bitcoin-qt (it will cache it’s position on the second screen).
4. Remove (physically unplug) the second screen.
5. Start bitcoin-qt.
6. You will find that bitcoin-qt starts in the cached second screen position and cannot be found on the only active screen. It just disappears. You need to realise that it is off screen and then do some fancy control keys to get it to come back to the primary display.   

This is not a critical bug, but when it happens the user experience is not good, hence this fix.  This bug also currently exists in both bitcoin core & bitcoin unlimited. 

As for the code changes….The position of bitcoin-qt is saved into QSettings on exit. When bitcoin-qt restarts it grabs this position and places itself at that location. However it never tests if this position actually still exists. So I have added a test that if the location does not exist on any of the current screens then it re-positions it to the default location. 

I also use abs() when calculating the center position. This is because there is the potential for the size of the application to be larger then the size of the current screen, abs() should handle that corner case. 

I have tested this change on Windows 10 & Ubuntu 16.04 LTS.