### PR TITLE
[Port] Eliminate unnecessary call to CheckBlock

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4364,14 +4364,6 @@ bool ProcessNewBlock(CValidationState &state,
     if (IsChainNearlySyncd())
         SendExpeditedBlock(*pblock, pfrom);
 
-    bool checked = CheckBlock(*pblock, state);
-    if (!checked)
-    {
-        int byteLen = ::GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION);
-        LogPrintf("Invalid block: ver:%x time:%d Tx size:%d len:%d\n", pblock->nVersion, pblock->nTime,
-            pblock->vtx.size(), byteLen);
-    }
-
     // WARNING: cs_main is not locked here throughout but is released and then re-locked during ActivateBestChain
     //          If you lock cs_main throughout ProcessNewBlock then you will in effect prevent PV from happening.
     //          TODO: in order to lock cs_main all the way through we must remove the locking from ActivateBestChain
@@ -4381,10 +4373,6 @@ bool ProcessNewBlock(CValidationState &state,
         LOCK(cs_main);
         bool fRequested = MarkBlockAsReceived(pblock->GetHash());
         fRequested |= fForceProcessing;
-        if (!checked)
-        {
-            return error("%s: CheckBlock FAILED", __func__);
-        }
 
         // Store to disk
         CBlockIndex *pindex = NULL;


### PR DESCRIPTION
From bitcoin#7225:

> ProcessNewBlock would return failure early if CheckBlock failed, before
> calling AcceptBlock.  AcceptBlock also calls CheckBlock, and upon failure
> would update mapBlockIndex to indicate that a block was failed.  By returning
> early in ProcessNewBlock, we were not marking blocks that fail a check in
> CheckBlock as permanently failed, and thus would continue to re-request and
> reprocess them.

For the reasons stated in the comments to the core PR, I think we should review the purpose and usefulness of the CheckBlockHeader call we have at the top of ProcessNewBlock and perhaps move the SendExpeditedBlock call to a more appropriate place, I don't think the current position is optimal.  But that's for a later PR once this is accepted.