### PR TITLE
[Backport to Release] Turn SENDHEADERS on when a peer requests it.

### DIFF
--- a/qa/rpc-tests/bip68-112-113-p2p.py
+++ b/qa/rpc-tests/bip68-112-113-p2p.py
@@ -217,7 +217,7 @@ class BIP68_112_113Test(ComparisonTestFramework):
 
         assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], 'defined')
         test_blocks = self.generate_blocks(61, 4)
-        yield TestInstance(test_blocks, sync_every_block=False) # 1
+        yield TestInstance(test_blocks, sync_every_block=True) # 1
         # Advanced from DEFINED to STARTED, height = 143
         assert_equal(get_bip9_status(self.nodes[0], 'csv')['status'], 'started')
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5250,13 +5250,8 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
     else if (strCommand == NetMsgType::SENDHEADERS)
     {
         LOCK(cs_main);
-        // BUIP010 Xtreme Thinblocks: We only do inv/getdata for xthinblocks and so we must have headersfirst turned off
-        if (IsThinBlocksEnabled())
-            State(pfrom->GetId())->fPreferHeaders = false;
-        else
-            State(pfrom->GetId())->fPreferHeaders = true;
+        State(pfrom->GetId())->fPreferHeaders = true;
     }
-
 
     else if (strCommand == NetMsgType::INV)
     {


### PR DESCRIPTION
If a peer requests HEADERS first then we'll send them otherwise we'll send an INV.  This has been in dev for several months but since we don't know when the next release will be we really should back port this.