### PR TITLE
Xthin cleanup

### DIFF
--- a/src/expedited.cpp
+++ b/src/expedited.cpp
@@ -172,8 +172,8 @@ bool HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom)
                 }
                 else
                 {
-                    LogPrint("blk", "Expedited transactions requested from peer %s but I am full\n",
-                        pfrom->GetLogName());
+                    LogPrint(
+                        "blk", "Expedited transactions requested from peer %s but I am full\n", pfrom->GetLogName());
                 }
             }
         }

--- a/src/expedited.cpp
+++ b/src/expedited.cpp
@@ -85,7 +85,7 @@ bool CheckAndRequestExpeditedBlocks(CNode *pfrom)
     return false;
 }
 
-void HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom)
+bool HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom)
 {
     uint64_t options;
     vRecv >> options;
@@ -95,7 +95,7 @@ void HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom)
     {
         LOCK(cs_main);
         Misbehaving(pfrom->GetId(), 5);
-        return;
+        return false;
     }
 
     if (options & EXPEDITED_BLOCKS)
@@ -104,7 +104,7 @@ void HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom)
 
         if (stop) // If stopping, find the array element and clear it.
         {
-            LogPrint("blk", "Stopping expedited blocks to peer %s (%d).\n", pfrom->addrName.c_str(), pfrom->id);
+            LogPrint("blk", "Stopping expedited blocks to peer %s\n", pfrom->GetLogName());
             std::vector<CNode *>::iterator it = std::find(xpeditedBlk.begin(), xpeditedBlk.end(), pfrom);
             if (it != xpeditedBlk.end())
             {
@@ -120,7 +120,7 @@ void HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom)
                 unsigned int maxExpedited = GetArg("-maxexpeditedblockrecipients", 32);
                 if (xpeditedBlk.size() < maxExpedited)
                 {
-                    LogPrint("blk", "Starting expedited blocks to peer %s (%d).\n", pfrom->addrName.c_str(), pfrom->id);
+                    LogPrint("blk", "Starting expedited blocks to peer %s\n", pfrom->GetLogName());
 
                     // find an empty array location
                     std::vector<CNode *>::iterator it =
@@ -133,8 +133,7 @@ void HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom)
                 }
                 else
                 {
-                    LogPrint("blk", "Expedited blocks requested from peer %s (%d), but I am full.\n",
-                        pfrom->addrName.c_str(), pfrom->id);
+                    LogPrint("blk", "Expedited blocks requested from peer %s but I am full\n", pfrom->GetLogName());
                 }
             }
         }
@@ -145,7 +144,7 @@ void HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom)
 
         if (stop) // If stopping, find the array element and clear it.
         {
-            LogPrint("blk", "Stopping expedited transactions to peer %s (%d).\n", pfrom->addrName.c_str(), pfrom->id);
+            LogPrint("blk", "Stopping expedited transactions to peer %s\n", pfrom->GetLogName());
             std::vector<CNode *>::iterator it = std::find(xpeditedTxn.begin(), xpeditedTxn.end(), pfrom);
             if (it != xpeditedTxn.end())
             {
@@ -161,8 +160,7 @@ void HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom)
                 unsigned int maxExpedited = GetArg("-maxexpeditedtxrecipients", 32);
                 if (xpeditedTxn.size() < maxExpedited)
                 {
-                    LogPrint("blk", "Starting expedited transactions to peer %s (%d).\n", pfrom->addrName.c_str(),
-                        pfrom->id);
+                    LogPrint("blk", "Starting expedited transactions to peer %s\n", pfrom->GetLogName());
 
                     std::vector<CNode *>::iterator it =
                         std::find(xpeditedTxn.begin(), xpeditedTxn.end(), ((CNode *)NULL));
@@ -174,12 +172,14 @@ void HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom)
                 }
                 else
                 {
-                    LogPrint("blk", "Expedited transactions requested from peer %s (%d), but I am full.\n",
-                        pfrom->addrName.c_str(), pfrom->id);
+                    LogPrint("blk", "Expedited transactions requested from peer %s but I am full\n",
+                        pfrom->GetLogName());
                 }
             }
         }
     }
