### PR TITLE
[Review] More UI fixes

### DIFF
--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -36,7 +36,7 @@
     <property name="verticalSpacing">
      <number>8</number>
     </property>
-    <item row="3" column="1">
+    <item row="4" column="1">
      <layout class="QHBoxLayout" name="horizontalLayoutAmount" stretch="0,1">
       <item>
        <widget class="BitcoinAmountField" name="payAmount"/>
@@ -53,7 +53,7 @@
       </item>
      </layout>
     </item>
-    <item row="4" column="0">
+    <item row="5" column="0">
      <widget class="QLabel" name="messageLabel">
       <property name="text">
        <string>Private Description:</string>
@@ -76,7 +76,7 @@
       </property>
      </widget>
     </item>
-    <item row="3" column="0">
+    <item row="4" column="0">
      <widget class="QLabel" name="amountLabel">
       <property name="text">
        <string>A&amp;mount:</string>
@@ -99,6 +99,13 @@
       </property>
       <property name="buddy">
        <cstring>payTo</cstring>
+      </property>
+     </widget>
+    </item>
+    <item row="6" column="0" colspan="2">
+     <widget class="Line" name="line">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
       </property>
      </widget>
     </item>
@@ -182,14 +189,7 @@
       </item>
      </layout>
     </item>
-    <item row="5" column="0" colspan="2">
-     <widget class="Line" name="line">
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="4" column="1">
+    <item row="5" column="1">
      <widget class="QLabel" name="messageTextLabel">
       <property name="toolTip">
        <string>A message that was attached to the bitcoin: URI which will be stored with the transaction for your reference. Note: This message will not be sent over the Bitcoin network.</string>
@@ -211,19 +211,29 @@
      </layout>
     </item>
     <item row="2" column="1">
-     <widget class="QLineEdit" name="lineEditPublic">
-      <property name="toolTip">
-       <string>Enter a public label for this transaction</string>
-      </property>
-     </widget>
+     <layout class="QHBoxLayout" name="labelPublicLayout">
+      <item>
+       <widget class="QLineEdit" name="lineEditPublic">
+        <property name="toolTip">
+         <string>Enter a public label for this transaction</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </item>
-    <item row="2" column="0" alignment="Qt::AlignRight">
+    <item row="2" column="0">
      <widget class="QLabel" name="labelPublic">
       <property name="text">
-       <string>Public Label:</string>
+       <string>&amp;Public Label:</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
       </property>
       <property name="margin">
-       <number>5</number>
+       <number>0</number>
+      </property>
+      <property name="buddy">
+       <cstring>lineEditPublic</cstring>
       </property>
      </widget>
     </item>
@@ -1287,10 +1297,10 @@
   <tabstop>lineEditPublic</tabstop>
   <tabstop>payAmount</tabstop>
   <tabstop>checkboxSubtractFeeFromAmount</tabstop>
-  <tabstop>deleteButton_is</tabstop>
   <tabstop>payAmount_s</tabstop>
   <tabstop>payAmount_is</tabstop>
   <tabstop>deleteButton_s</tabstop>
+  <tabstop>deleteButton_is</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -48,18 +48,21 @@ ReceiveCoinsDialog::ReceiveCoinsDialog(const PlatformStyle *platformStyle, QWidg
     }
 
     // context menu actions
+    QAction *copyAddressAction = new QAction(tr("Copy address"), this);
     QAction *copyLabelAction = new QAction(tr("Copy label"), this);
     QAction *copyMessageAction = new QAction(tr("Copy message"), this);
     QAction *copyAmountAction = new QAction(tr("Copy amount"), this);
 
     // context menu
     contextMenu = new QMenu();
+    contextMenu->addAction(copyAddressAction);
     contextMenu->addAction(copyLabelAction);
     contextMenu->addAction(copyMessageAction);
     contextMenu->addAction(copyAmountAction);
 
     // context menu signals
     connect(ui->recentRequestsView, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showMenu(QPoint)));
+    connect(copyAddressAction, SIGNAL(triggered()), this, SLOT(copyAddress()));
     connect(copyLabelAction, SIGNAL(triggered()), this, SLOT(copyLabel()));
     connect(copyMessageAction, SIGNAL(triggered()), this, SLOT(copyMessage()));
     connect(copyAmountAction, SIGNAL(triggered()), this, SLOT(copyAmount()));
@@ -322,6 +325,12 @@ void ReceiveCoinsDialog::showMenu(const QPoint &point)
     if(selection.empty())
         return;
     contextMenu->exec(QCursor::pos());
+}
+
+// context menu action: copy address
+void ReceiveCoinsDialog::copyAddress()
+{
+    copyColumnToClipboard(RecentRequestsTableModel::Address);
 }
 
 // context menu action: copy label

