### PR TITLE
[backport][release] Combine expedited block and xthin block handling

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4791,7 +4791,7 @@ std::string GetWarnings(const std::string& strFor)
 //
 
 
-static bool AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
+bool AlreadyHave(const CInv& inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
 {
     AssertLockHeld(cs_main);
 
@@ -5846,15 +5846,15 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
 
     else if (strCommand == NetMsgType::XPEDITEDBLK)
     {
-        // ignore the expedited message unless we are near the chain tip...
-        if (!fImporting && !fReindex && IsChainNearlySyncd())
-        {
+	// ignore the expedited message unless we are at the chain tip...
+    	if (!fImporting && !fReindex && !IsInitialBlockDownload())
+	{
 	    if (!HandleExpeditedBlock(vRecv, pfrom))
             {
                 LOCK(cs_main);
                 Misbehaving(pfrom->GetId(), 5);
-                return false;            
-            }
+                return false;
+	    }
         }
     }
 
@@ -5901,87 +5901,10 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         CheckAndRequestExpeditedBlocks(pfrom);
     }
 
-    else if (strCommand == NetMsgType::XTHINBLOCK && !fImporting && !fReindex && IsThinBlocksEnabled())
+    else if (strCommand == NetMsgType::XTHINBLOCK && !fImporting && !fReindex && !IsInitialBlockDownload()
+    	     && IsThinBlocksEnabled())
     {
-        if (!pfrom->ThinBlockCapable())
-        {
-            LOCK(cs_main);
-            Misbehaving(pfrom->GetId(), 100);
-            return error("xthinblock message received from a non thinblock node, peer=%d", pfrom->GetId());
-        }
-
-        CXThinBlock thinBlock;
-        vRecv >> thinBlock;
-
-        // Message consistency checking
-        if (!IsThinBlockValid(pfrom, thinBlock.vMissingTx, thinBlock.header))
-        {
-            LOCK(cs_main);
-            Misbehaving(pfrom->GetId(), 100);
-            return error("Invalid xthinblock received");
-        }
-
-        // Is there a previous block or header to connect with?
-        {
-            LOCK(cs_main);
-            uint256 prevHash = thinBlock.header.hashPrevBlock;
-            BlockMap::iterator mi = mapBlockIndex.find(prevHash);
-            if (mi == mapBlockIndex.end())
-            {
-                Misbehaving(pfrom->GetId(), 10);
-                return error("xthinblock from peer %s (%d) will not connect, unknown previous block %s",
-                    pfrom->addrName.c_str(),
-                    pfrom->id,
-                    prevHash.ToString());
-            }
-            CBlockIndex* pprev = mi->second;
-            CValidationState state;
-            if (!ContextualCheckBlockHeader(thinBlock.header, state, pprev))
-            {
-                // Thin block does not fit within our blockchain
-                Misbehaving(pfrom->GetId(), 100);
-                return error("thinblock from peer %s (%d) contextual error: %s",
-                    pfrom->addrName.c_str(),
-                    pfrom->id,
-                    state.GetRejectReason().c_str());
-            }
-        }
-
-        // Send expedited block without checking merkle root.
-        CInv inv(MSG_BLOCK, thinBlock.header.GetHash());
-        if (!IsRecentlyExpeditedAndStore(inv.hash))
-            SendExpeditedBlock(thinBlock, 0, pfrom);
-
-        int nSizeThinBlock = ::GetSerializeSize(thinBlock, SER_NETWORK, PROTOCOL_VERSION);
-        LogPrint("thin", "Received xthinblock %s from peer %s (%d). Size %d bytes.\n", inv.hash.ToString(),
-            pfrom->addrName.c_str(),
-            pfrom->id,
-            nSizeThinBlock);
-
-        // Ban a node for sending unrequested xthins unless from an expedited node.
-        bool fAlreadyHave = false;
-        {
-        LOCK(pfrom->cs_mapthinblocksinflight);
-        if (!pfrom->mapThinBlocksInFlight.count(inv.hash) && !IsExpeditedNode(pfrom))
-        {
-                LOCK(cs_main);
-                Misbehaving(pfrom->GetId(), 100);
-                return error("unrequested xthinblock from peer %s (%d)", pfrom->addrName.c_str(), pfrom->id);
-        }
-
-        // An expedited block or re-requested xthin can arrive and beat the original thin block request/response
-        if (!pfrom->mapThinBlocksInFlight.count(inv.hash))
-        {
-            LogPrint("thin", "xthinblock %s from peer %s (%d) received but we may already have processed it\n", inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id);
-            LOCK(cs_main);
-            fAlreadyHave = AlreadyHave(inv); // I'll still continue processing if we don't have an accepted block yet
-            if (fAlreadyHave)
-                requester.Received(inv, pfrom, nSizeThinBlock); // record the bytes received from the thinblock even though we had it already
-        }
-        }
-
-        if (!fAlreadyHave)
-            thinBlock.process(pfrom, nSizeThinBlock, strCommand);
+    	CXThinBlock::HandleMessage(vRecv, pfrom, strCommand, 0);
     }
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -234,7 +234,9 @@ bool LoadBlockIndex();
 void UnloadBlockIndex();
 /** Process protocol messages received from a given node */
 bool ProcessMessages(CNode* pfrom);
-extern bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, int64_t nTimeReceived);
+bool AlreadyHave(const CInv &);
+/** Process a single protocol messages received from a given node */
+bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, int64_t nTimeReceived);
 /**
  * Send queued protocol messages to be sent to a give node.
  *

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -481,6 +481,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     dummyNode1a.nServices |= NODE_XTHIN;
     dummyNode1a.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode1a.fSuccessfullyConnected = true;
+    dummyNode1a.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode1a, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
     SendMessages(&dummyNode1a);
     BOOST_CHECK(!xthin.vMissingTx[0].IsCoinBase());
@@ -497,6 +498,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     dummyNode1b.nServices |= NODE_XTHIN;
     dummyNode1b.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode1b.fSuccessfullyConnected = true;
+    dummyNode1b.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode1b, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
     SendMessages(&dummyNode1b);
     CValidationState state;
@@ -515,6 +517,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     dummyNode2.nServices |= NODE_XTHIN;
     dummyNode2.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode2.fSuccessfullyConnected = true;
+    dummyNode2.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode2, NetMsgType::THINBLOCK, vRecv2, GetTime());
     SendMessages(&dummyNode2);
     BOOST_CHECK(thin.vMissingTx.size() == 0);
@@ -531,6 +534,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     dummyNode2a.nServices |= NODE_XTHIN;
     dummyNode2a.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode2a.fSuccessfullyConnected = true;
+    dummyNode2a.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode2a, NetMsgType::THINBLOCK, vRecv2, GetTime());
     SendMessages(&dummyNode2a);
     BOOST_CHECK(!thin.vMissingTx[0].IsCoinBase());
@@ -547,6 +551,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     dummyNode2b.nServices |= NODE_XTHIN;
     dummyNode2b.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode2b.fSuccessfullyConnected = true;
+    dummyNode2b.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode2b, NetMsgType::THINBLOCK, vRecv2, GetTime());
     SendMessages(&dummyNode2b);
     BOOST_CHECK(!CheckBlockHeader(thin.header, state, true));
@@ -567,6 +572,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     dummyNode3.nServices |= NODE_XTHIN;
     dummyNode3.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode3.fSuccessfullyConnected = true;
+    dummyNode3.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode3, NetMsgType::XBLOCKTX, vRecv3, GetTime());
     SendMessages(&dummyNode3);
     BOOST_CHECK(nullhash.IsNull());
@@ -583,6 +589,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     dummyNode3a.nServices |= NODE_XTHIN;
     dummyNode3a.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode3a.fSuccessfullyConnected = true;
+    dummyNode3a.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode3a, NetMsgType::XBLOCKTX, vRecv3, GetTime());
     SendMessages(&dummyNode3a);
     BOOST_CHECK(vTxEmpty.size() == 0);
@@ -599,6 +606,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     dummyNode3b.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode3b.fSuccessfullyConnected = true;
     dummyNode3b.xThinBlockHashes.push_back(1); // add one hash to the vector which will cause a mismatch
+    dummyNode3b.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode3b, NetMsgType::XBLOCKTX, vRecv3, GetTime());
     SendMessages(&dummyNode3b);
     BOOST_CHECK(dummyNode3b.xThinBlockHashes.size() != dummyNode3b.thinBlock.vtx.size());
@@ -619,6 +627,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     dummyNode4.nServices |= NODE_XTHIN;
     dummyNode4.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode4.fSuccessfullyConnected = true;
+    dummyNode4.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode4, NetMsgType::GET_XBLOCKTX, vRecv4, GetTime());
     SendMessages(&dummyNode4);
     BOOST_CHECK(nullhash.IsNull());
@@ -635,6 +644,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     dummyNode4a.nServices |= NODE_XTHIN;
     dummyNode4a.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode4a.fSuccessfullyConnected = true;
+    dummyNode4a.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode4a, NetMsgType::GET_XBLOCKTX, vRecv4, GetTime());
     SendMessages(&dummyNode4a);
     BOOST_CHECK(setHashesToRequest.empty());
@@ -656,6 +666,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     dummyNode5.nServices |= NODE_XTHIN;
     dummyNode5.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode5.fSuccessfullyConnected = true;
+    dummyNode5.nServices = NODE_XTHIN;
     ProcessMessage(&dummyNode5, NetMsgType::GET_XTHIN, vRecv5, GetTime());
     SendMessages(&dummyNode5);
     BOOST_CHECK(nullhash.IsNull());
@@ -681,4 +692,3 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -15,6 +15,7 @@
 #include "protocol.h"
 #include <vector>
 
+class CDataStream;
 class CNode;
 
 class CThinBlock
@@ -54,6 +55,18 @@ public:
     CXThinBlock(const CBlock& block, CBloomFilter* filter); // Use the filter to determine which txns the client has
     CXThinBlock(const CBlock& block);  // Assume client has all of the transactions (except coinbase)
     CXThinBlock() {}
+    /**
+     * Handle an incoming Xthin or Xpedited block
+     * Once the block is validated apart from the Merkle root, forward the Xpedited block with a hop count of nHops.
+     * @param[in]  vRecv        The raw binary message
+     * @param[in] pFrom        The node the message was from
+     * @param[in]  strCommand   The message kind
+     * @param[in]  nHops        On the wire, an Xpedited block has a hop count of zero the first time it is sent, and
+     *                          the hop count is incremented each time it is forwarded.  nHops is zero for an incoming
+     *                          Xthin block, and for an incoming Xpedited block its hop count + 1.
+     * @return True if handling succeeded
+     */
+    static bool HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string strCommand, unsigned nHops);
 
     ADD_SERIALIZE_METHODS;
 


### PR DESCRIPTION
A common function that unifies the two message handlers to have a single codepath
for verification.  The only differences lie in determining new-ness of the block.
The prior expedited code path used to omit most of the validity checks.

Set the nodes as xthin-capable in exploit_tests.cpp