### PR TITLE
Refactor miner.cpp code slightly

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -73,6 +73,7 @@ private:
     void addPriorityTxs(CBlockTemplate *);
 
     // helper function for addScoreTxs and addPriorityTxs
+    bool IsIncrementallyGood(uint64_t nExtraSize, unsigned int nExtraSigOps);
     /** Test if tx will still "fit" in the block */
     bool TestForBlock(CTxMemPool::txiter iter);
     /** Test if tx still has unconfirmed parents not yet in block */


### PR DESCRIPTION
Break out the logic to test whether an incremental increase in block size and
sigop count is good.  No change in logic or functionality.
This will make it easier to review and merge the CPFP changes where txs are added
as a "package" not as single txs whilst retaining the BU block validity logic.