### PR TITLE
Partial clean up of copy & paste code for xthin stats

### DIFF
--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -12,6 +12,7 @@ globals.cpp
 expedited.cpp
 expedited.h
 test/thinblock_util_tests.cpp
+test/thinblock_data_tests.cpp
 main.cpp
 main.h
 net.cpp

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -84,6 +84,7 @@ BITCOIN_TESTS =\
   test/test_bitcoin.cpp \
   test/test_bitcoin.h \
   test/thinblock_tests.cpp \
+  test/thinblock_data_tests.cpp \
   test/thinblock_util_tests.cpp \
   test/testutil.cpp \
   test/testutil.h \

--- a/src/test/thinblock_data_tests.cpp
+++ b/src/test/thinblock_data_tests.cpp
@@ -1,0 +1,126 @@
+// Copyright (c) 2013-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "thinblock.h"
+#include "test/test_bitcoin.h"
+#include <assert.h>
+#include <boost/range/irange.hpp>
+#include <boost/test/unit_test.hpp>
+#include <limits>
+#include <string>
+#include <vector>
+
+using namespace std;
+
+class TestTBD : public CThinBlockData
+{
+protected:
+    virtual int64_t getTimeForStats() { return times[min(times_idx++, times.size() - 1)]; }
+    vector<int64_t> times;
+    size_t times_idx;
+
+public:
+    TestTBD(const vector<int64_t> &_times)
+    {
+        assert(_times.size() > 0);
+        times = _times;
+        times_idx = 0;
+    }
+    void resetTimeIdx() { times_idx = 0; }
+};
+
+
+BOOST_FIXTURE_TEST_SUITE(thinblock_data_tests, BasicTestingSetup)
+BOOST_AUTO_TEST_CASE(test_thinblockdata_stats1)
+{
+    vector<int64_t> times1(1000); // minutes
+
+    for (int i = 0; i < times1.size(); i++)
+    {
+        times1[i] = 1000 * 60 * i;
+    }
+
+    {
+        TestTBD tbd(times1);
+        // exercise summary methods on empty arrays to make sure they don't fail
+        // in weird ways
+        tbd.ToString();
+        tbd.InBoundPercentToString();
+        tbd.OutBoundPercentToString();
+        tbd.InBoundBloomFiltersToString();
+        tbd.OutBoundBloomFiltersToString();
+        tbd.ResponseTimeToString();
+        tbd.ValidationTimeToString();
+        tbd.ReRequestedTxToString();
+        tbd.MempoolLimiterBytesSavedToString();
+        tbd.GetThinBlockBytes();
+    }
+
+    {
+        TestTBD tbd(times1);
+
+        for (int64_t i : boost::irange(0, 100))
+            tbd.UpdateInBound(i, 3 * i);
+
+        string res = tbd.InBoundPercentToString();
+
+        BOOST_CHECK_MESSAGE(res.find("66.7%") != string::npos, "InBoundPercentToString() is " << res);
+    }
+
+    {
+        TestTBD tbd(times1);
+
+        for (int64_t i : boost::irange(0, 100))
+            tbd.UpdateOutBound(i, 3 * i);
+
+        string res = tbd.OutBoundPercentToString();
+
+        BOOST_CHECK_MESSAGE(res.find("66.7%") != string::npos, "OutBoundPercentToString() is " << res);
+    }
+
+    {
+        TestTBD tbd(times1);
+
+        for (int64_t i : boost::irange(0, 100))
+            tbd.UpdateInBoundBloomFilter(1000 * i);
+
+        string res = tbd.InBoundBloomFiltersToString();
+
+        BOOST_CHECK_MESSAGE(res.find("49.50KB") != string::npos, "InBoundBloomFiltersToString() is " << res);
+    }
+
+    {
+        TestTBD tbd(times1);
+
+        for (int64_t i : boost::irange(0, 100))
+            tbd.UpdateOutBoundBloomFilter(1000 * i);
+
+        string res = tbd.OutBoundBloomFiltersToString();
+        BOOST_CHECK_MESSAGE(res.find("49.50KB") != string::npos, "OutBoundBloomFiltersToString() is " << res);
+    }
+    // FIXME: check others somehow that depend on chain sync state
+
+    {
+        TestTBD tbd(times1);
+
+        for (int64_t i : boost::irange(0, 100))
+            tbd.UpdateInBoundReRequestedTx(1000 * i);
+
+        string res = tbd.ReRequestedTxToString();
+        BOOST_CHECK_MESSAGE(res.find(":100") != string::npos, "ReRequestedTxToString() is " << res);
+    }
+
+    {
+        TestTBD tbd(times1);
+
+        for (int64_t i : boost::irange(0, 100))
+            tbd.UpdateMempoolLimiterBytesSaved(1000 * i);
+
+        string res = tbd.MempoolLimiterBytesSavedToString();
+        BOOST_CHECK_MESSAGE(res.find("4.95MB") != string::npos, "MempoolLimiterBytesSavedToString() is " << res);
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -918,81 +918,84 @@ bool CXThinBlock::process(CNode *pfrom,
     return true;
 }
 
+template <class T>
+void CThinBlockData::expireStats(std::map<int64_t, T> &statsMap)
+{
+    AssertLockHeld(cs_thinblockstats);
+    // Delete any entries that are more than 24 hours old
+    int64_t nTimeCutoff = getTimeForStats() - 60 * 60 * 24 * 1000;
+
+    typename map<int64_t, T>::iterator iter = statsMap.begin();
+    while (iter != statsMap.end())
+    {
+        // increment to avoid iterator becoming invalid when erasing below
+        typename map<int64_t, T>::iterator mi = iter++;
+
+        if (mi->first < nTimeCutoff)
+            statsMap.erase(mi);
+    }
+}
+
+template <class T>
+void CThinBlockData::updateStats(std::map<int64_t, T> &statsMap, T value)
+{
+    AssertLockHeld(cs_thinblockstats);
+    statsMap[getTimeForStats()] = value;
+    expireStats(statsMap);
+}
+
+/**
+   Calculate average of values in map. Return 0 for no entries.
+   Expires values before calculation. */
+double CThinBlockData::average(std::map<int64_t, uint64_t> &map)
+{
+    AssertLockHeld(cs_thinblockstats);
+
+    expireStats(map);
+
+    if (map.size() == 0)
+        return 0.0;
+
+    uint64_t accum = 0U;
+    for (pair<int64_t, uint64_t> p : map)
+    {
+        // avoid wraparounds
+        accum = max(accum, accum + p.second);
+    }
+    return (double)accum / map.size();
+}
+
 void CThinBlockData::UpdateInBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize)
 {
     LOCK(cs_thinblockstats);
-
     // Update InBound thinblock tracking information
     nOriginalSize += nOriginalBlockSize;
     nThinSize += nThinBlockSize;
     nBlocks += 1;
-    mapThinBlocksInBound[GetTimeMillis()] = pair<uint64_t, uint64_t>(nThinBlockSize, nOriginalBlockSize);
-
-    // Delete any entries that are more than 24 hours old
-    int64_t nTimeCutoff = GetTimeMillis() - 60 * 60 * 24 * 1000;
-    map<int64_t, pair<uint64_t, uint64_t> >::iterator iter = mapThinBlocksInBound.begin();
-    while (iter != mapThinBlocksInBound.end())
-    {
-        map<int64_t, pair<uint64_t, uint64_t> >::iterator mi = iter++; // increment to avoid iterator becoming invalid
-        if ((*mi).first < nTimeCutoff)
-            mapThinBlocksInBound.erase(mi);
-    }
+    updateStats(mapThinBlocksInBound, pair<uint64_t, uint64_t>(nThinBlockSize, nOriginalBlockSize));
 }
 
 void CThinBlockData::UpdateOutBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize)
 {
     LOCK(cs_thinblockstats);
-
     nOriginalSize += nOriginalBlockSize;
     nThinSize += nThinBlockSize;
     nBlocks += 1;
-    mapThinBlocksOutBound[GetTimeMillis()] = pair<uint64_t, uint64_t>(nThinBlockSize, nOriginalBlockSize);
-
-    // Delete any entries that are more than 24 hours old
-    int64_t nTimeCutoff = GetTimeMillis() - 60 * 60 * 24 * 1000;
-    map<int64_t, pair<uint64_t, uint64_t> >::iterator iter = mapThinBlocksOutBound.begin();
-    while (iter != mapThinBlocksOutBound.end())
-    {
-        map<int64_t, pair<uint64_t, uint64_t> >::iterator mi = iter++; // increment to avoid iterator becoming invalid
-        if ((*mi).first < nTimeCutoff)
-            mapThinBlocksOutBound.erase(mi);
-    }
+    updateStats(mapThinBlocksOutBound, pair<uint64_t, uint64_t>(nThinBlockSize, nOriginalBlockSize));
 }
 
 void CThinBlockData::UpdateOutBoundBloomFilter(uint64_t nBloomFilterSize)
 {
     LOCK(cs_thinblockstats);
-
-    mapBloomFiltersOutBound[GetTimeMillis()] = nBloomFilterSize;
     nTotalBloomFilterBytes += nBloomFilterSize;
-
-    // Delete any entries that are more than 24 hours old
-    int64_t nTimeCutoff = GetTimeMillis() - 60 * 60 * 24 * 1000;
-    map<int64_t, uint64_t>::iterator iter = mapBloomFiltersOutBound.begin();
-    while (iter != mapBloomFiltersOutBound.end())
-    {
-        map<int64_t, uint64_t>::iterator mi = iter++; // increment to avoid iterator becoming invalid
-        if ((*mi).first < nTimeCutoff)
-            mapBloomFiltersOutBound.erase(mi);
-    }
+    updateStats(mapBloomFiltersOutBound, nBloomFilterSize);
 }
 
 void CThinBlockData::UpdateInBoundBloomFilter(uint64_t nBloomFilterSize)
 {
     LOCK(cs_thinblockstats);
-
-    mapBloomFiltersInBound[GetTimeMillis()] = nBloomFilterSize;
     nTotalBloomFilterBytes += nBloomFilterSize;
-
-    // Delete any entries that are more than 24 hours old
-    int64_t nTimeCutoff = GetTimeMillis() - 60 * 60 * 24 * 1000;
-    map<int64_t, uint64_t>::iterator iter = mapBloomFiltersInBound.begin();
-    while (iter != mapBloomFiltersInBound.end())
-    {
-        map<int64_t, uint64_t>::iterator mi = iter++; // increment to avoid iterator becoming invalid
-        if ((*mi).first < nTimeCutoff)
-            mapBloomFiltersInBound.erase(mi);
-    }
+    updateStats(mapBloomFiltersInBound, nBloomFilterSize);
 }
 
 void CThinBlockData::UpdateResponseTime(double nResponseTime)
