### PR TITLE
 Combine expedited block and xthin block handling

### DIFF
--- a/src/expedited.cpp
+++ b/src/expedited.cpp
@@ -197,58 +197,13 @@ bool HandleExpeditedBlock(CDataStream &vRecv, CNode *pfrom)
 
     if (msgType == EXPEDITED_MSG_XTHIN)
     {
-        CXThinBlock thinBlock;
-        vRecv >> thinBlock;
-        uint256 blkHash = thinBlock.header.GetHash();
-        CInv inv(MSG_BLOCK, blkHash);
-
-        bool newBlock = false;
-        unsigned int status = 0;
-        {
-            LOCK(cs_main);
-            BlockMap::iterator mapEntry = mapBlockIndex.find(blkHash);
-            CBlockIndex *blkidx = NULL;
-            if (mapEntry != mapBlockIndex.end())
-            {
-                blkidx = mapEntry->second;
-                if (blkidx)
-                    status = blkidx->nStatus;
-            }
-
-            // If we do not have the block on disk or do not have the header yet then treat the block as new.
-            newBlock = ((blkidx == NULL) || (!(blkidx->nStatus & BLOCK_HAVE_DATA)));
-        }
-
-        int nSizeThinBlock = ::GetSerializeSize(thinBlock, SER_NETWORK, PROTOCOL_VERSION);
-        LogPrint("thin",
-            "Received %s expedited thinblock %s from peer %s (%d). Hop %d. Size %d bytes. (status %d,0x%x)\n",
-            newBlock ? "new" : "repeated", inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id, hops,
-            nSizeThinBlock, status, status);
-
-        // TODO: Move this section above the print once we ensure no unexpected dups.
-        // Skip if we've already seen this block
-        if (IsRecentlyExpeditedAndStore(blkHash))
-            return true;
-        if (!newBlock)
-            return true;
-
-        CValidationState state;
-        if (!CheckBlockHeader(thinBlock.header, state, true))
-            return false;
-
-        // TODO: Start headers-only mining now
-
-        SendExpeditedBlock(thinBlock, hops + 1, pfrom);
-
-        // Process the thinblock
-        thinBlock.process(pfrom, nSizeThinBlock, NetMsgType::XPEDITEDBLK);
+        return CXThinBlock::HandleMessage(vRecv, pfrom, NetMsgType::XPEDITEDBLK, hops + 1);
     }
     else
     {
         return error("Received unknown (0x%x) expedited message from peer %s (%d). Hop %d.\n", msgType,
             pfrom->addrName.c_str(), pfrom->id, hops);
     }
-    return true;
 }
 
 void SendExpeditedBlock(CXThinBlock &thinBlock, unsigned char hops, const CNode *skip)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6002,11 +6002,6 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
             return error("Invalid xthinblock received");
         }
 
-        // Send expedited block ASAP
-        CInv inv(MSG_BLOCK, thinBlock.header.GetHash());
-        if (!IsRecentlyExpeditedAndStore(inv.hash))
-            SendExpeditedBlock(thinBlock, 0, pfrom);
-
         // Is there a previous block or header to connect with?
         {
             LOCK(cs_main);
@@ -6032,6 +6027,11 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
                     state.GetRejectReason().c_str());
             }
         }
+
+        // Send expedited block without checking merkle root.
+        CInv inv(MSG_BLOCK, thinBlock.header.GetHash());
+        if (!IsRecentlyExpeditedAndStore(inv.hash))
+            SendExpeditedBlock(thinBlock, 0, pfrom);
 
         int nSizeThinBlock = ::GetSerializeSize(thinBlock, SER_NETWORK, PROTOCOL_VERSION);
         LogPrint("thin", "Received xthinblock %s from peer %s (%d). Size %d bytes.\n", inv.hash.ToString(),

--- a/src/main.h
+++ b/src/main.h
@@ -228,6 +228,7 @@ bool LoadBlockIndex();
 void UnloadBlockIndex();
 /** Process protocol messages received from a given node */
 bool ProcessMessages(CNode* pfrom);
+bool AlreadyHave(const CInv &);
 /** Process a single protocol messages received from a given node */
 bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, int64_t nTimeReceived);
 

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -5,6 +5,7 @@
 #include "thinblock.h"
 #include "chainparams.h"
 #include "consensus/merkle.h"
+#include "expedited.h"
 #include "main.h"
 #include "net.h"
 #include "parallel.h"
@@ -245,6 +246,110 @@ bool CXThinBlock::CheckBlockHeader(const CBlockHeader &block, CValidationState &
             error("CheckBlockHeader(): block timestamp too far in the future"), REJECT_INVALID, "time-too-new");
 
     return true;
