### PR TITLE
[Port] Introduce ServiceFlags enum

### DIFF
--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -513,6 +513,24 @@ void CAddrMan::Connected_(const CService& addr, int64_t nTime)
         info.nTime = nTime;
 }
 
+void CAddrMan::SetServices_(const CService& addr, uint64_t nServices)
+{
+    CAddrInfo* pinfo = Find(addr);
+
+    // if not found, bail out
+    if (!pinfo)
+        return;
+
+    CAddrInfo& info = *pinfo;
+
+    // check whether we are talking about the exact same CService (including same port)
+    if (info != addr)
+        return;
+
+    // update info
+    info.nServices = nServices;
+}
+
 int CAddrMan::RandomInt(int nMax){
     return GetRandInt(nMax);
 }

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -262,7 +262,7 @@ bool CAddrMan::Add_(const CAddress& addr, const CNetAddr& source, int64_t nTimeP
             pinfo->nTime = std::max((int64_t)0, addr.nTime - nTimePenalty);
 
         // add services
-        pinfo->nServices |= addr.nServices;
+        pinfo->nServices = ServiceFlags(pinfo->nServices | addr.nServices);
 
         // do not update if no new information is present
         if (!addr.nTime || (pinfo->nTime && addr.nTime <= pinfo->nTime))
@@ -513,7 +513,7 @@ void CAddrMan::Connected_(const CService& addr, int64_t nTime)
         info.nTime = nTime;
 }
 
-void CAddrMan::SetServices_(const CService& addr, uint64_t nServices)
+void CAddrMan::SetServices_(const CService& addr, ServiceFlags nServices)
 {
     CAddrInfo* pinfo = Find(addr);
 

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -256,7 +256,7 @@ protected:
     void Connected_(const CService &addr, int64_t nTime);
 
     //! Update an entry's service bits.
-    void SetServices_(const CService &addr, uint64_t nServices);
+    void SetServices_(const CService &addr, ServiceFlags nServices);
 
 public:
     /**
@@ -591,7 +591,7 @@ public:
         }
     }
 
-    void SetServices(const CService &addr, uint64_t nServices)
+    void SetServices(const CService &addr, ServiceFlags nServices)
     {
         LOCK(cs);
         Check();

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -255,6 +255,9 @@ protected:
     //! Mark an entry as currently-connected-to.
     void Connected_(const CService &addr, int64_t nTime);
 
+    //! Update an entry's service bits.
+    void SetServices_(const CService &addr, uint64_t nServices);
+
 public:
     /**
      * serialized format:
@@ -586,6 +589,14 @@ public:
             Connected_(addr, nTime);
             Check();
         }
+    }
+
+    void SetServices(const CService &addr, uint64_t nServices)
+    {
+        LOCK(cs);
+        Check();
+        SetServices_(addr, nServices);
+        Check();
     }
 
 };

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -994,7 +994,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     SetMockTime(GetArg("-mocktime", 0)); // SetMockTime(0) is a no-op
 
     if (GetBoolArg("-peerbloomfilters", true))
-        nLocalServices |= NODE_BLOOM;
+        nLocalServices = ServiceFlags(nLocalServices | NODE_BLOOM);
 
     //BUIP010 Xtreme Thinblocks: begin section Initialize XTHIN service
     if (GetBoolArg("-use-thinblocks", true))
@@ -1269,7 +1269,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // after any wallet rescanning has taken place.
     if (fPruneMode) {
         LogPrintf("Unsetting NODE_NETWORK on prune mode\n");
-        nLocalServices &= ~NODE_NETWORK;
+        nLocalServices = ServiceFlags(nLocalServices & ~NODE_NETWORK);
         if (!fReindex) {
             uiInterface.InitMessage(_("Pruning blockstore..."));
             PruneAndFlush();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -998,7 +998,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     //BUIP010 Xtreme Thinblocks: begin section Initialize XTHIN service
     if (GetBoolArg("-use-thinblocks", true))
-        nLocalServices |= NODE_XTHIN;
+        nLocalServices = ServiceFlags(nLocalServices | NODE_XTHIN);
     // BUIP010 Xtreme Thinblocks: end section
 
     nMaxTipAge = GetArg("-maxtipage", DEFAULT_MAX_TIP_AGE);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5329,7 +5329,7 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
         {
             boost::this_thread::interruption_point();
 
-            if (!(addr.nServices & NODE_NETWORK))
+            if ((addr.nServices & REQUIRED_SERVICES) != REQUIRED_SERVICES)
                 continue;
 
             if (addr.nTime <= 100000000 || addr.nTime > nNow + 10 * 60)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5095,6 +5095,10 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
         CAddress addrFrom;
         uint64_t nNonce = 1;
         vRecv >> pfrom->nVersion >> pfrom->nServices >> nTime >> addrMe;
+        if (!pfrom->fInbound)
+        {
+            addrman.SetServices(pfrom->addr, pfrom->nServices);
+        }
 
         CheckNodeSupportForThinBlocks(); // BUIP010 Xtreme Thinblocks
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5099,6 +5099,14 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
         {
             addrman.SetServices(pfrom->addr, pfrom->nServices);
         }
+        if (pfrom->nServicesExpected & ~pfrom->nServices)
+        {
+            LogPrint("net", "peer=%d does not offer the expected services (%08x offered, %08x expected); disconnecting\n", pfrom->id, pfrom->nServices, pfrom->nServicesExpected);
+            pfrom->PushMessage(NetMsgType::REJECT, strCommand, REJECT_NONSTANDARD,
+                               strprintf("Expected to offer services %08x", pfrom->nServicesExpected));
+            pfrom->fDisconnect = true;
+            return false;
+        }
 
         CheckNodeSupportForThinBlocks(); // BUIP010 Xtreme Thinblocks
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5327,6 +5327,9 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
         {
             boost::this_thread::interruption_point();
 
+            if (!(addr.nServices & NODE_NETWORK))
+                continue;
+
             if (addr.nTime <= 100000000 || addr.nTime > nNow + 10 * 60)
                 addr.nTime = nNow - 5 * 24 * 60 * 60;
             pfrom->AddAddressKnown(addr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5094,7 +5094,9 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
         CAddress addrMe;
         CAddress addrFrom;
         uint64_t nNonce = 1;
-        vRecv >> pfrom->nVersion >> pfrom->nServices >> nTime >> addrMe;
+        uint64_t nServiceInt;
+        vRecv >> pfrom->nVersion >> nServiceInt >> nTime >> addrMe;
+        pfrom->nServices = ServiceFlags(nServiceInt);
         if (!pfrom->fInbound)
         {
             addrman.SetServices(pfrom->addr, pfrom->nServices);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -80,6 +80,9 @@ namespace
     };
 }
 
+/** Services this node implementation cares about */
+static const uint64_t nRelevantServices = NODE_NETWORK;
+
 //
 // Global state variables
 //
@@ -462,6 +465,7 @@ CNode* ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure
             vNodes.push_back(pnode);
         }
 
+        pnode->nServicesExpected = addrConnect.nServices & nRelevantServices;
         pnode->nTimeConnected = GetTime();
 
         return pnode;
