### PR TITLE
Factor out information unit formatting

### DIFF
--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -11,3 +11,4 @@ unlimited.h
 globals.cpp
 expedited.cpp
 expedited.h
+test/thinblock_util_tests.cpp

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -84,6 +84,7 @@ BITCOIN_TESTS =\
   test/test_bitcoin.cpp \
   test/test_bitcoin.h \
   test/thinblock_tests.cpp \
+  test/thinblock_util_tests.cpp \
   test/testutil.cpp \
   test/testutil.h \
   test/timedata_tests.cpp \

--- a/src/test/thinblock_util_tests.cpp
+++ b/src/test/thinblock_util_tests.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2013-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "thinblock.h"
+#include "test/test_bitcoin.h"
+#include <boost/test/unit_test.hpp>
+#include <limits>
+
+
+BOOST_FIXTURE_TEST_SUITE(thinblock_util_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_CASE(TestCBufferedFile)
+{
+    const double pinf = std::numeric_limits<double>::infinity();
+    const double ninf = -pinf;
+    const double qnan = std::numeric_limits<double>::quiet_NaN();
+    const double snan = std::numeric_limits<double>::signaling_NaN();
+
+    // exercise special values as well to make sure they don't due
+    // any overruns etc.
+    formatInfoUnit(pinf);
+    formatInfoUnit(ninf);
+    formatInfoUnit(qnan);
+    formatInfoUnit(snan);
+
+    assert(formatInfoUnit(-1001000.0) == "-1.00MB");
+    assert(formatInfoUnit(-1001.0) == "-1.00KB");
+    assert(formatInfoUnit(-1.0) == "-1.00B");
+    assert(formatInfoUnit(0.1) == "0.10B");
+    assert(formatInfoUnit(1.0) == "1.00B");
+    assert(formatInfoUnit(10.) == "10.00B");
+    assert(formatInfoUnit(1e3 + 1e0) == "1.00KB");
+    assert(formatInfoUnit(1e6 + 1e2) == "1.00MB");
+    assert(formatInfoUnit(1e9 + 1e5) == "1.00GB");
+    assert(formatInfoUnit(1e12 + 1e8) == "1.00TB");
+    assert(formatInfoUnit(1e15 + 1e11) == "1.00PB");
+    assert(formatInfoUnit(1e18 + 1e14) == "1.00EB");
+    assert(formatInfoUnit(1e21 + 1e17) == "1000.10EB");
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -28,6 +28,23 @@ extern CCriticalSection cs_thinblockstats;
 extern CCriticalSection cs_orphancache;
 extern map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(cs_orphancache);
 
+string formatInfoUnit(double value)
+{
+    static const char *units[] = {"B", "KB", "MB", "GB", "TB", "PB", "EB"};
+
+    size_t i = 0;
+    while ((value > 1000.0 || value < -1000.0) && i < (sizeof(units) / sizeof(units[0])) - 1)
+    {
+        value /= 1000.0;
+        i++;
+    }
+
+    ostringstream ss;
+    ss << fixed << setprecision(2);
+    ss << value << units[i];
+    return ss.str();
+}
+
 CThinBlock::CThinBlock(const CBlock &block, CBloomFilter &filter)
 {
     header = block.GetBlockHeader();
@@ -696,19 +713,9 @@ void CThinBlockData::UpdateMempoolLimiterBytesSaved(unsigned int nBytesSaved)
 string CThinBlockData::ToString()
 {
     LOCK(cs_thinblockstats);
-
-    static const char *units[] = {"B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
-    int i = 0;
     double size = double(nOriginalSize() - nThinSize() - nTotalBloomFilterBytes());
-    while (size > 1000)
-    {
-        size /= 1000;
-        i++;
-    }
-
     ostringstream ss;
-    ss << fixed << setprecision(2);
-    ss << nBlocks() << " thin " << ((nBlocks() > 1) ? "blocks have" : "block has") << " saved " << size << units[i]
+    ss << nBlocks() << " thin " << ((nBlocks() > 1) ? "blocks have" : "block has") << " saved " << formatInfoUnit(size)
        << " of bandwidth";
     return ss.str();
 }
@@ -823,17 +830,8 @@ string CThinBlockData::InBoundBloomFiltersToString()
     if (nInBoundBloomFilters > 0)
         avgBloomSize = (double)nInBoundBloomFilterSize / nInBoundBloomFilters;
 
-    static const char *units[] = {"B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
-    int i = 0;
-    while (avgBloomSize > 1000)
-    {
-        avgBloomSize /= 1000;
-        i++;
-    }
-
     ostringstream ss;
-    ss << fixed << setprecision(1);
-    ss << "Inbound bloom filter size (last 24hrs) AVG: " << avgBloomSize << units[i];
+    ss << "Inbound bloom filter size (last 24hrs) AVG: " << formatInfoUnit(avgBloomSize);
     return ss.str();
 }
 
@@ -864,17 +862,8 @@ string CThinBlockData::OutBoundBloomFiltersToString()
     if (nOutBoundBloomFilters > 0)
         avgBloomSize = (double)nOutBoundBloomFilterSize / nOutBoundBloomFilters;
 
-    static const char *units[] = {"B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
-    int i = 0;
-    while (avgBloomSize > 1000)
-    {
-        avgBloomSize /= 1000;
-        i++;
-    }
-
     ostringstream ss;
-    ss << fixed << setprecision(1);
-    ss << "Outbound bloom filter size (last 24hrs) AVG: " << avgBloomSize << units[i];
+    ss << "Outbound bloom filter size (last 24hrs) AVG: " << formatInfoUnit(avgBloomSize);
     return ss.str();
 }
 // Calculate the xthin percentage compression over the last 24 hours
@@ -984,19 +973,9 @@ string CThinBlockData::ReRequestedTxToString()
 string CThinBlockData::MempoolLimiterBytesSavedToString()
 {
     LOCK(cs_thinblockstats);
-
-    static const char *units[] = {"B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"};
-    int i = 0;
     double size = (double)nMempoolLimiterBytesSaved();
-    while (size > 1000)
-    {
-        size /= 1000;
-        i++;
-    }
-
     ostringstream ss;
-    ss << fixed << setprecision(2);
-    ss << "Thinblock mempool limiting has saved " << size << units[i] << " of bandwidth";
+    ss << "Thinblock mempool limiting has saved " << formatInfoUnit(size) << " of bandwidth";
     return ss.str();
 }
 

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -18,6 +18,23 @@
 class CDataStream;
 class CNode;
 
+
+/**
+ Format an amount of bytes with a unit symbol attached, such as MB, KB, GB.
+ Uses Kilobytes x1000, not Kibibytes x1024.
+
+ Output value has two digits after the dot. No space between unit symbol and
+ amount.
+
+ Also works for negative amounts. The maximum unit supported is 1 Exabyte (EB).
+ This formatting is used by the thinblock statistics functions, and this
+ is a factored-out utility function.
+
+ @param [value] The value to format
+ @return String with unit
+ */
+extern std::string formatInfoUnit(double value);
+
 class CThinBlock
 {
 public:


### PR DESCRIPTION
There's a couple places where a floating point amount of bytes is
formatted  with units attached (KB, MB, ...).

This factors all of them out and puts them into a single function
static string formatInfoUnit(double).

It also fixes a couple potential array-out-of-bounds-access errors,
as none of the upper bounds had been checked before.