--- a/src/qt/receivecoinsdialog.h
+++ b/src/qt/receivecoinsdialog.h
@@ -79,6 +79,7 @@ private Q_SLOTS:
     void recentRequestsView_selectionChanged(const QItemSelection &selected, const QItemSelection &deselected);
     void updateDisplayUnit();
     void showMenu(const QPoint &point);
+    void copyAddress();
     void copyLabel();
     void copyMessage();
     void copyAmount();

--- a/src/qt/recentrequeststablemodel.cpp
+++ b/src/qt/recentrequeststablemodel.cpp
@@ -64,6 +64,8 @@ QVariant RecentRequestsTableModel::data(const QModelIndex &index, int role) cons
         {
         case Date:
             return GUIUtil::dateTimeStr(rec->date);
+        case Address:
+            return rec->recipient.address;
         case Label:
             if(rec->recipient.label.isEmpty() && role == Qt::DisplayRole)
             {

--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -70,6 +70,7 @@ public:
         Label = 1,
         Message = 2,
         Amount = 3,
+        Address = 4,
         NUMBER_OF_COLUMNS
     };
 

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -277,40 +277,45 @@ void SendCoinsDialog::on_sendButton_clicked()
     QStringList formatted;
     Q_FOREACH(const SendCoinsRecipient &rcp, currentTransaction.getRecipients())
     {
-
-        // generate bold amount string
-        QString amount = "<b>" + BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp.amount);
-        amount.append("</b>");
-        // generate monospace address string
-        QString address = "<span style='font-family: monospace;'>" + rcp.address;
-        address.append("</span>");
-
         QString recipientElement;
 
-        if (!rcp.paymentRequest.IsInitialized()) // normal payment
-        {
-            if(rcp.label.length() > 0) // label with address
+        // Show public label on send confirmation dialog if it exists
+        if (!rcp.labelPublic.isEmpty())
+            recipientElement = tr("<b>Public label:</b> %1").arg(rcp.labelPublic);
+        else {
+            // generate bold amount string
+            QString amount = "<b>" + BitcoinUnits::formatHtmlWithUnit(model->getOptionsModel()->getDisplayUnit(), rcp.amount);
+            amount.append("</b>");
+            // generate monospace address string
+            QString address = "<span style='font-family: monospace;'>" + rcp.address;
+            address.append("</span>");
+
+            if (!rcp.paymentRequest.IsInitialized()) // normal payment
             {
-                recipientElement = tr("%1 to %2").arg(amount, GUIUtil::HtmlEscape(rcp.label));
-                recipientElement.append(QString(" (%1)").arg(address));
+                if(rcp.label.length() > 0) // label with address
+                {
+                    recipientElement = tr("%1 to %2").arg(amount, GUIUtil::HtmlEscape(rcp.label));
+                    recipientElement.append(QString(" (%1)").arg(address));
+                }
+                else // just address
+                {
+                    recipientElement = tr("%1 to %2").arg(amount, address);
+                }
             }
-            else // just address
+            else if(!rcp.authenticatedMerchant.isEmpty()) // authenticated payment request
+            {
+                recipientElement = tr("%1 to %2").arg(amount, GUIUtil::HtmlEscape(rcp.authenticatedMerchant));
+            }
+            else // unauthenticated payment request
             {
                 recipientElement = tr("%1 to %2").arg(amount, address);
             }
-        }
-        else if(!rcp.authenticatedMerchant.isEmpty()) // authenticated payment request
-        {
-            recipientElement = tr("%1 to %2").arg(amount, GUIUtil::HtmlEscape(rcp.authenticatedMerchant));
-        }
-        else // unauthenticated payment request
-        {
-            recipientElement = tr("%1 to %2").arg(amount, address);
-        }
-        if (!rcp.freezeLockTime.isEmpty()) // freeze payment
-        {
-            recipientElement.append(tr("<br><br><b>WARNING!!! DESTINATION IS A FREEZE ADDRESS<br>UNSPENDABLE UNTIL</b> %1 <br>*********************************************<br>").arg(GUIUtil::HtmlEscape(rcp.freezeLockTime)));
-        }
+            if (!rcp.freezeLockTime.isEmpty()) // freeze payment
+            {
+                recipientElement.append(tr("<br><br><b>WARNING!!! DESTINATION IS A FREEZE ADDRESS<br>UNSPENDABLE UNTIL</b> %1 <br>*************************************************<br>").arg(GUIUtil::HtmlEscape(rcp.freezeLockTime)));
+            }
+
+        } // else if (!rcp.labelPublic.isEmpty())
 
 
         formatted.append(recipientElement);

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -181,8 +181,9 @@ QWidget *SendCoinsEntry::setupTabChain(QWidget *prev)
 {
     QWidget::setTabOrder(prev, ui->payTo);
     QWidget::setTabOrder(ui->payTo, ui->addAsLabel);
-    QWidget *w = ui->payAmount->setupTabChain(ui->addAsLabel);
-    QWidget::setTabOrder(w, ui->checkboxSubtractFeeFromAmount);
+    QWidget::setTabOrder(ui->addAsLabel, ui->labelPublic);
+    QWidget::setTabOrder(ui->labelPublic, ui->payAmount);
+    QWidget::setTabOrder(ui->payAmount, ui->checkboxSubtractFeeFromAmount);
     QWidget::setTabOrder(ui->checkboxSubtractFeeFromAmount, ui->addressBookButton);
     QWidget::setTabOrder(ui->addressBookButton, ui->pasteButton);
     QWidget::setTabOrder(ui->pasteButton, ui->deleteButton);

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -96,14 +96,28 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
                 if (wallet->mapAddressBook.count(address))
                 {
                     strHTML += "<b>" + tr("From") + ":</b> " + tr("unknown") + "<br>";
+
+                    // Include in description public label if it exists
+                    std::string labelPublic = getLabelPublic(wtx.vout[0].scriptPubKey);
+                    if (labelPublic != "")
+                        strHTML += "<b>" + tr("Public label:") + "</b> " + labelPublic.c_str() + "<br>";
+
                     strHTML += "<b>" + tr("To") + ":</b> ";
-                    strHTML += GUIUtil::HtmlEscape(rec->addresses.begin()->first);
-                    QString addressOwned = (wallet->IsMine(address) == ISMINE_SPENDABLE) ? tr("own address") : tr("watch-only");
                     if (!wallet->mapAddressBook[address].name.empty())
-                        strHTML += " (" + addressOwned + ", " + tr("label") + ": " + GUIUtil::HtmlEscape(wallet->mapAddressBook[address].name) + ")";
+                        strHTML += GUIUtil::HtmlEscape(wallet->mapAddressBook[address].name) + " ";
+
+                    strHTML += GUIUtil::HtmlEscape(rec->addresses.begin()->first);
+                    QString addressOwned;
+                    // Include in description label for change address, own address or watch-only
+                    if (wtx.vout[0].nValue == wtx.GetChange() && wallet->IsMine(address) == ISMINE_SPENDABLE)
+                        addressOwned = tr("change address");
                     else
-                        strHTML += " (" + addressOwned + ")";
+                        (wallet->IsMine(address) == ISMINE_SPENDABLE) ? tr("own address") : tr("watch-only");
+
+                    if (addressOwned != "") strHTML += " (" + addressOwned + ")";
+
                     strHTML += "<br>";
+
                 }
             }
         }
