### PR TITLE
[Port] Only send one GetAddr response per connection.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6763,6 +6763,15 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             return true;
         }
 
+        // Only send one GetAddr response per connection to reduce resource waste
+        //  and discourage addr stamping of INV announcements.
+        if (pfrom->fSentAddr)
+        {
+            LogPrint("net", "Ignoring repeated \"getaddr\". peer=%d\n", pfrom->id);
+            return true;
+        }
+        pfrom->fSentAddr = true;
+
         pfrom->vAddrToSend.clear();
         std::vector<CAddress> vAddr = addrman.GetAddr();
         BOOST_FOREACH (const CAddress &addr, vAddr)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2983,6 +2983,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
     nNextAddrSend = 0;
     nNextInvSend = 0;
     fRelayTxes = false;
+    fSentAddr = false;
     pfilter = new CBloomFilter();
     pThinBlockFilter = new CBloomFilter(); // BUIP010 - Xtreme Thinblocks
     nPingNonceSent = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -400,6 +400,7 @@ public:
     // b) the peer may tell us in its version message that we should not relay tx invs
     //    unless it loads a bloom filter.
     bool fRelayTxes;
+    bool fSentAddr;
     CSemaphoreGrant grantOutbound;
     CCriticalSection cs_filter;
     CBloomFilter *pfilter;


### PR DESCRIPTION
bitcoin#7856

This conserves resources from abusive peers that just send
 getaddr in a loop. Also makes correlating addr messages
 against INVs less effective.