### PR TITLE
Reduce the default number of max orphans in the orphan pool.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -59,7 +59,7 @@ static const CAmount HIGH_TX_FEE_PER_KB = 0.01 * COIN;
 //! -maxtxfee will warn if called with a higher fee than this amount (in satoshis)
 static const CAmount HIGH_MAX_TX_FEE = 100 * HIGH_TX_FEE_PER_KB;
 /** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
-static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 5000;  // BU Xtreme Thinblocks change to 5000 or 25MB (5000 x 5000KB max orphan size)
+static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 2500;
 /** Default for -limitancestorcount, max number of in-mempool ancestors */
 static const unsigned int DEFAULT_ANCESTOR_LIMIT = 25;
 /** Default for -limitancestorsize, maximum kilobytes of tx + all in-mempool ancestors */


### PR DESCRIPTION
With the latest updates to the way we handle the orphan cache we no
longer need such a big default cache.  It is rare that we get beyond
1000 now, even with severe backups in the mempool.  Generally we see
the cache now anywhere from 0 to 500 txns.

NOTE: we already have unit tests for this parameter.