### PR TITLE
Move xthin-related message handlers to thinblock.cpp

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -231,6 +231,7 @@ bool LoadBlockIndex();
 void UnloadBlockIndex();
 /** Process protocol messages received from a given node */
 bool ProcessMessages(CNode* pfrom);
+bool AlreadyHave(const CInv &);
 /** Process a single protocol messages received from a given node */
 bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, int64_t nTimeReceived);
 

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -324,33 +324,6 @@ BOOST_AUTO_TEST_CASE(inv_tests)
     BOOST_CHECK(CNode::IsBanned(addr1));
 
 
-    // send empty INV which will result in an exception
-    vRecv1.clear();
-    CNode::ClearBanned();
-
-    vInv.clear(); // use an empty vector
-
-    CNode dummyNode4(INVALID_SOCKET, addr4, "", true);
-    dummyNode4.nVersion = MIN_PEER_PROTO_VERSION;
-    dummyNode4.fSuccessfullyConnected = true;
-    vRecv1 << vInv;
-    ProcessMessage(&dummyNode4, NetMsgType::INV, vRecv1, GetTime());
-    vRecv1 << vInv;
-    ProcessMessage(&dummyNode4, NetMsgType::INV, vRecv1, GetTime());
-    vRecv1 << vInv;
-    ProcessMessage(&dummyNode4, NetMsgType::INV, vRecv1, GetTime());
-    vRecv1 << vInv;
-    ProcessMessage(&dummyNode4, NetMsgType::INV, vRecv1, GetTime());
-    SendMessages(&dummyNode4); // should four messages should not cause a ban
-    BOOST_CHECK(!CNode::IsBanned(addr4));
-
-    vRecv1 << vInv;
-    ProcessMessage(&dummyNode4, NetMsgType::INV, vRecv1, GetTime());
-    SendMessages(&dummyNode4); // send a fifth message should cause a ban
-    BOOST_CHECK(vInv.empty());
-    BOOST_CHECK(CNode::IsBanned(addr4));
-
-
     // INV with invalid type
     vRecv1.clear();
     vInv.clear();

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -378,12 +378,15 @@ bool CXThinBlock::process(CNode *pfrom,
         }
     } // End locking cs_orphancache, mempool.cs and cs_xval
 
-    // This must be checked outside the above section or a deadlock may occur
+    // This must be done outside of the above section or a deadlock may occur.
     if (!fMerkleRootCorrect)
     {
-        LOCK(cs_main);
-        Misbehaving(pfrom->GetId(), 100);
-        return error("Thinblock merkelroot does not match computed merkleroot, peer=%d", pfrom->GetId());
+        vector<CInv> vGetData;
+        vGetData.push_back(CInv(MSG_THINBLOCK, header.GetHash())); 
+        pfrom->PushMessage("getdata", vGetData); 
+        LogPrintf("xthinblock merkelroot does not match computed merkleroot - requesting full thinblock, peer=%d",
+            pfrom->GetId());
+        return true;
     }
 
     // There is a remote possiblity of a Tx hash collision therefore if it occurs we re-request a normal

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -5,6 +5,7 @@
 #include "thinblock.h"
 #include "chainparams.h"
 #include "consensus/merkle.h"
+#include "expedited.h"
 #include "main.h"
 #include "net.h"
 #include "parallel.h"
@@ -148,7 +149,7 @@ bool CThinBlock::process(CNode *pfrom, int nSizeThinBlock, string strCommand)
         // finish reassembling the block, we need to re-request the full regular block:
         vector<CInv> vGetData;
         vGetData.push_back(CInv(MSG_BLOCK, header.GetHash()));
-        pfrom->PushMessage("getdata", vGetData);
+        pfrom->PushMessage(NetMsgType::GETDATA, vGetData);
         setPreVerifiedTxHash.clear(); // Xpress Validation - clear the set since we do not do XVal on regular blocks
         LogPrint("thin", "Missing %d Thinblock transactions, re-requesting a regular block\n",
             pfrom->thinBlockWaitingForTxns);
