### PR TITLE
Net backports

### DIFF
--- a/contrib/devtools/security-check.py
+++ b/contrib/devtools/security-check.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python2
 '''
 Perform basic ELF security checks on a series of executables.
-Exit status will be 0 if succesful, and the program will be silent.
+Exit status will be 0 if successful, and the program will be silent.
 Otherwise the exit status will be 1 and it will log which executables failed which checks.
 Needs `readelf` (for ELF) and `objdump` (for PE).
 '''

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -71,7 +71,7 @@ class MerkleBlockTest(BitcoinTestFramework):
         txid_spent = txin_spent["txid"]
         txid_unspent = txid1 if txin_spent["txid"] != txid1 else txid2
 
-        # We cant find the block from a fully-spent tx
+        # We can't find the block from a fully-spent tx
         assert_raises(JSONRPCException, self.nodes[2].gettxoutproof, [txid_spent])
         # ...but we can if we specify the block
         assert_equal(self.nodes[2].verifytxoutproof(self.nodes[2].gettxoutproof([txid_spent], blockhash)), [txid_spent])

--- a/src/compat.h
+++ b/src/compat.h
@@ -102,4 +102,6 @@ bool static inline IsSelectableSocket(SOCKET s) {
 #endif
 }
 
+#define IPV6_ADDR_SCOPE_GLOBAL          0x0e
+#define IPV6_ADDR_SCOPE_RESERVED        0x0
 #endif // BITCOIN_COMPAT_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1422,10 +1422,11 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     if (mapArgs.count("-externalip")) {
         BOOST_FOREACH(const std::string& strAddr, mapMultiArgs["-externalip"]) {
-            CService addrLocal(strAddr, GetListenPort(), fNameLookup);
-            if (!addrLocal.IsValid())
+            CService addrLocal;
+            if (Lookup(strAddr.c_str(), addrLocal, GetListenPort(), fNameLookup) && addrLocal.IsValid())
+                AddLocal(addrLocal, LOCAL_MANUAL);
+            else
                 return InitError(strprintf(_("Cannot resolve -externalip address: '%s'"), strAddr));
-            AddLocal(CService(strAddr, GetListenPort(), fNameLookup), LOCAL_MANUAL);
         }
     }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1957,7 +1957,7 @@ void ThreadOpenAddedConnections()
         list<vector<CService> > lservAddressesToAdd(0);
         BOOST_FOREACH(const std::string& strAddNode, lAddresses) {
             vector<CService> vservNode(0);
-            if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), fNameLookup, 0))
+            if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), 0,fNameLookup))
             {
                 lservAddressesToAdd.push_back(vservNode);
                 {
@@ -2238,7 +2238,7 @@ void static Discover(boost::thread_group& threadGroup)
                     LogPrintf("%s: IPv4 %s: %s\n", __func__, ifa->ifa_name, addr.ToString());
             } else if (ifa->ifa_addr->sa_family == AF_INET6) {
                 struct sockaddr_in6* s6 = (struct sockaddr_in6*)(ifa->ifa_addr);
-                CNetAddr addr(s6->sin6_addr);
+                CNetAddr addr(s6->sin6_addr, s6->sin6_scope_id);
                 if (AddLocal(addr, LOCAL_IF))
                     LogPrintf("%s: IPv6 %s: %s\n", __func__, ifa->ifa_name, addr.ToString());
             }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1654,7 +1654,15 @@ void ThreadDNSAddressSeed()
                     found++;
                 }
             }
-            addrman.Add(vAdd, CNetAddr(seed.name, true));
+            // TODO: The seed name resolve may fail, yielding an IP of [::], which results in
+            // addrman assigning the same source to results from different seeds.
+            // This should switch to a hard-coded stable dummy IP for each seed name, so that the
+            // resolve is not required at all.
+            if (!vIPs.empty()) {
+                CService seedSource;
+                Lookup(seed.name.c_str(), seedSource, 0, true);
+                addrman.Add(vAdd, seedSource);
+            }
         }
     }
 
@@ -2193,10 +2201,13 @@ void static Discover(boost::thread_group& threadGroup)
 #ifdef WIN32
     // Get local host IP
     char pszHostName[256] = "";
