### PR TITLE
Combine expedited block and xthin block handling

### DIFF
--- a/src/expedited.cpp
+++ b/src/expedited.cpp
@@ -209,62 +209,13 @@ bool HandleExpeditedBlock(CDataStream &vRecv, CNode *pfrom)
 
     if (msgType == EXPEDITED_MSG_XTHIN)
     {
-        CXThinBlock thinBlock;
-        vRecv >> thinBlock;
-        uint256 blkHash = thinBlock.header.GetHash();
-        CInv inv(MSG_BLOCK, blkHash);
-
-        // Message consistency checking
-        if (!IsThinBlockValid(pfrom, thinBlock.vMissingTx, thinBlock.header))
-        {
-            LOCK(cs_main);
-            Misbehaving(pfrom->GetId(), 100);
-            return error("Invalid EXPEDITED_MSG_XTHIN received");
-        }
-
-        bool newBlock = false;
-        unsigned int status = 0;
-        {
-            LOCK(cs_main);
-            BlockMap::iterator mapEntry = mapBlockIndex.find(blkHash);
-            CBlockIndex *blkidx = NULL;
-            if (mapEntry != mapBlockIndex.end())
-            {
-                blkidx = mapEntry->second;
-                if (blkidx)
-                    status = blkidx->nStatus;
-            }
-
-            // If we do not have the block on disk or do not have the header yet then treat the block as new.
-            newBlock = ((blkidx == NULL) || (!(blkidx->nStatus & BLOCK_HAVE_DATA)));
-        }
-
-        int nSizeThinBlock = ::GetSerializeSize(thinBlock, SER_NETWORK, PROTOCOL_VERSION);
-        LogPrint("thin",
-            "Received %s expedited thinblock %s from peer %s (%d). Hop %d. Size %d bytes. (status %d,0x%x)\n",
-            newBlock ? "new" : "repeated", inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id, hops,
-            nSizeThinBlock, status, status);
-
-        // TODO: Move this section above the print once we ensure no unexpected dups.
-        // Skip if we've already seen this block
-        if (IsRecentlyExpeditedAndStore(blkHash))
-            return true;
-        if (!newBlock)
-            return true;
-
-        // TODO: Start headers-only mining now
-
-        SendExpeditedBlock(thinBlock, hops + 1, pfrom);
-
-        // Process the thinblock
-        thinBlock.process(pfrom, nSizeThinBlock, NetMsgType::XPEDITEDBLK);
+        return CXThinBlock::HandleMessage(vRecv, pfrom, NetMsgType::XPEDITEDBLK, hops + 1);
     }
     else
     {
         return error("Received unknown (0x%x) expedited message from peer %s (%d). Hop %d.\n", msgType,
             pfrom->addrName.c_str(), pfrom->id, hops);
     }
-    return true;
 }
 
 void SendExpeditedBlock(CXThinBlock &thinBlock, unsigned char hops, const CNode *skip)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4819,7 +4819,7 @@ std::string GetWarnings(const std::string& strFor)
 //
 
 
-static bool AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+bool AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 
@@ -5935,14 +5935,14 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
 
     else if (strCommand == NetMsgType::XPEDITEDBLK)
     {
-        // ignore the expedited message unless we are near the chain tip...
-        if (!fImporting && !fReindex && IsChainNearlySyncd())
+        // ignore the expedited message unless we are at the chain tip...
+        if (!fImporting && !fReindex && !IsInitialBlockDownload())
         {
-	    if (!HandleExpeditedBlock(vRecv, pfrom))
+            if (!HandleExpeditedBlock(vRecv, pfrom))
             {
                 LOCK(cs_main);
                 Misbehaving(pfrom->GetId(), 5);
-                return false;            
+                return false;
             }
         }
     }
@@ -5990,89 +5990,10 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
         CheckAndRequestExpeditedBlocks(pfrom);
     }
 
