### PR TITLE
[Release] thintimer backport

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -635,6 +635,9 @@ void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<CBl
     CNodeState *state = State(nodeid);
     DbgAssert(state != NULL, return);
 
+    // If started then clear the thinblock timer used for preferential downloading
+    thindata.ClearThinBlockTimer(hash);
+
     // BU why mark as received? because this erases it from the inflight list.  Instead we'll check for it
     // BU removed: MarkBlockAsReceived(hash);
     map<uint256, pair<NodeId, list<QueuedBlock>::iterator> >::iterator itInFlight = mapBlocksInFlight.find(hash);

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -845,6 +845,12 @@ string CThinBlockData::MempoolLimiterBytesSavedToString()
     return ss.str();
 }
 
+// Preferential Thinblock Timer:
+// The purpose of the timer is to ensure that we more often download an XTHINBLOCK rather than a full block.
+// The timer is started when we receive the first announcement indicating there is a new block to download.  If the
+// block inventory is from a non XTHIN node then we will continue to wait for block announcements until either we
+// get one from an XTHIN capable node or the timer is exceeded.  If the timer is exceeded before receiving an
+// announcement from an XTHIN node then we just download a full block instead of an xthin.
 bool CThinBlockData::CheckThinblockTimer(uint256 hash)
 {
     LOCK(cs_mapThinBlockTimer);
@@ -864,7 +870,7 @@ bool CThinBlockData::CheckThinblockTimer(uint256 hash)
     }
     return true;
 }
-
+// The timer is cleared as soon as we request a block or thinblock.
 void CThinBlockData::ClearThinBlockTimer(uint256 hash)
 {
     LOCK(cs_mapThinBlockTimer);

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1235,9 +1235,6 @@ void HandleBlockMessage(CNode *pfrom, const string &strCommand, CBlock &block, c
             setUnVerifiedOrphanTxHash.clear();
         }
     }
-
-    // Clear the thinblock timer used for preferential download
-    thindata.ClearThinBlockTimer(inv.hash);
 }
 
 bool CheckAndRequestExpeditedBlocks(CNode* pfrom)


### PR DESCRIPTION
…ived

Fix for issue #477

Clearing the timer after the request is sent rather than when the block
is received prevents the possiblity of downloading a block twice before
the RequestManager re-request timeout is exceeded.  Rely instead
only on the RequestManager to determine whether a block download timeout
has been exceeded.

Add documentation explaining the functioning of the thinblock timer.