### PR TITLE
[port]: Fix various things -fsanitize complains about

### DIFF
--- a/src/crypto/common.h
+++ b/src/crypto/common.h
@@ -11,57 +11,73 @@
 #endif
 
 #include <stdint.h>
+#include <string.h>
 
 #include "compat/endian.h"
 
 uint16_t static inline ReadLE16(const unsigned char* ptr)
 {
-    return le16toh(*((uint16_t*)ptr));
+    uint16_t x;
+    memcpy((char*)&x, ptr, 2);
+    return le16toh(x);
 }
 
 uint32_t static inline ReadLE32(const unsigned char* ptr)
 {
-    return le32toh(*((uint32_t*)ptr));
+    uint32_t x;
+    memcpy((char*)&x, ptr, 4);
+    return le32toh(x);
 }
 
 uint64_t static inline ReadLE64(const unsigned char* ptr)
 {
-    return le64toh(*((uint64_t*)ptr));
+    uint64_t x;
+    memcpy((char*)&x, ptr, 8);
+    return le64toh(x);
 }
 
 void static inline WriteLE16(unsigned char* ptr, uint16_t x)
 {
-    *((uint16_t*)ptr) = htole16(x);
+    uint16_t v = htole16(x);
+    memcpy(ptr, (char*)&v, 2);
 }
 
 void static inline WriteLE32(unsigned char* ptr, uint32_t x)
 {
-    *((uint32_t*)ptr) = htole32(x);
+    uint32_t v = htole32(x);
+    memcpy(ptr, (char*)&v, 4);
 }
 
 void static inline WriteLE64(unsigned char* ptr, uint64_t x)
 {
-    *((uint64_t*)ptr) = htole64(x);
+    uint64_t v = htole64(x);
+    memcpy(ptr, (char*)&v, 8);
 }
 
 uint32_t static inline ReadBE32(const unsigned char* ptr)
 {
-    return be32toh(*((uint32_t*)ptr));
+    uint32_t x;
+    memcpy((char*)&x, ptr, 4);
+    return be32toh(x);
 }
 
 uint64_t static inline ReadBE64(const unsigned char* ptr)
 {
-    return be64toh(*((uint64_t*)ptr));
+    uint64_t x;
+    memcpy((char*)&x, ptr, 8);
+    return be64toh(x);
 }
 
 void static inline WriteBE32(unsigned char* ptr, uint32_t x)
 {
-    *((uint32_t*)ptr) = htobe32(x);
+    uint32_t v = htobe32(x);
+    memcpy(ptr, (char*)&v, 4);
 }
 
 void static inline WriteBE64(unsigned char* ptr, uint64_t x)
 {
-    *((uint64_t*)ptr) = htobe64(x);
+    uint64_t v = htobe64(x);
+    memcpy(ptr, (char*)&v, 8);
 }
 
 #endif // BITCOIN_CRYPTO_COMMON_H

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -109,7 +109,7 @@ static bool multiUserAuthorized(std::string strUserPass)
             std::string strHash = vFields[2];
 
             unsigned int KEY_SIZE = 32;
-            unsigned char *out = new unsigned char[KEY_SIZE];
+            unsigned char out[KEY_SIZE];
 
             CHMAC_SHA256(reinterpret_cast<const unsigned char*>(strSalt.c_str()), strSalt.size()).Write(reinterpret_cast<const unsigned char*>(strPass.c_str()), strPass.size()).Finalize(out);
             std::vector<unsigned char> hexvec(out, out+KEY_SIZE);

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -18,7 +18,6 @@
 #include "version.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/dynamic_bitset.hpp>
 
 #include <univalue.h>
 
@@ -502,7 +501,8 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
     vector<unsigned char> bitmap;
     vector<CCoin> outs;
     std::string bitmapStringRepresentation;