-    if (gethostname(pszHostName, sizeof(pszHostName)) != SOCKET_ERROR) {
+    if (gethostname(pszHostName, sizeof(pszHostName)) != SOCKET_ERROR)
+    {
         vector<CNetAddr> vaddr;
-        if (LookupHost(pszHostName, vaddr)) {
-            BOOST_FOREACH (const CNetAddr& addr, vaddr) {
+        if (LookupHost(pszHostName, vaddr, 0, true))
+        {
+            BOOST_FOREACH (const CNetAddr &addr, vaddr)
+            {
                 if (AddLocal(addr, LOCAL_IF))
                     LogPrintf("%s: %s - %s\n", __func__, pszHostName, addr.ToString());
             }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -93,7 +93,7 @@ int nMinXthinNodes = MIN_XTHIN_NODES;
 bool fAddressesInitialized = false;
 std::string strSubVersion;
 
-// BU moved to global.cpp 
+// BU moved to global.cpp
 // extern vector<CNode*> vNodes;
 // extern CCriticalSection cs_vNodes;
 // map<CInv, CDataStream> mapRelay;
@@ -717,9 +717,9 @@ bool CNode::ReceiveMsgBytes(const char* pch, unsigned int nBytes)
         if (handled < 0)
                 return false;
 
-        // BU: only reject the message if it is some multiple of the excessive 
+        // BU: only reject the message if it is some multiple of the excessive
         // block size.  Since traffic shaping will keep the bandwidth in check
-        // this basically eliminates nodes that are deliberately trying to screw us up. 
+        // this basically eliminates nodes that are deliberately trying to screw us up.
         if (maxMessageSizeMultiplier && msg.in_data && (msg.hdr.nMessageSize > BLOCKSTREAM_CORE_MAX_BLOCK_SIZE) && (msg.hdr.nMessageSize > (maxMessageSizeMultiplier*excessiveBlockSize))) {
             LogPrint("net", "Oversized message from peer=%i, disconnecting\n", GetId());
             //BU: TODO warn if too many nodes are doing this
@@ -742,13 +742,13 @@ bool CNode::ReceiveMsgBytes(const char* pch, unsigned int nBytes)
                 nActivityBytes += msg.hdr.nMessageSize;
 
                 // BU: furthermore, if the message is a priority message then move from the back to the front of the deque
-                // NOTE: for GET_XTHIN we don't jump the queue on test environments because the GET_XTHIN can get ahead of 
+                // NOTE: for GET_XTHIN we don't jump the queue on test environments because the GET_XTHIN can get ahead of
                 // a previous GET_XTHIN/HEADER requests and result in a DOS if the block returns out of order and with no headers
                 // in the block index or the setblockindexcandidates.
-                if ((strCommand == NetMsgType::GET_XTHIN && Params().NetworkIDString() == "main") || 
-                    strCommand == NetMsgType::XTHINBLOCK || 
-                    strCommand == NetMsgType::THINBLOCK || 
-                    strCommand == NetMsgType::XBLOCKTX || 
+                if ((strCommand == NetMsgType::GET_XTHIN && Params().NetworkIDString() == "main") ||
+                    strCommand == NetMsgType::XTHINBLOCK ||
+                    strCommand == NetMsgType::THINBLOCK ||
+                    strCommand == NetMsgType::XBLOCKTX ||
                     strCommand == NetMsgType::GET_XBLOCKTX )
                 {
                     vRecvMsg.push_front(msg);
@@ -831,9 +831,9 @@ int SocketSendData(CNode* pnode)
         int amt2Send = min((int64_t)(data.size() - pnode->nSendOffset), sendShaper.available(SEND_SHAPER_MIN_FRAG));
         if (amt2Send == 0)
             break;
-        SOCKET hSocket = pnode->hSocket;  
+        SOCKET hSocket = pnode->hSocket;
         if (hSocket == INVALID_SOCKET)
-            break;        
+            break;
         int nBytes = send(hSocket, &data[pnode->nSendOffset], amt2Send, MSG_NOSIGNAL | MSG_DONTWAIT);
         if (nBytes > 0) {
             progress++;  // BU
@@ -977,7 +977,7 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
         static int64_t nLastTime = GetTime();
         BOOST_FOREACH(CNode *node, vNodes)
         {
-            // Decay the activity bytes for each node over a period of 2 hours.  This gradually de-prioritizes a connection 
+            // Decay the activity bytes for each node over a period of 2 hours.  This gradually de-prioritizes a connection
             // that was once active but has gone stale for some reason and allows lower priority active nodes to climb the ladder.
             int64_t nNow = GetTime();
             node->nActivityBytes *= pow(1.0 - 1.0/7200, (double)(nNow - nLastTime)); // exponential 2 hour decay
@@ -1021,7 +1021,7 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection) {
             int64_t nTimeElapsed = GetTime() - mapInboundConnectionTracker[ipAddress].nLastEvictionTime;
             double nRatioElapsed = (double)nTimeElapsed / 1800;
             nEvictions = mapInboundConnectionTracker[ipAddress].nEvictions - (nRatioElapsed * mapInboundConnectionTracker[ipAddress].nEvictions);
-            if (nEvictions < 0) 
+            if (nEvictions < 0)
                 nEvictions = 0;
         }
 
@@ -1139,7 +1139,7 @@ static void AcceptConnection(const ListenSocket& hListenSocket) {
             int64_t nTimeElapsed = GetTime() - mapInboundConnectionTracker[ipAddress].nLastConnectionTime;
             double nRatioElapsed = (double)nTimeElapsed / 60;
             nConnections = mapInboundConnectionTracker[ipAddress].nConnections - (nRatioElapsed * mapInboundConnectionTracker[ipAddress].nConnections);
-            if (nConnections < 0) 
+            if (nConnections < 0)
                 nConnections = 0;
         }
 
@@ -1157,7 +1157,7 @@ static void AcceptConnection(const ListenSocket& hListenSocket) {
         }
     }
     // BU - end section
- 
+
     CNode* pnode = new CNode(hSocket, addr, "", true);
     pnode->AddRef();
     pnode->fWhitelisted = whitelisted;
@@ -1266,7 +1266,7 @@ void ThreadSocketHandler()
             BOOST_FOREACH (CNode* pnode, vNodes) {
                 // It is necessary to use a temporary variable to ensure that pnode->hSocket is not changed by another thread during execution.
                 // If the socket is closed and even reopened for some unrelated connection, the worst case is that we get a spurious wakeup, so a mutex is not needed to protect the entire use of the socket.
-  	        SOCKET hSocket = pnode->hSocket;  
+  	        SOCKET hSocket = pnode->hSocket;
                 if (hSocket == INVALID_SOCKET)
                     continue;
                 FD_SET(hSocket, &fdsetError);
@@ -1435,7 +1435,7 @@ void ThreadSocketHandler()
                 pnode->Release();
         }
 
-        if (progress == 0 && fAquiredAllRecvLocks) // BU: Nothing happened even though select did not block.  So slow us down. 
+        if (progress == 0 && fAquiredAllRecvLocks) // BU: Nothing happened even though select did not block.  So slow us down.
             MilliSleep(5);
     }
 }
@@ -1555,11 +1555,12 @@ void MapPort(bool)
 void ThreadBitnodesAddressSeed()
 {
     // Get nodes from websites offering Bitnodes API
-    if ((addrman.size() > 0) &&
-        (!GetBoolArg("-forcebitnodes", DEFAULT_FORCEBITNODES))) {
+    if ((addrman.size() > 0) && (!GetBoolArg("-forcebitnodes", DEFAULT_FORCEBITNODES)))
+    {
         MilliSleep(11 * 1000);
         LOCK(cs_vNodes);
-        if (vNodes.size() >= 2) {
+        if (vNodes.size() >= 2)
+        {
             LogPrintf("P2P peers available. Skipped Bitnodes seeding.\n");
             return;
         }
@@ -1570,17 +1571,21 @@ void ThreadBitnodesAddressSeed()
     vector<string> vIPs;
     vector<CAddress> vAdd;
     bool success = GetLeaderboardFromBitnodes(vIPs);
-    if (success) {
+    if (success)
+    {
         int portOut;
         std::string hostOut = "";
-        BOOST_FOREACH(const string &seed, vIPs) {
+        BOOST_FOREACH (const string &seed, vIPs)
+        {
             SplitHostPort(seed, portOut, hostOut);
-            CNetAddr ip(hostOut, false);
+            CNetAddr ip(hostOut);
             CAddress addr = CAddress(CService(ip, portOut));
             addr.nTime = GetTime();
             vAdd.push_back(addr);
         }
-        addrman.Add(vAdd, CNetAddr("bitnodes.21.co", true));
+        CService bitnodes;
+        if (Lookup("bitnodes.21.co", bitnodes, 0, true))
+            addrman.Add(vAdd, bitnodes);
     }
 
     LogPrintf("%d addresses found from Bitnodes API\n", vAdd.size());
@@ -1934,9 +1939,9 @@ void ThreadOpenAddedConnections()
                 OpenNetworkConnection(addr, false, &grant, strAddNode.c_str());
                 MilliSleep(500);
             }
-            // Retry every 15 seconds.  It is important to check often to make sure the Xpedited Relay network 
+            // Retry every 15 seconds.  It is important to check often to make sure the Xpedited Relay network
             // nodes reconnect quickly after the remote peers restart
-            MilliSleep(15000); 
+            MilliSleep(15000);
         }
     }
 
@@ -1986,9 +1991,9 @@ void ThreadOpenAddedConnections()
             OpenNetworkConnection(CAddress(vserv[i % vserv.size()]), false, &grant);
             MilliSleep(500);
         }
-        // Retry every 15 seconds.  It is important to check often to make sure the Xpedited Relay network 
+        // Retry every 15 seconds.  It is important to check often to make sure the Xpedited Relay network
         // nodes reconnect quickly after the remote peers restart
-        MilliSleep(15000); 
+        MilliSleep(15000);
     }
 }
 
@@ -2035,7 +2040,7 @@ void ThreadMessageHandler()
 
     // SetThreadPriority(THREAD_PRIORITY_BELOW_NORMAL);
     while (true) {
-        requester.SendRequests();  // BU send out any requests for tx or blks that I don't know about yet        
+        requester.SendRequests();  // BU send out any requests for tx or blks that I don't know about yet
 
         vector<CNode*> vNodesCopy;
         {
@@ -2887,7 +2892,7 @@ void CNode::EndMessage() UNLOCK_FUNCTION(cs_vSend)
     char strCommand[CMessageHeader::COMMAND_SIZE + 1];
     strncpy(strCommand, &(*(ssSend.begin() + MESSAGE_START_SIZE)), CMessageHeader::COMMAND_SIZE);
     strCommand[CMessageHeader::COMMAND_SIZE] = '\0';
-    if (strcmp(strCommand, NetMsgType::PING) != 0 && 
+    if (strcmp(strCommand, NetMsgType::PING) != 0 &&
         strcmp(strCommand, NetMsgType::PONG) != 0 &&
         strcmp(strCommand, NetMsgType::ADDR) != 0 &&
         strcmp(strCommand, NetMsgType::VERSION) != 0 &&
@@ -2897,10 +2902,10 @@ void CNode::EndMessage() UNLOCK_FUNCTION(cs_vSend)
         nActivityBytes += nSize;
 
         // BU: furthermore, if the message is a priority message then move to the front of the deque
-        if (strcmp(strCommand, NetMsgType::GET_XTHIN) == 0 || 
-            strcmp(strCommand, NetMsgType::XTHINBLOCK) == 0 || 
-            strcmp(strCommand, NetMsgType::THINBLOCK) == 0 || 
-            strcmp(strCommand, NetMsgType::XBLOCKTX) == 0 || 
+        if (strcmp(strCommand, NetMsgType::GET_XTHIN) == 0 ||
+            strcmp(strCommand, NetMsgType::XTHINBLOCK) == 0 ||
+            strcmp(strCommand, NetMsgType::THINBLOCK) == 0 ||
+            strcmp(strCommand, NetMsgType::XBLOCKTX) == 0 ||
             strcmp(strCommand, NetMsgType::GET_XBLOCKTX) == 0 ) {
             it = vSendMsg.insert(vSendMsg.begin(), CSerializeData());
             LogPrint("thin", "Send Queue: pushed %s to the front of the queue\n", strCommand);
@@ -3012,14 +3017,14 @@ bool CBanDB::Read(banmap_t& banSet)
         // ... verify the network matches ours
         if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp)))
             return error("%s: Invalid network magic number", __func__);
-        
+
         // de-serialize address data into one CAddrMan object
         ssBanlist >> banSet;
     }
     catch (const std::exception& e) {
         return error("%s: Deserialize or I/O error - %s", __func__, e.what());
     }
-    
+
     return true;
 }
 

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -142,7 +142,7 @@ bool static LookupIntern(const char *pszName, std::vector<CNetAddr>& vIP, unsign
         return false;
 
     do {
-        // Should set the timeout limit to a resonable value to avoid
+        // Should set the timeout limit to a reasonable value to avoid
         // generating unnecessary checking call during the polling loop,
         // while it can still response to stop request quick enough.
         // 2 seconds looks fine in our situation.

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -619,10 +619,12 @@ bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest
     proxyType nameProxy;
     GetNameProxy(nameProxy);
 
-    CService addrResolved(CNetAddr(strDest, fNameLookup && !HaveNameProxy()), port);
-    if (addrResolved.IsValid()) {
-        addr = addrResolved;
-        return ConnectSocket(addr, hSocketRet, nTimeout);
+    CService addrResolved;
+    if (Lookup(strDest.c_str(), addrResolved, port, fNameLookup && !HaveNameProxy())) {
+        if (addrResolved.IsValid()) {
+            addr = addrResolved;
+            return ConnectSocket(addr, hSocketRet, nTimeout);
+        }
     }
 
     addr = CService("0.0.0.0:0");
@@ -691,19 +693,19 @@ CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr, const uint32_t scope)
     scopeId = scope;
 }
 
-CNetAddr::CNetAddr(const char *pszIp, bool fAllowLookup)
+CNetAddr::CNetAddr(const char *pszIp)
 {
     Init();
     std::vector<CNetAddr> vIP;
-    if (LookupHost(pszIp, vIP, 1, fAllowLookup))
+    if (LookupHost(pszIp, vIP, 1, false))
         *this = vIP[0];
 }
 
-CNetAddr::CNetAddr(const std::string &strIp, bool fAllowLookup)
+CNetAddr::CNetAddr(const std::string &strIp)
 {
     Init();
     std::vector<CNetAddr> vIP;
-    if (LookupHost(strIp.c_str(), vIP, 1, fAllowLookup))
+    if (LookupHost(strIp.c_str(), vIP, 1, false))
         *this = vIP[0];
 }
 
@@ -1126,35 +1128,35 @@ bool CService::SetSockAddr(const struct sockaddr *paddr)
     }
 }
 
-CService::CService(const char *pszIpPort, bool fAllowLookup)
+CService::CService(const char *pszIpPort)
 {
     Init();
     CService ip;
-    if (Lookup(pszIpPort, ip, 0, fAllowLookup))
+    if (Lookup(pszIpPort, ip, 0, false))
         *this = ip;
 }
 
-CService::CService(const char *pszIpPort, int portDefault, bool fAllowLookup)
+CService::CService(const char *pszIpPort, int portDefault)
 {
     Init();
     CService ip;
-    if (Lookup(pszIpPort, ip, portDefault, fAllowLookup))
+    if (Lookup(pszIpPort, ip, portDefault, false))
         *this = ip;
 }
 
-CService::CService(const std::string &strIpPort, bool fAllowLookup)
+CService::CService(const std::string &strIpPort)
 {
     Init();
     CService ip;
-    if (Lookup(strIpPort.c_str(), ip, 0, fAllowLookup))
+    if (Lookup(strIpPort.c_str(), ip, 0, false))
         *this = ip;
 }
 
-CService::CService(const std::string &strIpPort, int portDefault, bool fAllowLookup)
+CService::CService(const std::string &strIpPort, int portDefault)
 {
     Init();
     CService ip;
-    if (Lookup(strIpPort.c_str(), ip, portDefault, fAllowLookup))
+    if (Lookup(strIpPort.c_str(), ip, portDefault, false))
         *this = ip;
 }
 
@@ -1248,7 +1250,7 @@ CSubNet::CSubNet():
     memset(netmask, 0, sizeof(netmask));
 }
 
-CSubNet::CSubNet(const std::string &strSubnet, bool fAllowLookup)
+CSubNet::CSubNet(const std::string &strSubnet)
 {
     size_t slash = strSubnet.find_last_of('/');
     std::vector<CNetAddr> vIP;
@@ -1258,7 +1260,7 @@ CSubNet::CSubNet(const std::string &strSubnet, bool fAllowLookup)
     memset(netmask, 255, sizeof(netmask));
 
     std::string strAddress = strSubnet.substr(0, slash);
-    if (LookupHost(strAddress.c_str(), vIP, 1, fAllowLookup))
+    if (LookupHost(strAddress.c_str(), vIP, 1, false))
     {
         network = vIP[0];
         if (slash != strSubnet.npos)

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -197,7 +197,7 @@ bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nM
     return LookupIntern(strHost.c_str(), vIP, nMaxSolutions, fAllowLookup);
 }
 
-bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault, bool fAllowLookup, unsigned int nMaxSolutions)
+bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault, unsigned int nMaxSolutions, bool fAllowLookup)
 {
     if (pszName[0] == 0)
         return false;
@@ -218,7 +218,7 @@ bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault, 
 bool Lookup(const char *pszName, CService& addr, int portDefault, bool fAllowLookup)
 {
     std::vector<CService> vService;
-    bool fRet = Lookup(pszName, vService, portDefault, fAllowLookup, 1);
+    bool fRet = Lookup(pszName, vService, portDefault, 1, fAllowLookup);
     if (!fRet)
         return false;
     addr = vService[0];
@@ -620,8 +620,10 @@ bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest
     GetNameProxy(nameProxy);
 
     CService addrResolved;
-    if (Lookup(strDest.c_str(), addrResolved, port, fNameLookup && !HaveNameProxy())) {
-        if (addrResolved.IsValid()) {
+    if (Lookup(strDest.c_str(), addrResolved, port, fNameLookup && !HaveNameProxy()))
+    {
+        if (addrResolved.IsValid())
+        {
             addr = addrResolved;
             return ConnectSocket(addr, hSocketRet, nTimeout);
         }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -172,7 +172,8 @@ bool static LookupIntern(const char *pszName, std::vector<CNetAddr>& vIP, unsign
         if (aiTrav->ai_family == AF_INET6)
         {
             assert(aiTrav->ai_addrlen >= sizeof(sockaddr_in6));
-            vIP.push_back(CNetAddr(((struct sockaddr_in6*)(aiTrav->ai_addr))->sin6_addr));
+            struct sockaddr_in6* s6 = (struct sockaddr_in6*) aiTrav->ai_addr;
+            vIP.push_back(CNetAddr(s6->sin6_addr, s6->sin6_scope_id));
         }
 
         aiTrav = aiTrav->ai_next;
@@ -634,6 +635,7 @@ bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest
 void CNetAddr::Init()
 {
     memset(ip, 0, sizeof(ip));
+    scopeId = 0;
 }
 
 void CNetAddr::SetIP(const CNetAddr& ipIn)
@@ -683,9 +685,10 @@ CNetAddr::CNetAddr(const struct in_addr& ipv4Addr)
     SetRaw(NET_IPV4, (const uint8_t*)&ipv4Addr);
 }
 
-CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr)
+CNetAddr::CNetAddr(const struct in6_addr& ipv6Addr, const uint32_t scope)
 {
     SetRaw(NET_IPV6, (const uint8_t*)&ipv6Addr);
+    scopeId = scope;
 }
 
 CNetAddr::CNetAddr(const char *pszIp, bool fAllowLookup)
@@ -1104,7 +1107,7 @@ CService::CService(const struct sockaddr_in& addr) : CNetAddr(addr.sin_addr), po
     assert(addr.sin_family == AF_INET);
 }
 
-CService::CService(const struct sockaddr_in6 &addr) : CNetAddr(addr.sin6_addr), port(ntohs(addr.sin6_port))
+CService::CService(const struct sockaddr_in6 &addr) : CNetAddr(addr.sin6_addr, addr.sin6_scope_id), port(ntohs(addr.sin6_port))
 {
    assert(addr.sin6_family == AF_INET6);
 }
@@ -1197,6 +1200,7 @@ bool CService::GetSockAddr(struct sockaddr* paddr, socklen_t *addrlen) const
         memset(paddrin6, 0, *addrlen);
         if (!GetIn6Addr(&paddrin6->sin6_addr))
             return false;
+        paddrin6->sin6_scope_id = scopeId;
         paddrin6->sin6_family = AF_INET6;
         paddrin6->sin6_port = htons(port);
         return true;

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -50,8 +50,8 @@ class CNetAddr
     public:
         CNetAddr();
         CNetAddr(const struct in_addr& ipv4Addr);
-        explicit CNetAddr(const char *pszIp, bool fAllowLookup = false);
-        explicit CNetAddr(const std::string &strIp, bool fAllowLookup = false);
+        explicit CNetAddr(const char *pszIp);
+        explicit CNetAddr(const std::string &strIp);
         void Init();
         void SetIP(const CNetAddr& ip);
 
@@ -120,7 +120,7 @@ class CSubNet
 
     public:
         CSubNet();
-        explicit CSubNet(const std::string &strSubnet, bool fAllowLookup = false);
+        explicit CSubNet(const std::string &strSubnet);
 
         //constructor for single ip subnet (<ipv4>/32 or <ipv6>/128)
         explicit CSubNet(const CNetAddr &addr);
@@ -155,10 +155,10 @@ class CService : public CNetAddr
         CService(const CNetAddr& ip, unsigned short port);
         CService(const struct in_addr& ipv4Addr, unsigned short port);
         CService(const struct sockaddr_in& addr);
-        explicit CService(const char *pszIpPort, int portDefault, bool fAllowLookup = false);
-        explicit CService(const char *pszIpPort, bool fAllowLookup = false);
-        explicit CService(const std::string& strIpPort, int portDefault, bool fAllowLookup = false);
-        explicit CService(const std::string& strIpPort, bool fAllowLookup = false);
+        explicit CService(const char *pszIpPort, int portDefault);
+        explicit CService(const char *pszIpPort);
+        explicit CService(const std::string& strIpPort, int portDefault);
+        explicit CService(const std::string& strIpPort);
         void Init();
         void SetPort(unsigned short portIn);
         unsigned short GetPort() const;
@@ -207,9 +207,9 @@ bool GetProxy(enum Network net, proxyType &proxyInfoOut);
 bool IsProxy(const CNetAddr &addr);
 bool SetNameProxy(const proxyType &addrProxy);
 bool HaveNameProxy();
-bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions = 0, bool fAllowLookup = true);
-bool Lookup(const char *pszName, CService& addr, int portDefault = 0, bool fAllowLookup = true);
-bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault = 0, bool fAllowLookup = true, unsigned int nMaxSolutions = 0);
+bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions, bool fAllowLookup);
+bool Lookup(const char *pszName, CService& addr, int portDefault, bool fAllowLookup);
+bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault, bool fAllowLookup, unsigned int nMaxSolutions);
 bool LookupNumeric(const char *pszName, CService& addr, int portDefault = 0);
 bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout, bool *outProxyConnectionFailed = 0);
 bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault, int nTimeout, bool *outProxyConnectionFailed = 0);

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -45,6 +45,7 @@ class CNetAddr
 {
     protected:
         unsigned char ip[16]; // in network byte order
+        uint32_t scopeId; // for scoped/link-local ipv6 addresses
 
     public:
         CNetAddr();
@@ -90,7 +91,7 @@ class CNetAddr
         std::vector<unsigned char> GetGroup() const;
         int GetReachabilityFrom(const CNetAddr *paddrPartner = NULL) const;
 
-        CNetAddr(const struct in6_addr& pipv6Addr);
+        CNetAddr(const struct in6_addr& pipv6Addr, const uint32_t scope = 0);
         bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
 
         friend bool operator==(const CNetAddr& a, const CNetAddr& b);

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -91,7 +91,7 @@ class CNetAddr
         std::vector<unsigned char> GetGroup() const;
         int GetReachabilityFrom(const CNetAddr *paddrPartner = NULL) const;
 
-        CNetAddr(const struct in6_addr& pipv6Addr, const uint32_t scope = 0);
+        CNetAddr(const struct in6_addr& pipv6Addr, const uint32_t scope = IPV6_ADDR_SCOPE_RESERVED);
         bool GetIn6Addr(struct in6_addr* pipv6Addr) const;
 
         friend bool operator==(const CNetAddr& a, const CNetAddr& b);
@@ -207,10 +207,49 @@ bool GetProxy(enum Network net, proxyType &proxyInfoOut);
 bool IsProxy(const CNetAddr &addr);
 bool SetNameProxy(const proxyType &addrProxy);
 bool HaveNameProxy();
-bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions, bool fAllowLookup);
-bool Lookup(const char *pszName, CService& addr, int portDefault, bool fAllowLookup);
-bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault, bool fAllowLookup, unsigned int nMaxSolutions);
+
+/**
+ * Resolve a string hostname into an array of possible IP addresses.
+ * @param[in]  pszName             The host name or dotted IP
+ * @param[out] vIP                 The host's IP addresses
+ * @param[in]  nMaxSolutions       Don't find more than this number of solutions
+ * @param[in]  fAllowDnsResolution If true, pszName may be a dotted-name address, and an attempt will be made to
+                                   resolve.  This can be very time consuming depending on your machine's DNS lookup time
+ * @return True if resolution succeeded
+ */
+bool LookupHost(const char *pszName, std::vector<CNetAddr>& vIP, unsigned int nMaxSolutions, bool fAllowDnsResolution);
+
+/**
+ * Resolve a string hostname into an IP address:port "service".
+ * @param[in]  pszName             The host name or dotted IP
+ * @param[out] addr                The resolved IP address:port
+ * @param[in]  portDefault         If a port is not specified in pszName, use this one.
+ * @param[in]  fAllowDnsResolution If true, pszName may be a dotted-name address, and an attempt will be made to
+                                   resolve.  This can be very time consuming depending on your machine's DNS lookup time
+ * @return True if resolution succeeded
+ */
+bool Lookup(const char *pszName, CService& addr, int portDefault, bool fAllowDnsResolution);
+
+/**
+ * Resolve a string hostname into an array of possible IP address/port "services".
+ * @param[in]  pszName             The host name or dotted IP
+ * @param[out] vAddr               All resolved IP address:ports
+ * @param[in]  nMaxSolutions       Don't find more than this number of solutions
+ * @param[in]  fAllowDnsResolution If true, pszName may be a dotted-name address, and an attempt will be made to
+                                   resolve.  This can be very time consuming depending on your machine's DNS lookup time
+ * @return True if resolution succeeded
+ */
+bool Lookup(const char *pszName, std::vector<CService>& vAddr, int portDefault, unsigned int nMaxSolutions, bool fAllowDnsResolution);
+
+/**
+ * Resolve a string numeric hostname into an IP address:port "service".
+ * @param[in]  pszName             The host name or dotted IP
+ * @param[out] addr                The resolved IP address:port
+ * @param[in]  portDefault         If a port is not specified in pszName, use this one.
+ * @return True if resolution succeeded
+ */
 bool LookupNumeric(const char *pszName, CService& addr, int portDefault = 0);
