### PR TITLE
[Backport to Release PR550] Prevent the mapThinBlocksInflight timer from tripping

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6701,7 +6701,7 @@ bool SendMessages(CNode* pto)
                 std::map<uint256, int64_t>::iterator iter = pto->mapThinBlocksInFlight.begin();
                 while (iter != pto->mapThinBlocksInFlight.end())
                 {
-                    if ((GetTime() - (*iter).second) > THINBLOCK_DOWNLOAD_TIMEOUT)
+                    if ((*iter).second != -1 && (GetTime() - (*iter).second) > THINBLOCK_DOWNLOAD_TIMEOUT)
                     {
                         if (!pto->fWhitelisted && Params().NetworkIDString() != "regtest")
                         {

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -459,6 +459,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     CNode::ClearBanned();
     CXThinBlock xthin = xthinblock;
     xthin.vMissingTx.clear(); // empty the missingtx vector. This should cause an error.
+    vRecv1.clear();
     vRecv1 << xthin;
 
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);


### PR DESCRIPTION
In the event that we have received that thinblock and were
successful in reconstructing it we need to prevent the timer
from tripping before the block has finished processing. Set
the time = -1 and use it as a flag to prevent the node from
being disconnected if the time goes over limit.  We must
do this because we still need to maintain the map entry
to prevent us from downloading the block again.