-    else if (strCommand == NetMsgType::XTHINBLOCK && !fImporting && !fReindex &&
-        !IsInitialBlockDownload() &&
-        IsThinBlocksEnabled())
+    else if (strCommand == NetMsgType::XTHINBLOCK && !fImporting && !fReindex && !IsInitialBlockDownload()
+    	     && IsThinBlocksEnabled())
     {
-        if (!pfrom->ThinBlockCapable())
-        {
-            LOCK(cs_main);
-            Misbehaving(pfrom->GetId(), 100);
-            return error("xthinblock message received from a non thinblock node, peer=%d", pfrom->GetId());
-        }
-
-        CXThinBlock thinBlock;
-        vRecv >> thinBlock;
-
-        // Message consistency checking
-        if (!IsThinBlockValid(pfrom, thinBlock.vMissingTx, thinBlock.header))
-        {
-            LOCK(cs_main);
-            Misbehaving(pfrom->GetId(), 100);
-            return error("Invalid xthinblock received");
-        }
-
-        // Is there a previous block or header to connect with?
-        {
-            LOCK(cs_main);
-            uint256 prevHash = thinBlock.header.hashPrevBlock;
-            BlockMap::iterator mi = mapBlockIndex.find(prevHash);
-            if (mi == mapBlockIndex.end())
-            {
-                Misbehaving(pfrom->GetId(), 10);
-                return error("xthinblock from peer %s (%d) will not connect, unknown previous block %s",
-                    pfrom->addrName.c_str(),
-                    pfrom->id,
-                    prevHash.ToString());
-            }
-            CBlockIndex* pprev = mi->second;
-            CValidationState state;
-            if (!ContextualCheckBlockHeader(thinBlock.header, state, pprev))
-            {
-                // Thin block does not fit within our blockchain
-                Misbehaving(pfrom->GetId(), 100);
-                return error("thinblock from peer %s (%d) contextual error: %s",
-                    pfrom->addrName.c_str(),
-                    pfrom->id,
-                    state.GetRejectReason().c_str());
-            }
-        }
-
-        // Send expedited block without checking merkle root.
-        CInv inv(MSG_BLOCK, thinBlock.header.GetHash());
-        if (!IsRecentlyExpeditedAndStore(inv.hash))
-            SendExpeditedBlock(thinBlock, 0, pfrom);
-
-        int nSizeThinBlock = ::GetSerializeSize(thinBlock, SER_NETWORK, PROTOCOL_VERSION);
-        LogPrint("thin", "Received xthinblock %s from peer %s (%d). Size %d bytes.\n", inv.hash.ToString(),
-            pfrom->addrName.c_str(),
-            pfrom->id,
-            nSizeThinBlock);
-
-        // Ban a node for sending unrequested xthins unless from an expedited node.
-        bool fAlreadyHave = false;
-        {
-        LOCK(pfrom->cs_mapthinblocksinflight);
-        if (!pfrom->mapThinBlocksInFlight.count(inv.hash) && !IsExpeditedNode(pfrom))
-        {
-                LOCK(cs_main);
-                Misbehaving(pfrom->GetId(), 100);
-                return error("unrequested xthinblock from peer %s (%d)", pfrom->addrName.c_str(), pfrom->id);
-        }
-
-        // An expedited block or re-requested xthin can arrive and beat the original thin block request/response
-        if (!pfrom->mapThinBlocksInFlight.count(inv.hash))
-        {
-            LogPrint("thin", "xthinblock %s from peer %s (%d) received but we may already have processed it\n", inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id);
-            LOCK(cs_main);
-            fAlreadyHave = AlreadyHave(inv); // I'll still continue processing if we don't have an accepted block yet
-            if (fAlreadyHave)
-                requester.Received(inv, pfrom, nSizeThinBlock); // record the bytes received from the thinblock even though we had it already
-        }
-        }
-
-        if (!fAlreadyHave)
-           thinBlock.process(pfrom, nSizeThinBlock, strCommand);
+    	CXThinBlock::HandleMessage(vRecv, pfrom, strCommand, 0);
     }
 
 