@@ -2765,6 +2769,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     filterInventoryKnown(50000, 0.000001)
 {
     nServices = 0;
+    nServicesExpected = 0;
     hSocket = hSocketIn;
     nRecvVersion = INIT_PROTO_VERSION;
     nLastSend = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1928,7 +1928,7 @@ void ThreadOpenConnections()
                 continue;
 
             // only connect to full nodes
-            if (!(addr.nServices & NODE_NETWORK))
+            if ((addr.nServices & REQUIRED_SERVICES) != REQUIRED_SERVICES)
                 continue;
 
             // only consider very recently tried nodes after 30 failed attempts

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1928,6 +1928,10 @@ void ThreadOpenConnections()
             if (IsLimited(addr))
                 continue;
 
+            // only connect to full nodes
+            if (!(addr.nServices & NODE_NETWORK))
+                continue;
+
             // only consider very recently tried nodes after 30 failed attempts
             if (nANow - addr.nLastTry < 600 && nTries < 30)
                 continue;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1602,7 +1602,7 @@ void ThreadBitnodesAddressSeed()
         {
             SplitHostPort(seed, portOut, hostOut);
             CNetAddr ip(hostOut);
-            CAddress addr = CAddress(CService(ip, portOut));
+            CAddress addr = CAddress(CService(ip, portOut), NODE_NETWORK);
             addr.nTime = GetTime();
             vAdd.push_back(addr);
         }
@@ -1616,7 +1616,7 @@ void ThreadBitnodesAddressSeed()
 // BITCOINUNLIMITED END
 
 
-static std::string GetDNSHost(const CDNSSeedData& data, uint64_t requiredServiceBits)
+static std::string GetDNSHost(const CDNSSeedData& data, ServiceFlags requiredServiceBits)
 {
     //use default host for non-filter-capable seeds or if we use the default service bits (NODE_NETWORK)
     if (!data.supportsServiceBitsFiltering || requiredServiceBits == NODE_NETWORK) {

--- a/src/net.h
+++ b/src/net.h
@@ -348,6 +348,7 @@ class CNode
 public:
     // socket
     uint64_t nServices;
+    uint64_t nServicesExpected;
     SOCKET hSocket;
     CDataStream ssSend;
     size_t nSendSize;   // total size of all vSendMsg entries

--- a/src/net.h
+++ b/src/net.h
@@ -89,6 +89,8 @@ static const bool DEFAULT_FORCEDNSSEED = false;
 static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
 static const size_t DEFAULT_MAXSENDBUFFER    = 1 * 1000;
 
+static const ServiceFlags REQUIRED_SERVICES = NODE_NETWORK;
+
 // NOTE: When adjusting this, update rpcnet:setban's help ("24h")
 static const unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24;  // Default 24-hour ban
 

--- a/src/net.h
+++ b/src/net.h
@@ -174,7 +174,7 @@ CAddress GetLocalAddress(const CNetAddr *paddrPeer = NULL);
 
 extern bool fDiscover;
 extern bool fListen;
-extern uint64_t nLocalServices;
+extern ServiceFlags nLocalServices;
 extern uint64_t nLocalHostNonce;
 extern CAddrMan addrman;
 
@@ -210,7 +210,7 @@ class CNodeStats
 {
 public:
     NodeId nodeid;
-    uint64_t nServices;
+    ServiceFlags nServices;
     bool fRelayTxes;
     int64_t nLastSend;
     int64_t nLastRecv;
@@ -347,8 +347,8 @@ class CNode
 {
 public:
     // socket
-    uint64_t nServices;
-    uint64_t nServicesExpected;
+    ServiceFlags nServices;
+    ServiceFlags nServicesExpected;
     SOCKET hSocket;
     CDataStream ssSend;
     size_t nSendSize;   // total size of all vSendMsg entries

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -162,7 +162,7 @@ CAddress::CAddress() : CService()
     Init();
 }
 
-CAddress::CAddress(CService ipIn, uint64_t nServicesIn) : CService(ipIn)
+CAddress::CAddress(CService ipIn, ServiceFlags nServicesIn) : CService(ipIn)
 {
     Init();
     nServices = nServicesIn;
@@ -170,7 +170,7 @@ CAddress::CAddress(CService ipIn, uint64_t nServicesIn) : CService(ipIn)
 
 void CAddress::Init()
 {
-    nServices = 0;
+    nServices = NODE_NONE;
     nTime = 100000000;
 }
 

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -170,7 +170,7 @@ CAddress::CAddress(CService ipIn, uint64_t nServicesIn) : CService(ipIn)
 
 void CAddress::Init()
 {
-    nServices = NODE_NETWORK;
+    nServices = 0;
     nTime = 100000000;
 }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -309,7 +309,7 @@ class CAddress : public CService
 {
 public:
     CAddress();
-    explicit CAddress(CService ipIn, uint64_t nServicesIn = NODE_NETWORK);
+    explicit CAddress(CService ipIn, uint64_t nServicesIn);
 
     void Init();
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -269,7 +269,9 @@ extern const char *BUVERACK;
 const std::vector<std::string> &getAllNetMessageTypes();
 
 /** nServices flags */
-enum {
+enum ServiceFlags : uint64_t {
+    // Nothing
+    NODE_NONE = 0,
     // NODE_NETWORK means that the node is capable of serving the block chain. It is currently
     // set by all Bitcoin Unlimited nodes, and is unset by SPV clients or other peers that just want
     // network services but don't provide them.
@@ -309,7 +311,7 @@ class CAddress : public CService
 {
 public:
     CAddress();
-    explicit CAddress(CService ipIn, uint64_t nServicesIn);
+    explicit CAddress(CService ipIn, ServiceFlags nServicesIn);
 
     void Init();
 
@@ -325,13 +327,15 @@ public:
         if ((nType & SER_DISK) ||
             (nVersion >= CADDR_TIME_VERSION && !(nType & SER_GETHASH)))
             READWRITE(nTime);
-        READWRITE(nServices);
+        uint64_t nServicesInt = nServices;
+        READWRITE(nServicesInt);
+        nServices = (ServiceFlags)nServicesInt;
         READWRITE(*(CService*)this);
     }
 
     // TODO: make private (improves encapsulation)
 public:
-    uint64_t nServices;
+    ServiceFlags nServices;
 
     // disk and network only
     unsigned int nTime;

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -41,7 +41,7 @@ BOOST_FIXTURE_TEST_SUITE(DoS_tests, TestingSetup)
 BOOST_AUTO_TEST_CASE(DoS_banning)
 {
     CNode::ClearBanned();
-    CAddress addr1(ip(0xa0b0c001));
+    CAddress addr1(ip(0xa0b0c001), 0);
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100); // Should get banned
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     BOOST_CHECK(CNode::IsBanned(addr1));
     BOOST_CHECK(!CNode::IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
 
-    CAddress addr2(ip(0xa0b0c002));
+    CAddress addr2(ip(0xa0b0c002), 0);
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
     dummyNode2.nVersion = 1;
     Misbehaving(dummyNode2.GetId(), 50);
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
 {
     CNode::ClearBanned();
     mapArgs["-banscore"] = "111"; // because 11 is my favorite number
-    CAddress addr1(ip(0xa0b0c001));
+    CAddress addr1(ip(0xa0b0c001), 0);
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100);
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     int64_t nStartTime = GetTime();
     SetMockTime(nStartTime); // Overrides future calls to GetTime()
 
-    CAddress addr(ip(0xa0b0c001));
+    CAddress addr(ip(0xa0b0c001), 0);
     CNode dummyNode(INVALID_SOCKET, addr, "", true);
     dummyNode.nVersion = 1;
 

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -41,7 +41,7 @@ BOOST_FIXTURE_TEST_SUITE(DoS_tests, TestingSetup)
 BOOST_AUTO_TEST_CASE(DoS_banning)
 {
     CNode::ClearBanned();
-    CAddress addr1(ip(0xa0b0c001), 0);
+    CAddress addr1(ip(0xa0b0c001), NODE_NONE);
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100); // Should get banned
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     BOOST_CHECK(CNode::IsBanned(addr1));
     BOOST_CHECK(!CNode::IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
 
-    CAddress addr2(ip(0xa0b0c002), 0);
+    CAddress addr2(ip(0xa0b0c002), NODE_NONE);
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
     dummyNode2.nVersion = 1;
     Misbehaving(dummyNode2.GetId(), 50);
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
 {
     CNode::ClearBanned();
     mapArgs["-banscore"] = "111"; // because 11 is my favorite number
-    CAddress addr1(ip(0xa0b0c001), 0);
+    CAddress addr1(ip(0xa0b0c001), NODE_NONE);
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100);
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     int64_t nStartTime = GetTime();
     SetMockTime(nStartTime); // Overrides future calls to GetTime()
 
-    CAddress addr(ip(0xa0b0c001), 0);
+    CAddress addr(ip(0xa0b0c001), NODE_NONE);
     CNode dummyNode(INVALID_SOCKET, addr, "", true);
     dummyNode.nVersion = 1;
 

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
 
     // Test 2: Does Addrman::Add work as expected.
     CService addr1 = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1), source);
+    addrman.Add(CAddress(addr1, 0), source);
     BOOST_CHECK(addrman.size() == 1);
     CAddrInfo addr_ret1 = addrman.Select();
     BOOST_CHECK(addr_ret1.ToString() == "250.1.1.1:8333");
@@ -77,14 +77,14 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
     // Test 3: Does IP address deduplication work correctly.
     //  Expected dup IP should not be added.
     CService addr1_dup = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1_dup), source);
+    addrman.Add(CAddress(addr1_dup, 0), source);
     BOOST_CHECK(addrman.size() == 1);
 
 
     // Test 5: New table has one addr and we add a diff addr we should
     //  have two addrs.
     CService addr2 = CService("250.1.1.2", 8333);
-    addrman.Add(CAddress(addr2), source);
+    addrman.Add(CAddress(addr2, 0), source);
     BOOST_CHECK(addrman.size() == 2);
 
     // Test 6: AddrMan::Clear() should empty the new table.
@@ -107,18 +107,18 @@ BOOST_AUTO_TEST_CASE(addrman_ports)
 
     // Test 7; Addr with same IP but diff port does not replace existing addr.
     CService addr1 = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1), source);
+    addrman.Add(CAddress(addr1, 0), source);
     BOOST_CHECK(addrman.size() == 1);
 
     CService addr1_port = CService("250.1.1.1", 8334);
-    addrman.Add(CAddress(addr1_port), source);
+    addrman.Add(CAddress(addr1_port, 0), source);
     BOOST_CHECK(addrman.size() == 1);
     CAddrInfo addr_ret2 = addrman.Select();
     BOOST_CHECK(addr_ret2.ToString() == "250.1.1.1:8333");
 
     // Test 8: Add same IP but diff port to tried table, it doesn't get added.
     //  Perhaps this is not ideal behavior but it is the current behavior.
-    addrman.Good(CAddress(addr1_port));
+    addrman.Good(CAddress(addr1_port, 0));
     BOOST_CHECK(addrman.size() == 1);
     bool newOnly = true;
     CAddrInfo addr_ret3 = addrman.Select(newOnly);
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(addrman_select)
 
     // Test 9: Select from new with 1 addr in new.
     CService addr1 = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1), source);
+    addrman.Add(CAddress(addr1, 0), source);
     BOOST_CHECK(addrman.size() == 1);
 
     bool newOnly = true;
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(addrman_select)
     BOOST_CHECK(addr_ret1.ToString() == "250.1.1.1:8333");
 
     // Test 10: move addr to tried, select from new expected nothing returned.
-    addrman.Good(CAddress(addr1));
+    addrman.Good(CAddress(addr1, 0));
     BOOST_CHECK(addrman.size() == 1);
     CAddrInfo addr_ret2 = addrman.Select(newOnly);
     BOOST_CHECK(addr_ret2.ToString() == "[::]:0");
@@ -161,21 +161,21 @@ BOOST_AUTO_TEST_CASE(addrman_select)
     CService addr3 = CService("250.3.2.2", 9999);
     CService addr4 = CService("250.3.3.3", 9999);
 
-    addrman.Add(CAddress(addr2), CService("250.3.1.1", 8333));
-    addrman.Add(CAddress(addr3), CService("250.3.1.1", 8333));
-    addrman.Add(CAddress(addr4), CService("250.4.1.1", 8333));
+    addrman.Add(CAddress(addr2, 0), CService("250.3.1.1", 8333));
+    addrman.Add(CAddress(addr3, 0), CService("250.3.1.1", 8333));
+    addrman.Add(CAddress(addr4, 0), CService("250.4.1.1", 8333));
 
     // Add three addresses to tried table.
     CService addr5 = CService("250.4.4.4", 8333);
     CService addr6 = CService("250.4.5.5", 7777);
     CService addr7 = CService("250.4.6.6", 8333);
 
-    addrman.Add(CAddress(addr5), CService("250.3.1.1", 8333));
-    addrman.Good(CAddress(addr5));
-    addrman.Add(CAddress(addr6), CService("250.3.1.1", 8333));
-    addrman.Good(CAddress(addr6));
-    addrman.Add(CAddress(addr7), CService("250.1.1.3", 8333));
-    addrman.Good(CAddress(addr7));
+    addrman.Add(CAddress(addr5, 0), CService("250.3.1.1", 8333));
+    addrman.Good(CAddress(addr5, 0));
+    addrman.Add(CAddress(addr6, 0), CService("250.3.1.1", 8333));
+    addrman.Good(CAddress(addr6, 0));
+    addrman.Add(CAddress(addr7, 0), CService("250.1.1.3", 8333));
+    addrman.Good(CAddress(addr7, 0));
 
     // Test 11: 6 addrs + 1 addr from last test = 7.
     BOOST_CHECK(addrman.size() == 7);
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(addrman_new_collisions)
 
     for (unsigned int i = 1; i < 18; i++) {
         CService addr = CService("250.1.1." + boost::to_string(i));
-        addrman.Add(CAddress(addr), source);
+        addrman.Add(CAddress(addr, 0), source);
 
         //Test 13: No collision in new table yet.
         BOOST_CHECK(addrman.size() == i);
@@ -208,11 +208,11 @@ BOOST_AUTO_TEST_CASE(addrman_new_collisions)
 
     //Test 14: new table collision!
     CService addr1 = CService("250.1.1.18");
-    addrman.Add(CAddress(addr1), source);
+    addrman.Add(CAddress(addr1, 0), source);
     BOOST_CHECK(addrman.size() == 17);
 
     CService addr2 = CService("250.1.1.19");
-    addrman.Add(CAddress(addr2), source);
+    addrman.Add(CAddress(addr2, 0), source);
     BOOST_CHECK(addrman.size() == 18);
 }
 
@@ -229,8 +229,8 @@ BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
 
     for (unsigned int i = 1; i < 80; i++) {
         CService addr = CService("250.1.1." + boost::to_string(i));
-        addrman.Add(CAddress(addr), source);
-        addrman.Good(CAddress(addr));
+        addrman.Add(CAddress(addr, 0), source);
+        addrman.Good(CAddress(addr, 0));
 
         //Test 15: No collision in tried table yet.
         BOOST_TEST_MESSAGE(addrman.size());
@@ -239,11 +239,11 @@ BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
 
     //Test 16: tried table collision!
     CService addr1 = CService("250.1.1.80");
-    addrman.Add(CAddress(addr1), source);
+    addrman.Add(CAddress(addr1, 0), source);
     BOOST_CHECK(addrman.size() == 79);
 
     CService addr2 = CService("250.1.1.81");
-    addrman.Add(CAddress(addr2), source);
+    addrman.Add(CAddress(addr2, 0), source);
     BOOST_CHECK(addrman.size() == 80);
 }
 
@@ -256,9 +256,9 @@ BOOST_AUTO_TEST_CASE(addrman_find)
 
     BOOST_CHECK(addrman.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333));
-    CAddress addr2 = CAddress(CService("250.1.2.1", 9999));
-    CAddress addr3 = CAddress(CService("251.255.2.1", 8333));
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
+    CAddress addr2 = CAddress(CService("250.1.2.1", 9999), 0);
+    CAddress addr3 = CAddress(CService("251.255.2.1", 8333), 0);
 
     CNetAddr source1 = CNetAddr("250.1.2.1");
     CNetAddr source2 = CNetAddr("250.1.2.2");
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(addrman_create)
 
     BOOST_CHECK(addrman.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333));
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
     CNetAddr source1 = CNetAddr("250.1.2.1");
 
     int nId;
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(addrman_delete)
 
     BOOST_CHECK(addrman.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333));
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
     CNetAddr source1 = CNetAddr("250.1.2.1");
 
     int nId;
