### PR TITLE
Activate SENDHEADERS functionality

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -188,7 +188,7 @@ testScripts = [ RpcTest(t) for t in [
     Disabled('p2p-fullblocktest', "TODO"),
     'blockchain',
     'disablewallet',
-    Disabled('sendheaders', "BU requests INVs not headers -- in the future we may add support for headers, at least by treating them like INVs)"),
+    'sendheaders',
     'keypool',
     Disabled('prioritise_transaction', "TODO"),
     Disabled('invalidblockrequest', "TODO"),

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -283,8 +283,10 @@ class SendHeadersTest(BitcoinTestFramework):
     def setup_network(self):
         # TODO: currently mininode does not have support for thinblocks so we can not sync a get_xthin request and must
         #       therefore have thinblocks turned off during testing.
+        # Currently there are mininode syncronization issues when Parallel Validation is turned on
+        # and therefore have -parallel=0 when running these tests.
         self.nodes = []
-        self.nodes = start_nodes(2, self.options.tmpdir, [["-debug", "-logtimemicros=1", "-use-thinblocks=0"]]*2)
+        self.nodes = start_nodes(2, self.options.tmpdir, [["-debug", "-logtimemicros=1", "-parallel=0", "-use-thinblocks=0"]]*2)
         connect_nodes(self.nodes[0], 1)
 
     # mine count blocks and return the new tip

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -199,7 +199,7 @@ class BaseNode(NodeConnCB):
 
             time.sleep(self.sleep_time)
             timeout -= self.sleep_time
-        raise AssertionError("Sync failed to complete")
+        raise AssertionError("Sync getdata failed to complete")
 
     def sync_with_ping(self, timeout=60):
         self.send_message(msg_ping(nonce=self.ping_counter))
@@ -246,8 +246,10 @@ class SendHeadersTest(BitcoinTestFramework):
         initialize_chain_clean(self.options.tmpdir, 2)
 
     def setup_network(self):
+        # TODO: currently mininode does not have support for thinblocks so we can not sync a get_xthin request and must
+        #       therefore have thinblocks turned off during testing.
         self.nodes = []
-        self.nodes = start_nodes(2, self.options.tmpdir, [["-debug", "-logtimemicros=1", "-parallel=0", "-use-thinblocks=0"]]*2)
+        self.nodes = start_nodes(2, self.options.tmpdir, [["-debug", "-logtimemicros=1", "-use-thinblocks=0"]]*2)
         connect_nodes(self.nodes[0], 1)
 
     # mine count blocks and return the new tip

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -63,6 +63,21 @@ e. Announce 16 more headers that build on that fork.
    Expect: getdata request for 14 more blocks.
 f. Announce 1 more header that builds on that fork.
    Expect: no response.
+
+Part 5: Test handling of headers that don't connect.
+a. Repeat 10 times:
+   1. Announce a header that doesn't connect.
+      Expect: getheaders message
+   2. Send headers chain.
+      Expect: getdata for the missing blocks, tip update.
+b. Then send 9 more headers that don't connect.
+   Expect: getheaders message each time.
+c. Announce a header that does connect.
+   Expect: no response.
+d. Announce 49 headers that don't connect.
+   Expect: getheaders message each time.
+e. Announce one more that doesn't connect.
+   Expect: disconnect.
 '''
 
 class BaseNode(NodeConnCB):
@@ -77,6 +92,8 @@ class BaseNode(NodeConnCB):
         self.last_getdata = []
         self.sleep_time = 0.05
         self.block_announced = False
+        self.last_getheaders = None
+        self.disconnected = False
 
     def clear_last_announcement(self):
         with mininode_lock:
@@ -126,6 +143,12 @@ class BaseNode(NodeConnCB):
 
     def on_pong(self, conn, message):
         self.last_pong = message
+
+    def on_getheaders(self, conn, message):
+        self.last_getheaders = message
+
+    def on_close(self, conn):
+        self.disconnected = True
 
     # Test whether the last announcement we received had the
     # right header or the right inv
@@ -213,11 +236,21 @@ class BaseNode(NodeConnCB):
         self.sync(test_function, timeout)
         return
 
+    def wait_for_getheaders(self, timeout=60):
+        test_function = lambda: self.last_getheaders != None
+        self.sync(test_function, timeout)
+        return
+
     def wait_for_getdata(self, hash_list, timeout=60):
         if hash_list == []:
             return
 
         self.sync_getdata(hash_list, timeout)
+        return
+
+    def wait_for_disconnect(self, timeout=60):
+        test_function = lambda: self.disconnected
+        self.sync(test_function, timeout)
         return
 
     def send_header_for_blocks(self, new_blocks):
@@ -548,6 +581,78 @@ class SendHeadersTest(BitcoinTestFramework):
             assert_equal(test_node.last_getdata, [])
 
         print("Part 4: success!")
+
+        # Now deliver all those blocks we announced.
+        [ test_node.send_message(msg_block(x)) for x in blocks ]
+
+        print("Part 5: Testing handling of unconnecting headers")
+        # First we test that receipt of an unconnecting header doesn't prevent
+        # chain sync.
+        for i in range(10):
+            test_node.last_getdata = None
+            blocks = []
+            # Create two more blocks.
+            for j in range(2):
+                blocks.append(create_block(tip, create_coinbase(height), block_time))
+                blocks[-1].solve()
+                tip = blocks[-1].sha256
+                block_time += 1
+                height += 1
+            # Send the header of the second block -> this won't connect.
+            with mininode_lock:
+                test_node.last_getheaders = None
+            test_node.send_header_for_blocks([blocks[1]])
+            test_node.wait_for_getheaders(timeout=1)
+            test_node.send_header_for_blocks(blocks)
+            test_node.wait_for_getdata([x.sha256 for x in blocks])
+            [ test_node.send_message(msg_block(x)) for x in blocks ]
+            test_node.sync_with_ping()
+            assert_equal(int(self.nodes[0].getbestblockhash(), 16), blocks[1].sha256)
+
+        blocks = []
+        # Now we test that if we repeatedly don't send connecting headers, we
+        # don't go into an infinite loop trying to get them to connect.
+        MAX_UNCONNECTING_HEADERS = 10
+        for j in range(MAX_UNCONNECTING_HEADERS+1):
+            blocks.append(create_block(tip, create_coinbase(height), block_time))
+            blocks[-1].solve()
+            tip = blocks[-1].sha256
+            block_time += 1
+            height += 1
+
+        for i in range(1, MAX_UNCONNECTING_HEADERS):
+            # Send a header that doesn't connect, check that we get a getheaders.
+            with mininode_lock:
+                test_node.last_getheaders = None
+            test_node.send_header_for_blocks([blocks[i]])
+            test_node.wait_for_getheaders(timeout=1)
+
+        # Next header will connect, should re-set our count:
+        test_node.send_header_for_blocks([blocks[0]])
+
+        # Remove the first two entries (blocks[1] would connect):
+        blocks = blocks[2:]
+
+        # Now try to see how many unconnecting headers we can send
+        # before we get disconnected.  Should be 5*MAX_UNCONNECTING_HEADERS
+        for i in range(5*MAX_UNCONNECTING_HEADERS - 1):
+            # Send a header that doesn't connect, check that we get a getheaders.
+            with mininode_lock:
+                test_node.last_getheaders = None
+            test_node.send_header_for_blocks([blocks[i%len(blocks)]])
+            test_node.wait_for_getheaders(timeout=1)
+
+        # Eventually this stops working.
+        with mininode_lock:
+            self.last_getheaders = None
+        test_node.send_header_for_blocks([blocks[-1]])
+
+        # Should get disconnected
+        test_node.wait_for_disconnect()
+        with mininode_lock:
+            self.last_getheaders = True
+
+        print("Part 5: success!")
 
         # Finally, check that the inv node never received a getdata request,
         # throughout the test

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -69,19 +69,19 @@ class BaseNode(NodeConnCB):
     def __init__(self):
         NodeConnCB.__init__(self)
         self.connection = None
-        self.last_inv = None
+        self.last_inv = []
         self.last_headers = None
         self.last_block = None
         self.ping_counter = 1
         self.last_pong = msg_pong(0)
-        self.last_getdata = None
+        self.last_getdata = []
         self.sleep_time = 0.05
         self.block_announced = False
 
     def clear_last_announcement(self):
         with mininode_lock:
             self.block_announced = False
-            self.last_inv = None
+            self.last_inv = []
             self.last_headers = None
 
     def add_connection(self, conn):
@@ -110,7 +110,7 @@ class BaseNode(NodeConnCB):
         self.connection.send_message(message)
 
     def on_inv(self, conn, message):
-        self.last_inv = message
+        self.last_inv.append(message)
         self.block_announced = True
 
     def on_headers(self, conn, message):
@@ -122,7 +122,7 @@ class BaseNode(NodeConnCB):
         self.last_block.calc_sha256()
 
     def on_getdata(self, conn, message):
-        self.last_getdata = message
+        self.last_getdata.append(message)
 
     def on_pong(self, conn, message):
         self.last_pong = message
@@ -130,31 +130,46 @@ class BaseNode(NodeConnCB):
     # Test whether the last announcement we received had the
     # right header or the right inv
     # inv and headers should be lists of block hashes
-    def check_last_announcement(self, headers=None, inv=None):
+    def check_last_announcement(self, headers=None, inv=[]):
         expect_headers = headers if headers != None else []
-        expect_inv = inv if inv != None else []
+        expect_inv = inv if inv != [] else []
         test_function = lambda: self.block_announced
         self.sync(test_function)
-        with mininode_lock:
-            self.block_announced = False
+        timeout = 5
+        while timeout > 0:
+            with mininode_lock:
+                self.block_announced = False
 
-            success = True
-            compare_inv = []
-            if self.last_inv != None:
-                compare_inv = [x.hash for x in self.last_inv.inv]
-            if compare_inv != expect_inv:
-                success = False
+                success = True
+                compare_inv = []
+                if self.last_inv != []:
+                    all_inv =  [x.inv for x in self.last_inv]
+                    for x in all_inv:
+                        test_inv = [y.hash for y in x]
+                        compare_inv = compare_inv + test_inv
 
-            hash_headers = []
-            if self.last_headers != None:
-                # treat headers as a list of block hashes
-                hash_headers = [ x.sha256 for x in self.last_headers.headers ]
-            if hash_headers != expect_headers:
-                success = False
+                #Check whether the inventory received is within the list of block hashes that were
+                #mined (During a large reorg the inv's will be fewer than the actual hashes mined).
+                s = set(compare_inv)
+                expect_inv =  [x for x in expect_inv if x in s]
+                if compare_inv != expect_inv:
+                    success = False
 
-            self.last_inv = None
-            self.last_headers = None
-        return success
+                hash_headers = []
+                if self.last_headers != None:
+                    # treat headers as a list of block hashes
+                    hash_headers = [ x.sha256 for x in self.last_headers.headers ]
+                if hash_headers != expect_headers:
+                    success = False
+
+                self.last_inv = []
+                self.last_headers = None
+
+            if success == True:
+                return success
+
+            time.sleep(self.sleep_time)
+            timeout -= self.sleep_time
 
     # Syncing helpers
     def sync(self, test_function, timeout=60):
@@ -162,10 +177,30 @@ class BaseNode(NodeConnCB):
             with mininode_lock:
                 if test_function():
                     return
+
             time.sleep(self.sleep_time)
             timeout -= self.sleep_time
         raise AssertionError("Sync failed to complete")
         
+    # The request manager does not deal with vectors of GETDATA requests but rather one GETDATA per
+    # hash, therefore we need to be able to sync_getdata one message at a time rather than in batches.
+    def sync_getdata(self, hash_list, timeout=60):
+        while timeout > 0:
+            with mininode_lock:
+                #Check whether any getdata responses are in the hash list and
+                #if so remove them from both lists.
+                for x in self.last_getdata:
+                    for y in hash_list:
+                        if (str(x.inv).find(hex(y)[2:]) > 0):
+                            self.last_getdata.remove(x)
+                            hash_list.remove(y)
+                if hash_list == []:
+                    return
+
+            time.sleep(self.sleep_time)
+            timeout -= self.sleep_time
+        raise AssertionError("Sync failed to complete")
+
     def sync_with_ping(self, timeout=60):
         self.send_message(msg_ping(nonce=self.ping_counter))
         test_function = lambda: self.last_pong.nonce == self.ping_counter
@@ -182,8 +217,7 @@ class BaseNode(NodeConnCB):
         if hash_list == []:
             return
 
-        test_function = lambda: self.last_getdata != None and [x.hash for x in self.last_getdata.inv] == hash_list
-        self.sync(test_function, timeout)
+        self.sync_getdata(hash_list, timeout)
         return
 
     def send_header_for_blocks(self, new_blocks):
@@ -213,7 +247,7 @@ class SendHeadersTest(BitcoinTestFramework):
 
     def setup_network(self):
         self.nodes = []
-        self.nodes = start_nodes(2, self.options.tmpdir, [["-debug", "-logtimemicros=1"]]*2)
+        self.nodes = start_nodes(2, self.options.tmpdir, [["-debug", "-logtimemicros=1", "-parallel=0", "-use-thinblocks=0"]]*2)
         connect_nodes(self.nodes[0], 1)
 
     # mine count blocks and return the new tip
@@ -320,7 +354,7 @@ class SendHeadersTest(BitcoinTestFramework):
             # with block header, even though the blocks are never requested
             for j in range(2):
                 blocks = []
-                for b in range(i+1):
+                for b in range(1):
                     blocks.append(create_block(tip, create_coinbase(height), block_time))
                     blocks[-1].solve()
                     tip = blocks[-1].sha256
@@ -335,6 +369,7 @@ class SendHeadersTest(BitcoinTestFramework):
                     inv_node.send_block_inv(tip)
                     # Should have received a getheaders as well!
                     test_node.send_header_for_blocks(blocks)
+                    test_node.sync_with_ping()
                     test_node.wait_for_getdata([x.sha256 for x in blocks[0:-1]], timeout=5)
                     [ inv_node.send_block_inv(x.sha256) for x in blocks[0:-1] ]
                     inv_node.sync_with_ping()
@@ -351,7 +386,7 @@ class SendHeadersTest(BitcoinTestFramework):
                 inv_node.sync_with_ping()
                 # This block should not be announced to the inv node (since it also
                 # broadcast it)
-                assert_equal(inv_node.last_inv, None)
+                assert_equal(inv_node.last_inv, [])
                 assert_equal(inv_node.last_headers, None)
                 tip = self.mine_blocks(1)
                 assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
@@ -368,17 +403,17 @@ class SendHeadersTest(BitcoinTestFramework):
         for j in range(2):
             # First try mining a reorg that can propagate with header announcement
             new_block_hashes = self.mine_reorg(length=7)
-            tip = new_block_hashes[-1]
-            assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
+            assert_equal(inv_node.check_last_announcement(inv=new_block_hashes), True)
             assert_equal(test_node.check_last_announcement(headers=new_block_hashes), True)
 
             block_time += 8 
 
-            # Mine a too-large reorg, which should be announced with a single inv
+            # Mine a too-large reorg - we will receive only the first 8 inv's for the 9 block hashes mined.
+            # which represents the MAX_BLOCKS_TO_ANNOUNCE=8
             new_block_hashes = self.mine_reorg(length=8)
             tip = new_block_hashes[-1]
-            assert_equal(inv_node.check_last_announcement(inv=[tip]), True)
-            assert_equal(test_node.check_last_announcement(inv=[tip]), True)
+            assert_equal(inv_node.check_last_announcement(inv=new_block_hashes), True)
+            assert_equal(test_node.check_last_announcement(inv=new_block_hashes), True)
 
             block_time += 9
 
@@ -442,12 +477,12 @@ class SendHeadersTest(BitcoinTestFramework):
             inv_node.send_message(msg_block(blocks[-1]))
 
         inv_node.sync_with_ping() # Make sure blocks are processed
-        test_node.last_getdata = None
+        test_node.last_getdata = []
         test_node.send_header_for_blocks(blocks)
         test_node.sync_with_ping()
         # should not have received any getdata messages
         with mininode_lock:
-            assert_equal(test_node.last_getdata, None)
+            assert_equal(test_node.last_getdata, [])
 
         # This time, direct fetch should work
         blocks = []
@@ -460,7 +495,7 @@ class SendHeadersTest(BitcoinTestFramework):
 
         test_node.send_header_for_blocks(blocks)
         test_node.sync_with_ping()
-        test_node.wait_for_getdata([x.sha256 for x in blocks], timeout=test_node.sleep_time)
+        test_node.wait_for_getdata([x.sha256 for x in blocks], timeout=5)
 
         [ test_node.send_message(msg_block(x)) for x in blocks ]
 
@@ -481,36 +516,40 @@ class SendHeadersTest(BitcoinTestFramework):
 
         # Announcing one block on fork should not trigger direct fetch
         # (less work than tip)
-        test_node.last_getdata = None
+        test_node.last_getdata = []
         test_node.send_header_for_blocks(blocks[0:1])
         test_node.sync_with_ping()
         with mininode_lock:
-            assert_equal(test_node.last_getdata, None)
+            assert_equal(test_node.last_getdata, [])
 
         # Announcing one more block on fork should trigger direct fetch for
         # both blocks (same work as tip)
         test_node.send_header_for_blocks(blocks[1:2])
         test_node.sync_with_ping()
-        test_node.wait_for_getdata([x.sha256 for x in blocks[0:2]], timeout=test_node.sleep_time)
+        test_node.wait_for_getdata([x.sha256 for x in blocks[0:2]], timeout=5)
 
         # Announcing 16 more headers should trigger direct fetch for 14 more
         # blocks
+        self.nodes[0].set("net.maxBlocksInTransitPerPeer=16")
+        self.nodes[1].set("net.maxBlocksInTransitPerPeer=16")
         test_node.send_header_for_blocks(blocks[2:18])
         test_node.sync_with_ping()
-        test_node.wait_for_getdata([x.sha256 for x in blocks[2:16]], timeout=test_node.sleep_time)
+        test_node.wait_for_getdata([x.sha256 for x in blocks[2:16]], timeout=5)
+        assert_equal(test_node.last_getdata, [])
 
-        # Announcing 1 more header should not trigger any response
-        test_node.last_getdata = None
+        # Announcing 1 more header should not trigger any response because we
+        # already have the maximumum blocks in flight
+        test_node.last_getdata = []
         test_node.send_header_for_blocks(blocks[18:19])
         test_node.sync_with_ping()
         with mininode_lock:
-            assert_equal(test_node.last_getdata, None)
+            assert_equal(test_node.last_getdata, [])
 
         print("Part 4: success!")
 
         # Finally, check that the inv node never received a getdata request,
         # throughout the test
-        assert_equal(inv_node.last_getdata, None)
+        assert_equal(inv_node.last_getdata, [])
 
 if __name__ == '__main__':
     SendHeadersTest().main()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5034,7 +5034,19 @@ static bool AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
                    pcoinsTip->HaveCoins(inv.hash);
         }
     case MSG_BLOCK:
-        return mapBlockIndex.count(inv.hash);
+    case MSG_XTHINBLOCK:
+    case MSG_THINBLOCK:
+        {
+            // The Request Manager functionality requires that we return true only when we actually have received
+            // the block and not when we have received the header only.  Otherwise the request manager may not
+            // be able to update its block source in order to make re-requests.
+            BlockMap::iterator mi = mapBlockIndex.find(inv.hash);
+            if (mi == mapBlockIndex.end())
+                return false;
+            if (!(mi->second->nStatus & BLOCK_HAVE_DATA))
+                return false;
+            return true;
+        }
     }
     // Don't know what it is, just say we already got one
     return true;
@@ -5392,9 +5404,7 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
             // non-NODE NETWORK peers can announce blocks (such as pruning
             // nodes)
 
-            // BUIP010 Extreme Thinblocks: We only do inv/getdata for xthinblocks and so we must have headersfirst turned off
-            if (!IsThinBlocksEnabled())
-                pfrom->PushMessage(NetMsgType::SENDHEADERS);
+            pfrom->PushMessage(NetMsgType::SENDHEADERS);
         }
 
         // BU expedited procecessing requires the exchange of the listening port id but we have to send it in a separate version
@@ -5867,68 +5877,88 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
         if (pindexLast)
             UpdateBlockAvailability(pfrom->GetId(), pindexLast->GetBlockHash());
 
-        if (nCount == MAX_HEADERS_RESULTS && pindexLast) {
+        if (nCount == MAX_HEADERS_RESULTS && pindexLast)
+        {
             // Headers message had its maximum size; the peer may have more headers.
             // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
             // from there instead.
-            LogPrint("net", "more getheaders (%d) to end to peer=%d (startheight:%d)\n", pindexLast->nHeight, pfrom->id, pfrom->nStartingHeight);
+            LogPrint("net", "more getheaders (%d) to end to peer=%d (startheight:%d)\n",
+                    pindexLast->nHeight, pfrom->id,
+                    pfrom->nStartingHeight);
             pfrom->PushMessage(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexLast), uint256());
         }
 
         bool fCanDirectFetch = CanDirectFetch(chainparams.GetConsensus());
         CNodeState *nodestate = State(pfrom->GetId());
         nodestate->fFirstHeadersReceived = true;
+
+        // update the syncd status.  This should come before we make calls to requester.AskFor().
+        IsChainNearlySyncdInit();
+        IsInitialBlockDownloadInit();
+
         // If this set of headers is valid and ends in a block with at least as
         // much work as our tip, download as much as possible.
-        if (fCanDirectFetch && pindexLast && pindexLast->IsValid(BLOCK_VALID_TREE) && chainActive.Tip()->nChainWork <= pindexLast->nChainWork) {
+        if (fCanDirectFetch && pindexLast && pindexLast->IsValid(BLOCK_VALID_TREE) &&
+            chainActive.Tip()->nChainWork <= pindexLast->nChainWork)
+        {
+            // Set tweak value.  Mostly used in testing direct fetch.
+            if (maxBlocksInTransitPerPeer.value != 0)
+                MAX_BLOCKS_IN_TRANSIT_PER_PEER = maxBlocksInTransitPerPeer.value;
+
             std::vector<CBlockIndex *> vToFetch;
             CBlockIndex *pindexWalk = pindexLast;
-            // Calculate all the blocks we'd need to switch to pindexLast, up to a limit.
-            while (pindexWalk && !chainActive.Contains(pindexWalk) && vToFetch.size() <= MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
-                if (!(pindexWalk->nStatus & BLOCK_HAVE_DATA) &&
-                        !mapBlocksInFlight.count(pindexWalk->GetBlockHash())) {
-                    // We don't have this block, and it's not yet in flight.
-                    vToFetch.push_back(pindexWalk);
-                }
+            // Calculate all the blocks we'd need to switch to pindexLast.
+            while (pindexWalk && !chainActive.Contains(pindexWalk))
+            {
+                vToFetch.push_back(pindexWalk);
                 pindexWalk = pindexWalk->pprev;
             }
+
             // If pindexWalk still isn't on our main chain, we're looking at a
             // very large reorg at a time we think we're close to caught up to
             // the main chain -- this shouldn't really happen.  Bail out on the
             // direct fetch and rely on parallel download instead.
-            if (pindexWalk && !chainActive.Contains(pindexWalk)) {
+            if (pindexWalk && !chainActive.Contains(pindexWalk))
+            {
                 LogPrint("net", "Large reorg, won't direct fetch to %s (%d)\n",
                         pindexLast->GetBlockHash().ToString(),
                         pindexLast->nHeight);
-            //} else {   BU: We don't support headers first for XThinblocks.
-            } else if (!IsThinBlocksEnabled()) {
-                std::vector<CInv> vGetData;
+            }
+            else
+            {
                 // Download as much as possible, from earliest to latest.
-                BOOST_REVERSE_FOREACH(CBlockIndex *pindex, vToFetch) {
-                    if (nodestate->nBlocksInFlight >= (int)MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
-                        // Can't download any more from this peer
+                unsigned int nAskFor = 0;
+                BOOST_REVERSE_FOREACH(CBlockIndex *pindex, vToFetch)
+                {
+                    // pindex must be nonnull because we populated vToFetch a few lines above
+                    CInv inv(MSG_BLOCK, pindex->GetBlockHash());
+                    if (!AlreadyHave(inv))
+                    {
+		        requester.AskFor(inv, pfrom);
+                        LogPrint("req", "AskFor block via headers direct fetch %s (%d) peer=%d\n",
+                                pindex->GetBlockHash().ToString(),
+                                pindex->nHeight, pfrom->id);
+                        nAskFor++;
+                    }
+                    // We don't care about how many blocks are in flight.  We just need to make sure we don't
+                    // ask for more than the maximum allowed per peer because the request manager will take care
+                    // of any duplicate requests.
+                    if (nAskFor >= MAX_BLOCKS_IN_TRANSIT_PER_PEER)
+                    {
+                        LogPrint("net", "Large reorg, could only direct fetch %d blocks\n", nAskFor);
                         break;
                     }
-                    // pindex must be nonnull because we populated vToFetch a few lines above
-                    vGetData.push_back(CInv(MSG_BLOCK, pindex->GetBlockHash()));
-                    MarkBlockAsInFlight(pfrom->GetId(), pindex->GetBlockHash(), chainparams.GetConsensus(), pindex);
-                    LogPrint("net", "Requesting block %s from  peer=%d\n",
-                            pindex->GetBlockHash().ToString(), pfrom->id);
                 }
-                if (vGetData.size() > 1) {
+                if (nAskFor > 1)
+                {
                     LogPrint("net", "Downloading blocks toward %s (%d) via headers direct fetch\n",
-                            pindexLast->GetBlockHash().ToString(), pindexLast->nHeight);
-                }
-                if (vGetData.size() > 0) {
-                    pfrom->PushMessage(NetMsgType::GETDATA, vGetData);
+                            pindexLast->GetBlockHash().ToString(),
+                            pindexLast->nHeight);
                 }
             }
         }
 
         CheckBlockIndex(chainparams.GetConsensus());
-
-        IsChainNearlySyncdInit(); // BUIP010 XTHIN
-        IsInitialBlockDownloadInit();
     }
 
     // BUIP010 Xtreme Thinblocks: begin section
@@ -6981,69 +7011,21 @@ bool SendMessages(CNode* pto)
         // Message: getdata (blocks)
         //
         std::vector<CInv> vGetData;
-        if (!pto->fDisconnect && !pto->fClient && (fFetch || !IsInitialBlockDownload()) && state.nBlocksInFlight < (int)MAX_BLOCKS_IN_TRANSIT_PER_PEER) {
-            std::vector<CBlockIndex*> vToDownload;
+        if (!pto->fDisconnect && !pto->fClient && (fFetch || !IsInitialBlockDownload()) &&
+            state.nBlocksInFlight < (int)MAX_BLOCKS_IN_TRANSIT_PER_PEER)
+        {
+            vector<CBlockIndex*> vToDownload;
             NodeId staller = -1;
             FindNextBlocksToDownload(pto->GetId(), MAX_BLOCKS_IN_TRANSIT_PER_PEER - state.nBlocksInFlight, vToDownload, staller);
-            BOOST_FOREACH(CBlockIndex *pindex, vToDownload) {
-                // BUIP010 Xtreme Thinblocks: begin section
-                if (IsThinBlocksEnabled() && IsChainNearlySyncd()) {
-                    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-                    CBloomFilter filterMemPool;
-                    if (HaveConnectThinblockNodes() || (HaveThinblockNodes() && thindata.CheckThinblockTimer(pindex->GetBlockHash()))) {
-                        // Must download a block from a ThinBlock peer
-                        if (pto->mapThinBlocksInFlight.size() < 1 && CanThinBlockBeDownloaded(pto)) { // We can only send one thinblock per peer at a time
-                            pto->mapThinBlocksInFlight[pindex->GetBlockHash()] = GetTime();
-                            std::vector<uint256> vOrphanHashes;
-                            {
-                                LOCK(cs_orphancache);
-                                for (std::map<uint256, COrphanTx>::iterator mi = mapOrphanTransactions.begin(); mi != mapOrphanTransactions.end(); ++mi)
-                                    vOrphanHashes.push_back((*mi).first);
-                            }
-                            BuildSeededBloomFilter(filterMemPool, vOrphanHashes, pindex->GetBlockHash());
-                            ss << CInv(MSG_XTHINBLOCK, pindex->GetBlockHash());
-                            ss << filterMemPool;
-                            pto->PushMessage(NetMsgType::GET_XTHIN, ss);
-                            MarkBlockAsInFlight(pto->GetId(), pindex->GetBlockHash(), consensusParams, pindex);
-                            LogPrint("thin", "Requesting Thinblock %s (%d) from peer %s (%d) pingtime(ms) %d\n", pindex->GetBlockHash().ToString(),
-                                     pindex->nHeight, pto->addrName.c_str(), pto->id,  pto->nPingUsecTime/1000);
-                        }
-                    }
-                    else {
-                        // Try to download a thinblock if possible otherwise just download a regular block
-                        if (pto->mapThinBlocksInFlight.size() < 1 && CanThinBlockBeDownloaded(pto)) { // We can only send one thinblock per peer at a time
-                            pto->mapThinBlocksInFlight[pindex->GetBlockHash()] = GetTime();
-                            std::vector<uint256> vOrphanHashes;
-                            {
-                                LOCK(cs_orphancache);
-                                for (std::map<uint256, COrphanTx>::iterator mi = mapOrphanTransactions.begin(); mi != mapOrphanTransactions.end(); ++mi)
-                                    vOrphanHashes.push_back((*mi).first);
-                            }
-                            BuildSeededBloomFilter(filterMemPool, vOrphanHashes, pindex->GetBlockHash());
-                            ss << CInv(MSG_XTHINBLOCK, pindex->GetBlockHash());
-                            ss << filterMemPool;
-                            pto->PushMessage(NetMsgType::GET_XTHIN, ss);
-                            LogPrint("thin", "Requesting Thinblock %s (%d) from peer %s (%d) pingtime(ms) %d\n", pindex->GetBlockHash().ToString(),
-                                     pindex->nHeight, pto->addrName.c_str(), pto->id, pto->nPingUsecTime/1000);
-                        }
-                        else {
-                            vGetData.push_back(CInv(MSG_BLOCK, pindex->GetBlockHash()));
-                            LogPrint("net", "Requesting block %s (%d) from peer %s (%d)\n", pindex->GetBlockHash().ToString(),
-                                     pindex->nHeight, pto->addrName.c_str(), pto->id);
-                        }
-                        MarkBlockAsInFlight(pto->GetId(), pindex->GetBlockHash(), consensusParams, pindex);
-                    }
-                }
-                else {
-                    //vGetData.push_back(CInv(MSG_BLOCK, pindex->GetBlockHash()));
-                    //MarkBlockAsInFlight(pto->GetId(), pindex->GetBlockHash(), consensusParams, pindex);
-                    //LogPrint("net", "Requesting block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
-                    //                 pindex->nHeight, pto->id);
-		    requester.AskFor(CInv(MSG_BLOCK, pindex->GetBlockHash()), pto);
+            BOOST_FOREACH(CBlockIndex *pindex, vToDownload)
+            {
+                CInv inv(MSG_BLOCK, pindex->GetBlockHash());
+                if (!AlreadyHave(inv))
+                {
+                    requester.AskFor(inv, pto);
                     LogPrint("req", "AskFor block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
-                                    pindex->nHeight, pto->id);
+                            pindex->nHeight, pto->id);
                 }
-                // BUIP010 Xtreme Thinblocks: end section
             }
             if (state.nBlocksInFlight == 0 && staller != -1) {
                 if (State(staller)->nStallingSince == 0) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7028,7 +7028,7 @@ bool SendMessages(CNode* pto)
         if (!pto->fDisconnect && !pto->fClient && (fFetch || !IsInitialBlockDownload()) &&
             state.nBlocksInFlight < (int)MAX_BLOCKS_IN_TRANSIT_PER_PEER)
         {
-            vector<CBlockIndex*> vToDownload;
+            std::vector<CBlockIndex*> vToDownload;
             NodeId staller = -1;
             FindNextBlocksToDownload(pto->GetId(), MAX_BLOCKS_IN_TRANSIT_PER_PEER - state.nBlocksInFlight, vToDownload, staller);
             BOOST_FOREACH(CBlockIndex *pindex, vToDownload)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5862,6 +5862,7 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
         // This prevents and attacker from keeping us from doing direct fetch by giving us out
         // of order headers.
         uint256 hashLastBlock;
+        hashLastBlock.SetNull();
         for (const CBlockHeader &header : headers)
         {
             if (!hashLastBlock.IsNull() && header.hashPrevBlock != hashLastBlock)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5930,38 +5930,36 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
                 pindexWalk = pindexWalk->pprev;
             }
 
+            // Download as much as possible, from earliest to latest.
+            unsigned int nAskFor = 0;
+            BOOST_REVERSE_FOREACH(CBlockIndex *pindex, vToFetch)
             {
-                // Download as much as possible, from earliest to latest.
-                unsigned int nAskFor = 0;
-                BOOST_REVERSE_FOREACH(CBlockIndex *pindex, vToFetch)
+                // pindex must be nonnull because we populated vToFetch a few lines above
+                CInv inv(MSG_BLOCK, pindex->GetBlockHash());
+                if (!AlreadyHave(inv))
                 {
-                    // pindex must be nonnull because we populated vToFetch a few lines above
-                    CInv inv(MSG_BLOCK, pindex->GetBlockHash());
-                    if (!AlreadyHave(inv))
-                    {
-		        requester.AskFor(inv, pfrom);
-                        LogPrint("req", "AskFor block via headers direct fetch %s (%d) peer=%d\n",
-                                pindex->GetBlockHash().ToString(),
-                                pindex->nHeight, pfrom->id);
-                        nAskFor++;
-                    }
-                    // We don't care about how many blocks are in flight.  We just need to make sure we don't
-                    // ask for more than the maximum allowed per peer because the request manager will take care
-                    // of any duplicate requests.
-                    if (nAskFor >= MAX_BLOCKS_IN_TRANSIT_PER_PEER)
-                    {
-                        LogPrint("net", "Large reorg, could only direct fetch %d blocks\n", nAskFor);
-                        break;
-                    }
+                    requester.AskFor(inv, pfrom);
+                    LogPrint("req", "AskFor block via headers direct fetch %s (%d) peer=%d\n",
+                            pindex->GetBlockHash().ToString(),
+                            pindex->nHeight, pfrom->id);
+                    nAskFor++;
                 }
-                if (nAskFor > 1)
+                // We don't care about how many blocks are in flight.  We just need to make sure we don't
+                // ask for more than the maximum allowed per peer because the request manager will take care
+                // of any duplicate requests.
+                if (nAskFor >= MAX_BLOCKS_IN_TRANSIT_PER_PEER)
                 {
-                    LogPrint("net", "Downloading blocks toward %s (%d) via headers direct fetch\n",
-                            pindexLast->GetBlockHash().ToString(),
-                            pindexLast->nHeight);
+                    LogPrint("net", "Large reorg, could only direct fetch %d blocks\n", nAskFor);
+                    break;
                 }
             }
-        }
+            if (nAskFor > 1)
+            {
+                LogPrint("net", "Downloading blocks toward %s (%d) via headers direct fetch\n",
+                        pindexLast->GetBlockHash().ToString(),
+                        pindexLast->nHeight);
+            }
+         }
 
         CheckBlockIndex(chainparams.GetConsensus());
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5840,33 +5840,48 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
 
         // Bypass the normal CBlock deserialization, as we don't want to risk deserializing 2000 full blocks.
         unsigned int nCount = ReadCompactSize(vRecv);
-        if (nCount > MAX_HEADERS_RESULTS) {
+        if (nCount > MAX_HEADERS_RESULTS)
+        {
             Misbehaving(pfrom->GetId(), 20);
             return error("headers message size = %u", nCount);
         }
         headers.resize(nCount);
-        for (unsigned int n = 0; n < nCount; n++) {
+        for (unsigned int n = 0; n < nCount; n++)
+        {
             vRecv >> headers[n];
             ReadCompactSize(vRecv); // ignore tx count; assume it is 0.
         }
 
         LOCK(cs_main);
 
-        if (nCount == 0) {
-            // Nothing interesting. Stop asking this peers for more headers.
+        // Nothing interesting. Stop asking this peers for more headers.
+        if (nCount == 0)
             return true;
-        }
 
-        CBlockIndex *pindexLast = NULL;
-        BOOST_FOREACH(const CBlockHeader& header, headers) {
-            CValidationState state;
-            if (pindexLast != NULL && header.hashPrevBlock != pindexLast->GetBlockHash()) {
+        // Check all headers to make sure they are continuous before attempting to accept them.
+        // This prevents and attacker from keeping us from doing direct fetch by giving us out
+        // of order headers.
+        uint256 hashLastBlock;
+        for (const CBlockHeader &header : headers)
+        {
+            if (!hashLastBlock.IsNull() && header.hashPrevBlock != hashLastBlock)
+            {
                 Misbehaving(pfrom->GetId(), 20);
                 return error("non-continuous headers sequence");
             }
-            if (!AcceptBlockHeader(header, state, chainparams, &pindexLast)) {
+            hashLastBlock = header.GetHash();
+        }
+
+        // Check and accept each header in order from youngest block to oldest
+        CBlockIndex *pindexLast = NULL;
+        for (const CBlockHeader &header : headers)
+        {
+            CValidationState state;
+            if (!AcceptBlockHeader(header, state, chainparams, &pindexLast))
+            {
                 int nDoS;
-                if (state.IsInvalid(nDoS)) {
+                if (state.IsInvalid(nDoS))
+                {
                     if (nDoS > 0)
                         Misbehaving(pfrom->GetId(), nDoS);
                     return error("invalid header received");
@@ -5883,7 +5898,8 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
             // TODO: optimize: if pindexLast is an ancestor of chainActive.Tip or pindexBestHeader, continue
             // from there instead.
             LogPrint("net", "more getheaders (%d) to end to peer=%d (startheight:%d)\n",
-                    pindexLast->nHeight, pfrom->id,
+                    pindexLast->nHeight,
+                    pfrom->id,
                     pfrom->nStartingHeight);
             pfrom->PushMessage(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexLast), uint256());
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5930,17 +5930,6 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
                 pindexWalk = pindexWalk->pprev;
             }
 
-            // If pindexWalk still isn't on our main chain, we're looking at a
-            // very large reorg at a time we think we're close to caught up to
-            // the main chain -- this shouldn't really happen.  Bail out on the
-            // direct fetch and rely on parallel download instead.
-            if (pindexWalk && !chainActive.Contains(pindexWalk))
-            {
-                LogPrint("net", "Large reorg, won't direct fetch to %s (%d)\n",
-                        pindexLast->GetBlockHash().ToString(),
-                        pindexLast->nHeight);
-            }
-            else
             {
                 // Download as much as possible, from earliest to latest.
                 unsigned int nAskFor = 0;

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -87,7 +87,7 @@ void CRequestManager::cleanup(OdMap::iterator &itemIt)
         if (node)
         {
             i->clear();
-            LogPrint("req", "ReqMgr: %s removed ref to %d count %d.\n", item.obj.ToString(), node->GetId(),
+            LogPrint("req", "ReqMgr: %s cleanup - removed ref to %d count %d.\n", item.obj.ToString(), node->GetId(),
                 node->GetRefCount());
             node->Release();
         }
@@ -490,7 +490,7 @@ void CRequestManager::SendRequests()
                         if (next.node->fDisconnect || (!IsChainNearlySyncd() && !IsNodePingAcceptable(next.node)))
                         {
                             LOCK(cs_vNodes);
-                            LogPrint("req", "ReqMgr: %s removed ref to %d count %d (disconnect).\n",
+                            LogPrint("req", "ReqMgr: %s removed block ref to %d count %d (on disconnect).\n",
                                 item.obj.ToString(), next.node->GetId(), next.node->GetRefCount());
                             next.node->Release();
                             next.node = NULL; // force the loop to get another node
@@ -524,7 +524,7 @@ void CRequestManager::SendRequests()
                     // Instead we'll forget about it -- the node is already popped of of the available list so now we'll
                     // release our reference.
                     LOCK(cs_vNodes);
-                    LogPrint("req", "ReqMgr: %s removed ref to %d count %d (disconnect).\n", item.obj.ToString(),
+                    LogPrint("req", "ReqMgr: %s removed block ref to %d count %d\n", item.obj.ToString(),
                         next.node->GetId(), next.node->GetRefCount());
                     next.node->Release();
                     next.node = NULL;
@@ -540,7 +540,7 @@ void CRequestManager::SendRequests()
                 // There can be no block sources because a node dropped out.  In this case, nothing can be done so
                 // remove the item.
                 LogPrint("req", "Block %s has no available sources. Removing\n", item.obj.ToString());
-                cleanup(itemIter); // node should never be null... but if it is then there's nothing to do.
+                cleanup(itemIter);
             }
         }
     }
@@ -593,7 +593,7 @@ void CRequestManager::SendRequests()
                             if (next.node->fDisconnect) // Node was disconnected so we can't request from it
                             {
                                 LOCK(cs_vNodes);
-                                LogPrint("req", "ReqMgr: %s removed ref to %d count %d (disconnect).\n",
+                                LogPrint("req", "ReqMgr: %s removed tx ref to %d count %d (on disconnect).\n",
                                     item.obj.ToString(), next.node->GetId(), next.node->GetRefCount());
                                 next.node->Release();
                                 next.node = NULL; // force the loop to get another node
@@ -621,7 +621,7 @@ void CRequestManager::SendRequests()
                         }
                         {
                             LOCK(cs_vNodes);
-                            LogPrint("req", "ReqMgr: %s removed ref to %d count %d (disconnect).\n",
+                            LogPrint("req", "ReqMgr: %s removed tx ref to %d count %d\n",
                                 item.obj.ToString(), next.node->GetId(), next.node->GetRefCount());
                             next.node->Release();
                             next.node = NULL;


### PR DESCRIPTION
The commits are a bit of a mess...i'll squash them down soon enough but I want to add another set of python tests at the end.

@gandrewstone When ready, this PR should be merged prior or at the same time as the block stalling PR #403, since block stalling can be effected by sendheaders during a special case when thinblocks is turned off.