@@ -6199,7 +6120,7 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
             {
                 LOCK(cs_main);
                 Misbehaving(pfrom->GetId(), 20);
-                return error("Requested block is not available");          
+                return error("Requested block is not available");
             }
             else
             {

--- a/src/main.h
+++ b/src/main.h
@@ -228,6 +228,7 @@ bool LoadBlockIndex();
 void UnloadBlockIndex();
 /** Process protocol messages received from a given node */
 bool ProcessMessages(CNode* pfrom);
+bool AlreadyHave(const CInv &);
 /** Process a single protocol messages received from a given node */
 bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, int64_t nTimeReceived);
 

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     SendMessages(&dummyNode1);
     BOOST_CHECK(xthin.vMissingTx.size() == 0);
     BOOST_CHECK(CNode::IsBanned(addr1));
-    
+
     // test invalid or missing coinbase
     CNode::ClearBanned();
     vRecv1.clear();
@@ -138,6 +138,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     CNode dummyNode1a(INVALID_SOCKET, addr1, "", true);
     dummyNode1a.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode1a.fSuccessfullyConnected = true;
+    dummyNode1a.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode1a, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
     SendMessages(&dummyNode1a);
     BOOST_CHECK(!xthin.vMissingTx[0].IsCoinBase());
@@ -153,6 +154,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     CNode dummyNode1b(INVALID_SOCKET, addr1, "", true);
     dummyNode1b.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode1b.fSuccessfullyConnected = true;
+    dummyNode1b.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode1b, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
     SendMessages(&dummyNode1b);
     CValidationState state;
@@ -170,6 +172,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
     dummyNode2.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode2.fSuccessfullyConnected = true;
+    dummyNode2.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode2, NetMsgType::THINBLOCK, vRecv2, GetTime());
     SendMessages(&dummyNode2);
     BOOST_CHECK(thin.vMissingTx.size() == 0);
@@ -185,6 +188,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     CNode dummyNode2a(INVALID_SOCKET, addr2, "", true);
     dummyNode2a.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode2a.fSuccessfullyConnected = true;
+    dummyNode2a.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode2a, NetMsgType::THINBLOCK, vRecv2, GetTime());
     SendMessages(&dummyNode2a);
     BOOST_CHECK(!thin.vMissingTx[0].IsCoinBase());
@@ -200,6 +204,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     CNode dummyNode2b(INVALID_SOCKET, addr2, "", true);
     dummyNode2b.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode2b.fSuccessfullyConnected = true;
+    dummyNode2b.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode2b, NetMsgType::THINBLOCK, vRecv2, GetTime());
     SendMessages(&dummyNode2b);
     BOOST_CHECK(!CheckBlockHeader(thin.header, state, true));
@@ -219,6 +224,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     CNode dummyNode3(INVALID_SOCKET, addr3, "", true);
     dummyNode3.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode3.fSuccessfullyConnected = true;
+    dummyNode3.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode3, NetMsgType::XBLOCKTX, vRecv3, GetTime());
     SendMessages(&dummyNode3);
     BOOST_CHECK(nullhash.IsNull());
@@ -234,6 +240,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     CNode dummyNode3a(INVALID_SOCKET, addr3, "", true);
     dummyNode3a.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode3a.fSuccessfullyConnected = true;
+    dummyNode3a.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode3a, NetMsgType::XBLOCKTX, vRecv3, GetTime());
     SendMessages(&dummyNode3a);
     BOOST_CHECK(vTxEmpty.size() == 0);
@@ -249,6 +256,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     dummyNode3b.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode3b.fSuccessfullyConnected = true;
     dummyNode3b.xThinBlockHashes.push_back(1); // add one hash to the vector which will cause a mismatch
+    dummyNode3b.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode3b, NetMsgType::XBLOCKTX, vRecv3, GetTime());
     SendMessages(&dummyNode3b);
     BOOST_CHECK(dummyNode3b.xThinBlockHashes.size() != dummyNode3b.thinBlock.vtx.size());
@@ -268,6 +276,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     CNode dummyNode4(INVALID_SOCKET, addr4, "", true);
     dummyNode4.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode4.fSuccessfullyConnected = true;
