### PR TITLE
[port] crypto 32/64 bit fixes

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -52,8 +52,12 @@ building. Effectively this means GCC 4.7 or higher, or Clang 3.3 or higher.
 When cross-compiling for a target that doesn't have C++11 libraries, configure with
 `./configure --enable-glibc-back-compat ... LDFLAGS=-static-libstdc++`.
 
-0.12.1 Change log
-=================
+RPC low-level changes
+----------------------
+
+- `gettxoutsetinfo` UTXO hash (`hash_serialized`) has changed. There was a divergence between
+  32-bit and 64-bit platforms, and the txids were missing in the hashed data. This has been
+  fixed, but this means that the output will be different than from previous versions.
 
 Detailed release notes follow. This overview includes changes that affect
 behavior, not code moves, refactors and string updates. For convenience in locating
@@ -65,10 +69,10 @@ git merge commit are mentioned.
 Asm script outputs replacements for OP_NOP2 and OP_NOP3
 -------------------------------------------------------
 
-OP_NOP2 has been renamed to OP_CHECKLOCKTIMEVERIFY by [BIP 
+OP_NOP2 has been renamed to OP_CHECKLOCKTIMEVERIFY by [BIP
 65](https://github.com/bitcoin/bips/blob/master/bip-0065.mediawiki)
 
-OP_NOP3 has been renamed to OP_CHECKSEQUENCEVERIFY by [BIP 
+OP_NOP3 has been renamed to OP_CHECKSEQUENCEVERIFY by [BIP
 112](https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki)
 
 The following outputs are affected by this change:

--- a/src/crypto/ripemd160.h
+++ b/src/crypto/ripemd160.h
@@ -15,7 +15,7 @@ class CRIPEMD160
 private:
     uint32_t s[5];
     unsigned char buf[64];
-    size_t bytes;
+    uint64_t bytes;
 
 public:
     static const size_t OUTPUT_SIZE = 20;

--- a/src/crypto/sha1.h
+++ b/src/crypto/sha1.h
@@ -15,7 +15,7 @@ class CSHA1
 private:
     uint32_t s[5];
     unsigned char buf[64];
-    size_t bytes;
+    uint64_t bytes;
 
 public:
     static const size_t OUTPUT_SIZE = 20;

--- a/src/crypto/sha256.h
+++ b/src/crypto/sha256.h
@@ -15,7 +15,7 @@ class CSHA256
 private:
     uint32_t s[8];
     unsigned char buf[64];
-    size_t bytes;
+    uint64_t bytes;
 
 public:
     static const size_t OUTPUT_SIZE = 32;

--- a/src/crypto/sha512.h
+++ b/src/crypto/sha512.h
@@ -15,7 +15,7 @@ class CSHA512
 private:
     uint64_t s[8];
     unsigned char buf[128];
-    size_t bytes;
+    uint64_t bytes;
 
 public:
     static const size_t OUTPUT_SIZE = 64;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -133,6 +133,7 @@ bool CCoinsViewDB::GetStats(CCoinsStats &stats) const {
         if (pcursor->GetKey(key) && key.first == DB_COINS) {
             if (pcursor->GetValue(coins)) {
                 stats.nTransactions++;
+                ss << key;
                 for (unsigned int i=0; i<coins.vout.size(); i++) {
                     const CTxOut &out = coins.vout[i];
                     if (!out.IsNull()) {


### PR DESCRIPTION
This is a port of bitcoin#7848 for a 32/64 bit issue.  It's the first of several PRs to get src/crpyto directory up-to-date.

Before this core moved the coins stats stuff to the RPC directory; I looked at that change a while ago and didn't like it, so here the 1-line fix is applied to the original place in txdb.cpp.  Otherwise identical.