### PR TITLE
memory checking and profiling changes.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -158,6 +158,12 @@ AC_ARG_ENABLE([lcov],
   [use_lcov=yes],
   [use_lcov=no])
 
+AC_ARG_ENABLE([gperf],
+  [AS_HELP_STRING([--enable-gperf],
+  [enable gperftools testing (default is no)])],
+  [use_gperf=yes],
+  [use_gperf=no])
+
 AC_ARG_ENABLE([glibc-back-compat],
   [AS_HELP_STRING([--enable-glibc-back-compat],
   [enable backwards compatibility with glibc])],
@@ -347,6 +353,10 @@ case $host in
    *linux*)
      TARGET_OS=linux
      LEVELDB_TARGET_FLAGS="-DOS_LINUX"
+     if test "x$use_gperf" = "xyes"; then
+       AC_CHECK_LIB([tcmalloc],      [malloc],, AC_MSG_ERROR(tcmalloc lib missing))
+       AC_DEFINE([ENABLE_GPERF],[1],[Define to 1 to enable GPERF])
+     fi
      ;;
    *)
      OTHER_OS=`echo ${host_os} | awk '{print toupper($0)}'`
@@ -932,6 +942,7 @@ AM_CONDITIONAL([ENABLE_QT_TESTS],[test x$BUILD_TEST_QT = xyes])
 AM_CONDITIONAL([ENABLE_BENCH],[test x$use_bench = xyes])
 AM_CONDITIONAL([USE_QRCODE], [test x$use_qr = xyes])
 AM_CONDITIONAL([USE_LCOV],[test x$use_lcov = xyes])
+AM_CONDITIONAL([ENABLE_GPERF],[test x$use_gperf = xyes])
 AM_CONDITIONAL([USE_COMPARISON_TOOL],[test x$use_comparison_tool != xno])
 AM_CONDITIONAL([USE_COMPARISON_TOOL_REORG_TESTS],[test x$use_comparison_tool_reorg_test != xno])
 AM_CONDITIONAL([GLIBC_BACK_COMPAT],[test x$use_glibc_compat = xyes])

--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -124,6 +124,25 @@ can be very difficult to track down. Compiling with -DDEBUG_LOCKORDER (configure
 CXXFLAGS="-DDEBUG_LOCKORDER -g") inserts run-time checks to keep track of which locks
 are held, and adds warnings to the debug.log file if inconsistencies are detected.
 
+**Memory Profiling**
+
+*Currently only available on Linux*
+
+Bitcoin Unlimited can be compiled with the libtcmalloc allocation library and
+memory profiling tool.  First install libtcmalloc either from source here
+https://github.com/gperftools/gperftools or via package manager:
+```bash
+sudo apt-get install libgoogle-perftools-dev
+```
+Next reconfigure:
+```bash
+make distclean
+./configure --enable-gperf --disable-hardening --enable-debug
+```
+For detailed instructions on how to use gperftools please read the gperftools
+documentation.
+
+
 Locking/mutex usage notes
 -------------------------
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,9 +1,15 @@
 DIST_SUBDIRS = secp256k1 univalue
 
 AM_LDFLAGS = $(PTHREAD_CFLAGS) $(LIBTOOL_LDFLAGS) $(HARDENED_LDFLAGS)
+if ENABLE_GPERF
+AM_CXXFLAGS = -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free $(HARDENED_CXXFLAGS)
+AM_CPPFLAGS = -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free $(HARDENED_CPPFLAGS)
+else
 AM_CXXFLAGS = $(HARDENED_CXXFLAGS)
 AM_CPPFLAGS = $(HARDENED_CPPFLAGS)
+endif
 EXTRA_LIBRARIES =
+# libtcmalloc.a
 
 BITCOIN_CONFIG_INCLUDES=-I$(builddir)/config
 BITCOIN_INCLUDES=-I$(builddir) -I$(builddir)/obj $(BOOST_CPPFLAGS) $(LEVELDB_CPPFLAGS) $(CRYPTO_CFLAGS) $(SSL_CFLAGS)

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -42,7 +42,7 @@
 #include <boost/thread.hpp>
 #include <inttypes.h>
 #include <queue>
-
+#include <list>
 
 using namespace std;
 
@@ -141,6 +141,7 @@ CTxMemPool mempool(::minRelayTxFee);
 boost::posix_time::milliseconds statMinInterval(10000);
 boost::asio::io_service stat_io_service;
 
+std::list<CStatBase*> mallocedStats;
 CStatMap statistics;
 CTweakMap tweaks;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -258,6 +258,7 @@ void Shutdown()
 
     NetCleanup();
     MainCleanup();
+    UnlimitedCleanup();
     LogPrintf("%s: done\n", __func__);
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2924,7 +2924,8 @@ bool static DisconnectTip(CValidationState& state, const Consensus::Params& cons
         CCoinsViewCache view(pcoinsTip);
         if (!DisconnectBlock(block, state, pindexDelete, view))
             return error("DisconnectTip(): DisconnectBlock %s failed", pindexDelete->GetBlockHash().ToString());
-        assert(view.Flush());
+        bool result = view.Flush();
+        assert(result);
     }
     LogPrint("bench", "- Disconnect block: %.2fms\n", (GetTimeMicros() - nStart) * 0.001);
     // Write the chain state to disk, if necessary.
