### PR TITLE
Improved documentation on how to build a windows binary.

### DIFF
--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -7,7 +7,7 @@ Most developers use cross-compilation from Ubuntu to build executables for
 Windows. This is also used to build the release binaries.
 
 Building on Windows itself is possible (for example using msys / mingw-w64),
-see `build-windows-mingw.md`
+see `build-windows-mingw.md` or 'Compiling with Windows Subsystem for Linux' below.
 
 Cross-compilation
 -------------------
@@ -25,7 +25,8 @@ To build executables for Windows 32-bit:
     cd depends
     make HOST=i686-w64-mingw32 -j4
     cd ..
-    ./configure --prefix=`pwd`/depends/i686-w64-mingw32
+    ./autogen.sh # not required when building from tarball
+    ./configure --prefix=`pwd`/depends/i687-w64-mingw32
     make
 
 To build executables for Windows 64-bit:
@@ -33,8 +34,94 @@ To build executables for Windows 64-bit:
     cd depends
     make HOST=x86_64-w64-mingw32 -j4
     cd ..
+    ./autogen.sh # not required when building from tarball
     ./configure --prefix=`pwd`/depends/x86_64-w64-mingw32
     make
 
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
+
+Compiling with Windows Subsystem For Linux
+-------------------------------------------
+
+With Windows 10, Microsoft has released a new feature named the [Windows
+Subsystem for Linux](https://msdn.microsoft.com/commandline/wsl/about). This
+feature allows you to run a bash shell directly on Windows in an Ubuntu-based
+environment. Within this environment you can cross compile for Windows without
+the need for a separate Linux VM or server.
+
+This feature is not supported in versions of Windows prior to Windows 10 or on
+Windows Server SKUs. In addition, it is available [only for 64-bit versions of
+Windows](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide).
+
+To get the bash shell, you must first activate the feature in Windows.
+
+1. Turn on Developer Mode
+  * Open Settings -> Update and Security -> For developers
+  * Select the Developer Mode radio button
+  * Restart if necessary
+2. Enable the Windows Subsystem for Linux feature
+  * From Start, search for "Turn Windows features on or off" (type 'turn')
+  * Select Windows Subsystem for Linux (beta)
+  * Click OK
+  * Restart if necessary
+3. Complete Installation
+  * Open a cmd prompt and type "bash"
+  * Accept the license
+  * Create a new UNIX user account (this is a separate account from your Windows account)
+
+After the bash shell is active, you can follow the instructions below, starting
+with the "Cross-compilation" section. Compiling the 64-bit version is
+recommended but it is possible to compile the 32-bit version.
+
+Install the general dependencies:
+
+    sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl
+
+A host toolchain (`build-essential`) is necessary because some dependency
+packages (such as `protobuf`) need to build host utilities that are used in the
+build process.
+
+## Building for 64-bit Windows
+
+To build executables for Windows 64-bit, install the following dependencies:
+
+    sudo apt-get install g++-mingw-w64-x86-64 mingw-w64-x86-64-dev
+
+Then build using:
+
+    cd depends
+    make HOST=x86_64-w64-mingw32
+    cd ..
+    ./autogen.sh # not required when building from tarball
+    CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
+    make
+
+## Building for 32-bit Windows
+
+To build executables for Windows 32-bit, install the following dependencies:
+
+    sudo apt-get install g++-mingw-w64-i686 mingw-w64-i686-dev
+
+Then build using:
+
+    cd depends
+    make HOST=i686-w64-mingw32
+    cd ..
+    ./autogen.sh # not required when building from tarball
+    CONFIG_SITE=$PWD/depends/i686-w64-mingw32/share/config.site ./configure --prefix=/
+    make
+
+## Depends system
+
+For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
+
+Installation
+-------------
+
+After building using the Windows subsystem it can be useful to copy the compiled
+executables to a directory on the windows drive in the same directory structure
+as they appear in the release `.zip` archive. This can be done in the following
+way. This will install to `c:\workspace\bitcoin`, for example:
+
+    make install DESTDIR=/mnt/c/workspace/bitcoin
 


### PR DESCRIPTION
I attempted to build a windows binary & I soon realised the current build doc does not work. It was missing a './autogen.sh' command in the middle of the process. I get my code using 'git clone...' but apparently if you get a windows tarball you do not need the 'autogen.sh' rule(?). However this is not apparent to anyone that just does a 'git clone...' of the BU repo. So this issue is fixed in this pull request. (This issue was identified by core some time ago). 

I also copied & edited a slab of text from the core repo on how to build using buntu bash on Windows. I tested this works on the BU repo. This is added to the bottom of the document.