+}
+
+/**
+ * Handle an incoming Xthin or Xpedited block
+ * Once the block is validated apart from the Merkle root, forward the Xpedited block with a hop count of nHops.
+ */
+bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strCommand, unsigned nHops)
+{
+    if (!pfrom->ThinBlockCapable())
+    {
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 100);
+        return error("%s message received from a non thinblock node, peer=%d", strCommand, pfrom->GetId());
+    }
+
+    int nSizeThinBlock = vRecv.size();
+    CXThinBlock thinBlock;
+    vRecv >> thinBlock;
+
+    // Message consistency checking
+    if (!IsThinBlockValid(pfrom, thinBlock.vMissingTx, thinBlock.header))
+    {
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 100);
+        return error("Invalid %s received", strCommand);
+    }
+
+    // Is there a previous block or header to connect with?
+    {
+        LOCK(cs_main);
+        uint256 prevHash = thinBlock.header.hashPrevBlock;
+        BlockMap::iterator mi = mapBlockIndex.find(prevHash);
+        if (mi == mapBlockIndex.end())
+        {
+            Misbehaving(pfrom->GetId(), 10);
+            return error("%s from peer %s (%d) will not connect, unknown previous block %s",
+                strCommand, pfrom->addrName.c_str(), pfrom->id, prevHash.ToString());
+        }
+        CBlockIndex *pprev = mi->second;
+        CValidationState state;
+        if (!ContextualCheckBlockHeader(thinBlock.header, state, pprev))
+        {
+            // Thin block does not fit within our blockchain
+            Misbehaving(pfrom->GetId(), 100);
+            return error("%s from peer %s (%d) contextual error: %s", strCommand, pfrom->addrName.c_str(),
+                pfrom->id, state.GetRejectReason().c_str());
+        }
+    }
+
+    CInv inv(MSG_BLOCK, thinBlock.header.GetHash());
+    bool fAlreadyHave = false;
+
+    if (nHops > 0)
+    {
+        bool newBlock = false;
+        unsigned int status = 0;
+
+        LOCK(cs_main);
+        BlockMap::iterator mapEntry = mapBlockIndex.find(inv.hash);
+        CBlockIndex *blkidx = NULL;
+        if (mapEntry != mapBlockIndex.end())
+        {
+            blkidx = mapEntry->second;
+            if (blkidx)
+                status = blkidx->nStatus;
+        }
+
+        // If we do not have the block on disk or do not have the header yet then treat the block as new.
+        newBlock = blkidx == NULL || !(blkidx->nStatus & BLOCK_HAVE_DATA);
+
+        LogPrint("thin",
+            "Received %s expedited thinblock %s from peer %s (%d). Hop %d. Size %d bytes. (status %d,0x%x)\n",
+            newBlock ? "new" : "repeated", inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id, nHops,
+            nSizeThinBlock, status, status);
+
+        if (!newBlock)
+            return true;
+    }
+    else
+    {
+        LogPrint("thin", "Received %s %s from peer %s (%d). Size %d bytes.\n", strCommand, inv.hash.ToString(),
+            pfrom->addrName.c_str(), pfrom->id, nSizeThinBlock);
+
+        // An expedited block or re-requested xthin can arrive and beat the original thin block request/response
+        if (!pfrom->mapThinBlocksInFlight.count(inv.hash))
+        {
+            LogPrint("thin", "%s %s from peer %s (%d) received but we may already have processed it\n",
+                strCommand, inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id);
+            LOCK(cs_main);
+            fAlreadyHave = AlreadyHave(inv); // I'll still continue processing if we don't have an accepted block yet
+            if (fAlreadyHave)
+                // record the bytes received from the thinblock even though we had it already
+                requester.Received(inv, pfrom, nSizeThinBlock);
+        }
+    }
+
+    // Send expedited block without checking merkle root.
+    if (!IsRecentlyExpeditedAndStore(inv.hash))
+        SendExpeditedBlock(thinBlock, nHops, pfrom);
+
+    if (fAlreadyHave)
+        return true;
+
+    return thinBlock.process(pfrom, nSizeThinBlock, strCommand);
 }
 
 bool CXThinBlock::process(CNode *pfrom,

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -15,6 +15,7 @@
 #include "uint256.h"
 #include <vector>
 
+class CDataStream;
 class CNode;
 
 class CThinBlock
@@ -53,6 +54,19 @@ public:
     CXThinBlock(const CBlock &block, CBloomFilter *filter); // Use the filter to determine which txns the client has
     CXThinBlock(const CBlock &block); // Assume client has all of the transactions (except coinbase)
     CXThinBlock() {}
+    /**
+     * Handle an incoming Xthin or Xpedited block
+     * Once the block is validated apart from the Merkle root, forward the Xpedited block with a hop count of nHops.
+     * @param[in]  vRecv        The raw binary message
+     * @param[in] pFrom        The node the message was from
+     * @param[in]  strCommand   The message kind
+     * @param[in]  nHops        On the wire, an Xpedited block has a hop count of zero the first time it is sent, and
+     *                          the hop count is incremented each time it is forwarded.  nHops is zero for an incoming
+     *                          Xthin block, and for an incoming Xpedited block its hop count + 1.
+     * @return True if handling succeeded
+     */
+    static bool HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string strCommand, unsigned nHops);
+
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>


### PR DESCRIPTION
A common function that unifies the two message handlers to have a single codepath
for verification.  The only differences lie in determining new-ness of the block.
The prior expedited code path used to omit most of the validity checks.

This is built on #482 and #502.  Unfortunately they conflict (with trivial resolution as in this PR); it's probably cleanest to apply them in that order.