@@ -345,15 +345,15 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     vector<CAddress> vAddr1 = addrman.GetAddr();
     BOOST_CHECK(vAddr1.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.250.2.1", 8333));
+    CAddress addr1 = CAddress(CService("250.250.2.1", 8333), 0);
     addr1.nTime = GetAdjustedTime(); // Set time so isTerrible = false
-    CAddress addr2 = CAddress(CService("250.251.2.2", 9999));
+    CAddress addr2 = CAddress(CService("250.251.2.2", 9999), 0);
     addr2.nTime = GetAdjustedTime();
-    CAddress addr3 = CAddress(CService("251.252.2.3", 8333));
+    CAddress addr3 = CAddress(CService("251.252.2.3", 8333), 0);
     addr3.nTime = GetAdjustedTime();
-    CAddress addr4 = CAddress(CService("252.253.3.4", 8333));
+    CAddress addr4 = CAddress(CService("252.253.3.4", 8333), 0);
     addr4.nTime = GetAdjustedTime();
-    CAddress addr5 = CAddress(CService("252.254.4.5", 8333));
+    CAddress addr5 = CAddress(CService("252.254.4.5", 8333), 0);
     addr5.nTime = GetAdjustedTime();
     CNetAddr source1 = CNetAddr("250.1.2.1");
     CNetAddr source2 = CNetAddr("250.2.3.3");
@@ -369,8 +369,8 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     BOOST_CHECK(addrman.GetAddr().size() == 1); 
 
     // Test 24: Ensure GetAddr works with new and tried addresses.
-    addrman.Good(CAddress(addr1));
-    addrman.Good(CAddress(addr2));
+    addrman.Good(CAddress(addr1, 0));
+    addrman.Good(CAddress(addr2, 0));
     BOOST_CHECK(addrman.GetAddr().size() == 1);
 
     // Test 25: Ensure GetAddr still returns 23% when addrman has many addrs.
@@ -379,7 +379,7 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
         int octet2 = (i / 256) % 256;
         int octet3 = (i / (256 * 2)) % 256;
         string strAddr = boost::to_string(octet1) + "." + boost::to_string(octet2) + "." + boost::to_string(octet3) + ".23";
-        CAddress addr = CAddress(CService(strAddr));
+        CAddress addr = CAddress(CService(strAddr), 0);
         
         // Ensure that for all addrs in addrman, isTerrible == false.
         addr.nTime = GetAdjustedTime();
@@ -404,8 +404,8 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     // Set addrman addr placement to be deterministic.
     addrman.MakeDeterministic();
 
-    CAddress addr1 = CAddress(CService("250.1.1.1", 8333));
-    CAddress addr2 = CAddress(CService("250.1.1.1", 9999));
+    CAddress addr1 = CAddress(CService("250.1.1.1", 8333), 0);
+    CAddress addr2 = CAddress(CService("250.1.1.1", 9999), 0);
 
     CNetAddr source1 = CNetAddr("250.1.1.1");
 
@@ -432,7 +432,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     set<int> buckets;
     for (int i = 0; i < 255; i++) {
         CAddrInfo infoi = CAddrInfo(
-            CAddress(CService("250.1.1." + boost::to_string(i))),
+            CAddress(CService("250.1.1." + boost::to_string(i)), 0),
             CNetAddr("250.1.1." + boost::to_string(i)));
         int bucket = infoi.GetTriedBucket(nKey1);
         buckets.insert(bucket);
@@ -444,7 +444,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     buckets.clear();
     for (int j = 0; j < 255; j++) {
         CAddrInfo infoj = CAddrInfo(
-            CAddress(CService("250." + boost::to_string(j) + ".1.1")),
+            CAddress(CService("250." + boost::to_string(j) + ".1.1"), 0),
             CNetAddr("250." + boost::to_string(j) + ".1.1"));
         int bucket = infoj.GetTriedBucket(nKey1);
         buckets.insert(bucket);
@@ -461,8 +461,8 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     // Set addrman addr placement to be deterministic.
     addrman.MakeDeterministic();
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333));
-    CAddress addr2 = CAddress(CService("250.1.2.1", 9999));
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
+    CAddress addr2 = CAddress(CService("250.1.2.1", 9999), 0);
 
     CNetAddr source1 = CNetAddr("250.1.2.1");
 
@@ -485,7 +485,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     set<int> buckets;
     for (int i = 0; i < 255; i++) {
         CAddrInfo infoi = CAddrInfo(
-            CAddress(CService("250.1.1." + boost::to_string(i))),
+            CAddress(CService("250.1.1." + boost::to_string(i)), 0),
             CNetAddr("250.1.1." + boost::to_string(i)));
         int bucket = infoi.GetNewBucket(nKey1);
         buckets.insert(bucket);
@@ -498,7 +498,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     for (int j = 0; j < 4 * 255; j++) {
         CAddrInfo infoj = CAddrInfo(CAddress(
                                         CService(
-                                            boost::to_string(250 + (j / 255)) + "." + boost::to_string(j % 256) + ".1.1")),
+                                            boost::to_string(250 + (j / 255)) + "." + boost::to_string(j % 256) + ".1.1"), 0),
             CNetAddr("251.4.1.1"));
         int bucket = infoj.GetNewBucket(nKey1);
         buckets.insert(bucket);
@@ -510,7 +510,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     buckets.clear();
     for (int p = 0; p < 255; p++) {
         CAddrInfo infoj = CAddrInfo(
-            CAddress(CService("250.1.1.1")),
+            CAddress(CService("250.1.1.1"), 0),
             CNetAddr("250." + boost::to_string(p) + ".1.1"));
         int bucket = infoj.GetNewBucket(nKey1);
         buckets.insert(bucket);

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
 
     // Test 2: Does Addrman::Add work as expected.
     CService addr1 = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1, 0), source);