+
 bool ConnectSocket(const CService &addr, SOCKET& hSocketRet, int nTimeout, bool *outProxyConnectionFailed = 0);
 bool ConnectSocketByName(CService &addr, SOCKET& hSocketRet, const char *pszDest, int portDefault, int nTimeout, bool *outProxyConnectionFailed = 0);
 /** Return readable error string for a network error code */

--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -87,7 +87,7 @@ double TxConfirmStats::EstimateMedianVal(int confTarget, double sufficientTxVal,
     int maxbucketindex = buckets.size() - 1;
 
     // requireGreater means we are looking for the lowest fee/priority such that all higher
-    // values pass, so we start at maxbucketindex (highest fee) and look at succesively
+    // values pass, so we start at maxbucketindex (highest fee) and look at successively
     // smaller buckets until we reach failure.  Otherwise, we are looking for the highest
     // fee/priority such that all lower values fail, and we go in the opposite direction.
     unsigned int startbucket = requireGreater ? maxbucketindex : 0;

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -29,7 +29,7 @@ class CTxMemPool;
  * included in blocks before transactions of lower fee/priority.   So for
  * example if you wanted to know what fee you should put on a transaction to
  * be included in a block within the next 5 blocks, you would start by looking
- * at the bucket with with the highest fee transactions and verifying that a
+ * at the bucket with the highest fee transactions and verifying that a
  * sufficiently high percentage of them were confirmed within 5 blocks and
  * then you would look at the next highest fee bucket, and so on, stopping at
  * the last bucket to pass the test.   The average fee of transactions in this
@@ -87,13 +87,13 @@ private:
     // Count the total # of txs in each bucket
     // Track the historical moving average of this total over blocks
     std::vector<double> txCtAvg;
-    // and calcuate the total for the current block to update the moving average
+    // and calculate the total for the current block to update the moving average
     std::vector<int> curBlockTxCt;
 
     // Count the total # of txs confirmed within Y blocks in each bucket
     // Track the historical moving average of theses totals over blocks
     std::vector<std::vector<double> > confAvg; // confAvg[Y][X]
-    // and calcuate the totals for the current block to update the moving averages
+    // and calculate the totals for the current block to update the moving averages
     std::vector<std::vector<int> > curBlockConf; // curBlockConf[Y][X]
 
     // Sum the total priority/fee of all tx's in each bucket

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -132,7 +132,7 @@ double ClientModel::getVerificationProgress(const CBlockIndex *tipIn) const
 void ClientModel::updateTimer1()
 {
     // no locking required at this point
-    // the following calls will aquire the required lock
+    // the following calls will acquire the required lock
     Q_EMIT mempoolSizeChanged(getMempoolSize(), getMempoolDynamicUsage());
     Q_EMIT transactionsPerSecondChanged(getTransactionsPerSecond());
 }

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -792,7 +792,7 @@ void SendCoinsDialog::coinControlUpdateLabels()
 
     if (model->getOptionsModel()->getCoinControlFeatures())
     {
-        // enable minium absolute fee UI controls
+        // enable minimum absolute fee UI controls
         ui->radioCustomAtLeast->setVisible(true);
 
         // only enable the feature if inputs are selected

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -322,7 +322,7 @@ UniValue getaddednodeinfo(const UniValue& params, bool fHelp)
     list<pair<string, vector<CService> > > laddedAddreses(0);
     BOOST_FOREACH(const std::string& strAddNode, laddedNodes) {
         vector<CService> vservNode(0);
-        if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), fNameLookup, 0))
+        if(Lookup(strAddNode.c_str(), vservNode, Params().GetDefaultPort(), 0, fNameLookup))
             laddedAddreses.push_back(make_pair(strAddNode, vservNode));
         else
         {

--- a/src/script/ismine.h
+++ b/src/script/ismine.h
@@ -18,7 +18,7 @@ class CScript;
 enum isminetype
 {
     ISMINE_NO = 0,
-    //! Indicates that we dont know how to create a scriptSig that would solve this if we were given the appropriate private keys
+    //! Indicates that we don't know how to create a scriptSig that would solve this if we were given the appropriate private keys
     ISMINE_WATCH_UNSOLVABLE = 1,
     //! Indicates that we know how to create a scriptSig that would solve this if we were given the appropriate private keys
     ISMINE_WATCH_SOLVABLE = 2,

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(merkle_test)
             int duplicate2 = mutate >= 2 ? 1 << ctz(ntx1) : 0; // Likewise for the second mutation.
             if (duplicate2 >= ntx1) break;
             int ntx2 = ntx1 + duplicate2;
-            int duplicate3 = mutate >= 3 ? 1 << ctz(ntx2) : 0; // And for the the third mutation.
+            int duplicate3 = mutate >= 3 ? 1 << ctz(ntx2) : 0; // And for the third mutation.
             if (duplicate3 >= ntx2) break;
             int ntx3 = ntx2 + duplicate3;
             // Build a block with ntx different transactions.

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -438,7 +438,7 @@ void TorController::add_onion_cb(TorControlConnection& conn, const TorControlRep
                 private_key = i->second;
         }
 
-        service = CService(service_id+".onion", GetListenPort(), false);
+        service = CService(service_id+".onion", GetListenPort());
         LogPrintf("tor: Got service ID %s, advertising service %s\n", service_id, service.ToString());
         if (WriteBinaryFile(GetPrivateKeyFile(), private_key)) {
             LogPrint("tor", "tor: Cached service private key to %s\n", GetPrivateKeyFile());

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -303,7 +303,7 @@ static std::map<std::string,std::string> ParseTorReplyMapping(const std::string 
 
 /** Read full contents of a file and return them in a std::string.
  * Returns a pair <status, string>.
- * If an error occured, status will be false, otherwise status will be true and the data will be returned in string.
+ * If an error occurred, status will be false, otherwise status will be true and the data will be returned in string.
  *
  * @param maxsize Puts a maximum size limit on the file that is read. If the file is larger than this, truncated data
  *         (with len > maxsize) will be returned.

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -79,7 +79,7 @@ public:
     /**
      * Connect to a Tor control port.
      * target is address of the form host:port.
-     * connected is the handler that is called when connection is succesfully established.
+     * connected is the handler that is called when connection is successfully established.
      * disconnected is a handler that is called when the connection is broken.
      * Return true on success.
      */
@@ -177,7 +177,7 @@ void TorControlConnection::eventcb(struct bufferevent *bev, short what, void *ct
 {
     TorControlConnection *self = (TorControlConnection*)ctx;
     if (what & BEV_EVENT_CONNECTED) {
-        LogPrint("tor", "tor: Succesfully connected!\n");
+        LogPrint("tor", "tor: Successfully connected!\n");
         self->connected(*self);
     } else if (what & (BEV_EVENT_EOF|BEV_EVENT_ERROR)) {
         if (what & BEV_EVENT_ERROR)
@@ -380,7 +380,7 @@ private:
     void authchallenge_cb(TorControlConnection& conn, const TorControlReply& reply);
     /** Callback for PROTOCOLINFO result */
     void protocolinfo_cb(TorControlConnection& conn, const TorControlReply& reply);
-    /** Callback after succesful connection */
+    /** Callback after successful connection */
     void connected_cb(TorControlConnection& conn);
     /** Callback after connection lost or failed connection attempt */
     void disconnected_cb(TorControlConnection& conn);
@@ -424,7 +424,7 @@ TorController::~TorController()
 void TorController::add_onion_cb(TorControlConnection& conn, const TorControlReply& reply)
 {
     if (reply.code == 250) {
-        LogPrint("tor", "tor: ADD_ONION succesful\n");
+        LogPrint("tor", "tor: ADD_ONION successful\n");
         BOOST_FOREACH(const std::string &s, reply.lines) {
             std::map<std::string,std::string> m = ParseTorReplyMapping(s);
             std::map<std::string,std::string>::iterator i;
@@ -453,7 +453,7 @@ void TorController::add_onion_cb(TorControlConnection& conn, const TorControlRep
 void TorController::auth_cb(TorControlConnection& conn, const TorControlReply& reply)
 {
     if (reply.code == 250) {
-        LogPrint("tor", "tor: Authentication succesful\n");
+        LogPrint("tor", "tor: Authentication successful\n");
 
         // Now that we know Tor is running setup the proxy for onion addresses
         // if -onion isn't set to something else.
@@ -506,7 +506,7 @@ static std::vector<uint8_t> ComputeResponse(const std::string &key, const std::v
 void TorController::authchallenge_cb(TorControlConnection& conn, const TorControlReply& reply)
 {
     if (reply.code == 250) {
-        LogPrint("tor", "tor: SAFECOOKIE authentication challenge succesful\n");
+        LogPrint("tor", "tor: SAFECOOKIE authentication challenge successful\n");
         std::pair<std::string,std::string> l = SplitTorReplyLine(reply.lines[0]);
         if (l.first == "AUTHCHALLENGE") {
             std::map<std::string,std::string> m = ParseTorReplyMapping(l.second);

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2015-2016 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
 #include "torcontrol.h"
 #include "utilstrencodings.h"
 #include "net.h"
@@ -698,4 +702,3 @@ void StopTorControl()
         base = 0;
     }
 }
-

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -389,8 +389,8 @@ private:
     static void reconnect_cb(evutil_socket_t fd, short what, void *arg);
 };
 
-TorController::TorController(struct event_base* base, const std::string& target):
-    base(base),
+TorController::TorController(struct event_base* baseIn, const std::string& target):
+    base(baseIn),
     target(target), conn(base), reconnect(true), reconnect_ev(0),
     reconnect_timeout(RECONNECT_TIMEOUT_START)
 {

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1443,7 +1443,7 @@ UniValue listtransactions(const UniValue& params, bool fHelp)
             "                                         'send' category of transactions.\n"
             "    \"confirmations\": n,       (numeric) The number of confirmations for the transaction. Available for 'send' and \n"
             "                                         'receive' category of transactions. Negative confirmations indicate the\n"
-            "                                         transation conflicts with the block chain\n"
+            "                                         transaction conflicts with the block chain\n"
             "    \"trusted\": xxx            (bool) Whether we consider the outputs of this unconfirmed transaction safe to spend.\n"
             "    \"blockhash\": \"hashvalue\", (string) The block hash containing the transaction. Available for 'send' and 'receive'\n"
             "                                          category of transactions.\n"


### PR DESCRIPTION
Backports of spelling fixes and changes to netbase that bring us closer to 0.13.0 for it and torcontrol.cpp.

Main API change is to move towards storage-only structures for basic network concepts, and splitting out DNS lookup.  In later changes in Core CNetAddr moves to its own file netaddress.cpp.

bitcoin#7313
bitcoin#7329
bitcoin#7683
bitcoin#7570
bitcoin#7868
+ BU-specific changes