### PR TITLE
Don't process xthin blocks unless they extend the chain

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3747,7 +3747,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, CBlockIn
     return true;
 }
 
-static bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex=NULL)
+bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex)
 {
     AssertLockHeld(cs_main);
     // Check for duplicate

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5981,7 +5981,7 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
     else if (strCommand == NetMsgType::XTHINBLOCK && !fImporting && !fReindex && !IsInitialBlockDownload()
     	     && IsThinBlocksEnabled())
     {
-    	CXThinBlock::HandleMessage(vRecv, pfrom, strCommand, 0);
+    	return CXThinBlock::HandleMessage(vRecv, pfrom, strCommand, 0);
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -480,23 +480,6 @@ void ProcessBlockAvailability(NodeId nodeid) {
     }
 }
 
-/** Update tracking information about which blocks a peer is assumed to have. */
-void UpdateBlockAvailability(NodeId nodeid, const uint256 &hash) {
-    CNodeState *state = State(nodeid);
-    DbgAssert(state != NULL, return);  // node already destructed, nothing to do in production mode
-
-    ProcessBlockAvailability(nodeid);
-
-    BlockMap::iterator it = mapBlockIndex.find(hash);
-    if (it != mapBlockIndex.end() && it->second->nChainWork > 0) {
-        // An actually better block was announced.
-        if (state->pindexBestKnownBlock == NULL || it->second->nChainWork >= state->pindexBestKnownBlock->nChainWork)
-            state->pindexBestKnownBlock = it->second;
-    } else {
-        // An unknown block was announced; just assume that the latest one is the best one.
-        state->hashLastUnknownBlock = hash;
-    }
-}
 
 // Requires cs_main
 bool PeerHasHeader(CNodeState *state, CBlockIndex *pindex)
@@ -614,7 +597,23 @@ void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<CBl
 
 } // anon namespace
 
+/** Update tracking information about which blocks a peer is assumed to have. */
+void UpdateBlockAvailability(NodeId nodeid, const uint256 &hash) {
+    CNodeState *state = State(nodeid);
+    DbgAssert(state != NULL, return);  // node already destructed, nothing to do in production mode
 
+    ProcessBlockAvailability(nodeid);
+
+    BlockMap::iterator it = mapBlockIndex.find(hash);
+    if (it != mapBlockIndex.end() && it->second->nChainWork > 0) {
+        // An actually better block was announced.
+        if (state->pindexBestKnownBlock == NULL || it->second->nChainWork >= state->pindexBestKnownBlock->nChainWork)
+            state->pindexBestKnownBlock = it->second;
+    } else {
+        // An unknown block was announced; just assume that the latest one is the best one.
+        state->hashLastUnknownBlock = hash;
+    }
+}
 
   void MarkBlockAsInFlight(NodeId nodeid, const uint256& hash, const Consensus::Params& consensusParams, CBlockIndex *pindex = NULL) {
     LOCK(cs_main);
@@ -5978,10 +5977,10 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
         CheckAndRequestExpeditedBlocks(pfrom);
     }
 
-    else if (strCommand == NetMsgType::XTHINBLOCK && !fImporting && !fReindex && !IsInitialBlockDownload()
-    	     && IsThinBlocksEnabled())
+    else if (strCommand == NetMsgType::XTHINBLOCK && !fImporting && !fReindex && !IsInitialBlockDownload() &&
+             IsThinBlocksEnabled())
     {
-    	return CXThinBlock::HandleMessage(vRecv, pfrom, strCommand, 0);
+        return CXThinBlock::HandleMessage(vRecv, pfrom, strCommand, 0);
     }
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -407,7 +407,9 @@ bool SequenceLocks(const CTransaction &tx, int flags, std::vector<int>* prevHeig
  */
 bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints* lp = NULL, bool useExistingLockPoints = false);
 
-//  BU: This was all moved to parallel.cpp
+/** Update tracking information about which blocks a peer is assumed to have. */
+void UpdateBlockAvailability(NodeId nodeid, const uint256 &hash);
+
 /**
  * Class that keeps track of number of signature operations
  * and bytes hashed to compute signature hashes.

--- a/src/main.h
+++ b/src/main.h
@@ -229,6 +229,8 @@ void UnloadBlockIndex();
 /** Process protocol messages received from a given node */
 bool ProcessMessages(CNode* pfrom);
 bool AlreadyHave(const CInv &);
+bool AcceptBlockHeader(const CBlockHeader& block, CValidationState& state, const CChainParams& chainparams, CBlockIndex** ppindex=NULL);
+
 /** Process a single protocol messages received from a given node */
 bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, int64_t nTimeReceived);
 

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -261,84 +261,90 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
         return error("%s message received from a non thinblock node, peer=%d", strCommand, pfrom->GetId());
     }
 
+    bool fAlreadyHave = false;
     int nSizeThinBlock = vRecv.size();
