### PR TITLE
Improvements to rpc-tests.py (add -force-enable / -f , better options handling)

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -411,13 +411,13 @@ def runtests():
             print("%-44s  Total time (s): %7s" % (" ", sum(execution_time.values())))
 
             print
-            print("%d test(s) passed / %d test(s) failed / %d test(s) executed" % (test_passed.values().count(True),
-                                                                       test_passed.values().count(False),
+            print("%d test(s) passed / %d test(s) failed / %d test(s) executed" % (list(test_passed.values()).count(True),
+                                                                       list(test_passed.values()).count(False),
                                                                        len(test_passed)))
             print("%d test(s) disabled / %d test(s) skipped due to platform" % (len(disabled), len(skipped)))
 
         # signal that tests have failed using exit code
-        if test_passed.values().count(False):
+        if list(test_passed.values()).count(False):
             sys.exit(1)
 
     else:

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -64,33 +64,38 @@ ENABLE_COVERAGE=0
 opts = set()
 double_opts = set()  # BU: added for checking validity of -- opts
 passOn = ""
+showHelp = False  # if we need to print help
 p = re.compile("^--")
 # some of the single-dash options applicable only to this runner script
 # are also allowed in double-dash format (but are not passed on to the
 # test scripts themselves)
 private_single_opts = ('-h',
+                       '-f',    # equivalent to -force-enable
                        '-help',
                        '-list',
                        '-extended',
                        '-extended-only',
                        '-only-extended',
+                       '-force-enable',
                        '-win')
 private_double_opts = ('--list',
                        '--extended',
                        '--extended-only',
                        '--only-extended',
+                       '--force-enable',
                        '--win')
-test_script_opts = ('--tracerpc',
-                    '--help',
-                    '--noshutdown',
-                    '--nocleanup',
-                    '--srcdir',
-                    '--tmpdir',
-                    '--coveragedir',
-                    '--mineblock',
-                    '--randomseed',
-                    '--testbinary',
-                    '--refbinary')
+framework_opts = ('--tracerpc',
+                  '--help',
+                  '--noshutdown',
+                  '--nocleanup',
+                  '--srcdir',
+                  '--tmpdir',
+                  '--coveragedir',
+                  '--randomseed',
+                  '--testbinary',
+                  '--refbinary')
+test_script_opts = ('--mineblock',
+                    '--extensive')
 
 def option_passed(option_without_dashes):
     """check if option was specified in single-dash or double-dash format"""
@@ -106,11 +111,12 @@ for arg in sys.argv[1:]:
         ENABLE_COVERAGE = 1
     elif (p.match(arg) or arg in ('-h', '-help')):
         if arg not in private_double_opts:
-            if arg == '-help' or arg == '-h':
-                pass_arg = '--help'
+            if arg == '--help' or arg == '-help' or arg == '-h':
+                passOn = '--help'
+                showHelp = True
             else:
-                pass_arg = arg
-            passOn += " " + pass_arg
+                if passOn is not '--help':
+                    passOn += " " + arg
         # add it to double_opts only for validation
         double_opts.add(arg)
     else:
@@ -123,7 +129,7 @@ bad_opts_found = []
 bad_opt_str="Unrecognized option: %s"
 for o in opts | double_opts:
     if o.startswith('--'):
-        if o not in test_script_opts + private_double_opts:
+        if o not in framework_opts + test_script_opts + private_double_opts:
             print(bad_opt_str % o)
             bad_opts_found.append(o)
     elif o.startswith('-'):
@@ -200,7 +206,7 @@ testScripts = [ RpcTest(t) for t in [
 
 testScriptsExt = [ RpcTest(t) for t in [
     'txPerf',
-    'excessive --extended',
+    'excessive --extensive',
     'bip9-softforks',
     'bip65-cltv',
     'bip65-cltv-p2p',
@@ -230,15 +236,17 @@ if ENABLE_ZMQ == 1:
 
 def show_wrapper_options():
     """ print command line options specific to wrapper """
-    print( "Wrapper options:")
+    print("Wrapper options:")
     print()
-    print( "  -extended/--extended  run the extended set of tests")
-    print( "  -only-extended / -extended-only\n" + \
+    print("  -extended/--extended  run the extended set of tests")
+    print("  -only-extended / -extended-only\n" + \
           "  --only-extended / --extended-only\n" + \
           "                        run ONLY the extended tests")
-    print( "  -list / --list        only list test names")
-    print( "  -win / --win          signal running on Windows and run those tests")
-    print( "  -h / -help / --help   print this help")
+    print("  -list / --list        only list test names")
+    print("  -win / --win          signal running on Windows and run those tests")
+    print("  -f / -force-enable / --force-enable\n" + \
+          "                        attempt to run disabled/skipped tests")
+    print("  -h / -help / --help   print this help")
 
 def runtests():
     global passOn
@@ -248,7 +256,9 @@ def runtests():
     test_failure_info = {}
     disabled = []
     skipped = []
+    tests_to_run = []
 
+    force_enable = option_passed('force-enable') or '-f' in opts
     run_only_extended = option_passed('only-extended') or option_passed('extended-only')
 
     if option_passed('list'):
@@ -274,85 +284,111 @@ def runtests():
         cov_flag = coverage.flag if coverage else ''
         flags = " --srcdir %s/src %s %s" % (buildDir, cov_flag, passOn)
 
-        #Run Tests
-        p = re.compile(" -h| --help| -help")
-        for i in range(len(testScripts)):
-            scriptname=re.sub(".py$", "", str(testScripts[i]).split(' ')[0])
-            fullscriptcmd=str(testScripts[i])
-            if ((len(opts) == 0
-                    or p.match(passOn)
-                    or option_passed('extended')
-                    or option_passed('win')
-                    or scriptname in opts
-                    or (scriptname + '.py') in opts )
-                and not run_only_extended):
+        # compile the list of tests to check
 
-                if testScripts[i].is_disabled():
-                    print("Disabled testscript %s%s%s (reason: %s)" % (bold[1], testScripts[i], bold[0], testScripts[i].reason))
-                    disabled.append(str(testScripts[i]))
-                elif testScripts[i].is_skipped():
-                    print("Skipping testscript %s%s%s on this platform (reason: %s)" % (bold[1], testScripts[i], bold[0], testScripts[i].reason))
-                    skipped.append(str(testScripts[i]))
+        # check for explicit tests
+        if showHelp:
+            tests_to_run = [ testScripts[0] ]
+        else:
+            for o in opts:
+                if not o.startswith('-'):
+                    found = False
+                    for t in testScripts + testScriptsExt:
+                        t_rep = str(t).split(' ')
+                        if (t_rep[0] == o or t_rep[0] == o + '.py') and len(t_rep) > 1:
+                            # it is a test with args - check all args match what was passed, otherwise don't add this test
+                            t_args = t_rep[1:]
+                            all_args_found = True
+                            for targ in t_args:
+                                if not targ in passOn.split(' '):
+                                    all_args_found = False
+                            if all_args_found:
+                                tests_to_run.append(t)
+                                found = True
+                        elif t_rep[0] == o or t_rep[0] == o + '.py':
+                            passOnSplit = [x for x in passOn.split(' ') if x != '']
+                            found_non_framework_opt = False
+                            for p in passOnSplit:
+                                if p in test_script_opts:
+                                    found_non_framework_opt = True
+                            if not found_non_framework_opt:
+                                tests_to_run.append(t)
+                                found = True
+                    if not found:
+                        print("Error: %s is not a known test." % o)
+                        sys.exit(1)
+
+        # if no explicit tests specified, use the lists
+        if not len(tests_to_run):
+            if run_only_extended:
+                tests_to_run = testScriptsExt
+            else:
+                tests_to_run += testScripts
+                if run_extended:
+                    tests_to_run += testScriptsExt
+
+        # weed out the disabled / skipped tests and print them beforehand
+        # this allows earlier intervention in case a test is unexpectedly
+        # skipped
+        if not force_enable:
+            trimmed_tests_to_run = []
+            for t in tests_to_run:
+                if t.is_disabled():
+                    print("Disabled testscript %s%s%s (reason: %s)" % (bold[1], t, bold[0], t.reason))
+                    disabled.append(str(t))
+                elif t.is_skipped():
+                    print("Skipping testscript %s%s%s on this platform (reason: %s)" % (bold[1], t, bold[0], t.reason))
+                    skipped.append(str(t))
                 else:
-                    # not disabled or skipped - execute test (or print help if requested)
+                    trimmed_tests_to_run.append(t)
+            tests_to_run = trimmed_tests_to_run
 
-                    # print the wrapper-specific help options
-                    if p.match(passOn):
-                        show_wrapper_options()
+        # now run the tests
+        p = re.compile(" -h| --help| -help")
+        for t in tests_to_run:
+            scriptname=re.sub(".py$", "", str(t).split(' ')[0])
+            fullscriptcmd=str(t)
 
-                    if bad_opts_found:
-                        if not ' --help' in passOn:
-                            passOn += ' --help'
+            # print the wrapper-specific help options
+            if showHelp:
+                show_wrapper_options()
 
-                    print("Running testscript %s%s%s ..." % (bold[1], testScripts[i], bold[0]))
-                    time0 = time.time()
-                    test_passed[fullscriptcmd] = False
-                    try:
-                        subprocess.check_call(
-                            rpcTestDir + repr(testScripts[i]) + flags, shell=True)
-                        test_passed[fullscriptcmd] = True
-                    except subprocess.CalledProcessError as e:
-                        test_failure_info[fullscriptcmd] = e
-                        print("CalledProcessError for test %s: %s" % (scriptname, e))
+            if bad_opts_found:
+                if not ' --help' in passOn:
+                    passOn += ' --help'
 
-                    # exit if help was called
-                    if p.match(passOn):
-                        sys.exit(0)
-                    else:
-                        execution_time[fullscriptcmd] = int(time.time() - time0)
-                        print("Duration: %s s\n" % execution_time[fullscriptcmd])
+            if len(double_opts):
+                for additional_opt in fullscriptcmd.split(' ')[1:]:
+                    if additional_opt not in double_opts:
+                        continue
 
-        # Run Extended Tests
-        for i in range(len(testScriptsExt)):
-            scriptname = re.sub(".py$", "", str(testScriptsExt[i]).split(' ')[0])
-            fullscriptcmd=str(testScriptsExt[i])
-            if (run_extended or str(testScriptsExt[i]) in opts
-                    or re.sub(".py$", "", str(testScriptsExt[i])) in opts):
+            if fullscriptcmd not in execution_time.keys():
+                if t in testScripts:
+                    print("Running testscript %s%s%s ..." % (bold[1], t, bold[0]))
+                else:
+                    print("Running 2nd level testscript "
+                          + "%s%s%s ..." % (bold[1], t, bold[0]))
 
-                if testScriptsExt[i].is_disabled():
-                    print("Disabled testscript %s%s%s (reason: %s)" % (bold[1], testScriptsExt[i], bold[0], testScriptsExt[i].reason))
-                    disabled.append(str(testScriptsExt[i]))
-                elif testScripts[i].is_skipped():
-                    print("Skipping testscript %s%s%s on this platform (reason: %s)" % (bold[1], testScriptsExt[i], bold[0], testScriptsExt[i].reason))
-                    skipped.append(str(testScriptsExt[i]))
-                elif fullscriptcmd not in execution_time.keys():
-                    # not disabled, skipped or already executed - run test
-                    print(
-                        "Running 2nd level testscript "
-                        + "%s%s%s ..." % (bold[1], testScriptsExt[i], bold[0]))
-                    time0 = time.time()
-                    test_passed[fullscriptcmd] = False
-                    try:
-                        subprocess.check_call(
-                            rpcTestDir + repr(testScriptsExt[i]) + flags, shell=True)
-                        test_passed[fullscriptcmd] = True
-                    except subprocess.CalledProcessError as e:
-                        test_failure_info[fullscriptcmd] = e
-                        #print "CalledProcessError for test %s: %s" % (scriptname, e)
+                time0 = time.time()
+                test_passed[fullscriptcmd] = False
+                try:
+                    subprocess.check_call(
+                        rpcTestDir + repr(t) + flags, shell=True)
+                    test_passed[fullscriptcmd] = True
+                except subprocess.CalledProcessError as e:
+                    print("well shucks")
+                    print( e )
+                    test_failure_info[fullscriptcmd] = e
+
+                # exit if help was called
+                if showHelp:
+                    sys.exit(0)
+                else:
                     execution_time[fullscriptcmd] = int(time.time() - time0)
                     print("Duration: %s s\n" % execution_time[fullscriptcmd])
-                else:
-                    print("Skipping extended test name %s - already executed in regular\n" % scriptname)
+
+            else:
+                print("Skipping extended test name %s - already executed in regular\n" % scriptname)
 
         if coverage:
             coverage.report_rpc_coverage()
@@ -360,27 +396,28 @@ def runtests():
             print("Cleaning up coverage data")
             coverage.cleanup()
 
-        # show some overall results and aggregates
-        print()
-        print("%-50s  Status    Time (s)" % "Test")
-        print('-' * 70)
-        for k in sorted(execution_time.keys()):
-            print("%-50s  %-6s    %7s" % (k, "PASS" if test_passed[k] else "FAILED", execution_time[k]))
-        for d in disabled:
-            print("%-50s  %-8s" % (d, "DISABLED"))
-        for s in skipped:
-            print("%-50s  %-8s" % (s, "SKIPPED"))
-        print('-' * 70)
-        print("%-44s  Total time (s): %7s" % (" ", sum(execution_time.values())))
+        if not showHelp:
+            # show some overall results and aggregates
+            print()
+            print("%-50s  Status    Time (s)" % "Test")
+            print('-' * 70)
+            for k in sorted(execution_time.keys()):
+                print("%-50s  %-6s    %7s" % (k, "PASS" if test_passed[k] else "FAILED", execution_time[k]))
+            for d in disabled:
+                print("%-50s  %-8s" % (d, "DISABLED"))
+            for s in skipped:
+                print("%-50s  %-8s" % (s, "SKIPPED"))
+            print('-' * 70)
+            print("%-44s  Total time (s): %7s" % (" ", sum(execution_time.values())))
 
-        print()
-        print("%d test(s) passed / %d test(s) failed / %d test(s) executed" % (list(test_passed.values()).count(True),
-                                                                   list(test_passed.values()).count(False),
-                                                                   len(test_passed)))
-        print("%d test(s) disabled / %d test(s) skipped due to platform" % (len(disabled), len(skipped)))
+            print
+            print("%d test(s) passed / %d test(s) failed / %d test(s) executed" % (test_passed.values().count(True),
+                                                                       test_passed.values().count(False),
+                                                                       len(test_passed)))
+            print("%d test(s) disabled / %d test(s) skipped due to platform" % (len(disabled), len(skipped)))
 
         # signal that tests have failed using exit code
-        if list(test_passed.values()).count(False):
+        if test_passed.values().count(False):
             sys.exit(1)
 
     else:

--- a/qa/rpc-tests/excessive.py
+++ b/qa/rpc-tests/excessive.py
@@ -587,10 +587,15 @@ class ExcessiveBlockTest (BitcoinTestFramework):
 if __name__ == '__main__':
     
     
-    if "--extended" in sys.argv:
+    if "--extensive" in sys.argv:
       longTest=True
-      sys.argv.remove("--extended")
-      logging.info("Running extended tests")
+      # we must remove duplicate 'extensive' arg here
+      while True:
+          try:
+              sys.argv.remove('--extensive')
+          except:
+              break
+      logging.info("Running extensive tests")
     else:
       longTest=False
 


### PR DESCRIPTION
This is a cross-port of improvements to the test runner from MVF-BU.

It adds a -f option to force running of specified disabled tests, e.g. to run the currently disabled 'pruning' test:

`$ qa/pull-tester/rpc-tests.py -f pruning`

No more editing the rpc-tests.py just to run a disabled test!

It also passes down test-specific option correctly, so one can now specify a test plus its custom option for specific execution. The previous command line option handling was severely broken - it still is not great, but this improves it to the point where it is possible to run e.g.

`$ qa/pull-tester/rpc-tests.py txn_doublespend --mineblock`
`$ qa/pull-tester/rpc-tests.py excessive --extensive`

**Note 1**: it is not yet possible to combine multiple tests with options, e.g.

`$ qa/pull-tester/rpc-tests.py txn_doublespend --mineblock excessive --extensive`

This is because they all get passed all the test-specific options, and currently do not handle this well.

It *is* possible to specify multiple tests without extra options, e.g.

`$ qa/pull-tester/rpc-tests.py txn_doublespend excessive`

**Note 2**: Because the 'excessive.py' test used the '--extended' option which is now classed as a 'private' option of the top-level runner script (and therefore does not get passed on to the called script), that option had to be renamed to '--extensive'.

Any tests that take their own options should have these added in the `test_script_opts` list in rpc.tests.py .

I've refrained from reformatting rpc-tests.py using PEP8 as I'll do a general overhaul of the Python scripts in a later PR.