### PR TITLE
Documentation enhancements for building binary images.

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -266,9 +266,10 @@ These steps can be performed on, for example, an Ubuntu VM. The depends system
 will also work on other Linux distributions, however the commands for
 installing the toolchain will be different.
 
-First install the toolchain:
+Make sure you install the build requirements mentioned above.
+Then, install the toolchain and curl:
 
-    sudo apt-get install g++-arm-linux-gnueabihf
+    sudo apt-get install g++-arm-linux-gnueabihf curl
 
 To build executables for ARM:
 

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -16,9 +16,11 @@ These steps can be performed on, for example, an Ubuntu VM. The depends system
 will also work on other Linux distributions, however the commands for
 installing the toolchain will be different.
 
-First install the toolchains:
+Make sure you install the build requirements mentioned in
+[build-unix.md](/doc/build-unix.md).
+Then, install the toolchains and curl:
 
-    sudo apt-get install g++-mingw-w64-i686 mingw-w64-i686-dev g++-mingw-w64-x86-64 mingw-w64-x86-64-dev
+    sudo apt-get install g++-mingw-w64-i686 mingw-w64-i686-dev g++-mingw-w64-x86-64 mingw-w64-x86-64-dev curl
 
 To build executables for Windows 32-bit:
 

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -27,6 +27,7 @@ To build executables for Windows 32-bit:
     cd depends
     make HOST=i686-w64-mingw32 -j4
     cd ..
+    ./autogen.sh # not required when building from tarball
     ./configure --prefix=`pwd`/depends/i686-w64-mingw32
     make
 
@@ -35,6 +36,7 @@ To build executables for Windows 64-bit:
     cd depends
     make HOST=x86_64-w64-mingw32 -j4
     cd ..
+    ./autogen.sh # not required when building from tarball
     ./configure --prefix=`pwd`/depends/x86_64-w64-mingw32
     make
 

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -12,9 +12,11 @@ A second alternative way of building on windows using msys / mingw-w64 is docume
 Compiling with Windows Subsystem For Linux
 -------------------------------------------
 