+    CInv inv(MSG_BLOCK, uint256());
+
     CXThinBlock thinBlock;
     vRecv >> thinBlock;
 
-    // Message consistency checking
-    if (!IsThinBlockValid(pfrom, thinBlock.vMissingTx, thinBlock.header))
     {
         LOCK(cs_main);
-        Misbehaving(pfrom->GetId(), 100);
-        return error("Invalid %s received", strCommand);
-    }
 
-    // Is there a previous block or header to connect with?
-    {
-        LOCK(cs_main);
-        uint256 prevHash = thinBlock.header.hashPrevBlock;
-        BlockMap::iterator mi = mapBlockIndex.find(prevHash);
-        if (mi == mapBlockIndex.end())
+        // Message consistency checking (FIXME: some redundancy here with AcceptBlockHeader)
+        if (!IsThinBlockValid(pfrom, thinBlock.vMissingTx, thinBlock.header))
         {
-            Misbehaving(pfrom->GetId(), 10);
-            return error("%s from peer %s (%d) will not connect, unknown previous block %s", strCommand,
-                pfrom->addrName.c_str(), pfrom->id, prevHash.ToString());
-        }
-        CBlockIndex *pprev = mi->second;
-        CValidationState state;
-        if (!ContextualCheckBlockHeader(thinBlock.header, state, pprev))
-        {
-            // Thin block does not fit within our blockchain
             Misbehaving(pfrom->GetId(), 100);
-            return error("%s from peer %s (%d) contextual error: %s", strCommand, pfrom->addrName.c_str(), pfrom->id,
-                state.GetRejectReason().c_str());
-        }
-    }
-
-    CInv inv(MSG_BLOCK, thinBlock.header.GetHash());
-    bool fAlreadyHave = false;
-
-    if (nHops > 0)
-    {
-        bool newBlock = false;
-        unsigned int status = 0;
-
-        LOCK(cs_main);
-        BlockMap::iterator mapEntry = mapBlockIndex.find(inv.hash);
-        CBlockIndex *blkidx = NULL;
-        if (mapEntry != mapBlockIndex.end())
-        {
-            blkidx = mapEntry->second;
-            if (blkidx)
-                status = blkidx->nStatus;
-        }
-
-        // If we do not have the block on disk or do not have the header yet then treat the block as new.
-        newBlock = blkidx == NULL || !(blkidx->nStatus & BLOCK_HAVE_DATA);
-
-        LogPrint("thin",
-            "Received %s expedited thinblock %s from peer %s (%d). Hop %d. Size %d bytes. (status %d,0x%x)\n",
-            newBlock ? "new" : "repeated", inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id, nHops,
-            nSizeThinBlock, status, status);
-
-        if (!newBlock)
+            LogPrintf("Received an invalid %s from peer %s (%d)\n",
+                      strCommand, pfrom->addrName.c_str(), pfrom->id);
             return true;
-    }
-    else
-    {
-        LogPrint("thin", "Received %s %s from peer %s (%d). Size %d bytes.\n", strCommand, inv.hash.ToString(),
-            pfrom->addrName.c_str(), pfrom->id, nSizeThinBlock);
+        }
 
