### PR TITLE
Clear Timer after the request is sent  : issue #477

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -628,6 +628,9 @@ void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<CBl
     CNodeState *state = State(nodeid);
     DbgAssert(state != NULL, return);
 
+    // If started then clear the thinblock timer used for preferential downloading
+    thindata.ClearThinBlockTimer(hash);
+
     // BU why mark as received? because this erases it from the inflight list.  Instead we'll check for it
     // BU removed: MarkBlockAsReceived(hash);
     std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> >::iterator itInFlight = mapBlocksInFlight.find(hash);
@@ -6180,9 +6183,6 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
                 pfrom->thinBlockWaitingForTxns = -1;
                 pfrom->thinBlock.SetNull();
             }
-
-            // Clear the thinblock timer used for preferential download
-            thindata.ClearThinBlockTimer(inv.hash);
 
             LOCK(cs_main);
             Misbehaving(pfrom->GetId(), 100);

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -576,9 +576,6 @@ void HandleBlockMessageThread(CNode *pfrom, const string &strCommand, const CBlo
         }
     }
 
-    // Clear the thinblock timer used for preferential download
-    thindata.ClearThinBlockTimer(inv.hash);
-
     // Erase any txns from the orphan cache that are no longer needed
     PV.ClearOrphanCache(block);
 

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -891,6 +891,12 @@ string CThinBlockData::MempoolLimiterBytesSavedToString()
     return ss.str();
 }
 
+// Preferential Thinblock Timer:
+// The purpose of the timer is to ensure that we more often download an XTHINBLOCK rather than a full block.
+// The timer is started when we receive the first announcement indicating there is a new block to download.  If the
+// block inventory is from a non XTHIN node then we will continue to wait for block announcements until either we
+// get one from an XTHIN capable node or the timer is exceeded.  If the timer is exceeded before receiving an
+// announcement from an XTHIN node then we just download a full block instead of an xthin.
 bool CThinBlockData::CheckThinblockTimer(uint256 hash)
 {
     LOCK(cs_mapThinBlockTimer);
@@ -913,7 +919,7 @@ bool CThinBlockData::CheckThinblockTimer(uint256 hash)
     }
     return true;
 }
-
+// The timer is cleared as soon as we request a block or thinblock.
 void CThinBlockData::ClearThinBlockTimer(uint256 hash)
 {
     LOCK(cs_mapThinBlockTimer);


### PR DESCRIPTION


Clearing the thinblock timer after the request is sent rather than when the block
is received prevents the possiblity of downloading a block twice before
the RequestManager re-request timeout is exceeded.  Rely instead
only on the RequestManager to determine whether a block download timeout
has been exceeded.