### PR TITLE
Don't send expedited blocks until PoW verified

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5958,11 +5958,6 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
             return error("Invalid xthinblock received");
         }
 
-        // Send expedited block ASAP
-        CInv inv(MSG_BLOCK, thinBlock.header.GetHash());
-        if (!IsRecentlyExpeditedAndStore(inv.hash))
-            SendExpeditedBlock(thinBlock, 0, pfrom);
-
         // Is there a previous block or header to connect with?
         {
             LOCK(cs_main);
@@ -5988,6 +5983,11 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
                     state.GetRejectReason().c_str());
             }
         }
+
+        // Send expedited block without checking merkle root.
+        CInv inv(MSG_BLOCK, thinBlock.header.GetHash());
+        if (!IsRecentlyExpeditedAndStore(inv.hash))
+            SendExpeditedBlock(thinBlock, 0, pfrom);
 
         int nSizeThinBlock = ::GetSerializeSize(thinBlock, SER_NETWORK, PROTOCOL_VERSION);
         LogPrint("thin", "Received xthinblock %s from peer %s (%d). Size %d bytes.\n", inv.hash.ToString(),


### PR DESCRIPTION
At present we send an expedited block before checking the PoW or merkle root.  This is a bad idea, but worse it means our peer will ban us if we send something bad, and without the above checks it's easy for an attacker to get a BU node to send an invalid expedited block.

This patch remedies that by not sending one until both checks are done.