+    dummyNode4.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode4, NetMsgType::GET_XBLOCKTX, vRecv4, GetTime());
     SendMessages(&dummyNode4);
     BOOST_CHECK(nullhash.IsNull());
@@ -283,6 +292,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     CNode dummyNode4a(INVALID_SOCKET, addr4, "", true);
     dummyNode4a.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode4a.fSuccessfullyConnected = true;
+    dummyNode4a.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode4a, NetMsgType::GET_XBLOCKTX, vRecv4, GetTime());
     SendMessages(&dummyNode4a);
     BOOST_CHECK(setHashesToRequest.empty());
@@ -303,6 +313,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     CNode dummyNode5(INVALID_SOCKET, addr5, "", true);
     dummyNode5.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode5.fSuccessfullyConnected = true;
+    dummyNode5.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode5, NetMsgType::GET_XTHIN, vRecv5, GetTime());
     SendMessages(&dummyNode5);
     BOOST_CHECK(nullhash.IsNull());
@@ -320,6 +331,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     CNode dummyNode5a(INVALID_SOCKET, addr5, "", true);
     dummyNode5a.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode5a.fSuccessfullyConnected = true;
+    dummyNode5a.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode5a, NetMsgType::GET_XTHIN, vRecv5, GetTime());
     SendMessages(&dummyNode5a);
     BOOST_CHECK(inv2.type != MSG_THINBLOCK && inv2.type != MSG_XTHINBLOCK);
@@ -327,4 +339,3 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -5,6 +5,7 @@
 #include "thinblock.h"
 #include "chainparams.h"
 #include "consensus/merkle.h"
+#include "expedited.h"
 #include "main.h"
 #include "net.h"
 #include "parallel.h"
@@ -245,6 +246,110 @@ bool CXThinBlock::CheckBlockHeader(const CBlockHeader &block, CValidationState &
             error("CheckBlockHeader(): block timestamp too far in the future"), REJECT_INVALID, "time-too-new");
 
     return true;