+
+    return true;
 }
 
 bool IsRecentlyExpeditedAndStore(const uint256 &hash)

--- a/src/expedited.h
+++ b/src/expedited.h
@@ -37,7 +37,7 @@ extern bool CheckAndRequestExpeditedBlocks(CNode *pfrom);
 // be an expedited block source and if so, request them.
 extern void SendExpeditedBlock(CXThinBlock &thinBlock, unsigned char hops, const CNode *skip = NULL);
 extern void SendExpeditedBlock(const CBlock &block, const CNode *skip = NULL);
-extern void HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom);
+extern bool HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom);
 extern bool IsRecentlyExpeditedAndStore(const uint256 &hash);
 
 // process incoming unsolicited block

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5916,7 +5916,7 @@ bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, in
 
     else if (strCommand == NetMsgType::XPEDITEDREQUEST)
     {
-        HandleExpeditedRequest(vRecv, pfrom);
+        return HandleExpeditedRequest(vRecv, pfrom);
     }
 
 

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -369,7 +369,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
         if (pIndex->nChainWork <= chainActive.Tip()->nChainWork)
         {
             vector<CInv> vGetData;
-            vGetData.push_back(CInv(MSG_THINBLOCK, inv.hash));
+            vGetData.push_back(inv);
             pfrom->PushMessage(NetMsgType::GETDATA, vGetData);
 
             LogPrintf("%s %s from peer %s received but does not extend longest chain; requesting full block\n",

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -365,7 +365,6 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
             return true;
         }
 
-
         // Request full block if it isn't extending the best chain
         if (pIndex->nChainWork <= chainActive.Tip()->nChainWork)
         {
@@ -373,26 +372,26 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
             vGetData.push_back(CInv(MSG_THINBLOCK, inv.hash));
             pfrom->PushMessage(NetMsgType::GETDATA, vGetData);
 
-            LogPrintf("%s %s from peer %s (%d) received but does not extend longest chain; requesting full block\n",
-                strCommand, inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id);
+            LogPrintf("%s %s from peer %s received but does not extend longest chain; requesting full block\n",
+                strCommand, inv.hash.ToString(), pfrom->GetLogName());
             return true;
         }
 
         if (nHops > 0)
         {
-            LogPrint("thin", "Received new expedited thinblock %s from peer %s (%d) hop %d size %d bytes\n",
-                inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id, nHops, nSizeThinBlock);
+            LogPrint("thin", "Received new expedited thinblock %s from peer %s hop %d size %d bytes\n",
+                inv.hash.ToString(), pfrom->GetLogName(), nHops, nSizeThinBlock);
         }
         else
         {
-            LogPrint("thin", "Received %s %s from peer %s (%d). Size %d bytes.\n", strCommand, inv.hash.ToString(),
-                pfrom->addrName.c_str(), pfrom->id, nSizeThinBlock);
+            LogPrint("thin", "Received %s %s from peer %s. Size %d bytes.\n", strCommand, inv.hash.ToString(),
+                pfrom->GetLogName(), nSizeThinBlock);
 
             // An expedited block or re-requested xthin can arrive and beat the original thin block request/response
             if (!pfrom->mapThinBlocksInFlight.count(inv.hash))
             {
-                LogPrint("thin", "%s %s from peer %s (%d) received but we may already have processed it\n", strCommand,
-                    inv.hash.ToString(), pfrom->addrName.c_str(), pfrom->id);
+                LogPrint("thin", "%s %s from peer %s received but we may already have processed it\n", strCommand,
+                    inv.hash.ToString(), pfrom->GetLogName());
                 // I'll still continue processing if we don't have an accepted block yet
                 fAlreadyHave = AlreadyHave(inv);
                 if (fAlreadyHave)


### PR DESCRIPTION
2 commits on top of xthin-checks:

-   Fall back to full block (not thin block) as comment and log states
     A block not at tip is unlikely to benefit much from the current mempool

-  Have HandleExpeditedRequest return a result
    Use GetLogName() for reporting peer