-    boost::dynamic_bitset<unsigned char> hits(vOutPoints.size());
+    std::vector<bool> hits;
+    bitmap.resize((vOutPoints.size() + 7) / 8);
     {
         LOCK2(cs_main, mempool.cs);
 
@@ -518,10 +518,11 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
         for (size_t i = 0; i < vOutPoints.size(); i++) {
             CCoins coins;
             uint256 hash = vOutPoints[i].hash;
+            bool hit = false;
             if (view.GetCoins(hash, coins)) {
                 mempool.pruneSpent(hash, coins);
                 if (coins.IsAvailable(vOutPoints[i].n)) {
-                    hits[i] = true;
+                    hit = true;
                     // Safe to index into vout here because IsAvailable checked if it's off the end of the array, or if
                     // n is valid but points to an already spent output (IsNull).
                     CCoin coin;
@@ -533,10 +534,11 @@ static bool rest_getutxos(HTTPRequest* req, const std::string& strURIPart)
                 }
             }
 
-            bitmapStringRepresentation.append(hits[i] ? "1" : "0"); // form a binary string representation (human-readable for json output)
+            hits.push_back(hit);
+            bitmapStringRepresentation.append(hit ? "1" : "0"); // form a binary string representation (human-readable for json output)
+            bitmap[i / 8] |= ((uint8_t)hit) << (i % 8);
         }
     }
-    boost::to_block_range(hits, std::back_inserter(bitmap));
 
     switch (rf) {
     case RF_BINARY: {

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -139,18 +139,18 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
 
     in_addr ipv4Addr;
     ipv4Addr.s_addr = 0xa0b0c001;
-    
+
     CAddress addr = CAddress(CService(ipv4Addr, 7777), NODE_NETWORK);
     std::string pszDest = "";
     bool fInboundIn = false;
 
     // Test that fFeeler is false by default.
-    CNode* pnode1 = new CNode(hSocket, addr, pszDest, fInboundIn);
+    std::unique_ptr<CNode> pnode1(new CNode(hSocket, addr, pszDest, fInboundIn));
     BOOST_CHECK(pnode1->fInbound == false);
     BOOST_CHECK(pnode1->fFeeler == false);
 
     fInboundIn = true;
-    CNode* pnode2 = new CNode(hSocket, addr, pszDest, fInboundIn);
+    std::unique_ptr<CNode> pnode2(new CNode(hSocket, addr, pszDest, fInboundIn));
     BOOST_CHECK(pnode2->fInbound == true);
     BOOST_CHECK(pnode2->fFeeler == false);
 }

--- a/src/test/scriptnum_tests.cpp
+++ b/src/test/scriptnum_tests.cpp
@@ -13,8 +13,10 @@
 
 BOOST_FIXTURE_TEST_SUITE(scriptnum_tests, BasicTestingSetup)
 
-static const int64_t values[] = \
-{ 0, 1, CHAR_MIN, CHAR_MAX, UCHAR_MAX, SHRT_MIN, USHRT_MAX, INT_MIN, INT_MAX, UINT_MAX, LONG_MIN, LONG_MAX };
+/** A selection of numbers that do not trigger int64_t overflow
+ *  when added/subtracted. */
+static const int64_t values[] = { 0, 1, -2, 127, 128, -255, 256, (1LL << 15) - 1, -(1LL << 16), (1LL << 24) - 1, (1LL << 31), 1 - (1LL << 32), 1LL << 40 };
+
 static const int64_t offsets[] = { 1, 0x79, 0x80, 0x81, 0xFF, 0x7FFF, 0x8000, 0xFFFF, 0x10000};
 
 static bool verify(const CScriptNum10& bignum, const CScriptNum& scriptnum)


### PR DESCRIPTION
This is bitcoin#9512; cleanup for various minor leaks and correctness issues.  Along with the other 2 crypto-PRs I've submitted, this makes BU's src/crypto in line with core's, except I've not imported their ChaCha as we do not use it yet.

82e8baa Avoid boost dynamic_bitset in rest_getutxos (Pieter Wuille)
99f001e Fix memory leak in multiUserAuthorized (Pieter Wuille)
5a0b7e4 Fix memory leak in net_tests (Pieter Wuille)
6b03bfb Fix memory leak in wallet tests (Pieter Wuille)
f94f3e0 Avoid integer overflows in scriptnum tests (Pieter Wuille)
843c560 Avoid unaligned access in crypto i/o (Pieter Wuille)