@@ -114,6 +128,11 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
     //
     if (wtx.mapValue.count("to") && !wtx.mapValue["to"].empty())
     {
+        // Include in description public label if it exists
+        std::string labelPublic = getLabelPublic(wtx.vout[0].scriptPubKey);
+        if (labelPublic != "")
+            strHTML += "<b>" + tr("Public label:") + "</b> " + labelPublic.c_str() + "<br>";
+
         // Online transaction
         std::string strAddress = wtx.mapValue["to"];
         strHTML += "<b>" + tr("To") + ":</b> ";
@@ -121,6 +140,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
         if (wallet->mapAddressBook.count(dest) && !wallet->mapAddressBook[dest].name.empty())
             strHTML += GUIUtil::HtmlEscape(wallet->mapAddressBook[dest].name) + " ";
         strHTML += GUIUtil::HtmlEscape(strAddress) + "<br>";
+
     }
 
     if (labelFreeze != "")
@@ -140,6 +160,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
         CAmount nUnmatured = 0;
         BOOST_FOREACH(const CTxOut& txout, wtx.vout)
             nUnmatured += wallet->GetCredit(txout, ISMINE_ALL);
+
         strHTML += "<b>" + tr("Credit") + ":</b> ";
         if (wtx.IsInMainChain())
             strHTML += BitcoinUnits::formatHtmlWithUnit(unit, nUnmatured)+ " (" + tr("matures in %n more block(s)", "", wtx.GetBlocksToMaturity()) + ")";
@@ -183,28 +204,44 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
                 // Ignore change
                 isminetype toSelf = wallet->IsMine(txout);
 