@@ -2995,7 +2996,8 @@ bool static ConnectTip(CValidationState& state, const CChainParams& chainparams,
         mapBlockSource.erase(pindexNew->GetBlockHash());
         nTime3 = GetTimeMicros(); nTimeConnectTotal += nTime3 - nTime2;
         LogPrint("bench", "  - Connect total: %.2fms [%.2fs]\n", (nTime3 - nTime2) * 0.001, nTimeConnectTotal * 0.000001);
-        assert(view.Flush());
+        bool result = view.Flush();
+        assert(result);
     }
     int64_t nTime4 = GetTimeMicros(); nTimeFlush += nTime4 - nTime3;
     LogPrint("bench", "  - Flush: %.2fms [%.2fs]\n", (nTime4 - nTime3) * 0.001, nTimeFlush * 0.000001);

--- a/src/net.h
+++ b/src/net.h
@@ -422,6 +422,9 @@ protected:
     void Fuzz(int nChance); // modifies ssSend
 
 public:
+#ifdef DEBUG
+    friend UniValue getstructuresizes(const UniValue& params, bool fHelp);
+#endif
     uint256 hashContinue;
     int nStartingHeight;
 
@@ -750,6 +753,16 @@ public:
     }
 
     void CloseSocketDisconnect();
+
+    //! returns the name of this node for logging.  Respects the user's choice to not log the node's IP
+    std::string GetLogName()
+    {
+        std::string idstr = boost::lexical_cast<std::string>(id);
+        if (fLogIPs)
+            return addrName + " (" + idstr + ")";
+        return idstr;
+    }
+
 
     // Denial-of-service detection/prevention
     // The idea is to detect peers that are behaving

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -330,7 +330,10 @@ static bool Socks5(const std::string& strDest, int port, const ProxyCredentials 
         std::vector<uint8_t> vAuth;
         vAuth.push_back(0x01);
         if (auth->username.size() > 255 || auth->password.size() > 255)
+        {
+            CloseSocket(hSocket);
             return error("Proxy username or password too long");
+        }
         vAuth.push_back(auth->username.size());
         vAuth.insert(vAuth.end(), auth->username.begin(), auth->username.end());
         vAuth.push_back(auth->password.size());

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -131,8 +131,10 @@ void CRequestManager::AskFor(const CInv& obj, CNode* from, int priority)
       // if (result.second)  // means this was inserted rather than already existed
       // { } nothing to do
       data.priority = max(priority,data.priority);
-      data.AddSource(from);
-      LogPrint("blk", "%s available at %s\n", obj.ToString().c_str(), from->addrName.c_str());
+      if (data.AddSource(from))
+      {
+          LogPrint("blk", "%s available at %s\n", obj.ToString(), from->GetLogName());
+      }
     }
   else
     {
@@ -286,26 +288,30 @@ CNodeRequestData::CNodeRequestData(CNode* n)
   desirability -= latency;
 }
 
-void CUnknownObj::AddSource(CNode* from)
+bool CUnknownObj::AddSource(CNode* from)
 {
-  if (std::find_if(availableFrom.begin(), availableFrom.end(), IsCNodeRequestDataThisNode(from)) == availableFrom.end())  // node is not in the request list
+    // if node is not in the request list, add it
+    if (std::find_if(availableFrom.begin(), availableFrom.end(), MatchCNodeRequestData(from)) == availableFrom.end())
     {
-      LogPrint("req", "%s added ref to node %d.  Current count %d.\n", obj.ToString(), from->GetId(), from->GetRefCount());
+      LogPrint("req", "%s added ref to node %d.  Current count %d.\n", obj.ToString(), from->GetId(),
+               from->GetRefCount());
       {
         LOCK(cs_vNodes);  // This lock is needed to ensure that AddRef happens atomically
         from->AddRef();
       }
       CNodeRequestData req(from);
       for (ObjectSourceList::iterator i = availableFrom.begin(); i != availableFrom.end(); ++i)
-        {
-	  if (i->desirability < req.desirability)
-	    {
+      {
+          if (i->desirability < req.desirability)
+          {
               availableFrom.insert(i, req);
-              return;
-	    }
-        }
+              return true;
+          }
+      }
       availableFrom.push_back(req);
+      return true;
     }
+  return false;
 }
 
 void RequestBlock(CNode* pfrom, CInv obj)

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -29,10 +29,10 @@ public:
   bool operator<(const CNodeRequestData &rhs) const { return desirability < rhs.desirability; }
 };
 
-struct IsCNodeRequestDataThisNode // Compare a CNodeRequestData object to a node
+struct MatchCNodeRequestData // Compare a CNodeRequestData object to a node
 {
   CNode* node;
-  IsCNodeRequestDataThisNode(CNode* n):node(n) {};
+  MatchCNodeRequestData(CNode* n):node(n) {};
   inline bool operator()(const CNodeRequestData& nd) const { return nd.node == node; }
 };
 
