### PR TITLE
Track global thinblock bytes in use - cleanup data and disconnect node if over the limit

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6203,10 +6203,9 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
                     pfrom->nLocalThinBlockBytes += nTxSize - nSizeNullTx;
                     if (thindata.AddThinBlockBytes(nTxSize) > maxAllowedSize)
                     {
-                        ClearLargestThinBlockAndDisconnect();
-                        return error("xthin block has exceeded memory limits of %ld bytes", maxAllowedSize);
+                        if (ClearLargestThinBlockAndDisconnect(pfrom))
+                            return error("xthin block has exceeded memory limits of %ld bytes", maxAllowedSize);
                     }
-
                 }
                 count++;
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6199,9 +6199,8 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
 
                     // In order to prevent a memory exhaustion attack we track transaction bytes used to create Block
                     // to see if we've exceeded any limits and if so clear out data and return.
-                    uint64_t nTxSize = RecursiveDynamicUsage(val->second);
-                    pfrom->nLocalThinBlockBytes += nTxSize - nSizeNullTx;
-                    if (thindata.AddThinBlockBytes(nTxSize) > maxAllowedSize)
+                    uint64_t nTxSize = RecursiveDynamicUsage(val->second) - nSizeNullTx;
+                    if (thindata.AddThinBlockBytes(nTxSize, pfrom) > maxAllowedSize)
                     {
                         if (ClearLargestThinBlockAndDisconnect(pfrom))
                             return error("xthin block has exceeded memory limits of %ld bytes", maxAllowedSize);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6184,6 +6184,9 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
             mapMissingTx[tx.GetHash().GetCheapHash()] = tx;
 
         int count = 0;
+        uint64_t maxAllowedSize = maxMessageSizeMultiplier * excessiveBlockSize;
+        CTransaction nulltx;
+        uint64_t nSizeNullTx =  RecursiveDynamicUsage(nulltx);
         for (size_t i = 0; i < pfrom->thinBlock.vtx.size(); i++)
         {
             if (pfrom->thinBlock.vtx[i].IsNull())
@@ -6193,6 +6196,17 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
                 {
                     pfrom->thinBlock.vtx[i] = val->second;
                     pfrom->thinBlockWaitingForTxns--;
+
+                    // In order to prevent a memory exhaustion attack we track transaction bytes used to create Block
+                    // to see if we've exceeded any limits and if so clear out data and return.
+                    uint64_t nTxSize = RecursiveDynamicUsage(val->second);
+                    pfrom->nLocalThinBlockBytes += nTxSize - nSizeNullTx;
+                    if (thindata.AddThinBlockBytes(nTxSize) > maxAllowedSize)
+                    {
+                        ClearLargestThinBlockAndDisconnect();
+                        return error("xthin block has exceeded memory limits of %ld bytes", maxAllowedSize);
+                    }
+
                 }
                 count++;
             }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2810,6 +2810,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress& addrIn, const std::string& addrNa
     nMinPingUsecTime = std::numeric_limits<int64_t>::max();
     thinBlockWaitingForTxns = -1; // BUIP010 Xtreme Thinblocks
     addrFromPort = 0; // BU
+    nLocalThinBlockBytes = 0;
 
     // BU instrumentation
     std::string xmledName;

--- a/src/net.h
+++ b/src/net.h
@@ -408,6 +408,7 @@ public:
     CBlock thinBlock;
     std::vector<uint256> thinBlockHashes;
     std::vector<uint64_t> xThinBlockHashes;
+    uint64_t nLocalThinBlockBytes; // the bytes used in creating this thinblock, updated dynamically
     int nSizeThinBlock;   // Original on-wire size of the block. Just used for reporting
     int thinBlockWaitingForTxns;   // if -1 then not currently waiting
     CCriticalSection cs_mapthinblocksinflight; // lock mapThinBlocksInFlight

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -557,8 +557,8 @@ void HandleBlockMessageThread(CNode *pfrom, const string &strCommand, const CBlo
             // Erase this thinblock from the tracking map now that we're done with it.
             if (pfrom->mapThinBlocksInFlight.erase(inv.hash))
             {
-                pfrom->thinBlockWaitingForTxns = -1;
-                pfrom->thinBlock.SetNull();
+                // Clear out and reset thinblock data
+                thindata.ClearThinBlockData(pfrom);
             }
 
             // Count up any other remaining nodes with thinblocks in flight.
@@ -570,10 +570,12 @@ void HandleBlockMessageThread(CNode *pfrom, const string &strCommand, const CBlo
             pfrom->firstBlock += 1; // update statistics, requires cs_vNodes
         }
 
-        // When we no longer have any thinblocks in flight then clear the set
+        // When we no longer have any thinblocks in flight then clear our any data
         // just to make sure we don't somehow get growth over time.
         if (nTotalThinBlocksInFlight == 0)
         {
+            thindata.ResetThinBlockBytes();
+
             LOCK(cs_xval);
             setPreVerifiedTxHash.clear();
             setUnVerifiedOrphanTxHash.clear();

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -431,12 +431,9 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     // manually set the nLocalThinBlockBytes to be lower than the actual bytes of the thinblock that we will
     // use to test the over limit condition. Also set the global bytes to be the sum of all current nodes.
     thindata.ResetThinBlockBytes();
-    dummyNode7.nLocalThinBlockBytes = 100;
-    thindata.AddThinBlockBytes(dummyNode7.nLocalThinBlockBytes);
-    dummyNode8.nLocalThinBlockBytes = 110;
-    thindata.AddThinBlockBytes(dummyNode8.nLocalThinBlockBytes);
-    dummyNode9.nLocalThinBlockBytes = 120;
-    thindata.AddThinBlockBytes(dummyNode9.nLocalThinBlockBytes);
+    thindata.AddThinBlockBytes(100, &dummyNode7);
+    thindata.AddThinBlockBytes(110, &dummyNode8);
+    thindata.AddThinBlockBytes(120, &dummyNode9);
 
     // Process an xthinblock which will be the largest over limit and will be the one that gets disconnected.
     vRecv1.clear();
@@ -495,12 +492,12 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     // manually set two of the nLocalThinBlockBytes to be higher than the actual bytes of the thinblock that we will
     // use to test the over limit condition. Also set the global bytes to be the sum of all current nodes.
     thindata.ResetThinBlockBytes();
-    dummyNode7.nLocalThinBlockBytes = 3000;
-    thindata.AddThinBlockBytes(dummyNode7.nLocalThinBlockBytes);
-    dummyNode8.nLocalThinBlockBytes = 600;
-    thindata.AddThinBlockBytes(dummyNode8.nLocalThinBlockBytes);
-    dummyNode9.nLocalThinBlockBytes = 100;
-    thindata.AddThinBlockBytes(dummyNode9.nLocalThinBlockBytes);
+    dummyNode7.nLocalThinBlockBytes = 0;
+    dummyNode8.nLocalThinBlockBytes = 0;
+    dummyNode9.nLocalThinBlockBytes = 0;
+    thindata.AddThinBlockBytes(3000, &dummyNode7);
+    thindata.AddThinBlockBytes(600, &dummyNode8);
+    thindata.AddThinBlockBytes(100, &dummyNode9);
 
     // Process an xthinblock which will also be the over limit and will cause the largest block to disconnect
     // which in this case is dummyNode7. As it continues to process it (dummyNode6) will also go over the limit

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -348,6 +348,204 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     SendMessages(&dummyNode5a);
     BOOST_CHECK(inv2.type != MSG_THINBLOCK && inv2.type != MSG_XTHINBLOCK);
     BOOST_CHECK(CNode::IsBanned(addr5));
+
+
+    /* Thinblock memory exhaustion attack 1 */
+
+    // test a single valid thinblock reconstruction that goes over the limit.
+    // result: the peer should have it data cleared and node should be disconnected.
+    CNode::ClearBanned();
+    CXThinBlock xthin2 = xthinblock;
+    CThinBlock thin2 = thinblock;
+
+    CNode dummyNode6(INVALID_SOCKET, addr1, "", true);
+
+    // The number of tx bytes in this block is 3784 bytes.  In order for the node to be disconnected
+    // we have to make the maxAllowedSize be less than 3784/maxMessageSizeMultiplier (maxMessageSizeMultiplier = 16).
+    // Therefore the excesssiveBlockSize must be less than 236.5 inorder to trigger an oversized block and susequent
+    // disconnection.
+    uint64_t old_excessiveBlockSize = excessiveBlockSize;
+    excessiveBlockSize = 234;
+
+    // Add the node to vNodes and also we need a thinblockinflight entry
+    dummyNode6.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    vNodes.push_back(&dummyNode6);
+
+    // Process an xthinblock
+    vRecv1.clear();
+    vRecv1 << xthin;
+    dummyNode6.fDisconnect = false;
+    xthin2.process(&dummyNode6, vRecv1.size(), NetMsgType::XTHINBLOCK);
+    BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
+    BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
+    BOOST_CHECK_EQUAL(-1, dummyNode6.thinBlockWaitingForTxns);
+    BOOST_CHECK(dummyNode6.thinBlock.IsNull());
+    BOOST_CHECK(dummyNode6.xThinBlockHashes.empty());
+    BOOST_CHECK(dummyNode6.thinBlockHashes.empty());
+
+    // Process a regular thinblock
+    vRecv1.clear();
+    vRecv1 << thin;
+    dummyNode6.fDisconnect = false;
+    thin2.process(&dummyNode6, vRecv1.size(), NetMsgType::THINBLOCK);
+    BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
+    BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
+    BOOST_CHECK_EQUAL(-1, dummyNode6.thinBlockWaitingForTxns);
+    BOOST_CHECK(dummyNode6.thinBlock.IsNull());
+    BOOST_CHECK(dummyNode6.xThinBlockHashes.empty());
+    BOOST_CHECK(dummyNode6.thinBlockHashes.empty());
+
+    // clean up vNodes and mapthinblocksinflight
+    vNodes.pop_back();
+    dummyNode6.mapThinBlocksInFlight.erase(TestBlock1().GetHash());
+
+    /* Thinblock memory exhaustion attack 2 */
+
+    // test correct disconnection of a multiple valid thinblock reconstruction that goes over the limit.
+    // result: the peer with largest thinblock set of data should have it data cleared
+    //         and node should be disconnected.
+
+    CNode::ClearBanned();
+    CXThinBlock xthin3 = xthinblock;
+
+    CNode dummyNode7(INVALID_SOCKET, addr2, "", true);
+    CNode dummyNode8(INVALID_SOCKET, addr3, "", true);
+    CNode dummyNode9(INVALID_SOCKET, addr4, "", true);
+
+    // The number of tx bytes in this block is 3784 bytes.  In order for the node to be disconnected
+    // we have to make the maxAllowedSize be less than 3784/maxMessageSizeMultiplier (maxMessageSizeMultiplier = 16).
+    // Therefore the excesssiveBlockSize must be less than 236.5 inorder to trigger an oversized block and susequent
+    // disconnection.
+    excessiveBlockSize = 234;
+
+    // Add the node to vNodes and also we need a thinblockinflight entry
+    dummyNode6.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    vNodes.push_back(&dummyNode6);
+    dummyNode7.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    vNodes.push_back(&dummyNode7);
+    dummyNode8.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    vNodes.push_back(&dummyNode8);
+    dummyNode9.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    vNodes.push_back(&dummyNode9);
+
+    // manually set the nLocalThinBlockBytes to be lower than the actual bytes of the thinblock that we will
+    // use to test the over limit condition. Also set the global bytes to be the sum of all current nodes.
+    thindata.ResetThinBlockBytes();
+    dummyNode7.nLocalThinBlockBytes = 100;
+    thindata.AddThinBlockBytes(dummyNode7.nLocalThinBlockBytes);
+    dummyNode8.nLocalThinBlockBytes = 110;
+    thindata.AddThinBlockBytes(dummyNode8.nLocalThinBlockBytes);
+    dummyNode9.nLocalThinBlockBytes = 120;
+    thindata.AddThinBlockBytes(dummyNode9.nLocalThinBlockBytes);
+
+    // Process an xthinblock which will be the largest over limit and will be the one that gets disconnected.
+    vRecv1.clear();
+    vRecv1 << xthin;
+    dummyNode6.fDisconnect = false;
+    xthin3.process(&dummyNode6, vRecv1.size(), NetMsgType::XTHINBLOCK);
+
+    BOOST_CHECK(!dummyNode7.fDisconnect); // node should *not* be disconnected
+    BOOST_CHECK_EQUAL(100, dummyNode7.nLocalThinBlockBytes);
+    BOOST_CHECK(!dummyNode8.fDisconnect); // node should *not* be disconnected
+    BOOST_CHECK_EQUAL(110, dummyNode8.nLocalThinBlockBytes);
+    BOOST_CHECK(!dummyNode9.fDisconnect); // node should *not* be disconnected
+    BOOST_CHECK_EQUAL(120, dummyNode9.nLocalThinBlockBytes);
+
+    BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
+    BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
+    BOOST_CHECK_EQUAL(-1, dummyNode6.thinBlockWaitingForTxns);
+    BOOST_CHECK(dummyNode6.thinBlock.IsNull());
+    BOOST_CHECK(dummyNode6.xThinBlockHashes.empty());
+    BOOST_CHECK(dummyNode6.thinBlockHashes.empty());
+
+    // clean up vNodes and mapthinblocksinflight
+    vNodes.pop_back();
+    dummyNode6.mapThinBlocksInFlight.erase(TestBlock1().GetHash());
+    vNodes.pop_back();
+    dummyNode7.mapThinBlocksInFlight.erase(TestBlock1().GetHash());
+    vNodes.pop_back();
+    dummyNode8.mapThinBlocksInFlight.erase(TestBlock1().GetHash());
+    vNodes.pop_back();
+    dummyNode9.mapThinBlocksInFlight.erase(TestBlock1().GetHash());
+
+    /* Thinblock memory exhaustion attack 3 */
+
+    // test correct disconnection of a multiple valid thinblock reconstruction that goes over the limit.
+    // However here, the last thinblock although causing the limit to be exceeded is not the largest.
+    // result: the peer with largest thinblock set of data should have it data cleared
+    //         and node should be disconnected.
+
+    CNode::ClearBanned();
+    CXThinBlock xthin4 = xthinblock;
+
+    // This time we don't want the xthinblock to cause an overlimit but have some other node disconnected.
+    // So we use a 1000 excessive size which gives us a 16 * 1000 byte limit.
+    excessiveBlockSize = 234;
+
+    // Add the node to vNodes and also we need a thinblockinflight entry
+    dummyNode6.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    vNodes.push_back(&dummyNode6);
+    dummyNode7.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    vNodes.push_back(&dummyNode7);
+    dummyNode8.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    vNodes.push_back(&dummyNode8);
+    dummyNode9.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    vNodes.push_back(&dummyNode9);
+
+    // manually set two of the nLocalThinBlockBytes to be higher than the actual bytes of the thinblock that we will
+    // use to test the over limit condition. Also set the global bytes to be the sum of all current nodes.
+    thindata.ResetThinBlockBytes();
+    dummyNode7.nLocalThinBlockBytes = 3000;
+    thindata.AddThinBlockBytes(dummyNode7.nLocalThinBlockBytes);
+    dummyNode8.nLocalThinBlockBytes = 600;
+    thindata.AddThinBlockBytes(dummyNode8.nLocalThinBlockBytes);
+    dummyNode9.nLocalThinBlockBytes = 100;
+    thindata.AddThinBlockBytes(dummyNode9.nLocalThinBlockBytes);
+
+    // Process an xthinblock which will also be the over limit and will cause the largest block to disconnect
+    // which in this case is dummyNode7. As it continues to process it (dummyNode6) will also go over the limit
+    // and cause itself to be disconnected.
+    vRecv1.clear();
+    vRecv1 << xthin4;
+    dummyNode6.fDisconnect = false;
+    xthin4.process(&dummyNode6, vRecv1.size(), NetMsgType::XTHINBLOCK);
+    BOOST_CHECK(!dummyNode8.fDisconnect); // node should *not* be disconnected
+    BOOST_CHECK_EQUAL(600, dummyNode8.nLocalThinBlockBytes);
+    BOOST_CHECK(!dummyNode9.fDisconnect); // node should *not* be disconnected
+    BOOST_CHECK_EQUAL(100, dummyNode9.nLocalThinBlockBytes);
+
+    BOOST_CHECK(dummyNode6.fDisconnect); // node should *not* be disconnected
+    BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
+    BOOST_CHECK_EQUAL(-1, dummyNode6.thinBlockWaitingForTxns);
+    BOOST_CHECK(dummyNode6.thinBlock.IsNull());
+    BOOST_CHECK(dummyNode6.xThinBlockHashes.empty());
+    BOOST_CHECK(dummyNode6.thinBlockHashes.empty());
+
+    BOOST_CHECK(dummyNode7.fDisconnect); // node should be disconnected
+    BOOST_CHECK_EQUAL(0, dummyNode7.nLocalThinBlockBytes);
+    BOOST_CHECK_EQUAL(-1, dummyNode7.thinBlockWaitingForTxns);
+    BOOST_CHECK(dummyNode7.thinBlock.IsNull());
+    BOOST_CHECK(dummyNode7.xThinBlockHashes.empty());
+    BOOST_CHECK(dummyNode7.thinBlockHashes.empty());
+
+    // clean up vNodes and mapthinblocksinflight
+    vNodes.pop_back();
+    dummyNode6.mapThinBlocksInFlight.erase(TestBlock1().GetHash());
+    vNodes.pop_back();
+    dummyNode7.mapThinBlocksInFlight.erase(TestBlock1().GetHash());
+    vNodes.pop_back();
+    dummyNode8.mapThinBlocksInFlight.erase(TestBlock1().GetHash());
+    vNodes.pop_back();
+    dummyNode9.mapThinBlocksInFlight.erase(TestBlock1().GetHash());
+
+    excessiveBlockSize = old_excessiveBlockSize; // reset
+
+    // cleanup received queues
+    vRecv1.clear();
+    vRecv2.clear();
+    vRecv3.clear();
+    vRecv4.clear();
+    vRecv5.clear();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -173,7 +173,9 @@ bool CThinBlock::process(CNode *pfrom, int nSizeThinBlock, string strCommand)
     else if (pfrom->thinBlockWaitingForTxns > 0)
     {
         // This marks the end of the transactions we've received. If we get this and we have NOT been able to
-        // finish reassembling the block, we need to re-request the full regular block:
+        // finish reassembling the block, we need to re-request the full regular block
+        thindata.ClearThinBlockData(pfrom);
+
         vector<CInv> vGetData;
         vGetData.push_back(CInv(MSG_BLOCK, header.GetHash()));
         pfrom->PushMessage(NetMsgType::GETDATA, vGetData);

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -123,14 +123,17 @@ bool CThinBlock::process(CNode *pfrom, int nSizeThinBlock, string strCommand)
             // In order to prevent a memory exhaustion attack we track transaction bytes used to create Block
             // to see if we've exceeded any limits and if so clear out data and return.
             uint64_t nTxSize = RecursiveDynamicUsage(tx);
-            if (thindata.AddThinBlockBytes(nTxSize, pfrom) > maxAllowedSize - nTxSize)
+            uint64_t nCurrentMax = 0;
+            if (maxAllowedSize >= nTxSize)
+                nCurrentMax = maxAllowedSize - nTxSize;
+            if (thindata.AddThinBlockBytes(nTxSize, pfrom) > nCurrentMax)
             {
                 LogPrint("thin", "thin block too large %lu %llu %llu\n", vTxHashes.size(), nTxSize,
                     pfrom->nLocalThinBlockBytes);
                 if (ClearLargestThinBlockAndDisconnect(pfrom))
                     return error("Thinblock has exceeded memory limits of %ld bytes", maxAllowedSize);
             }
-            if (pfrom->nLocalThinBlockBytes > maxAllowedSize - nTxSize)
+            if (pfrom->nLocalThinBlockBytes > nCurrentMax)
             {
                 LogPrint("thin", "node %s xthin block is too large %lu %llu %llu\n", pfrom->GetLogName(),
                     vTxHashes.size(), nTxSize, pfrom->nLocalThinBlockBytes);
@@ -528,14 +531,17 @@ bool CXThinBlock::process(CNode *pfrom,
                     // In order to prevent a memory exhaustion attack we track transaction bytes used to create Block
                     // to see if we've exceeded any limits and if so clear out data and return.
                     uint64_t nTxSize = RecursiveDynamicUsage(tx);
-                    if (thindata.AddThinBlockBytes(nTxSize, pfrom) > maxAllowedSize - nTxSize)
+                    uint64_t nCurrentMax = 0;
+                    if (maxAllowedSize >= nTxSize)
+                        nCurrentMax = maxAllowedSize - nTxSize;
+                    if (thindata.AddThinBlockBytes(nTxSize, pfrom) > nCurrentMax)
                     {
                         LogPrint("thin", "xthin block too large %lu %llu %llu\n", fullTxHashes.size(), nTxSize,
                             pfrom->nLocalThinBlockBytes);
                         if (ClearLargestThinBlockAndDisconnect(pfrom))
                             return error("xthin block has exceeded memory limits of %ld bytes", maxAllowedSize);
                     }
-                    if (pfrom->nLocalThinBlockBytes > maxAllowedSize - nTxSize)
+                    if (pfrom->nLocalThinBlockBytes > nCurrentMax)
                     {
                         LogPrint("thin", "node %s xthin block is too large %lu %llu %llu\n", pfrom->GetLogName(),
                             fullTxHashes.size(), nTxSize, pfrom->nLocalThinBlockBytes);
@@ -1136,10 +1142,14 @@ uint64_t CThinBlockData::AddThinBlockBytes(uint64_t bytes, CNode *pfrom)
 
 void CThinBlockData::DeleteThinBlockBytes(uint64_t bytes, CNode *pfrom)
 {
-    pfrom->nLocalThinBlockBytes -= bytes;
+    if (bytes <= pfrom->nLocalThinBlockBytes)
+        pfrom->nLocalThinBlockBytes -= bytes;
 
-    LOCK(cs_thinblockstats);
-    nThinBlockBytes -= bytes;
+    if (bytes <= nThinBlockBytes)
+    {
+        LOCK(cs_thinblockstats);
+        nThinBlockBytes -= bytes;
+    }
 }
 
 void CThinBlockData::ResetThinBlockBytes()

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -119,17 +119,24 @@ bool CThinBlock::process(CNode *pfrom, int nSizeThinBlock, string strCommand)
             }
             if (tx.IsNull())
                 missingCount++;
-            // This will push an empty/invalid transaction if we don't have it yet
-            pfrom->thinBlock.vtx.push_back(tx);
 
             // In order to prevent a memory exhaustion attack we track transaction bytes used to create Block
             // to see if we've exceeded any limits and if so clear out data and return.
             uint64_t nTxSize = RecursiveDynamicUsage(tx);
-            if (thindata.AddThinBlockBytes(nTxSize, pfrom) > maxAllowedSize)
+            if (thindata.AddThinBlockBytes(nTxSize, pfrom) > maxAllowedSize-nTxSize)
             {
                 if (ClearLargestThinBlockAndDisconnect(pfrom))
                     return error("Thinblock has exceeded memory limits of %ld bytes", maxAllowedSize);
             }
+            if (pfrom->nLocalThinBlockBytes > maxAllowedSize-nTxSize)
+            {
+                thindata.ClearThinBlockData(pfrom);
+                return error("This thinblock has exceeded memory limits of %ld bytes", maxAllowedSize);
+            }
+
+            // This will push an empty/invalid transaction if we don't have it yet
+            pfrom->thinBlock.vtx.push_back(tx);
+
         }
         pfrom->thinBlockWaitingForTxns = missingCount;
         LogPrint("thin", "Thinblock %s waiting for: %d, unnecessary: %d, txs: %d full: %d\n",
@@ -454,13 +461,29 @@ bool CXThinBlock::process(CNode *pfrom,
             mapPartialTxHash[cheapHash] = (*mi).first;
         }
 
+        std::vector<uint256> fullTxHashes;
         if (!collision)
         {
             // Check that the merkleroot matches the merkelroot calculated from the hashes provided.
-            std::vector<uint256> fullTxHashes;
             for (const uint64_t &cheapHash : vTxHashes)
-                fullTxHashes.push_back(mapPartialTxHash[cheapHash]);
-
+            {
+                map<uint64_t, uint256>::iterator val = mapPartialTxHash.find(cheapHash);
+                if (val != mapPartialTxHash.end())
+                {
+                    fullTxHashes.push_back(val->second);
+                    // Remove this transaction so attack blocks that repeat the same transaction stop here.
+                    mapPartialTxHash.erase(val);
+                }
+                else
+                {
+                    LogPrint("thin", "Xthin block has either repeated or missing transactions");
+                    collision = true;
+                    break;
+                }
+            }
+        }
+        if (!collision)
+        {
             bool mutated;
             uint256 merkleroot = ComputeMerkleRoot(fullTxHashes, &mutated);
             if (header.hashMerkleRoot != merkleroot)
@@ -505,6 +528,7 @@ bool CXThinBlock::process(CNode *pfrom,
                     uint64_t nTxSize = RecursiveDynamicUsage(tx);
                     if (thindata.AddThinBlockBytes(nTxSize, pfrom) > maxAllowedSize)
                     {
+                        LogPrint("thin", "xthin block too large %lu %llu %llu\n", fullTxHashes.size(), nTxSize, pfrom->nLocalThinBlockBytes);
                         if (ClearLargestThinBlockAndDisconnect(pfrom))
                             return error("xthin block has exceeded memory limits of %ld bytes", maxAllowedSize);
                     }
@@ -1251,8 +1275,10 @@ bool ClearLargestThinBlockAndDisconnect(CNode *pfrom)
     BOOST_FOREACH (CNode *pnode, vNodes)
     {
         if (pnode->mapThinBlocksInFlight.size() > 0)
-            if (pLargest == NULL || pnode->nLocalThinBlockBytes > pLargest->nLocalThinBlockBytes)
+        {
+            if ((pLargest == NULL) || (pnode->nLocalThinBlockBytes > pLargest->nLocalThinBlockBytes))
                 pLargest = pnode;
+        }
     }
     if (pLargest != NULL)
     {

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -130,10 +130,10 @@ public:
 class CThinBlockData
 {
 private:
-    CCriticalSection cs_mapThinBlockTimer;
+    CCriticalSection cs_mapThinBlockTimer; // locks mapThinBlockTimer
     std::map<uint256, uint64_t> mapThinBlockTimer;
 
-    CCriticalSection cs_thinblockstats;
+    CCriticalSection cs_thinblockstats; // locks everything below this point
     CStatHistory<uint64_t> nOriginalSize;
     CStatHistory<uint64_t> nThinSize;
     CStatHistory<uint64_t> nBlocks;
@@ -146,6 +146,8 @@ private:
     std::map<int64_t, double> mapThinBlockResponseTime;
     std::map<int64_t, double> mapThinBlockValidationTime;
     std::map<int64_t, int> mapThinBlocksInBoundReRequestedTx;
+    /* The sum total of all bytes for thinblocks currently in process of being reconstructed */
+    uint64_t nThinBlockBytes;
 
 public:
     void UpdateInBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
@@ -168,6 +170,13 @@ public:
 
     bool CheckThinblockTimer(uint256 hash);
     void ClearThinBlockTimer(uint256 hash);
+
+    void ClearThinBlockData(CNode *pfrom);
+
+    uint64_t AddThinBlockBytes(uint64_t);
+    void DeleteThinBlockBytes(uint64_t);
+    void ResetThinBlockBytes();
+    uint64_t GetThinBlockBytes();
 };
 extern CThinBlockData thindata; // Singleton class
 
@@ -178,6 +187,7 @@ bool IsThinBlocksEnabled();
 bool CanThinBlockBeDownloaded(CNode *pto);
 void ConnectToThinBlockNodes();
 void CheckNodeSupportForThinBlocks();
+void ClearLargestThinBlockAndDisconnect();
 void SendXThinBlock(CBlock &block, CNode *pfrom, const CInv &inv);
 bool IsThinBlockValid(const CNode *pfrom, const std::vector<CTransaction> &vMissingTx, const CBlockHeader &header);
 void BuildSeededBloomFilter(CBloomFilter &memPoolFilter,

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -173,8 +173,8 @@ public:
 
     void ClearThinBlockData(CNode *pfrom);
 
-    uint64_t AddThinBlockBytes(uint64_t);
-    void DeleteThinBlockBytes(uint64_t);
+    uint64_t AddThinBlockBytes(uint64_t, CNode *pfrom);
+    void DeleteThinBlockBytes(uint64_t, CNode *pfrom);
     void ResetThinBlockBytes();
     uint64_t GetThinBlockBytes();
 };

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -187,7 +187,7 @@ bool IsThinBlocksEnabled();
 bool CanThinBlockBeDownloaded(CNode *pto);
 void ConnectToThinBlockNodes();
 void CheckNodeSupportForThinBlocks();
-void ClearLargestThinBlockAndDisconnect();
+bool ClearLargestThinBlockAndDisconnect(CNode *pfrom);
 void SendXThinBlock(CBlock &block, CNode *pfrom, const CInv &inv);
 bool IsThinBlockValid(const CNode *pfrom, const std::vector<CTransaction> &vMissingTx, const CBlockHeader &header);
 void BuildSeededBloomFilter(CBloomFilter &memPoolFilter,


### PR DESCRIPTION
Here we track thebytes we've added to the thinblock that we're currently re-constructing. If we go over the global limit then we disconnect the node with the largest number of bytes in use and clear the thinblock data from memory before continuing to process.  This will prevent us from ever exceeding EB*16 in terms of memory used total for thinblock re-construction. (total being the sum of all current thinblocks being re-constructed)