-                if (!wtx.mapValue.count("to") || wtx.mapValue["to"].empty())
                 {
-                    // Offline transaction
-                    CTxDestination address;
-                    if (ExtractDestination(txout.scriptPubKey, address))
+                    // Include in description public label if it exists
+                    std::string labelPublic = getLabelPublic(txout.scriptPubKey);
+                    if (labelPublic != "")
+                        strHTML += "<b>" + tr("Public label:") + "</b> " + labelPublic.c_str() + "<br>";
+
+                    if (!wtx.mapValue.count("to") || wtx.mapValue["to"].empty())
                     {
-                        strHTML += "<b>" + tr("To") + ":</b> ";
-                        if (wallet->mapAddressBook.count(address) && !wallet->mapAddressBook[address].name.empty())
-                            strHTML += GUIUtil::HtmlEscape(wallet->mapAddressBook[address].name) + " ";
-                        strHTML += GUIUtil::HtmlEscape(CBitcoinAddress(address).ToString());
-                        if(toSelf == ISMINE_SPENDABLE)
-                            strHTML += " (own address)";
-                        else if(toSelf & ISMINE_WATCH_ONLY)
-                            strHTML += " (watch-only)";
-                        strHTML += "<br>";
+
+
+                        // Offline transaction
+                        CTxDestination address;
+                        if (ExtractDestination(txout.scriptPubKey, address))
+                        {
+                            strHTML += "<b>" + tr("To") + ":</b> ";
+                            if (wallet->mapAddressBook.count(address) && !wallet->mapAddressBook[address].name.empty())
+                                strHTML += GUIUtil::HtmlEscape(wallet->mapAddressBook[address].name) + " ";
+                            strHTML += GUIUtil::HtmlEscape(CBitcoinAddress(address).ToString());
+                            if(txout.nValue == wtx.GetChange() && toSelf == ISMINE_SPENDABLE)
+                                strHTML += " (change address)";
+                            else if(toSelf == ISMINE_SPENDABLE)
+                                strHTML += " (own address)";
+                            else if(toSelf & ISMINE_WATCH_ONLY)
+                                strHTML += " (watch-only)";
+                            strHTML += "<br>";
+
+                        }
+                    }
+
+                    if (labelPublic == "") // hide on public label txout
+                    {
+                        if(toSelf)
+                            strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, txout.nValue) + " ";
+
+                        strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -txout.nValue) + "<br>";
                     }
                 }
