### PR TITLE
[Backport][release] Combine expedited block and xthin block handling

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -234,7 +234,9 @@ bool LoadBlockIndex();
 void UnloadBlockIndex();
 /** Process protocol messages received from a given node */
 bool ProcessMessages(CNode* pfrom);
-extern bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, int64_t nTimeReceived);
+bool AlreadyHave(const CInv &);
+/** Process a single protocol messages received from a given node */
+bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, int64_t nTimeReceived);
 /**
  * Send queued protocol messages to be sent to a give node.
  *

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -681,4 +681,3 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -15,6 +15,7 @@
 #include "protocol.h"
 #include <vector>
 
+class CDataStream;
 class CNode;
 
 class CThinBlock
@@ -54,6 +55,18 @@ public:
     CXThinBlock(const CBlock& block, CBloomFilter* filter); // Use the filter to determine which txns the client has
     CXThinBlock(const CBlock& block);  // Assume client has all of the transactions (except coinbase)
     CXThinBlock() {}
+    /**
+     * Handle an incoming Xthin or Xpedited block
+     * Once the block is validated apart from the Merkle root, forward the Xpedited block with a hop count of nHops.
+     * @param[in]  vRecv        The raw binary message
+     * @param[in] pFrom        The node the message was from
+     * @param[in]  strCommand   The message kind
+     * @param[in]  nHops        On the wire, an Xpedited block has a hop count of zero the first time it is sent, and
+     *                          the hop count is incremented each time it is forwarded.  nHops is zero for an incoming
+     *                          Xthin block, and for an incoming Xpedited block its hop count + 1.
+     * @return True if handling succeeded
+     */
+    static bool HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string strCommand, unsigned nHops);
 
     ADD_SERIALIZE_METHODS;
 


### PR DESCRIPTION
A common function that unifies the two message handlers to have a single codepath
for verification.  The only differences lie in determining new-ness of the block.
The prior expedited code path used to omit most of the validity checks.