@@ -1002,17 +1005,7 @@ void CThinBlockData::UpdateResponseTime(double nResponseTime)
     // only update stats if IBD is complete
     if (IsChainNearlySyncd() && IsThinBlocksEnabled())
     {
-        mapThinBlockResponseTime[GetTimeMillis()] = nResponseTime;
-
-        // Delete any entries that are more than 24 hours old
-        int64_t nTimeCutoff = GetTimeMillis() - 60 * 60 * 24 * 1000;
-        map<int64_t, double>::iterator iter = mapThinBlockResponseTime.begin();
-        while (iter != mapThinBlockResponseTime.end())
-        {
-            map<int64_t, double>::iterator mi = iter++; // increment to avoid iterator becoming invalid
-            if ((*mi).first < nTimeCutoff)
-                mapThinBlockResponseTime.erase(mi);
-        }
+        updateStats(mapThinBlockResponseTime, nResponseTime);
     }
 }
 
@@ -1023,17 +1016,7 @@ void CThinBlockData::UpdateValidationTime(double nValidationTime)
     // only update stats if IBD is complete
     if (IsChainNearlySyncd() && IsThinBlocksEnabled())
     {
-        mapThinBlockValidationTime[GetTimeMillis()] = nValidationTime;
-
-        // Delete any entries that are more than 24 hours old
-        int64_t nTimeCutoff = GetTimeMillis() - 60 * 60 * 24 * 1000;
-        map<int64_t, double>::iterator iter = mapThinBlockValidationTime.begin();
-        while (iter != mapThinBlockValidationTime.end())
-        {
-            map<int64_t, double>::iterator mi = iter++; // increment to avoid iterator becoming invalid
-            if ((*mi).first < nTimeCutoff)
-                mapThinBlockValidationTime.erase(mi);
-        }
+        updateStats(mapThinBlockValidationTime, nValidationTime);
     }
 }
 
