### PR TITLE
[WIP][port] Prepare to move some concensus code out of main.cpp

### DIFF
--- a/qa/rpc-tests/validateblocktemplate.py
+++ b/qa/rpc-tests/validateblocktemplate.py
@@ -144,7 +144,7 @@ class ValidateblocktemplateTest(BitcoinTestFramework):
         block.rehash()
         hexblk = ToHex(block)
         expectException(lambda: self.nodes[0].validateblocktemplate(hexblk),
-                        JSONRPCException, "invalid block: bad-blk-length")
+                        JSONRPCException, "invalid block: bad-no-txs")
 
         logging.info("good block")
         block = create_block(tip, coinbase, cur_time + 600)


### PR DESCRIPTION
This is bitcoin#7287.  We lose the extra info BU had in the bad height rejection message, but I think that is unavoidable given the goal of this PR.

@gandrewstone Note the BU SigOp fail case sets CorruptionPossible to true in the DoS call.  This is the opposite of Core - I've preserved it but can you justify this?  Is it related to the comment above the line?  

Original PR comment:

Remove calls to error() and FormatStateMessage() from some consensus code in main.

This is necessary because libconsensus cannot depend on util.cpp, which exposes globals among other things. Doing this before moving this consensus code out of main allows consensus/consensus.cpp to never depend on util.cpp and it removes the necessity to make FormatStateMessage() non-static to call it, temporarily, from consensus/consensus.cpp.

This also restores some error reporting that seems to have been lost, maybe while moving to use FormatStateMessage().