-With Windows 10, Microsoft has released a new feature named the [Windows Subsystem for Linux](https://msdn.microsoft.com/commandline/wsl/about).  This feature allows you to run a bash shell directly on Windows in an Ubuntu based environment.  Within this environment you can cross compile for Windows without the need for a separate Linux VM or Server.
+With Windows 10, Microsoft has released a new feature named the [Windows Subsystem for Linux](https://msdn.microsoft.com/commandline/wsl/about).  This feature allows you to run a bash shell directly on Windows in an Ubuntu-based environment.  Within this environment you can cross compile for Windows without the need for a separate Linux VM or server.
 
-This feature is not supported in versions of Windows prior to Windows 10 or on Windows Server SKUs.
+This feature is not supported in versions of Windows prior to Windows 10 or on
+Windows Server SKUs. In addition, it is available [only for 64-bit versions of
+Windows](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide).
 
 To get the bash shell, you must first activate the feature in Windows.
 
@@ -32,7 +34,9 @@ To get the bash shell, you must first activate the feature in Windows.
   * Accept the license
   * Create a new UNIX user account (this is a separate account from your Windows account)
 
-After the bash shell is active, you can follow the instructions below for Windows 64-bit Cross-compilation.
+After the bash shell is active, you can follow the instructions below, starting
+with the "Cross-compilation" section. Compiling the 64-bit version is
+recommended but it is possible to compile the 32-bit version.
 
 Cross-compilation
 -------------------
@@ -56,7 +60,7 @@ To build executables for Windows 64-bit, install the following dependencies:
 Then build using:
 
     cd depends
-    make HOST=x86_64-w64-mingw32 -j4
+    make HOST=x86_64-w64-mingw32
     cd ..
     ./autogen.sh # not required when building from tarball
     CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
@@ -71,7 +75,7 @@ To build executables for Windows 32-bit, install the following dependencies:
 Then build using:
 
     cd depends
-    make HOST=i686-w64-mingw32 -j4
+    make HOST=i686-w64-mingw32
     cd ..
     ./autogen.sh # not required when building from tarball
     CONFIG_SITE=$PWD/depends/i686-w64-mingw32/share/config.site ./configure --prefix=/
@@ -86,4 +90,3 @@ as they appear in the release `.zip` archive. This can be done in the following
 way. This will install to `c:\workspace\bitcoin`, for example:
 
     make install DESTDIR=/mnt/c/workspace/bitcoin
-

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -1,23 +1,45 @@
 WINDOWS BUILD NOTES
 ====================
 
-Some notes on how to build Bitcoin Core for Windows.
+Below are some notes on how to build Bitcoin Unlimited for Windows.
 
-Most developers use cross-compilation from Ubuntu to build executables for
-Windows. This is also used to build the release binaries.
+Most developers use cross-compilation from Ubuntu to build executables for Windows. This is also used to build the release binaries.
 
-Building on Windows itself is possible (for example using msys / mingw-w64),
-see `build-windows-mingw.md`
+While there are potentially a number of ways to build on Windows, using the Windows Subsystem For Linux is the most straight forward.  If you are building with an alternative method, please contribute the instructions here for others who are running versions of Windows that are not compatible with the Windows Subsystem for Linux.
+
+A second alternative way of building on windows using msys / mingw-w64 is documented in 'build-windows-mingw.md'.
+
+Compiling with the Windows Subsystem For Linux
+-------------------
+
+With Windows 10, Microsoft has released a new feature named the [Windows Subsystem for Linux](https://msdn.microsoft.com/commandline/wsl/about).  This feature allows you to run a bash shell directly on Windows in an Ubuntu based environment.  Within this environment you can cross compile for Windows without the need for a separate Linux VM or Server.
+
+This feature is not supported in versions of Windows prior to Windows 10 or on Windows Server SKUs.
+
+To get the bash shell, you must first activate the feature in Windows.
+
+1. Turn on Developer Mode
+  * Open Settings -> Update and Security -> For developers
+  * Select the Developer Mode radio button
+  * Restart if necessary
+2. Enable the Windows Subsystem for Linux feature
+  * From Start, search for "Turn Windows features on or off" (type 'turn')
+  * Select Windows Subsystem for Linux (beta)
+  * Click OK
+  * Restart if necessary
+3. Complete Installation
+  * Open a cmd prompt and type "bash"
+  * Accept the license
+  * Create a new UNIX user account (this is a separate account from your Windows account)
+
+After the bash shell is active, you can follow the instructions below for Windows 64-bit Cross-compilation. When building dependencies within the 'depends' folder, you may encounter an error building the protobuf dependency.  If this occurs, re-run the command with sudo.  This is likely a bug with the Windows Subsystem for Linux feature and may be fixed with a future update.
 
 Cross-compilation
 -------------------
 
-These steps can be performed on, for example, an Ubuntu VM. The depends system
-will also work on other Linux distributions, however the commands for
-installing the toolchain will be different.
+These steps can be performed on, for example, an Ubuntu VM. The depends system will also work on other Linux distributions, however the commands for installing the toolchain will be different.
 
-Make sure you install the build requirements mentioned in
-[build-unix.md](/doc/build-unix.md).
+Make sure you install the build requirements mentioned in [build-unix.md](/doc/build-unix.md).
 Then, install the toolchains and curl:
 
     sudo apt-get install g++-mingw-w64-i686 mingw-w64-i686-dev g++-mingw-w64-x86-64 mingw-w64-x86-64-dev curl
@@ -41,4 +63,3 @@ To build executables for Windows 64-bit:
     make
 
 For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
-

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -81,6 +81,8 @@ Then build using:
     CONFIG_SITE=$PWD/depends/i686-w64-mingw32/share/config.site ./configure --prefix=/
     make
 
+For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.
+
 Installation
 -------------
 

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -62,4 +62,3 @@ To build executables for Windows 64-bit:
     ./configure --prefix=`pwd`/depends/x86_64-w64-mingw32
     make
 
-For further documentation on the depends system see [README.md](../depends/README.md) in the depends directory.

--- a/doc/build-windows.md
+++ b/doc/build-windows.md
@@ -9,8 +9,8 @@ While there are potentially a number of ways to build on Windows, using the Wind
 
 A second alternative way of building on windows using msys / mingw-w64 is documented in 'build-windows-mingw.md'.
 
-Compiling with the Windows Subsystem For Linux
--------------------
+Compiling with Windows Subsystem For Linux
+-------------------------------------------
 
 With Windows 10, Microsoft has released a new feature named the [Windows Subsystem for Linux](https://msdn.microsoft.com/commandline/wsl/about).  This feature allows you to run a bash shell directly on Windows in an Ubuntu based environment.  Within this environment you can cross compile for Windows without the need for a separate Linux VM or Server.
 
@@ -32,33 +32,58 @@ To get the bash shell, you must first activate the feature in Windows.
   * Accept the license
   * Create a new UNIX user account (this is a separate account from your Windows account)
 
-After the bash shell is active, you can follow the instructions below for Windows 64-bit Cross-compilation. When building dependencies within the 'depends' folder, you may encounter an error building the protobuf dependency.  If this occurs, re-run the command with sudo.  This is likely a bug with the Windows Subsystem for Linux feature and may be fixed with a future update.
+After the bash shell is active, you can follow the instructions below for Windows 64-bit Cross-compilation.
 
 Cross-compilation
 -------------------
 
 These steps can be performed on, for example, an Ubuntu VM. The depends system will also work on other Linux distributions, however the commands for installing the toolchain will be different.
 
-Make sure you install the build requirements mentioned in [build-unix.md](/doc/build-unix.md).
-Then, install the toolchains and curl:
+First, install the general dependencies:
 
-    sudo apt-get install g++-mingw-w64-i686 mingw-w64-i686-dev g++-mingw-w64-x86-64 mingw-w64-x86-64-dev curl
+    sudo apt-get install build-essential libtool autotools-dev automake pkg-config bsdmainutils curl
 
-To build executables for Windows 32-bit:
+A host toolchain (`build-essential`) is necessary because some dependency
+packages (such as `protobuf`) need to build host utilities that are used in the
+build process.
 
-    cd depends
-    make HOST=i686-w64-mingw32 -j4
-    cd ..
-    ./autogen.sh # not required when building from tarball
-    ./configure --prefix=`pwd`/depends/i686-w64-mingw32
-    make
+## Building for 64-bit Windows
 
-To build executables for Windows 64-bit:
+To build executables for Windows 64-bit, install the following dependencies:
+
+    sudo apt-get install g++-mingw-w64-x86-64 mingw-w64-x86-64-dev
+
+Then build using:
 
     cd depends
     make HOST=x86_64-w64-mingw32 -j4
     cd ..
     ./autogen.sh # not required when building from tarball
-    ./configure --prefix=`pwd`/depends/x86_64-w64-mingw32
+    CONFIG_SITE=$PWD/depends/x86_64-w64-mingw32/share/config.site ./configure --prefix=/
     make
+
+## Building for 32-bit Windows
+
+To build executables for Windows 32-bit, install the following dependencies:
+
+    sudo apt-get install g++-mingw-w64-i686 mingw-w64-i686-dev 
+
+Then build using:
+
+    cd depends
+    make HOST=i686-w64-mingw32 -j4
+    cd ..
+    ./autogen.sh # not required when building from tarball
+    CONFIG_SITE=$PWD/depends/i686-w64-mingw32/share/config.site ./configure --prefix=/
+    make
+
+Installation
+-------------
+
+After building using the Windows subsystem it can be useful to copy the compiled
+executables to a directory on the windows drive in the same directory structure
+as they appear in the release `.zip` archive. This can be done in the following
+way. This will install to `c:\workspace\bitcoin`, for example:
+
+    make install DESTDIR=/mnt/c/workspace/bitcoin
 


### PR DESCRIPTION
There is a problem with the current windows build instructions that they do not work on a cloned repo (they only work on a tarball). Specifically the command 'autogen.sh' was missing from the procedure causing a build failure. 

Further there is now the option of building on windows using the WSL (Windows Subsystem for Linux). 

These changes originate from core and have been modified to suit BU.

I have tested these build instructions on Ubuntu 16.04LTS and Windows 10. 