### PR TITLE
Fix opt-in RBF reliance on compiler integer size

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1226,9 +1226,9 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
             if (!setConflicts.count(ptxConflicting->GetHash()))
             {
                 // Allow opt-out of transaction replacement by setting
-                // nSequence >= maxint-1 on all inputs.
+                // nSequence >= SEQUENCE_FINAL-1 on all inputs.
                 //
-                // maxint-1 is picked to still allow use of nLockTime by
+                // SEQUENCE_FINAL-1 is picked to still allow use of nLockTime by
                 // non-replacable transactions. All inputs rather than just one
                 // is for the sake of multi-party protocols, where we don't
                 // want a single party to be able to disable replacement.
@@ -1242,7 +1242,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState &state, const C
                 {
                     BOOST_FOREACH(const CTxIn &txin, ptxConflicting->vin)
                     {
-                        if (txin.nSequence < std::numeric_limits<unsigned int>::max()-1)
+                        if (txin.nSequence < CTxIn::SEQUENCE_FINAL-1)
                         {
                             fReplacementOptOut = false;
                             break;


### PR DESCRIPTION
Opt-in RBF was using std::numeric_limits<unsigned int>::max() for
determining whether a TXN is RBF- able or not, thus relying on an
architecture/compiler detail, which would fail e.g. for ILP64 data types.

This commit replaces the above with the SEQUENCE_FINAL protocol constant.

Note that opt-in RBF is disabled in BU with an if(0) { ... }, so this is
to fix the code in case it ever gets re-enabled or used in any way.

It is a port of this pull request submitted to Core:

https://github.com/bitcoin/bitcoin/pull/10172