### PR TITLE
[port] PR #8065 Addrman offline attempts

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -196,6 +196,9 @@ void CAddrMan::MakeTried(CAddrInfo& info, int nId)
 void CAddrMan::Good_(const CService& addr, int64_t nTime)
 {
     int nId;
+
+    nLastGood = nTime;
+
     CAddrInfo* pinfo = Find(addr, &nId);
 
     // if not found, bail out
@@ -310,7 +313,7 @@ bool CAddrMan::Add_(const CAddress& addr, const CNetAddr& source, int64_t nTimeP
     return fNew;
 }
 
-void CAddrMan::Attempt_(const CService& addr, int64_t nTime)
+void CAddrMan::Attempt_(const CService& addr, bool fCountFailure, int64_t nTime)
 {
     CAddrInfo* pinfo = Find(addr);
 
@@ -326,7 +329,10 @@ void CAddrMan::Attempt_(const CService& addr, int64_t nTime)
 
     // update info
     info.nLastTry = nTime;
-    info.nAttempts++;
+    if (fCountFailure && info.nLastCountAttempt < nLastGood) {
+        info.nLastCountAttempt = nTime;
+        info.nAttempts++;
+    }
 }
 
 CAddrInfo CAddrMan::Select_(bool newOnly)

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -28,6 +28,9 @@ public:
     //! last try whatsoever by us (memory only)
     int64_t nLastTry;
 
+    //! last counted attempt (memory only)
+    int64_t nLastCountAttempt;
+
 private:
     //! where knowledge about this address first came from
     CNetAddr source;
@@ -65,6 +68,7 @@ public:
     {
         nLastSuccess = 0;
         nLastTry = 0;
+        nLastCountAttempt = 0;
         nAttempts = 0;
         nRefCount = 0;
         fInTried = false;
@@ -199,6 +203,9 @@ private:
     //! list of "new" buckets
     int vvNew[ADDRMAN_NEW_BUCKET_COUNT][ADDRMAN_BUCKET_SIZE];
 
+    //! last time Good was called (memory only)
+    int64_t nLastGood;
+
 protected:
     //! secret key to randomize bucket select with
     uint256 nKey;
@@ -229,7 +236,7 @@ protected:
     bool Add_(const CAddress &addr, const CNetAddr& source, int64_t nTimePenalty);
 
     //! Mark an entry as attempted to connect.
-    void Attempt_(const CService &addr, int64_t nTime);
+    void Attempt_(const CService &addr, bool fCountFailure, int64_t nTime);
 
     //! Select an address to connect to, if newOnly is set to true, only the new table is selected from.
     CAddrInfo Select_(bool newOnly);
@@ -449,6 +456,7 @@ public:
         nIdCount = 0;
         nTried = 0;
         nNew = 0;
+        nLastGood = 1; //Initially at 1 so that "never" is strictly worse.
     }
 
     CAddrMan()
@@ -523,12 +531,12 @@ public:
     }
 
     //! Mark an entry as connection attempted to.
-    void Attempt(const CService &addr, int64_t nTime = GetAdjustedTime())
+    void Attempt(const CService &addr, bool fCountFailure, int64_t nTime = GetAdjustedTime())
     {
         {
             LOCK(cs);
             Check();
-            Attempt_(addr, nTime);
+            Attempt_(addr, fCountFailure, nTime);
             Check();
         }
     }

--- a/src/net.h
+++ b/src/net.h
@@ -98,7 +98,7 @@ CNode* FindNode(const std::string& addrName);
 CNode* FindNode(const CService& ip);
 int DisconnectSubNetNodes(const CSubNet& subNet);
 CNode* ConnectNode(CAddress addrConnect, const char* pszDest = NULL);
-bool OpenNetworkConnection(const CAddress& addrConnect, CSemaphoreGrant* grantOutbound = NULL, const char* strDest = NULL, bool fOneShot = false);
+bool OpenNetworkConnection(const CAddress& addrConnect, bool fCountFailure, CSemaphoreGrant *grantOutbound = NULL, const char *strDest = NULL, bool fOneShot = false);
 void MapPort(bool fUseUPnP);
 unsigned short GetListenPort();
 bool BindListenPort(const CService& bindAddr, std::string& strError, bool fWhitelisted = false);

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -204,7 +204,7 @@ UniValue addnode(const UniValue& params, bool fHelp)
         CAddress addr;
         //NOTE: Using RPC "addnode <node> onetry" ignores both the "maxconnections"
         //      and "maxoutconnections" limits and can cause both to be exceeded.
-        OpenNetworkConnection(addr, NULL, strNode.c_str());
+        OpenNetworkConnection(addr, false, NULL, strNode.c_str());
         return NullUniValue;
     }
 

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -990,7 +990,7 @@ void ConnectToThinBlockNodes()
             // NOTE: Because the only nodes we are connecting to here are the ones the user put in their
             //      bitcoin.conf/commandline args as "-connect-thinblock", we don't use the semaphore to limit outbound
             //      connections
-            OpenNetworkConnection(addr, NULL, strAddr.c_str());
+            OpenNetworkConnection(addr, false, NULL, strAddr.c_str());
             MilliSleep(500);
         }
     }


### PR DESCRIPTION
This is a port of Core #8065. 

Form original commit message:

> If a node is offline failed outbound connection attempts will crank up
the addrman counter and effectively blow away our state.

this is a prerequisite to port and addrman bug fix (#7696) and the feeler connections implementation (#8282) to defend against from the attack to bitcoin net described in "Eclipse Attacks on Bitcoin’s Peer-to-Peer Network", Ethan Heilman, Alison Kendler, Aviv Zohar, Sharon Goldberg. ePrint Archive Report
2015/263. March 2015.

`91b33b0` Adapt OpenNetworkConnection to the new semantic (Andrea Suisani)
`77a5dbc` Merge #8065: Addrman offline attempts (Wladimir J. van der Laan)