-
-                strHTML += "<b>" + tr("Debit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, -txout.nValue) + "<br>";
-                if(toSelf)
-                    strHTML += "<b>" + tr("Credit") + ":</b> " + BitcoinUnits::formatHtmlWithUnit(unit, txout.nValue) + "<br>";
-            }
+            } // BOOST_FOREACH(const CTxOut& txout, wtx.vout)
 
             if (fAllToMe)
             {

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -42,6 +42,8 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     qint64 amount = llabs(index.data(TransactionTableModel::AmountRole).toLongLong());
     int status = index.data(TransactionTableModel::StatusRole).toInt();
 
+    if (address == QString(" ")) // hide if no address specified
+        return false;
     if(!showInactive && status == TransactionStatus::Conflicted)
         return false;
     if(!(TYPE(type) & typeFilter))

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -37,13 +37,12 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     int type = index.data(TransactionTableModel::TypeRole).toInt();
     QDateTime datetime = index.data(TransactionTableModel::DateRole).toDateTime();
     bool involvesWatchAddress = index.data(TransactionTableModel::WatchonlyRole).toBool();
+    bool involvesPublicLabelAddress = index.data(TransactionTableModel::PublicLabelRole).toBool();
     QString address = index.data(TransactionTableModel::AddressRole).toString();
     QString label = index.data(TransactionTableModel::LabelRole).toString();
     qint64 amount = llabs(index.data(TransactionTableModel::AmountRole).toLongLong());
     int status = index.data(TransactionTableModel::StatusRole).toInt();
 
-    if (address == QString(" ")) // hide if no address specified
-        return false;
     if(!showInactive && status == TransactionStatus::Conflicted)
         return false;
     if(!(TYPE(type) & typeFilter))
@@ -51,6 +50,8 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     if (involvesWatchAddress && watchOnlyFilter == WatchOnlyFilter_No)
         return false;
     if (!involvesWatchAddress && watchOnlyFilter == WatchOnlyFilter_Yes)
+        return false;
+    if (involvesPublicLabelAddress != publicLabelFilter)
         return false;
     if(datetime < dateFrom || datetime > dateTo)
         return false;
@@ -90,6 +91,12 @@ void TransactionFilterProxy::setMinAmount(const CAmount& minimum)
 void TransactionFilterProxy::setWatchOnlyFilter(WatchOnlyFilter filter)
 {
     this->watchOnlyFilter = filter;
+    invalidateFilter();
+}
+
+void TransactionFilterProxy::setPublicLabelFilter(bool filter)
+{
+    this->publicLabelFilter = filter;
     invalidateFilter();
 }
 

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -43,6 +43,7 @@ public:
     void setTypeFilter(quint32 modes);
     void setMinAmount(const CAmount& minimum);
     void setWatchOnlyFilter(WatchOnlyFilter filter);
+    void setPublicLabelFilter(bool filter);
 
     /** Set maximum number of rows returned, -1 if unlimited. */
     void setLimit(int limit);
@@ -61,6 +62,7 @@ private:
     QString addrPrefix;
     quint32 typeFilter;
     WatchOnlyFilter watchOnlyFilter;
+    bool publicLabelFilter;
     CAmount minAmount;
     int limitRows;
     bool showInactive;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -53,9 +53,10 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
         // get public label if it exists
         std::string labelPublic = getLabelPublic(txout.scriptPubKey);
         if (labelPublic != "")
+        {
             // use public label instead of address
             listAllAddresses.push_back(std::make_pair("<" + labelPublic + ">", txout.scriptPubKey));
-
+        }
         else if (ExtractDestination(txout.scriptPubKey, address))
             // a standard address
             listAllAddresses.push_back(std::make_pair(CBitcoinAddress(address).ToString(), txout.scriptPubKey));
@@ -88,22 +89,29 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 sub.idx = parts.size(); // sequence number
                 sub.credit = txout.nValue;
                 sub.involvesWatchAddress = mine & ISMINE_WATCH_ONLY;
-                if (ExtractDestination(txout.scriptPubKey, address) && wallet->IsMine(address))
+                std::string labelPublic = getLabelPublic(txout.scriptPubKey);
+                if (labelPublic != "")
+                {
+                    // Public label
+                    sub.type = TransactionRecord::PublicLabel;
+                    //listAllAddresses.push_back(std::make_pair(labelPublic, txout.scriptPubKey));
+                }
+                else if (ExtractDestination(txout.scriptPubKey, address) && wallet->IsMine(address))
                 {
                     // Received by Bitcoin Address
                     sub.type = TransactionRecord::RecvWithAddress;
-                    listAllAddresses.push_back(std::make_pair(CBitcoinAddress(address).ToString(), txout.scriptPubKey));
+                    //listAllAddresses.push_back(std::make_pair(CBitcoinAddress(address).ToString(), txout.scriptPubKey));
+                }
+                else if (wtx.IsCoinBase())
+                {
+                    // Generated
+                    sub.type = TransactionRecord::Generated;
                 }
                 else
                 {
                     // Received by IP connection (deprecated features), or a multisignature or other non-simple transaction
                     sub.type = TransactionRecord::RecvFromOther;
-                    listAllAddresses.push_back(std::make_pair(mapValue["from "],txout.scriptPubKey));
-                }
-                if (wtx.IsCoinBase())
-                {
-                    // Generated
-                    sub.type = TransactionRecord::Generated;
+                    //listAllAddresses.push_back(std::make_pair(mapValue["from "],txout.scriptPubKey));
                 }
 
                 sub.addresses = listAllAddresses;
@@ -144,9 +152,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
             for (unsigned int nOut = 0; nOut < wtx.vout.size(); nOut++)
             {
                 const CTxOut& txout = wtx.vout[nOut];
-                TransactionRecord sub(hash, nTime);
-                sub.idx = parts.size();
-                sub.involvesWatchAddress = involvesWatchAddress;
+
                 if(wallet->IsMine(txout))
                 {
                     // Ignore parts sent to self, as this is usually the change
@@ -154,19 +160,32 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                     continue;
                 }
 
+                TransactionRecord sub(hash, nTime);
+                sub.idx = parts.size();
+                sub.involvesWatchAddress = involvesWatchAddress;
+
                 CTxDestination address;
-                if (ExtractDestination(txout.scriptPubKey, address))
+                std::string labelPublic = getLabelPublic(txout.scriptPubKey);
+                if (labelPublic != "")
+                {
+                    // Public label
+                    sub.type = TransactionRecord::PublicLabel;
+                    //listAllAddresses.push_back(std::make_pair(labelPublic, txout.scriptPubKey));
+                }
+                else if (ExtractDestination(txout.scriptPubKey, address))
                 {
                     // Sent to Bitcoin Address
                     sub.type = TransactionRecord::SendToAddress;
-                    sub.addresses.push_back(std::make_pair(CBitcoinAddress(address).ToString(), txout.scriptPubKey));
+                    //sub.addresses.push_back(std::make_pair(CBitcoinAddress(address).ToString(), txout.scriptPubKey));
                 }
                 else
                 {
                     // Sent to IP, or other non-address transaction like OP_EVAL
                     sub.type = TransactionRecord::SendToOther;
-                    sub.addresses.push_back(std::make_pair(mapValue["to"], txout.scriptPubKey));
+                    //sub.addresses.push_back(std::make_pair(mapValue["to"], txout.scriptPubKey));
                 }
+
+                sub.addresses = listAllAddresses;
 
                 CAmount nValue = txout.nValue;
                 /* Add fee to first output */

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -42,7 +42,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     CAmount nNet = nCredit - nDebit;
     uint256 hash = wtx.GetHash();
     std::map<std::string, std::string> mapValue = wtx.mapValue;
-    std::map<std::string, CScript> listAllAddresses;
+    AddressList listAllAddresses;
 
     // load all tx addresses for user display/filter
     isminetype fAllToMe = ISMINE_SPENDABLE;
@@ -50,19 +50,19 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     CTxDestination address;
     BOOST_FOREACH(const CTxOut& txout, wtx.vout)
     {
+        // get public label if it exists
+        std::string labelPublic = getLabelPublic(txout.scriptPubKey);
+        if (labelPublic != "")
+            // use public label instead of address
+            listAllAddresses.push_back(std::make_pair("<" + labelPublic + ">", txout.scriptPubKey));
 
-        if (ExtractDestination(txout.scriptPubKey, address))
+        else if (ExtractDestination(txout.scriptPubKey, address))
             // a standard address
-            listAllAddresses[CBitcoinAddress(address).ToString()] = txout.scriptPubKey;
-        else
-        {
-            std::string labelPublic = getLabelPublic(txout.scriptPubKey);
-            if (labelPublic != "")
-                listAllAddresses["<" + labelPublic + ">"] = txout.scriptPubKey;
+            listAllAddresses.push_back(std::make_pair(CBitcoinAddress(address).ToString(), txout.scriptPubKey));
+
             else
                 // add the unknown scriptPubKey as n/a - TODO could also skip these if there is no need to display/filter??
-                listAllAddresses["n/a"] = txout.scriptPubKey;
-        }
+                listAllAddresses.push_back(std::make_pair("n/a", txout.scriptPubKey));
 
         if (txout.nValue > 0)  // only checkout outputs which received bitcoin
         {
@@ -92,19 +92,20 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 {
                     // Received by Bitcoin Address
                     sub.type = TransactionRecord::RecvWithAddress;
-                    //sub.addresses[CBitcoinAddress(address).ToString()] = txout.scriptPubKey;
+                    listAllAddresses.push_back(std::make_pair(CBitcoinAddress(address).ToString(), txout.scriptPubKey));
                 }
                 else
                 {
                     // Received by IP connection (deprecated features), or a multisignature or other non-simple transaction
                     sub.type = TransactionRecord::RecvFromOther;
-                    listAllAddresses[mapValue["from"]] = txout.scriptPubKey;
+                    listAllAddresses.push_back(std::make_pair(mapValue["from "],txout.scriptPubKey));
                 }
                 if (wtx.IsCoinBase())
                 {
                     // Generated
                     sub.type = TransactionRecord::Generated;
                 }
+
                 sub.addresses = listAllAddresses;
 
                 parts.append(sub);
@@ -158,13 +159,13 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 {
                     // Sent to Bitcoin Address
                     sub.type = TransactionRecord::SendToAddress;
-                    sub.addresses[CBitcoinAddress(address).ToString()] = txout.scriptPubKey;
+                    sub.addresses.push_back(std::make_pair(CBitcoinAddress(address).ToString(), txout.scriptPubKey));
                 }
                 else
                 {
                     // Sent to IP, or other non-address transaction like OP_EVAL
                     sub.type = TransactionRecord::SendToOther;
-                    sub.addresses[mapValue["to"]] = txout.scriptPubKey;
+                    sub.addresses.push_back(std::make_pair(mapValue["to"], txout.scriptPubKey));
                 }
 
                 CAmount nValue = txout.nValue;

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -56,14 +56,24 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
         {
             // use public label instead of address
             listAllAddresses.push_back(std::make_pair("<" + labelPublic + ">", txout.scriptPubKey));
+
+            // append public label
+            TransactionRecord sub(hash, nTime);
+            sub.idx = parts.size(); // sequence number
+            sub.credit = txout.nValue;
+            sub.type = TransactionRecord::PublicLabel;
+            sub.addresses.push_back(std::make_pair(labelPublic, txout.scriptPubKey));
+
+            parts.append(sub);
+
         }
         else if (ExtractDestination(txout.scriptPubKey, address))
             // a standard address
             listAllAddresses.push_back(std::make_pair(CBitcoinAddress(address).ToString(), txout.scriptPubKey));
 
-            else
-                // add the unknown scriptPubKey as n/a - TODO could also skip these if there is no need to display/filter??
-                listAllAddresses.push_back(std::make_pair("n/a", txout.scriptPubKey));
+        else
+            // add the unknown scriptPubKey as n/a - TODO could also skip these if there is no need to display/filter??
+            listAllAddresses.push_back(std::make_pair("n/a", txout.scriptPubKey));
 
         if (txout.nValue > 0)  // only checkout outputs which received bitcoin
         {
@@ -90,12 +100,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
                 sub.credit = txout.nValue;
                 sub.involvesWatchAddress = mine & ISMINE_WATCH_ONLY;
                 std::string labelPublic = getLabelPublic(txout.scriptPubKey);
-                if (labelPublic != "")
-                {
-                    // Public label
-                    sub.type = TransactionRecord::PublicLabel;
-                    //listAllAddresses.push_back(std::make_pair(labelPublic, txout.scriptPubKey));
-                }
+                if (labelPublic != "") continue;
                 else if (ExtractDestination(txout.scriptPubKey, address) && wallet->IsMine(address))
                 {
                     // Received by Bitcoin Address
@@ -166,12 +171,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
 
                 CTxDestination address;
                 std::string labelPublic = getLabelPublic(txout.scriptPubKey);
-                if (labelPublic != "")
-                {
-                    // Public label
-                    sub.type = TransactionRecord::PublicLabel;
-                    //listAllAddresses.push_back(std::make_pair(labelPublic, txout.scriptPubKey));
-                }
+                if (labelPublic != "") continue;
                 else if (ExtractDestination(txout.scriptPubKey, address))
                 {
                     // Sent to Bitcoin Address

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -16,6 +16,10 @@
 class CWallet;
 class CWalletTx;
 
+// Addresses need to preserve their txout order for accurate display so implemented as list (instead of map)
+typedef std::pair<std::string,CScript> Address;
+typedef std::list<Address> AddressList;
+
 /** UI model for transaction status. The transaction status is the part of a transaction that will change over time.
  */
 class TransactionStatus
@@ -96,7 +100,7 @@ public:
     }
 
     TransactionRecord(uint256 hash, qint64 time,
-                Type type, const std::map <std::string,CScript> &addresses,
+                Type type, const AddressList &addresses,
                 const CAmount& debit, const CAmount& credit):
             hash(hash), time(time), type(type), addresses(addresses), debit(debit), credit(credit),
             idx(0)
@@ -113,7 +117,7 @@ public:
     uint256 hash;
     qint64 time;
     Type type;
-    std::map <std::string,CScript> addresses;
+    AddressList addresses;
     CAmount debit;
     CAmount credit;
     /**@}*/

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -82,7 +82,8 @@ public:
         SendToOther,
         RecvWithAddress,
         RecvFromOther,
-        SendToSelf
+        SendToSelf,
+        PublicLabel
     };
 
     /** Number of confirmation recommended for accepting a transaction */

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -613,6 +613,8 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         return QDateTime::fromTime_t(static_cast<uint>(rec->time));
     case WatchonlyRole:
         return rec->involvesWatchAddress;
+    case PublicLabelRole:
+        return (rec->type == TransactionRecord::PublicLabel);
     case WatchonlyDecorationRole:
         return txWatchonlyDecoration(rec);
     case LongDescriptionRole:

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -515,7 +515,7 @@ QString TransactionTableModel::formatTooltip(const TransactionRecord *rec) const
     return tooltip;
 }
 
-QString TransactionTableModel::pickLabelWithAddress(std::map <std::string,CScript> listAddresses, std::string& address) const
+QString TransactionTableModel::pickLabelWithAddress(AddressList listAddresses, std::string& address) const
 {
     /* returns the first address wiith a label or the last address on the list */
     QString label = "";

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -378,6 +378,8 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Payment to yourself");
     case TransactionRecord::Generated:
         return tr("Mined");
+    case TransactionRecord::PublicLabel:
+        return tr("Public label");
     default:
         return QString();
     }
@@ -414,10 +416,13 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
     QString label = pickLabelWithAddress(wtx->addresses, address);
 
     /* Get all the addresses so the user can filter for any of them */
-    std::string addressList;
+    std::string addressList = "";
     BOOST_FOREACH(const PAIRTYPE(std::string,CScript)& addr, wtx->addresses)
     {
-        addressList = addressList + " " + addr.first;
+        std::string nextAddress = boost::replace_all_copy(addr.first, "\n", " ");
+        // ensure list isn't prefixed by a space
+        if (addressList == "") addressList = nextAddress;
+            else addressList = addressList + " " + nextAddress;
     }
 
     if (label == "") return QString::fromStdString(addressList) + watchAddress;

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -102,7 +102,7 @@ private:
     QString formatTxToAddress(const TransactionRecord *wtx, bool tooltip) const;
     QString formatTxAmount(const TransactionRecord *wtx, bool showUnconfirmed=true, BitcoinUnits::SeparatorStyle separators=BitcoinUnits::separatorStandard) const;
     QString formatTooltip(const TransactionRecord *rec) const;
-    QString pickLabelWithAddress(std::map <std::string,CScript> listAddresses, std::string& address) const;
+    QString pickLabelWithAddress(AddressList listAddresses, std::string& address) const;
 
     QVariant txStatusDecoration(const TransactionRecord *wtx) const;
     QVariant txWatchonlyDecoration(const TransactionRecord *wtx) const;

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -50,6 +50,8 @@ public:
         DateRole,
         /** Watch-only boolean */
         WatchonlyRole,
+        /** Public label boolean */
+        PublicLabelRole,
         /** Watch-only icon */
         WatchonlyDecorationRole,
         /** Long description (HTML format) */

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -104,7 +104,9 @@ private:
     QString formatTxToAddress(const TransactionRecord *wtx, bool tooltip) const;
     QString formatTxAmount(const TransactionRecord *wtx, bool showUnconfirmed=true, BitcoinUnits::SeparatorStyle separators=BitcoinUnits::separatorStandard) const;
     QString formatTooltip(const TransactionRecord *rec) const;
+#ifdef ENABLE_WALLET
     QString pickLabelWithAddress(AddressList listAddresses, std::string& address) const;
+#endif
 
     QVariant txStatusDecoration(const TransactionRecord *wtx) const;
     QVariant txWatchonlyDecoration(const TransactionRecord *wtx) const;

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -184,6 +184,7 @@ void TransactionView::setModel(WalletModel *model)
     if(model)
     {
         transactionProxyModel = new TransactionFilterProxy(this);
+        transactionProxyModel->setPublicLabelFilter(false);
         transactionProxyModel->setSourceModel(model->getTransactionTableModel());
         transactionProxyModel->setDynamicSortFilter(true);
         transactionProxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -52,10 +52,11 @@ std::string getLabelPublic(const CScript& scriptPubKey)
             CScript labelPublic1(vSolutions[1]);
 
             if (labelPublic0 == OP_PUSHDATA1)
-                return "";
+                return ""; //TODO long formats not implemented yet
             else if (labelPublic0 == OP_PUSHDATA2)
-                return "";
+                return ""; //TODO long formats not implemented yet
             else
+                // small format
                 return std::string(labelPublic1.begin()+1,labelPublic1.end());
         }
     }
@@ -109,6 +110,7 @@ isminetype IsMine(const CKeyStore &keystore, const CScript& scriptPubKey, CBlock
     {
         case TX_NONSTANDARD:
         case TX_NULL_DATA:
+        case TX_LABELPUBLIC:
             break;
         case TX_PUBKEY:
             keyID = CPubKey(vSolutions[0]).GetID();

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -34,7 +34,7 @@ const char* GetTxnOutputType(txnouttype t)
     case TX_MULTISIG: return "multisig";
     case TX_NULL_DATA: return "nulldata";
     case TX_CLTV: return "cltv";  // CLTV HODL Freeze
-    case TX_LABELPUBLIC: return "labelpublic";
+    case TX_LABELPUBLIC: return "publiclabel";
     }
     return NULL;
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2019,8 +2019,10 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
 {
     CAmount nValue = 0;
     unsigned int nSubtractFeeFromAmount = 0;
+    bool involvesPublicLabel = false;
     BOOST_FOREACH (const CRecipient& recipient, vecSend)
     {
+        if (getLabelPublic(recipient.scriptPubKey) != "") involvesPublicLabel = true;
         if (nValue < 0 || recipient.nAmount < 0)
         {
             strFailReason = _("Transaction amounts must be positive");
@@ -2212,10 +2214,16 @@ bool CWallet::CreateTransaction(const vector<CRecipient>& vecSend, CWalletTx& wt
                     }
                     else
                     {
+                        if (!involvesPublicLabel)
+                        {
                         // Insert change txn at random position:
                         nChangePosRet = GetRandInt(txNew.vout.size()+1);
                         vector<CTxOut>::iterator position = txNew.vout.begin()+nChangePosRet;
                         txNew.vout.insert(position, newTxOut);
+                        }
+                        else
+                            // Insert change at end position because original txout order is critical for public label
+                            txNew.vout.insert(txNew.vout.end(), newTxOut);
                     }
                 }
                 else


### PR DESCRIPTION
This PR includes the following fixes:
* Fix Receive coin freeze inputs validation
* Add in Receive history "Copy address" to right click menu
* Fix Tx list to ignore txouts with public labels
* Add in Tx desc popup a description for the public label 
* Fix Tx desc to sort outputs by txout# instead of scriptPubKey 
* Fix Send tx 'Public label' &amp buddy missing from label
* Fix Send tx 'Public label' tab order wrong 
* Fix Send confirmation to a freeze address with a public label so only one warning is displayed

Appreciate any feedback from user testing. The PR branch coin_freeze_cltv has UI fixes and other newly exposed features such as coin freezing, public labels and improved address and tx filtering. Also if you have noticed any UI bugs/annoyances anywhere please comment with fix suggestions.  

Some screenshots can be viewed at PR #188.
