### PR TITLE
Make CBloomFilter more robust

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6421,7 +6421,6 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
             LOCK(pfrom->cs_filter);
             delete pfrom->pfilter;
             pfrom->pfilter = new CBloomFilter(filter);
-            pfrom->pfilter->UpdateEmptyFull();
         }
         pfrom->fRelayTxes = true;
     }

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1388,7 +1388,6 @@ void LoadFilter(CNode *pfrom, CBloomFilter *filter)
         LOCK(pfrom->cs_filter);
         delete pfrom->pThinBlockFilter;
         pfrom->pThinBlockFilter = new CBloomFilter(*filter);
-        pfrom->pThinBlockFilter->UpdateEmptyFull();
     }
     uint64_t nSizeFilter = ::GetSerializeSize(*pfrom->pThinBlockFilter, SER_NETWORK, PROTOCOL_VERSION);
     LogPrint("thin", "Thinblock Bloom filter size: %d\n", nSizeFilter);


### PR DESCRIPTION
If the FP rate becomes 1.0, the constructor as e.g. used in
thinblock.cpp will create a bloom filter without any elements
(vData.size() == 0), however the isFull flag will be false.

Note that there's no indication that thinblock.cpp will
*currently* ever allow this value, but a potential tweak of the
parameters could trigger this condition.

This means that an insert(..) operation will do an out-of-bounds
write (by one) on the vData vector!

This commit ensures that isFull is true iff vData.size() == 0
in the constructor.

Also adds a very simple test case to exercise this code path.

THIS TOUCHES CORE DATA STRUCTURES AND THUS NEEDS DETAILED REVIEW!!!