### PR TITLE
Make sure to clear mapThinBlocksInFlight()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5927,6 +5927,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
         }
 
         // Is there a previous block or header to connect with?
+        CInv inv(MSG_BLOCK, thinBlock.header.GetHash());
         {
             LOCK(cs_main);
             uint256 prevHash = thinBlock.header.hashPrevBlock;
@@ -5934,6 +5935,7 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             if (mi == mapBlockIndex.end())
             {
                 Misbehaving(pfrom->GetId(), 10);
+                ClearThinBlockInFlight(pfrom, inv.hash);
                 return error("thinblock from peer %s (%d) will not connect, unknown previous block %s",
                     pfrom->addrName.c_str(),
                     pfrom->id,
@@ -5952,7 +5954,6 @@ bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t
             }
         }
 
-        CInv inv(MSG_BLOCK, thinBlock.header.GetHash());
         int nSizeThinBlock = ::GetSerializeSize(thinBlock, SER_NETWORK, PROTOCOL_VERSION);
         LogPrint("thin", "received thinblock %s from peer %s (%d) of %d bytes\n", inv.hash.ToString(),
             pfrom->addrName.c_str(),

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -189,6 +189,7 @@ bool CanThinBlockBeDownloaded(CNode* pto);
 void ConnectToThinBlockNodes();
 void CheckNodeSupportForThinBlocks();
 bool ClearLargestThinBlockAndDisconnect(CNode *pfrom);
+void ClearThinBlockInFlight(CNode *pfrom, uint256 hash);
 void SendXThinBlock(CBlock &block, CNode *pfrom, const CInv &inv);
 bool IsThinBlockValid(const CNode *pfrom, const std::vector<CTransaction> &vMissingTx, const CBlockHeader &header);
 void BuildSeededBloomFilter(CBloomFilter& memPoolFilter, std::vector<uint256>& vOrphanHashes, uint256 hash, bool fDeterministic = false);


### PR DESCRIPTION
If a thinblock can not be processed or the block data already has
been received then make sure to clear the map entry for this
thinblock before returning.