@@ -57,12 +57,16 @@ public:
     lastRequestTime = 0;
   }
 
-  void AddSource(CNode* from);
+  bool AddSource(CNode* from); // returns true if the source did not already exist
 };
 
 class CRequestManager
 {
   protected:
+#ifdef DEBUG
+  friend UniValue getstructuresizes(const UniValue& params, bool fHelp);
+#endif
+
   // map of transactions
   typedef std::map<uint256, CUnknownObj> OdMap;
   OdMap mapTxnInfo;
@@ -79,7 +83,7 @@ class CRequestManager
   CStatHistory<int> rejectedTxns;
   CStatHistory<int> droppedTxns;
   CStatHistory<int> pendingTxns;
-  
+
   void cleanup(OdMap::iterator& item);
   CLeakyBucket requestPacer;
   CLeakyBucket blockPacer;

--- a/src/rpcserver.cpp
+++ b/src/rpcserver.cpp
@@ -343,7 +343,9 @@ static const CRPCCommand vRPCCommands[] =
     { "util",               "getstat",                &getstat,                true  },  // BU
     { "util",               "get",                    &gettweak,               true  },  // BU
     { "util",               "set",                    &settweak,               true  },  // BU
-
+#ifdef DEBUG
+    { "util",               "getstructuresizes",      &getstructuresizes,      true  },  // BU
+#endif
     /* Not shown in help */
     { "hidden",             "invalidateblock",        &invalidateblock,        true  },
     { "hidden",             "reconsiderblock",        &reconsiderblock,        true  },

--- a/src/stat.h
+++ b/src/stat.h
@@ -62,6 +62,7 @@ class CStatBase
 {
 public:
   CStatBase() {};
+  virtual ~CStatBase() {};
   virtual UniValue GetNow()=0;  // Returns the current value of this statistic
   virtual UniValue GetTotal()=0;  // Returns the cumulative value of this statistic
   virtual UniValue GetSeries(const std::string& name, int count)=0;  // Returns the historical or series data
@@ -111,7 +112,7 @@ void cleanup()
 {
   LOCK(cs_statMap);
   statistics.erase(CStatKey(name));
-  name = "";
+  name.clear();
 }
 
   CStat& operator=(const DataType& arg) { value=arg; return *this;}
@@ -136,12 +137,15 @@ void cleanup()
     return NullUniValue;  // Has no series data
   }
 
-  ~CStat()
-    {
-  LOCK(cs_statMap);
-  if (name.size())
-        statistics.erase(CStatKey(name));
-    }
+  virtual ~CStat()
+  {
+      LOCK(cs_statMap);
+      if (name.size())
+      {
+          statistics.erase(CStatKey(name));
+          name.clear();
+      }
+  }
 };
 
 
@@ -216,9 +220,9 @@ CStatHistory(const std::string& name, unsigned int operation=STAT_OP_SUM):CStat<
       Start();      
     }
 
-  ~CStatHistory()
-    {
-    }
+  virtual ~CStatHistory()
+  {
+  }
 
   CStatHistory& operator << (const DataType& rhs) 
     {

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -16,6 +16,7 @@
 #include "requestManager.h"
 #include <univalue.h>
 #include <vector>
+#include <list>
 
 enum {
     TYPICAL_BLOCK_SIZE = 200000,   // used for initial buffer size
@@ -81,6 +82,7 @@ extern void settingsToUserAgentString();
 extern std::string FormatCoinbaseMessage(const std::vector<std::string>& comments,const std::string& customComment);  
 
 extern void UnlimitedSetup(void);
+extern void UnlimitedCleanup(void);
 extern std::string UnlimitedCmdLineHelp();
 
 // Called whenever a new block is accepted
@@ -129,6 +131,9 @@ extern UniValue setblockversion(const UniValue& params, bool fHelp);
 extern UniValue getstatlist(const UniValue& params, bool fHelp);
 // RPC Get a particular statistic
 extern UniValue getstat(const UniValue& params, bool fHelp);
+
+// RPC debugging Get sizes of every data structure
+extern UniValue getstructuresizes(const UniValue& params, bool fHelp);
 
 // RPC Set a node to receive expedited blocks from
 UniValue expedited(const UniValue& params, bool fHelp);
@@ -196,6 +201,7 @@ extern CTweak<uint64_t> blockSigopsPerMb;
 extern CTweak<uint64_t> coinbaseReserve;
 extern CTweak<uint64_t> blockMiningSigopsPerMb;
 
+extern std::list<CStatBase*> mallocedStats;
 // Protocol changes:
 
 enum {


### PR DESCRIPTION
This patch adds the option to enable gperftools (heap profiler) to the build.
It also adds a RPC call that dumps the sizes of global structures at runtime.

It also cleans up some known 1 time allocations when Bitcoin shuts down, so the memory check results is easier to understand, fixes a rare socket-left-open issue, and moves some side-effecting code out of an assert() (even though asserts are always "on", let's follow normal assert conventions, in case we ever choose to turn them off in release mode)