@@ -1042,17 +1025,7 @@ void CThinBlockData::UpdateInBoundReRequestedTx(int nReRequestedTx)
     LOCK(cs_thinblockstats);
 
     // Update InBound thinblock tracking information
-    mapThinBlocksInBoundReRequestedTx[GetTimeMillis()] = nReRequestedTx;
-
-    // Delete any entries that are more than 24 hours old
-    int64_t nTimeCutoff = GetTimeMillis() - 60 * 60 * 24 * 1000;
-    map<int64_t, int>::iterator iter = mapThinBlocksInBoundReRequestedTx.begin();
-    while (iter != mapThinBlocksInBoundReRequestedTx.end())
-    {
-        map<int64_t, int>::iterator mi = iter++; // increment to avoid iterator becoming invalid
-        if ((*mi).first < nTimeCutoff)
-            mapThinBlocksInBoundReRequestedTx.erase(mi);
-    }
+    updateStats(mapThinBlocksInBoundReRequestedTx, nReRequestedTx);
 }
 
 void CThinBlockData::UpdateMempoolLimiterBytesSaved(unsigned int nBytesSaved)
@@ -1076,15 +1049,7 @@ string CThinBlockData::InBoundPercentToString()
 {
     LOCK(cs_thinblockstats);
 
-    // Delete any entries that are more than 24 hours old
-    int64_t nTimeCutoff = GetTimeMillis() - 60 * 60 * 24 * 1000;
-    map<int64_t, pair<uint64_t, uint64_t> >::iterator iter = mapThinBlocksInBound.begin();
-    while (iter != mapThinBlocksInBound.end())
-    {
-        map<int64_t, pair<uint64_t, uint64_t> >::iterator mi = iter++; // increment to avoid iterator becoming invalid
-        if ((*mi).first < nTimeCutoff)
-            mapThinBlocksInBound.erase(mi);
-    }
+    expireStats(mapThinBlocksInBound);
 
     double nCompressionRate = 0;
     uint64_t nThinSizeTotal = 0;
@@ -1119,15 +1084,7 @@ string CThinBlockData::OutBoundPercentToString()
 {
     LOCK(cs_thinblockstats);
 
-    // Delete any entries that are more than 24 hours old
-    int64_t nTimeCutoff = GetTimeMillis() - 60 * 60 * 24 * 1000;
-    map<int64_t, pair<uint64_t, uint64_t> >::iterator iter = mapThinBlocksOutBound.begin();
-    while (iter != mapThinBlocksOutBound.end())
-    {
-        map<int64_t, pair<uint64_t, uint64_t> >::iterator mi = iter++; // increment to avoid iterator becoming invalid
-        if ((*mi).first < nTimeCutoff)
-            mapThinBlocksOutBound.erase(mi);
-    }
+    expireStats(mapThinBlocksOutBound);
 
     double nCompressionRate = 0;
     uint64_t nThinSizeTotal = 0;
@@ -1159,28 +1116,7 @@ string CThinBlockData::OutBoundPercentToString()
 string CThinBlockData::InBoundBloomFiltersToString()
 {
     LOCK(cs_thinblockstats);
-
-    // Delete any entries that are more than 24 hours old
-    int64_t nTimeCutoff = GetTimeMillis() - 60 * 60 * 24 * 1000;
-    map<int64_t, uint64_t>::iterator iter = mapBloomFiltersInBound.begin();
-    while (iter != mapBloomFiltersInBound.end())
-    {
-        map<int64_t, uint64_t>::iterator mi = iter++; // increment to avoid iterator becoming invalid
-        if ((*mi).first < nTimeCutoff)
-            mapBloomFiltersInBound.erase(mi);
-    }
-
-    uint64_t nInBoundBloomFilters = 0;
-    uint64_t nInBoundBloomFilterSize = 0;
-    double avgBloomSize = 0;
-    for (map<int64_t, uint64_t>::iterator mi = mapBloomFiltersInBound.begin(); mi != mapBloomFiltersInBound.end(); ++mi)
-    {
-        nInBoundBloomFilterSize += (*mi).second;
-        nInBoundBloomFilters += 1;
-    }
-    if (nInBoundBloomFilters > 0)
-        avgBloomSize = (double)nInBoundBloomFilterSize / nInBoundBloomFilters;
-
+    double avgBloomSize = average(mapBloomFiltersInBound);
     ostringstream ss;
     ss << "Inbound bloom filter size (last 24hrs) AVG: " << formatInfoUnit(avgBloomSize);
     return ss.str();
@@ -1190,29 +1126,7 @@ string CThinBlockData::InBoundBloomFiltersToString()
 string CThinBlockData::OutBoundBloomFiltersToString()
 {
     LOCK(cs_thinblockstats);
-
-    // Delete any entries that are more than 24 hours old
-    int64_t nTimeCutoff = GetTimeMillis() - 60 * 60 * 24 * 1000;
-    map<int64_t, uint64_t>::iterator iter = mapBloomFiltersOutBound.begin();
-    while (iter != mapBloomFiltersOutBound.end())
-    {
-        map<int64_t, uint64_t>::iterator mi = iter++; // increment to avoid iterator becoming invalid
-        if ((*mi).first < nTimeCutoff)
-            mapBloomFiltersOutBound.erase(mi);
-    }
-
-    uint64_t nOutBoundBloomFilters = 0;
-    uint64_t nOutBoundBloomFilterSize = 0;
-    double avgBloomSize = 0;
-    for (map<int64_t, uint64_t>::iterator mi = mapBloomFiltersOutBound.begin(); mi != mapBloomFiltersOutBound.end();
-         ++mi)
-    {
-        nOutBoundBloomFilterSize += (*mi).second;
-        nOutBoundBloomFilters += 1;
-    }
-    if (nOutBoundBloomFilters > 0)
-        avgBloomSize = (double)nOutBoundBloomFilterSize / nOutBoundBloomFilters;
-
+    double avgBloomSize = average(mapBloomFiltersOutBound);
     ostringstream ss;
     ss << "Outbound bloom filter size (last 24hrs) AVG: " << formatInfoUnit(avgBloomSize);
     return ss.str();
@@ -1292,15 +1206,7 @@ string CThinBlockData::ReRequestedTxToString()
 {
     LOCK(cs_thinblockstats);
 
-    // Delete any entries that are more than 24 hours old
-    int64_t nTimeCutoff = GetTimeMillis() - 60 * 60 * 24 * 1000;
-    map<int64_t, int>::iterator iter = mapThinBlocksInBoundReRequestedTx.begin();
-    while (iter != mapThinBlocksInBoundReRequestedTx.end())
-    {
-        map<int64_t, int>::iterator mi = iter++; // increment to avoid iterator becoming invalid
-        if ((*mi).first < nTimeCutoff)
-            mapThinBlocksInBoundReRequestedTx.erase(mi);
-    }
+    expireStats(mapThinBlocksInBoundReRequestedTx);
 
     double nReRequestRate = 0;
     uint64_t nTotalReRequests = 0;

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -175,6 +175,7 @@ private:
     std::map<uint256, uint64_t> mapThinBlockTimer;
 
     CCriticalSection cs_thinblockstats; // locks everything below this point
+
     CStatHistory<uint64_t> nOriginalSize;
     CStatHistory<uint64_t> nThinSize;
     CStatHistory<uint64_t> nBlocks;
@@ -190,6 +191,29 @@ private:
     /* The sum total of all bytes for thinblocks currently in process of being reconstructed */
     uint64_t nThinBlockBytes;
 
+    /**
+        Add new entry to statistics array; also removes old timestamps
+        from statistics array using expireStats() below.
+        @param [statsMap] a statistics array
+        @param [value] the value to insert for the current time
+     */
+    template <class T>
+    void updateStats(std::map<int64_t, T> &statsMap, T value);
+
+    /**
+       Expire old statistics in given array (currently after one day).
+       Uses getTimeForStats() virtual method for timing. */
+    template <class T>
+    void expireStats(std::map<int64_t, T> &statsMap);
+
+    /**
+      Calculate average of long long values in given map. Return 0 for no entries.
+      Expires values before calculation. */
+    double average(std::map<int64_t, uint64_t> &map);
+
+protected:
+    //! Virtual method so it can be overridden for better unit testing
+    virtual int64_t getTimeForStats() { return GetTimeMillis(); }
 public:
     void UpdateInBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);
     void UpdateOutBound(uint64_t nThinBlockSize, uint64_t nOriginalBlockSize);


### PR DESCRIPTION
There's a lot of repeated code to deal with expiry of old
statistics values after a day.

This commit replaces the repeated sections with a call to a
template function to do so.