-        // An expedited block or re-requested xthin can arrive and beat the original thin block request/response
-        if (!pfrom->mapThinBlocksInFlight.count(inv.hash))
+        CValidationState state;
+        CBlockIndex *pIndex = NULL;
+        if (!AcceptBlockHeader(thinBlock.header, state, Params(), &pIndex))
         {
-            LogPrint("thin", "%s %s from peer %s (%d) received but we may already have processed it\n", strCommand,
-                inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id);
-            LOCK(cs_main);
-            fAlreadyHave = AlreadyHave(inv); // I'll still continue processing if we don't have an accepted block yet
-            if (fAlreadyHave)
-                // record the bytes received from the thinblock even though we had it already
-                requester.Received(inv, pfrom, nSizeThinBlock);
+            int nDoS;
+            if (state.IsInvalid(nDoS))
+            {
+                if (nDoS > 0)
+                    Misbehaving(pfrom->GetId(), nDoS);
+                LogPrintf("Received an invalid %s header from peer %s (%d)\n",
+                          strCommand, pfrom->addrName.c_str(), pfrom->id);
+            }
+
+            return true;
+        }
+
+        // pIndex should always be set by AcceptBlockHeader
+        if (!pIndex)
+        {
+            LogPrintf("INTERNAL ERROR: pIndex null in CXThinBlock::HandleMessage");
+            return true;
+        }
+
+        // FIXME: enable this later
+        // UpdateBlockAvailability(pfrom->GetId(), pIndex->GetBlockHash());
+
+        // Return early if we already have the block data
+        if (pIndex->nStatus & BLOCK_HAVE_DATA)
+            return true;
+
+        inv.hash = pIndex->GetBlockHash();
+
+        // Request thin block if it isn't extending the best chain
+        if (pIndex->nChainWork <= chainActive.Tip()->nChainWork)
+        {
+            vector<CInv> vGetData;
+            vGetData.push_back(CInv(MSG_THINBLOCK, inv.hash));
+
+            pfrom->PushMessage(NetMsgType::GETDATA, vGetData);
+            LogPrintf("xthinblock does not extend longest chain; re-requesting as a thinblock\n");
+            return true;
+        }
+
+        if (nHops > 0)
+        {
+            LogPrint("thin",
+                     "Received new expedited thinblock %s from peer %s (%d) hop %d size %d bytes\n",
+                     inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id, nHops, nSizeThinBlock);
+        }
+        else
+        {
+            LogPrint("thin", "Received %s %s from peer %s (%d). Size %d bytes.\n", strCommand, inv.hash.ToString(),
+                     pfrom->addrName.c_str(), pfrom->id, nSizeThinBlock);
+
+            // An expedited block or re-requested xthin can arrive and beat the original thin block request/response
+            if (!pfrom->mapThinBlocksInFlight.count(inv.hash))
+            {
+                LogPrint("thin", "%s %s from peer %s (%d) received but we may already have processed it\n", strCommand,
+                         inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id);
+                 // I'll still continue processing if we don't have an accepted block yet
+                fAlreadyHave = AlreadyHave(inv);
+                if (fAlreadyHave)
+                    // record the bytes received from the thinblock even though we had it already
+                    requester.Received(inv, pfrom, nSizeThinBlock);
+            }
         }
     }
 

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -275,8 +275,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
         if (!IsThinBlockValid(pfrom, thinBlock.vMissingTx, thinBlock.header))
         {
             Misbehaving(pfrom->GetId(), 100);
-            LogPrintf("Received an invalid %s from peer %s (%d)\n",
-                      strCommand, pfrom->addrName.c_str(), pfrom->id);
+            LogPrintf("Received an invalid %s from peer %s (%d)\n", strCommand, pfrom->addrName.c_str(), pfrom->id);
             return true;
         }
 
@@ -289,8 +288,8 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
             {
                 if (nDoS > 0)
                     Misbehaving(pfrom->GetId(), nDoS);
-                LogPrintf("Received an invalid %s header from peer %s (%d)\n",
-                          strCommand, pfrom->addrName.c_str(), pfrom->id);
+                LogPrintf("Received an invalid %s header from peer %s (%d)\n", strCommand, pfrom->addrName.c_str(),
+                    pfrom->id);
             }
 
             return true;
@@ -312,34 +311,34 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
 
         inv.hash = pIndex->GetBlockHash();
 
-        // Request thin block if it isn't extending the best chain
+        // Request full block if it isn't extending the best chain
         if (pIndex->nChainWork <= chainActive.Tip()->nChainWork)
         {
             vector<CInv> vGetData;
-            vGetData.push_back(CInv(MSG_THINBLOCK, inv.hash));
-
+            vGetData.push_back(inv);
             pfrom->PushMessage(NetMsgType::GETDATA, vGetData);
-            LogPrintf("xthinblock does not extend longest chain; re-requesting as a thinblock\n");
+
+            LogPrintf("%s %s from peer %s (%d) received but does not extend longest chain; requesting full block\n",
+                strCommand, inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id);
             return true;
         }
 
         if (nHops > 0)
         {
-            LogPrint("thin",
-                     "Received new expedited thinblock %s from peer %s (%d) hop %d size %d bytes\n",
-                     inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id, nHops, nSizeThinBlock);
+            LogPrint("thin", "Received new expedited thinblock %s from peer %s (%d) hop %d size %d bytes\n",
+                inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id, nHops, nSizeThinBlock);
         }
         else
         {
             LogPrint("thin", "Received %s %s from peer %s (%d). Size %d bytes.\n", strCommand, inv.hash.ToString(),
-                     pfrom->addrName.c_str(), pfrom->id, nSizeThinBlock);
+                pfrom->addrName.c_str(), pfrom->id, nSizeThinBlock);
 
             // An expedited block or re-requested xthin can arrive and beat the original thin block request/response
             if (!pfrom->mapThinBlocksInFlight.count(inv.hash))
             {
                 LogPrint("thin", "%s %s from peer %s (%d) received but we may already have processed it\n", strCommand,
-                         inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id);
-                 // I'll still continue processing if we don't have an accepted block yet
+                    inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id);
+                // I'll still continue processing if we don't have an accepted block yet
                 fAlreadyHave = AlreadyHave(inv);
                 if (fAlreadyHave)
                     // record the bytes received from the thinblock even though we had it already


### PR DESCRIPTION
Also:

- cleans up validation logic; most is now done in AcceptBlockHeader
- reworks the logic so cs_main is held only once