+}
+
+/**
+ * Handle an incoming Xthin or Xpedited block
+ * Once the block is validated apart from the Merkle root, forward the Xpedited block with a hop count of nHops.
+ */
+bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strCommand, unsigned nHops)
+{
+    if (!pfrom->ThinBlockCapable())
+    {
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 5);
+        return error("%s message received from a non thinblock node, peer=%d", strCommand, pfrom->GetId());
+    }
+
+    int nSizeThinBlock = vRecv.size();
+    CXThinBlock thinBlock;
+    vRecv >> thinBlock;
+
+    // Message consistency checking
+    if (!IsThinBlockValid(pfrom, thinBlock.vMissingTx, thinBlock.header))
+    {
+        LOCK(cs_main);
+        Misbehaving(pfrom->GetId(), 100);
+        return error("Invalid %s received", strCommand);
+    }
+
+    // Is there a previous block or header to connect with?
+    {
+        LOCK(cs_main);
+        uint256 prevHash = thinBlock.header.hashPrevBlock;
+        BlockMap::iterator mi = mapBlockIndex.find(prevHash);
+        if (mi == mapBlockIndex.end())
+        {
+            Misbehaving(pfrom->GetId(), 10);
+            return error("%s from peer %s (%d) will not connect, unknown previous block %s", strCommand,
+                pfrom->addrName.c_str(), pfrom->id, prevHash.ToString());
+        }
+        CBlockIndex *pprev = mi->second;
+        CValidationState state;
+        if (!ContextualCheckBlockHeader(thinBlock.header, state, pprev))
+        {
+            // Thin block does not fit within our blockchain
+            Misbehaving(pfrom->GetId(), 100);
+            return error("%s from peer %s (%d) contextual error: %s", strCommand, pfrom->addrName.c_str(), pfrom->id,
+                state.GetRejectReason().c_str());
+        }
+    }
+
+    CInv inv(MSG_BLOCK, thinBlock.header.GetHash());
+    bool fAlreadyHave = false;
+
+    if (nHops > 0)
+    {
+        bool newBlock = false;
+        unsigned int status = 0;
+
+        LOCK(cs_main);
+        BlockMap::iterator mapEntry = mapBlockIndex.find(inv.hash);
+        CBlockIndex *blkidx = NULL;
+        if (mapEntry != mapBlockIndex.end())
+        {
+            blkidx = mapEntry->second;
+            if (blkidx)
+                status = blkidx->nStatus;
+        }
+
+        // If we do not have the block on disk or do not have the header yet then treat the block as new.
+        newBlock = blkidx == NULL || !(blkidx->nStatus & BLOCK_HAVE_DATA);
+
+        LogPrint("thin",
+            "Received %s expedited thinblock %s from peer %s (%d). Hop %d. Size %d bytes. (status %d,0x%x)\n",
+            newBlock ? "new" : "repeated", inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id, nHops,
+            nSizeThinBlock, status, status);
+
+        if (!newBlock)
+            return true;
+    }
+    else
+    {
+        LogPrint("thin", "Received %s %s from peer %s (%d). Size %d bytes.\n", strCommand, inv.hash.ToString(),
+            pfrom->addrName.c_str(), pfrom->id, nSizeThinBlock);
+
+        // An expedited block or re-requested xthin can arrive and beat the original thin block request/response
+        if (!pfrom->mapThinBlocksInFlight.count(inv.hash))
+        {
+            LogPrint("thin", "%s %s from peer %s (%d) received but we may already have processed it\n", strCommand,
+                inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id);
+            LOCK(cs_main);
+            fAlreadyHave = AlreadyHave(inv); // I'll still continue processing if we don't have an accepted block yet
+            if (fAlreadyHave)
+                // record the bytes received from the thinblock even though we had it already
+                requester.Received(inv, pfrom, nSizeThinBlock);
+        }
+    }
+
+    // Send expedited block without checking merkle root.
+    if (!IsRecentlyExpeditedAndStore(inv.hash))
+        SendExpeditedBlock(thinBlock, nHops, pfrom);
+
+    if (fAlreadyHave)
+        return true;
+
+    return thinBlock.process(pfrom, nSizeThinBlock, strCommand);
 }
 
 bool CXThinBlock::process(CNode *pfrom,

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -15,6 +15,7 @@
 #include "uint256.h"
 #include <vector>
 
+class CDataStream;
 class CNode;
 
 class CThinBlock
@@ -53,6 +54,19 @@ public:
     CXThinBlock(const CBlock &block, CBloomFilter *filter); // Use the filter to determine which txns the client has
     CXThinBlock(const CBlock &block); // Assume client has all of the transactions (except coinbase)
     CXThinBlock() {}
+    /**
+     * Handle an incoming Xthin or Xpedited block
+     * Once the block is validated apart from the Merkle root, forward the Xpedited block with a hop count of nHops.
+     * @param[in]  vRecv        The raw binary message
+     * @param[in] pFrom        The node the message was from
+     * @param[in]  strCommand   The message kind
+     * @param[in]  nHops        On the wire, an Xpedited block has a hop count of zero the first time it is sent, and
+     *                          the hop count is incremented each time it is forwarded.  nHops is zero for an incoming
+     *                          Xthin block, and for an incoming Xpedited block its hop count + 1.
+     * @return True if handling succeeded
+     */
+    static bool HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string strCommand, unsigned nHops);
+
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>


### PR DESCRIPTION
A common function that unifies the two message handlers to have a single codepath
for verification.  The only differences lie in determining new-ness of the block.
The prior expedited code path used to omit most of the validity checks.

A re-attempt at #509, that is the same as #522 but with the main.cpp change to the correct hunk; this seems to have gone awry in the last rebase of #509.

@ptschip In creating this I noticed too that src/test/exploit_tests.cpp is not testing what it thinks it is.  It started failing because the xthin capable banhammer was reduced to a 5 misbehaving.

I believe every test was passing before not for the tested reason, but because they hit the xthincapable banhammer.  I've made the test set set every node as Xthin capable and it started passing again, but this may also be deceptive.  Can you enhance the tests there to ensure the ban reason is what the test thinks it should be?