+    addrman.Add(CAddress(addr1, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 1);
     CAddrInfo addr_ret1 = addrman.Select();
     BOOST_CHECK(addr_ret1.ToString() == "250.1.1.1:8333");
@@ -77,14 +77,14 @@ BOOST_AUTO_TEST_CASE(addrman_simple)
     // Test 3: Does IP address deduplication work correctly.
     //  Expected dup IP should not be added.
     CService addr1_dup = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1_dup, 0), source);
+    addrman.Add(CAddress(addr1_dup, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 1);
 
 
     // Test 5: New table has one addr and we add a diff addr we should
     //  have two addrs.
     CService addr2 = CService("250.1.1.2", 8333);
-    addrman.Add(CAddress(addr2, 0), source);
+    addrman.Add(CAddress(addr2, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 2);
 
     // Test 6: AddrMan::Clear() should empty the new table.
@@ -107,18 +107,18 @@ BOOST_AUTO_TEST_CASE(addrman_ports)
 
     // Test 7; Addr with same IP but diff port does not replace existing addr.
     CService addr1 = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1, 0), source);
+    addrman.Add(CAddress(addr1, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 1);
 
     CService addr1_port = CService("250.1.1.1", 8334);
-    addrman.Add(CAddress(addr1_port, 0), source);
+    addrman.Add(CAddress(addr1_port, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 1);
     CAddrInfo addr_ret2 = addrman.Select();
     BOOST_CHECK(addr_ret2.ToString() == "250.1.1.1:8333");
 
     // Test 8: Add same IP but diff port to tried table, it doesn't get added.
     //  Perhaps this is not ideal behavior but it is the current behavior.
-    addrman.Good(CAddress(addr1_port, 0));
+    addrman.Good(CAddress(addr1_port, NODE_NONE));
     BOOST_CHECK(addrman.size() == 1);
     bool newOnly = true;
     CAddrInfo addr_ret3 = addrman.Select(newOnly);
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(addrman_select)
 
     // Test 9: Select from new with 1 addr in new.
     CService addr1 = CService("250.1.1.1", 8333);
-    addrman.Add(CAddress(addr1, 0), source);
+    addrman.Add(CAddress(addr1, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 1);
 
     bool newOnly = true;
@@ -145,7 +145,7 @@ BOOST_AUTO_TEST_CASE(addrman_select)
     BOOST_CHECK(addr_ret1.ToString() == "250.1.1.1:8333");
 
     // Test 10: move addr to tried, select from new expected nothing returned.
-    addrman.Good(CAddress(addr1, 0));
+    addrman.Good(CAddress(addr1, NODE_NONE));
     BOOST_CHECK(addrman.size() == 1);
     CAddrInfo addr_ret2 = addrman.Select(newOnly);
     BOOST_CHECK(addr_ret2.ToString() == "[::]:0");
@@ -161,21 +161,21 @@ BOOST_AUTO_TEST_CASE(addrman_select)
     CService addr3 = CService("250.3.2.2", 9999);
     CService addr4 = CService("250.3.3.3", 9999);
 
-    addrman.Add(CAddress(addr2, 0), CService("250.3.1.1", 8333));
-    addrman.Add(CAddress(addr3, 0), CService("250.3.1.1", 8333));
-    addrman.Add(CAddress(addr4, 0), CService("250.4.1.1", 8333));
+    addrman.Add(CAddress(addr2, NODE_NONE), CService("250.3.1.1", 8333));
+    addrman.Add(CAddress(addr3, NODE_NONE), CService("250.3.1.1", 8333));
+    addrman.Add(CAddress(addr4, NODE_NONE), CService("250.4.1.1", 8333));
 
     // Add three addresses to tried table.
     CService addr5 = CService("250.4.4.4", 8333);
     CService addr6 = CService("250.4.5.5", 7777);
     CService addr7 = CService("250.4.6.6", 8333);
 
-    addrman.Add(CAddress(addr5, 0), CService("250.3.1.1", 8333));
-    addrman.Good(CAddress(addr5, 0));
-    addrman.Add(CAddress(addr6, 0), CService("250.3.1.1", 8333));
-    addrman.Good(CAddress(addr6, 0));
-    addrman.Add(CAddress(addr7, 0), CService("250.1.1.3", 8333));
-    addrman.Good(CAddress(addr7, 0));
+    addrman.Add(CAddress(addr5, NODE_NONE), CService("250.3.1.1", 8333));
+    addrman.Good(CAddress(addr5, NODE_NONE));
+    addrman.Add(CAddress(addr6, NODE_NONE), CService("250.3.1.1", 8333));
+    addrman.Good(CAddress(addr6, NODE_NONE));
+    addrman.Add(CAddress(addr7, NODE_NONE), CService("250.1.1.3", 8333));
+    addrman.Good(CAddress(addr7, NODE_NONE));
 
     // Test 11: 6 addrs + 1 addr from last test = 7.
     BOOST_CHECK(addrman.size() == 7);
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(addrman_new_collisions)
 
     for (unsigned int i = 1; i < 18; i++) {
         CService addr = CService("250.1.1." + boost::to_string(i));
-        addrman.Add(CAddress(addr, 0), source);
+        addrman.Add(CAddress(addr, NODE_NONE), source);
 
         //Test 13: No collision in new table yet.
         BOOST_CHECK(addrman.size() == i);
@@ -208,11 +208,11 @@ BOOST_AUTO_TEST_CASE(addrman_new_collisions)
 
     //Test 14: new table collision!
     CService addr1 = CService("250.1.1.18");
-    addrman.Add(CAddress(addr1, 0), source);
+    addrman.Add(CAddress(addr1, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 17);
 
     CService addr2 = CService("250.1.1.19");
-    addrman.Add(CAddress(addr2, 0), source);
+    addrman.Add(CAddress(addr2, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 18);
 }
 
@@ -229,8 +229,8 @@ BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
 
     for (unsigned int i = 1; i < 80; i++) {
         CService addr = CService("250.1.1." + boost::to_string(i));
-        addrman.Add(CAddress(addr, 0), source);
-        addrman.Good(CAddress(addr, 0));
+        addrman.Add(CAddress(addr, NODE_NONE), source);
+        addrman.Good(CAddress(addr, NODE_NONE));
 
         //Test 15: No collision in tried table yet.
         BOOST_TEST_MESSAGE(addrman.size());
@@ -239,11 +239,11 @@ BOOST_AUTO_TEST_CASE(addrman_tried_collisions)
 
     //Test 16: tried table collision!
     CService addr1 = CService("250.1.1.80");
-    addrman.Add(CAddress(addr1, 0), source);
+    addrman.Add(CAddress(addr1, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 79);
 
     CService addr2 = CService("250.1.1.81");
-    addrman.Add(CAddress(addr2, 0), source);
+    addrman.Add(CAddress(addr2, NODE_NONE), source);
     BOOST_CHECK(addrman.size() == 80);
 }
 
@@ -256,9 +256,9 @@ BOOST_AUTO_TEST_CASE(addrman_find)
 
     BOOST_CHECK(addrman.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
-    CAddress addr2 = CAddress(CService("250.1.2.1", 9999), 0);
-    CAddress addr3 = CAddress(CService("251.255.2.1", 8333), 0);
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), NODE_NONE);
+    CAddress addr2 = CAddress(CService("250.1.2.1", 9999), NODE_NONE);
+    CAddress addr3 = CAddress(CService("251.255.2.1", 8333), NODE_NONE);
 
     CNetAddr source1 = CNetAddr("250.1.2.1");
     CNetAddr source2 = CNetAddr("250.1.2.2");
@@ -295,7 +295,7 @@ BOOST_AUTO_TEST_CASE(addrman_create)
 
     BOOST_CHECK(addrman.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), NODE_NONE);
     CNetAddr source1 = CNetAddr("250.1.2.1");
 
     int nId;
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(addrman_delete)
 
     BOOST_CHECK(addrman.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), NODE_NONE);
     CNetAddr source1 = CNetAddr("250.1.2.1");
 
     int nId;
@@ -345,15 +345,15 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     vector<CAddress> vAddr1 = addrman.GetAddr();
     BOOST_CHECK(vAddr1.size() == 0);
 
-    CAddress addr1 = CAddress(CService("250.250.2.1", 8333), 0);
+    CAddress addr1 = CAddress(CService("250.250.2.1", 8333), NODE_NONE);
     addr1.nTime = GetAdjustedTime(); // Set time so isTerrible = false
-    CAddress addr2 = CAddress(CService("250.251.2.2", 9999), 0);
+    CAddress addr2 = CAddress(CService("250.251.2.2", 9999), NODE_NONE);
     addr2.nTime = GetAdjustedTime();
-    CAddress addr3 = CAddress(CService("251.252.2.3", 8333), 0);
+    CAddress addr3 = CAddress(CService("251.252.2.3", 8333), NODE_NONE);
     addr3.nTime = GetAdjustedTime();
-    CAddress addr4 = CAddress(CService("252.253.3.4", 8333), 0);
+    CAddress addr4 = CAddress(CService("252.253.3.4", 8333), NODE_NONE);
     addr4.nTime = GetAdjustedTime();
-    CAddress addr5 = CAddress(CService("252.254.4.5", 8333), 0);
+    CAddress addr5 = CAddress(CService("252.254.4.5", 8333), NODE_NONE);
     addr5.nTime = GetAdjustedTime();
     CNetAddr source1 = CNetAddr("250.1.2.1");
     CNetAddr source2 = CNetAddr("250.2.3.3");
@@ -369,8 +369,8 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
     BOOST_CHECK(addrman.GetAddr().size() == 1); 
 
     // Test 24: Ensure GetAddr works with new and tried addresses.
-    addrman.Good(CAddress(addr1, 0));
-    addrman.Good(CAddress(addr2, 0));
+    addrman.Good(CAddress(addr1, NODE_NONE));
+    addrman.Good(CAddress(addr2, NODE_NONE));
     BOOST_CHECK(addrman.GetAddr().size() == 1);
 
     // Test 25: Ensure GetAddr still returns 23% when addrman has many addrs.
@@ -379,7 +379,7 @@ BOOST_AUTO_TEST_CASE(addrman_getaddr)
         int octet2 = (i / 256) % 256;
         int octet3 = (i / (256 * 2)) % 256;
         string strAddr = boost::to_string(octet1) + "." + boost::to_string(octet2) + "." + boost::to_string(octet3) + ".23";
-        CAddress addr = CAddress(CService(strAddr), 0);
+        CAddress addr = CAddress(CService(strAddr), NODE_NONE);
         
         // Ensure that for all addrs in addrman, isTerrible == false.
         addr.nTime = GetAdjustedTime();
@@ -404,8 +404,8 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     // Set addrman addr placement to be deterministic.
     addrman.MakeDeterministic();
 
-    CAddress addr1 = CAddress(CService("250.1.1.1", 8333), 0);
-    CAddress addr2 = CAddress(CService("250.1.1.1", 9999), 0);
+    CAddress addr1 = CAddress(CService("250.1.1.1", 8333), NODE_NONE);
+    CAddress addr2 = CAddress(CService("250.1.1.1", 9999), NODE_NONE);
 
     CNetAddr source1 = CNetAddr("250.1.1.1");
 
@@ -432,7 +432,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     set<int> buckets;
     for (int i = 0; i < 255; i++) {
         CAddrInfo infoi = CAddrInfo(
-            CAddress(CService("250.1.1." + boost::to_string(i)), 0),
+            CAddress(CService("250.1.1." + boost::to_string(i)), NODE_NONE),
             CNetAddr("250.1.1." + boost::to_string(i)));
         int bucket = infoi.GetTriedBucket(nKey1);
         buckets.insert(bucket);
@@ -444,7 +444,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_tried_bucket)
     buckets.clear();
     for (int j = 0; j < 255; j++) {
         CAddrInfo infoj = CAddrInfo(
-            CAddress(CService("250." + boost::to_string(j) + ".1.1"), 0),
+            CAddress(CService("250." + boost::to_string(j) + ".1.1"), NODE_NONE),
             CNetAddr("250." + boost::to_string(j) + ".1.1"));
         int bucket = infoj.GetTriedBucket(nKey1);
         buckets.insert(bucket);
@@ -461,8 +461,8 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     // Set addrman addr placement to be deterministic.
     addrman.MakeDeterministic();
 
-    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), 0);
-    CAddress addr2 = CAddress(CService("250.1.2.1", 9999), 0);
+    CAddress addr1 = CAddress(CService("250.1.2.1", 8333), NODE_NONE);
+    CAddress addr2 = CAddress(CService("250.1.2.1", 9999), NODE_NONE);
 
     CNetAddr source1 = CNetAddr("250.1.2.1");
 
@@ -485,7 +485,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     set<int> buckets;
     for (int i = 0; i < 255; i++) {
         CAddrInfo infoi = CAddrInfo(
-            CAddress(CService("250.1.1." + boost::to_string(i)), 0),
+            CAddress(CService("250.1.1." + boost::to_string(i)), NODE_NONE),
             CNetAddr("250.1.1." + boost::to_string(i)));
         int bucket = infoi.GetNewBucket(nKey1);
         buckets.insert(bucket);
@@ -498,7 +498,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     for (int j = 0; j < 4 * 255; j++) {
         CAddrInfo infoj = CAddrInfo(CAddress(
                                         CService(
-                                            boost::to_string(250 + (j / 255)) + "." + boost::to_string(j % 256) + ".1.1"), 0),
+                                            boost::to_string(250 + (j / 255)) + "." + boost::to_string(j % 256) + ".1.1"), NODE_NONE),
             CNetAddr("251.4.1.1"));
         int bucket = infoj.GetNewBucket(nKey1);
         buckets.insert(bucket);
@@ -510,7 +510,7 @@ BOOST_AUTO_TEST_CASE(caddrinfo_get_new_bucket)
     buckets.clear();
     for (int p = 0; p < 255; p++) {
         CAddrInfo infoj = CAddrInfo(
-            CAddress(CService("250.1.1.1"), 0),
+            CAddress(CService("250.1.1.1"), NODE_NONE),
             CNetAddr("250." + boost::to_string(p) + ".1.1"));
         int bucket = infoj.GetNewBucket(nKey1);
         buckets.insert(bucket);

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -65,11 +65,11 @@ CService ipaddress(uint32_t i, uint32_t port)
 }
 
 // create dummy test addrs
-CAddress addr1(ipaddress(0xa0b0c001, 10000));
-CAddress addr2(ipaddress(0xa0b0c002, 10001));
-CAddress addr3(ipaddress(0xa0b0c003, 10002));
-CAddress addr4(ipaddress(0xa0b0c004, 10003));
-CAddress addr5(ipaddress(0xa0b0c005, 10004));
+CAddress addr1(ipaddress(0xa0b0c001, 10000), NODE_NETWORK);
+CAddress addr2(ipaddress(0xa0b0c002, 10001), NODE_NETWORK);
+CAddress addr3(ipaddress(0xa0b0c003, 10002), NODE_NETWORK);
+CAddress addr4(ipaddress(0xa0b0c004, 10003), NODE_NETWORK);
+CAddress addr5(ipaddress(0xa0b0c005, 10004), NODE_NETWORK);
 
 // create recv queues
 CDataStream vRecv1(SER_NETWORK, PROTOCOL_VERSION);
@@ -120,9 +120,9 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     vRecv1 << xthin;
 
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
-    dummyNode1.nServices |= NODE_XTHIN;
     dummyNode1.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode1.fSuccessfullyConnected = true;
+    dummyNode1.nServices = ServiceFlags(NODE_NETWORK | NODE_XTHIN);
     ProcessMessage(&dummyNode1, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
     SendMessages(&dummyNode1);
     BOOST_CHECK(xthin.vMissingTx.size() == 0);
@@ -136,10 +136,9 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     vRecv1 << xthin;
 
     CNode dummyNode1a(INVALID_SOCKET, addr1, "", true);
-    dummyNode1a.nServices |= NODE_XTHIN;
     dummyNode1a.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode1a.fSuccessfullyConnected = true;
-    dummyNode1a.nServices = NODE_XTHIN;
+    dummyNode1a.nServices = ServiceFlags(NODE_NETWORK | NODE_XTHIN);
     ProcessMessage(&dummyNode1a, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
     SendMessages(&dummyNode1a);
     BOOST_CHECK(!xthin.vMissingTx[0].IsCoinBase());
@@ -153,10 +152,9 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     vRecv1 << xthin;
 
     CNode dummyNode1b(INVALID_SOCKET, addr1, "", true);
-    dummyNode1b.nServices |= NODE_XTHIN;
     dummyNode1b.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode1b.fSuccessfullyConnected = true;
-    dummyNode1b.nServices = NODE_XTHIN;
+    dummyNode1b.nServices = ServiceFlags(NODE_NETWORK | NODE_XTHIN);
     ProcessMessage(&dummyNode1b, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
     SendMessages(&dummyNode1b);
     CValidationState state;
@@ -172,10 +170,9 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     vRecv2 << thin;
 
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
-    dummyNode2.nServices |= NODE_XTHIN;
     dummyNode2.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode2.fSuccessfullyConnected = true;
-    dummyNode2.nServices = NODE_XTHIN;
+    dummyNode2.nServices = ServiceFlags(NODE_NETWORK | NODE_XTHIN);
     ProcessMessage(&dummyNode2, NetMsgType::THINBLOCK, vRecv2, GetTime());
     SendMessages(&dummyNode2);
     BOOST_CHECK(thin.vMissingTx.size() == 0);
@@ -189,10 +186,9 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     vRecv2 << thin;
 
     CNode dummyNode2a(INVALID_SOCKET, addr2, "", true);
-    dummyNode2a.nServices |= NODE_XTHIN;
     dummyNode2a.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode2a.fSuccessfullyConnected = true;
-    dummyNode2a.nServices = NODE_XTHIN;
+    dummyNode2a.nServices = ServiceFlags(NODE_NETWORK | NODE_XTHIN);
     ProcessMessage(&dummyNode2a, NetMsgType::THINBLOCK, vRecv2, GetTime());
     SendMessages(&dummyNode2a);
     BOOST_CHECK(!thin.vMissingTx[0].IsCoinBase());
@@ -206,10 +202,9 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     vRecv2 << thin;
 
     CNode dummyNode2b(INVALID_SOCKET, addr2, "", true);
-    dummyNode2b.nServices |= NODE_XTHIN;
     dummyNode2b.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode2b.fSuccessfullyConnected = true;
-    dummyNode2b.nServices = NODE_XTHIN;
+    dummyNode2b.nServices = ServiceFlags(NODE_NETWORK | NODE_XTHIN);
     ProcessMessage(&dummyNode2b, NetMsgType::THINBLOCK, vRecv2, GetTime());
     SendMessages(&dummyNode2b);
     BOOST_CHECK(!CheckBlockHeader(thin.header, state, true));
@@ -227,10 +222,9 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     vRecv3 << xblocktx;
 
     CNode dummyNode3(INVALID_SOCKET, addr3, "", true);
-    dummyNode3.nServices |= NODE_XTHIN;
     dummyNode3.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode3.fSuccessfullyConnected = true;
-    dummyNode3.nServices = NODE_XTHIN;
+    dummyNode3.nServices = ServiceFlags(NODE_NETWORK | NODE_XTHIN);
     ProcessMessage(&dummyNode3, NetMsgType::XBLOCKTX, vRecv3, GetTime());
     SendMessages(&dummyNode3);
     BOOST_CHECK(nullhash.IsNull());
@@ -244,10 +238,9 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     vRecv3 << xblocktx2;
 
     CNode dummyNode3a(INVALID_SOCKET, addr3, "", true);
-    dummyNode3a.nServices |= NODE_XTHIN;
     dummyNode3a.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode3a.fSuccessfullyConnected = true;
-    dummyNode3a.nServices = NODE_XTHIN;
+    dummyNode3a.nServices = ServiceFlags(NODE_NETWORK | NODE_XTHIN);
     ProcessMessage(&dummyNode3a, NetMsgType::XBLOCKTX, vRecv3, GetTime());
     SendMessages(&dummyNode3a);
     BOOST_CHECK(vTxEmpty.size() == 0);
@@ -260,11 +253,10 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     vRecv3 << xblocktx3;
 
     CNode dummyNode3b(INVALID_SOCKET, addr3, "", true);
-    dummyNode3b.nServices |= NODE_XTHIN;
     dummyNode3b.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode3b.fSuccessfullyConnected = true;
     dummyNode3b.xThinBlockHashes.push_back(1); // add one hash to the vector which will cause a mismatch
-    dummyNode3b.nServices = NODE_XTHIN;
+    dummyNode3b.nServices = ServiceFlags(NODE_NETWORK | NODE_XTHIN);
     ProcessMessage(&dummyNode3b, NetMsgType::XBLOCKTX, vRecv3, GetTime());
     SendMessages(&dummyNode3b);
     BOOST_CHECK(dummyNode3b.xThinBlockHashes.size() != dummyNode3b.thinBlock.vtx.size());
@@ -282,10 +274,9 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     vRecv4 << get_xblocktx;
 
     CNode dummyNode4(INVALID_SOCKET, addr4, "", true);
-    dummyNode4.nServices |= NODE_XTHIN;
     dummyNode4.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode4.fSuccessfullyConnected = true;
-    dummyNode4.nServices = NODE_XTHIN;
+    dummyNode4.nServices = ServiceFlags(NODE_NETWORK | NODE_XTHIN);
     ProcessMessage(&dummyNode4, NetMsgType::GET_XBLOCKTX, vRecv4, GetTime());
     SendMessages(&dummyNode4);
     BOOST_CHECK(nullhash.IsNull());
@@ -299,10 +290,9 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     vRecv4 << get_xblocktx2;
 
     CNode dummyNode4a(INVALID_SOCKET, addr4, "", true);
-    dummyNode4a.nServices |= NODE_XTHIN;
     dummyNode4a.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode4a.fSuccessfullyConnected = true;
-    dummyNode4a.nServices = NODE_XTHIN;
+    dummyNode4a.nServices = ServiceFlags(NODE_NETWORK | NODE_XTHIN);
     ProcessMessage(&dummyNode4a, NetMsgType::GET_XBLOCKTX, vRecv4, GetTime());
     SendMessages(&dummyNode4a);
     BOOST_CHECK(setHashesToRequest.empty());
@@ -321,10 +311,9 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     vRecv5 << filterMemPool;
 
     CNode dummyNode5(INVALID_SOCKET, addr5, "", true);
-    dummyNode5.nServices |= NODE_XTHIN;
     dummyNode5.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode5.fSuccessfullyConnected = true;
-    dummyNode5.nServices = NODE_XTHIN;
+    dummyNode5.nServices = ServiceFlags(NODE_NETWORK | NODE_XTHIN);
     ProcessMessage(&dummyNode5, NetMsgType::GET_XTHIN, vRecv5, GetTime());
     SendMessages(&dummyNode5);
     BOOST_CHECK(nullhash.IsNull());
@@ -340,10 +329,9 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     vRecv5 << filterMemPool2;
 
     CNode dummyNode5a(INVALID_SOCKET, addr5, "", true);
-    dummyNode5a.nServices |= NODE_XTHIN;
     dummyNode5a.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode5a.fSuccessfullyConnected = true;
-    dummyNode5a.nServices = NODE_XTHIN;
+    dummyNode5a.nServices = ServiceFlags(NODE_NETWORK | NODE_XTHIN);
     ProcessMessage(&dummyNode5a, NetMsgType::GET_XTHIN, vRecv5, GetTime());
     SendMessages(&dummyNode5a);
     BOOST_CHECK(inv2.type != MSG_THINBLOCK && inv2.type != MSG_XTHINBLOCK);

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -51,7 +51,7 @@ public:
         int nUBuckets = ADDRMAN_NEW_BUCKET_COUNT ^ (1 << 30);
         s << nUBuckets;
 
-        CAddress addr = CAddress(CService("252.1.1.1", 7777), 0);
+        CAddress addr = CAddress(CService("252.1.1.1", 7777), NODE_NONE);
         CAddrInfo info = CAddrInfo(addr, CNetAddr("252.2.2.2"));
         s << info;
     }
@@ -79,9 +79,9 @@ BOOST_AUTO_TEST_CASE(caddrdb_read)
     CService addr3 = CService("250.7.3.3", 9999);
 
     // Add three addresses to new table.
-    addrmanUncorrupted.Add(CAddress(addr1, 0), CService("252.5.1.1", 8333));
-    addrmanUncorrupted.Add(CAddress(addr2, 0), CService("252.5.1.1", 8333));
-    addrmanUncorrupted.Add(CAddress(addr3, 0), CService("252.5.1.1", 8333));
+    addrmanUncorrupted.Add(CAddress(addr1, NODE_NONE), CService("252.5.1.1", 8333));
+    addrmanUncorrupted.Add(CAddress(addr2, NODE_NONE), CService("252.5.1.1", 8333));
+    addrmanUncorrupted.Add(CAddress(addr3, NODE_NONE), CService("252.5.1.1", 8333));
 
     // Test that the de-serialization does not throw an exception.
     CDataStream ssPeers1 = AddrmanToStream(addrmanUncorrupted);

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -51,7 +51,7 @@ public:
         int nUBuckets = ADDRMAN_NEW_BUCKET_COUNT ^ (1 << 30);
         s << nUBuckets;
 
-        CAddress addr = CAddress(CService("252.1.1.1", 7777));
+        CAddress addr = CAddress(CService("252.1.1.1", 7777), 0);
         CAddrInfo info = CAddrInfo(addr, CNetAddr("252.2.2.2"));
         s << info;
     }
@@ -79,9 +79,9 @@ BOOST_AUTO_TEST_CASE(caddrdb_read)
     CService addr3 = CService("250.7.3.3", 9999);
 
     // Add three addresses to new table.
-    addrmanUncorrupted.Add(CAddress(addr1), CService("252.5.1.1", 8333));
-    addrmanUncorrupted.Add(CAddress(addr2), CService("252.5.1.1", 8333));
-    addrmanUncorrupted.Add(CAddress(addr3), CService("252.5.1.1", 8333));
+    addrmanUncorrupted.Add(CAddress(addr1, 0), CService("252.5.1.1", 8333));
+    addrmanUncorrupted.Add(CAddress(addr2, 0), CService("252.5.1.1", 8333));
+    addrmanUncorrupted.Add(CAddress(addr3, 0), CService("252.5.1.1", 8333));
 
     // Test that the de-serialization does not throw an exception.
     CDataStream ssPeers1 = AddrmanToStream(addrmanUncorrupted);

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -314,9 +314,9 @@ BOOST_AUTO_TEST_CASE(rpc_ban)
 
 BOOST_AUTO_TEST_CASE(findlikelynode)
 {
-  CAddress addr1(CService("169.254.1.2"));
+  CAddress addr1(CService("169.254.1.2"), NODE_NETWORK);
   CNode n1(INVALID_SOCKET, addr1, "", true);
-  CAddress addr2(CService("169.254.2.3"));
+  CAddress addr2(CService("169.254.2.3"), NODE_NETWORK);
   CNode n2(INVALID_SOCKET, addr2, "", true);
   assert(vNodes.size() == 0);
   vNodes.push_back(&n1);


### PR DESCRIPTION
This is a port of bitcoin#7749 with a BU-specific follow-up:

> At this point, we do not:
> 
>     check that relayed/stored addr messages have the NODE_NETWORK bit set.
>     check that nodes selected for outbound connection have NODE_NETWORK advertized.
>     check that the nServices flag in the "version" message by a node corresponds to what we expected when deciding to connect to it.
>     store the updated nServices flag from the "version" message in addrman.
> 
> Fix this.

    ecd7fd3 Introduce REQUIRED_SERVICES constant (Pieter Wuille)
    ee06e04 Introduce enum ServiceFlags for service flags (Pieter Wuille)
    15bf863 Don't require services in -addnode (Pieter Wuille)
    5e7ab16 Only store and connect to NODE_NETWORK nodes (Pieter Wuille)
    fc83f18 Verify that outbound connections have expected services (Pieter Wuille)
    3764dec Keep addrman's nService bits consistent with outbound observations (Pieter Wuille)

This gets us to the point where netaddress.cpp is broken out of netbase.cpp, which will be a follow-up.