@@ -383,7 +384,7 @@ bool CXThinBlock::process(CNode *pfrom,
     {
         vector<CInv> vGetData;
         vGetData.push_back(CInv(MSG_THINBLOCK, header.GetHash()));
-        pfrom->PushMessage("getdata", vGetData);
+        pfrom->PushMessage(NetMsgType::GETDATA, vGetData);
         LogPrintf("xthinblock merkelroot does not match computed merkleroot - requesting full thinblock, peer=%d",
             pfrom->GetId());
         return true;
@@ -395,7 +396,8 @@ bool CXThinBlock::process(CNode *pfrom,
     {
         vector<CInv> vGetData;
         vGetData.push_back(CInv(MSG_THINBLOCK, header.GetHash()));
-        pfrom->PushMessage("getdata", vGetData); // This must be done outside of the mempool.cs lock or the deadlock
+        // This must be done outside of the mempool.cs lock or the deadlock
+        pfrom->PushMessage(NetMsgType::GETDATA, vGetData);
         // detection with pfrom->cs_vSend will be triggered.
         LogPrintf("TX HASH COLLISION for xthinblock: re-requesting a thinblock\n");
         return true;
@@ -1138,7 +1140,8 @@ void SendXThinBlock(CBlock &block, CNode *pfrom, const CInv &inv)
     pfrom->blocksSent += 1;
 }
 
-bool IsThinBlockValid(const CNode *pfrom, const std::vector<CTransaction> &vMissingTx, const CBlockHeader &header)
+static bool IsThinBlockValid(const CNode *pfrom, const std::vector<CTransaction> &vMissingTx,
+                             const CBlockHeader &header)
 {
     // Check that that there is at least one txn in the xthin and that the first txn is the coinbase
     if (vMissingTx.empty())
@@ -1163,6 +1166,396 @@ bool IsThinBlockValid(const CNode *pfrom, const std::vector<CTransaction> &vMiss
     {
         return error("Received invalid header for thinblock or xthinblock %s from peer %s (id=%d)",
             header.GetHash().ToString(), pfrom->addrName.c_str(), pfrom->id);
+    }
+
+    return true;
+}
+
+// An incoming thin block
+bool HandleThinBlock(CDataStream &vRecv, CNode *pfrom)
+{
+    if (!pfrom->ThinBlockCapable())
+    {
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 100);
+        return error("Thinblock message received from a non thinblock node, peer=%d", pfrom->GetId());
+    }
+
+    CThinBlock thinBlock;
+    vRecv >> thinBlock;
+
+    // Message consistency checking
+    if (!IsThinBlockValid(pfrom, thinBlock.vMissingTx, thinBlock.header))
+    {
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 100);
+        return error("Invalid thinblock received");
+    }
+
+    // Is there a previous block or header to connect with?
+    {
+        LOCK(cs_main);
+        uint256 prevHash = thinBlock.header.hashPrevBlock;
+        BlockMap::iterator mi = mapBlockIndex.find(prevHash);
+        if (mi == mapBlockIndex.end())
+        {
+            Misbehaving(pfrom->GetId(), 10);
+            return error("thinblock from peer %s (%d) will not connect, unknown previous block %s",
+                pfrom->addrName.c_str(), pfrom->id, prevHash.ToString());
+        }
+        CBlockIndex *pprev = mi->second;
+        CValidationState state;
+        if (!ContextualCheckBlockHeader(thinBlock.header, state, pprev))
+        {
+            // Thin block does not fit within our blockchain
+            Misbehaving(pfrom->GetId(), 100);
+            return error("thinblock from peer %s (%d) contextual error: %s", pfrom->addrName.c_str(), pfrom->id,
+                state.GetRejectReason().c_str());
+        }
+    }
+
+    CInv inv(MSG_BLOCK, thinBlock.header.GetHash());
+    int nSizeThinBlock = ::GetSerializeSize(thinBlock, SER_NETWORK, PROTOCOL_VERSION);
+    LogPrint("thin", "received thinblock %s from peer %s (%d) of %d bytes\n", inv.hash.ToString(),
+        pfrom->addrName.c_str(), pfrom->id, nSizeThinBlock);
+
+    if (!pfrom->mapThinBlocksInFlight.count(inv.hash))
+    {
+        LogPrint("thin", "Thinblock received but not requested %s  peer=%d\n", inv.hash.ToString(), pfrom->id);
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 20);
+    }
+
+    thinBlock.process(pfrom, nSizeThinBlock, NetMsgType::THINBLOCK);
+
+    return true;
+}
+
+// An incoming xthin block
+bool HandleXThinBlock(CDataStream &vRecv, CNode *pfrom)
+{
+    if (!pfrom->ThinBlockCapable())
+    {
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 100);
+        return error("xthinblock message received from a non thinblock node, peer=%d", pfrom->GetId());
+    }
+
+    CXThinBlock thinBlock;
+    vRecv >> thinBlock;
+
+    // Message consistency checking
+    if (!IsThinBlockValid(pfrom, thinBlock.vMissingTx, thinBlock.header))
+    {
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 100);
+        return error("Invalid xthinblock received");
+    }
+
+    // FIXME: should not send until fully validated
+    // Send expedited block ASAP
+    CInv inv(MSG_BLOCK, thinBlock.header.GetHash());
+    if (!IsRecentlyExpeditedAndStore(inv.hash))
+        SendExpeditedBlock(thinBlock, 0, pfrom);
+
+    // Is there a previous block or header to connect with?
+    {
+        LOCK(cs_main);
+        uint256 prevHash = thinBlock.header.hashPrevBlock;
+        BlockMap::iterator mi = mapBlockIndex.find(prevHash);
+        if (mi == mapBlockIndex.end())
+        {
+            Misbehaving(pfrom->GetId(), 10);
+            return error("xthinblock from peer %s (%d) will not connect, unknown previous block %s",
+                pfrom->addrName.c_str(), pfrom->id, prevHash.ToString());
+        }
+        CBlockIndex *pprev = mi->second;
+        CValidationState state;
+        if (!ContextualCheckBlockHeader(thinBlock.header, state, pprev))
+        {
+            // Thin block does not fit within our blockchain
+            Misbehaving(pfrom->GetId(), 100);
+            return error("thinblock from peer %s (%d) contextual error: %s", pfrom->addrName.c_str(), pfrom->id,
+                state.GetRejectReason().c_str());
+        }
+    }
+
+    int nSizeThinBlock = ::GetSerializeSize(thinBlock, SER_NETWORK, PROTOCOL_VERSION);
+    LogPrint("thin", "Received xthinblock %s from peer %s (%d). Size %d bytes.\n", inv.hash.ToString(),
+        pfrom->addrName.c_str(), pfrom->id, nSizeThinBlock);
+
+    bool fAlreadyHave = false;
+    // An expedited block or re-requested xthin can arrive and beat the original thin block request/response
+    if (!pfrom->mapThinBlocksInFlight.count(inv.hash))
+    {
+        LogPrint("thin", "xthinblock %s from peer %s (%d) received but we may already have processed it\n",
+            inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id);
+        LOCK(cs_main);
+        fAlreadyHave = AlreadyHave(inv); // I'll still continue processing if we don't have an accepted block yet
+        if (fAlreadyHave)
+            requester.Received(inv, pfrom,
+                nSizeThinBlock); // record the bytes received from the thinblock even though we had it already
+    }
+
+    if (!fAlreadyHave)
+        thinBlock.process(pfrom, nSizeThinBlock, NetMsgType::XTHINBLOCK);
+
+    return true;
+}
+
+// A request for an xthin block
+bool HandleGetXThin(CDataStream &vRecv, CNode *pfrom)
+{
+    if (!pfrom->ThinBlockCapable())
+    {
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 100);
+        return error("Thinblock message received from a non thinblock node, peer=%d", pfrom->GetId());
+    }
+
+    // Check for Misbehaving and DOS
+    // If they make more than 20 requests in 10 minutes then disconnect them
+    {
+        LOCK(cs_vNodes);
+        if (pfrom->nGetXthinLastTime <= 0)
+            pfrom->nGetXthinLastTime = GetTime();
+        uint64_t nNow = GetTime();
+        pfrom->nGetXthinCount *= std::pow(1.0 - 1.0 / 600.0, (double)(nNow - pfrom->nGetXthinLastTime));
+        pfrom->nGetXthinLastTime = nNow;
+        pfrom->nGetXthinCount += 1;
+        LogPrint("thin", "nGetXthinCount is %f\n", pfrom->nGetXthinCount);
+        if (Params().NetworkIDString() == "main") // other networks have variable mining rates
+        {
+            if (pfrom->nGetXthinCount >= 20)
+            {
+                LOCK(cs_main);
+                Misbehaving(pfrom->GetId(), 100); // If they exceed the limit then disconnect them
+                return error("requesting too many get_xthin");
+            }
+        }
+    }
+
+    CBloomFilter filterMemPool;
+    CInv inv;
+    vRecv >> inv >> filterMemPool;
+
+    // Message consistency checking
+    if (!((inv.type == MSG_XTHINBLOCK) || (inv.type == MSG_THINBLOCK)) || inv.hash.IsNull())
+    {
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 100);
+        return error("invalid get_xthin type=%u hash=%s", inv.type, inv.hash.ToString());
+    }
+
+
+    // Validates that the filter is reasonably sized.
+    LoadFilter(pfrom, &filterMemPool);
+    {
+        LOCK(cs_main);
+        BlockMap::iterator mi = mapBlockIndex.find(inv.hash);
+        if (mi == mapBlockIndex.end())
+        {
+            Misbehaving(pfrom->GetId(), 100);
+            return error(
+                "Peer %s (%d) requested nonexistent block %s", pfrom->addrName.c_str(), pfrom->id, inv.hash.ToString());
+        }
+
+        CBlock block;
+        const Consensus::Params &consensusParams = Params().GetConsensus();
+        if (!ReadBlockFromDisk(block, (*mi).second, consensusParams))
+        {
+            // We don't have the block yet, although we know about it.
+            return error("Peer %s (%d) requested block %s that cannot be read", pfrom->addrName.c_str(), pfrom->id,
+                inv.hash.ToString());
+        }
+        else
+        {
+            SendXThinBlock(block, pfrom, inv);
+        }
+    }
+
+    return true;
+}
+
+// A request for a missing tx
+bool HandleGetXBlockTx(CDataStream &vRecv, CNode *pfrom)
+{
+    if (!pfrom->ThinBlockCapable())
+    {
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 100);
+        return error("Thinblock message received from a non thinblock node, peer=%d", pfrom->GetId());
+    }
+
+    CXRequestThinBlockTx thinRequestBlockTx;
+    vRecv >> thinRequestBlockTx;
+
+    // Message consistency checking
+    if (thinRequestBlockTx.setCheapHashesToRequest.empty() || thinRequestBlockTx.blockhash.IsNull())
+    {
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 100);
+        return error("incorrectly constructed get_xblocktx received.  Banning peer=%d", pfrom->id);
+    }
+
+    // We use MSG_TX here even though we refer to blockhash because we need to track
+    // how many xblocktx requests we make in case of DOS
+    CInv inv(MSG_TX, thinRequestBlockTx.blockhash);
+    LogPrint("thin", "received get_xblocktx for %s peer=%d\n", inv.hash.ToString(), pfrom->id);
+
+    // Check for Misbehaving and DOS
+    // If they make more than 20 requests in 10 minutes then disconnect them
+    {
+        LOCK(cs_vNodes);
+        if (pfrom->nGetXBlockTxLastTime <= 0)
+            pfrom->nGetXBlockTxLastTime = GetTime();
+        uint64_t nNow = GetTime();
+        pfrom->nGetXBlockTxCount *= std::pow(1.0 - 1.0 / 600.0, (double)(nNow - pfrom->nGetXBlockTxLastTime));
+        pfrom->nGetXBlockTxLastTime = nNow;
+        pfrom->nGetXBlockTxCount += 1;
+        LogPrint("thin", "nGetXBlockTxCount is %f\n", pfrom->nGetXBlockTxCount);
+        if (pfrom->nGetXBlockTxCount >= 20)
+        {
+            LOCK(cs_main);
+            Misbehaving(pfrom->GetId(), 100); // If they exceed the limit then disconnect them
+            return error("DOS: Misbehaving - requesting too many xblocktx: %s\n", inv.hash.ToString());
+        }
+    }
+
+    {
+        LOCK(cs_main);
+        std::vector<CTransaction> vTx;
+        BlockMap::iterator mi = mapBlockIndex.find(inv.hash);
+        if (mi == mapBlockIndex.end())
+        {
+            LOCK(cs_main);
+            Misbehaving(pfrom->GetId(), 20);
+            return error("Requested block is not available");
+        }
+        else
+        {
+            CBlock block;
+            const Consensus::Params &consensusParams = Params().GetConsensus();
+            if (!ReadBlockFromDisk(block, (*mi).second, consensusParams))
+            {
+                LOCK(cs_main);
+                Misbehaving(pfrom->GetId(), 20);
+                return error("Cannot load block from disk -- Block txn request before assembled");
+            }
+            else
+            {
+                for (unsigned int i = 0; i < block.vtx.size(); i++)
+                {
+                    uint64_t cheapHash = block.vtx[i].GetHash().GetCheapHash();
+                    if (thinRequestBlockTx.setCheapHashesToRequest.count(cheapHash))
+                        vTx.push_back(block.vtx[i]);
+                }
+            }
+        }
+        CXThinBlockTx thinBlockTx(thinRequestBlockTx.blockhash, vTx);
+        pfrom->PushMessage(NetMsgType::XBLOCKTX, thinBlockTx);
+        pfrom->blocksSent += 1;
+    }
+
+    return true;
+}
+
+// An incoming missing tx
+bool HandleXBlockTx(CDataStream &vRecv, CNode *pfrom)
+{
+    if (!pfrom->ThinBlockCapable())
+    {
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 100);
+        return error("Thinblock message received from a non thinblock node, peer=%d", pfrom->GetId());
+    }
+
+    unsigned int msgSize = vRecv.size();
+
+    CXThinBlockTx thinBlockTx;
+    vRecv >> thinBlockTx;
+
+    // Message consistency checking
+    CInv inv(MSG_XTHINBLOCK, thinBlockTx.blockhash);
+    if (thinBlockTx.vMissingTx.empty() || thinBlockTx.blockhash.IsNull() ||
+        pfrom->xThinBlockHashes.size() != pfrom->thinBlock.vtx.size())
+    {
+        {
+            LOCK(cs_vNodes);
+            pfrom->mapThinBlocksInFlight.erase(inv.hash);
+            pfrom->thinBlockWaitingForTxns = -1;
+            pfrom->thinBlock.SetNull();
+        }
+
+        // Clear the thinblock timer used for preferential download
+        thindata.ClearThinBlockTimer(inv.hash);
+
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 100);
+        return error(
+            "incorrectly constructed xblocktx or inconsistent thinblock data received.  Banning peer=%d", pfrom->id);
+    }
+
+    LogPrint("net", "received blocktxs for %s peer=%d\n", inv.hash.ToString(), pfrom->id);
+    if (!pfrom->mapThinBlocksInFlight.count(inv.hash))
+    {
+        LogPrint("thin",
+            "xblocktx received but it was either not requested or it was beaten by another block %s  peer=%d\n",
+            inv.hash.ToString(), pfrom->id);
+        requester.Received(inv, pfrom, msgSize); // record the bytes received from the message
+        return true;
+    }
+
+    // Create the mapMissingTx from all the supplied tx's in the xthinblock
+    std::map<uint64_t, CTransaction> mapMissingTx;
+    BOOST_FOREACH (CTransaction tx, thinBlockTx.vMissingTx)
+        mapMissingTx[tx.GetHash().GetCheapHash()] = tx;
+
+    int count = 0;
+    for (size_t i = 0; i < pfrom->thinBlock.vtx.size(); i++)
+    {
+        if (pfrom->thinBlock.vtx[i].IsNull())
+        {
+            std::map<uint64_t, CTransaction>::iterator val = mapMissingTx.find(pfrom->xThinBlockHashes[i]);
+            if (val != mapMissingTx.end())
+            {
+                pfrom->thinBlock.vtx[i] = val->second;
+                pfrom->thinBlockWaitingForTxns--;
+            }
+            count++;
+        }
+    }
+    LogPrint("thin", "Got %d Re-requested txs, needed %d of them\n", thinBlockTx.vMissingTx.size(), count);
+
+    if (pfrom->thinBlockWaitingForTxns == 0)
+    {
+        // We have all the transactions now that are in this block: try to reassemble and process.
+        pfrom->thinBlockWaitingForTxns = -1;
+        requester.Received(inv, pfrom, msgSize);
+
+        // for compression statistics, we have to add up the size of xthinblock and the re-requested thinBlockTx.
+        int nSizeThinBlockTx = ::GetSerializeSize(thinBlockTx, SER_NETWORK, PROTOCOL_VERSION);
+        int blockSize = pfrom->thinBlock.GetSerializeSize(SER_NETWORK, CBlock::CURRENT_VERSION);
+        LogPrint("thin",
+            "Reassembled thin block for %s (%d bytes). Message was %d bytes (thinblock) and %d bytes (re-requested "
+            "tx), compression ratio %3.2f\n",
+            pfrom->thinBlock.GetHash().ToString(), blockSize, pfrom->nSizeThinBlock, nSizeThinBlockTx,
+            ((float)blockSize) / ((float)pfrom->nSizeThinBlock + (float)nSizeThinBlockTx));
+
+        // Update run-time statistics of thin block bandwidth savings.
+        // We add the original thinblock size with the size of transactions that were re-requested.
+        // This is NOT double counting since we never accounted for the original thinblock due to the re-request.
+        thindata.UpdateInBound(nSizeThinBlockTx + pfrom->nSizeThinBlock, blockSize);
+        LogPrint("thin", "thin block stats: %s\n", thindata.ToString());
+
+        PV.HandleBlockMessage(pfrom, NetMsgType::XBLOCKTX, pfrom->thinBlock, inv);
+    }
+    else
+    {
+        LogPrint("thin", "Failed to retrieve all transactions for block\n");
+        // An expedited block may request transactions that we don't have
+        // LOCK(cs_main);
+        // Misbehaving(pfrom->GetId(), 100);
     }
 
     return true;

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -382,8 +382,8 @@ bool CXThinBlock::process(CNode *pfrom,
     if (!fMerkleRootCorrect)
     {
         vector<CInv> vGetData;
-        vGetData.push_back(CInv(MSG_THINBLOCK, header.GetHash())); 
-        pfrom->PushMessage("getdata", vGetData); 
+        vGetData.push_back(CInv(MSG_THINBLOCK, header.GetHash()));
+        pfrom->PushMessage("getdata", vGetData);
         LogPrintf("xthinblock merkelroot does not match computed merkleroot - requesting full thinblock, peer=%d",
             pfrom->GetId());
         return true;

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -15,6 +15,7 @@
 #include "uint256.h"
 #include <vector>
 
+class CDataStream;
 class CNode;
 
 class CThinBlock
@@ -157,6 +158,12 @@ public:
 };
 extern CThinBlockData thindata; // Singleton class
 
+// Protocol message handlers
+bool HandleThinBlock(CDataStream &, CNode *);
+bool HandleXThinBlock(CDataStream &, CNode *);
+bool HandleGetXThin(CDataStream &, CNode *);
+bool HandleGetXBlockTx(CDataStream &, CNode *);
+bool HandleXBlockTx(CDataStream &, CNode *);
 
 bool HaveConnectThinblockNodes();
 bool HaveThinblockNodes();
@@ -165,7 +172,6 @@ bool CanThinBlockBeDownloaded(CNode *pto);
 void ConnectToThinBlockNodes();
 void CheckNodeSupportForThinBlocks();
 void SendXThinBlock(CBlock &block, CNode *pfrom, const CInv &inv);
-bool IsThinBlockValid(const CNode *pfrom, const std::vector<CTransaction> &vMissingTx, const CBlockHeader &header);
 void BuildSeededBloomFilter(CBloomFilter &memPoolFilter,
     std::vector<uint256> &vOrphanHashes,
     uint256 hash,


### PR DESCRIPTION
Logic is unchanged.
This puts most of the xthin-related code in the same file and will make simplifying / sharing more of the code easier.
This goes on top of #482 (and incorporates the minor fix I requested in that PR)