### PR TITLE
Fix getnetworkinfo XThinBlock statistics (port to `release`)

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -193,8 +193,8 @@ testScripts = [ RpcTest(t) for t in [
     Disabled('invalidblockrequest', "TODO"),
     'invalidtxrequest',
     'abandonconflict',
-    'p2p-versionbits-warning'
-    ,
+    'p2p-versionbits-warning',
+    'thinblocks'
 ] ]
 
 testScriptsExt = [ RpcTest(t) for t in [

--- a/qa/rpc-tests/thinblocks.py
+++ b/qa/rpc-tests/thinblocks.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2017 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+
+class ThinBlockTest(BitcoinTestFramework):
+    def __init__(self):
+        self.rep = False
+        BitcoinTestFramework.__init__(self)
+
+    def setup_chain(self):
+        print ("Initializing test directory " + self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 2)
+
+    def setup_network(self, split=False):
+        node_opts = [
+            "-rpcservertimeout=0",
+            "-debug=thin",
+            "-use-thinblocks=1",
+            "-excessiveblocksize=6000000",
+            "-blockprioritysize=6000000",
+            "-blockmaxsize=6000000"]
+
+        self.nodes = [
+            start_node(0, self.options.tmpdir, node_opts),
+            start_node(1, self.options.tmpdir, node_opts)
+        ]
+        interconnect_nodes(self.nodes)
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test(self):
+        self.nodes[0].generate(30)
+        self.sync_all()
+
+        gni = self.nodes[0].getnetworkinfo()
+        assert "thinblockstats" in gni
+
+        tbs = gni["thinblockstats"]
+        assert "enabled" in tbs and tbs["enabled"]
+
+        assert set(tbs) == {"enabled",
+                            "summary",
+                            "mempool_limiter",
+                            "inbound_percent",
+                            "outbound_percent",
+                            "response_time",
+                            "validation_time",
+                            "outbound_bloom_filters",
+                            "inbound_bloom_filters",
+                            "rerequested"}
+
+
+if __name__ == '__main__':
+    ThinBlockTest().main()

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -437,14 +437,14 @@ static UniValue GetThinBlockStats()
     obj.push_back(Pair("enabled", enabled));
     if (enabled) {
         obj.push_back(Pair("summary", thindata.ToString()));
-        obj.push_back(Pair("summary", thindata.MempoolLimiterBytesSavedToString()));
-        obj.push_back(Pair("summary", thindata.InBoundPercentToString()));
-        obj.push_back(Pair("summary", thindata.OutBoundPercentToString()));
-        obj.push_back(Pair("summary", thindata.ResponseTimeToString()));
-        obj.push_back(Pair("summary", thindata.ValidationTimeToString()));
-        obj.push_back(Pair("summary", thindata.OutBoundBloomFiltersToString()));
-        obj.push_back(Pair("summary", thindata.InBoundBloomFiltersToString()));
-        obj.push_back(Pair("summary", thindata.ReRequestedTxToString()));
+        obj.push_back(Pair("mempool_limiter", thindata.MempoolLimiterBytesSavedToString()));
+        obj.push_back(Pair("inbound_percent", thindata.InBoundPercentToString()));
+        obj.push_back(Pair("outbound_percent", thindata.OutBoundPercentToString()));
+        obj.push_back(Pair("response_time", thindata.ResponseTimeToString()));
+        obj.push_back(Pair("validation_time", thindata.ValidationTimeToString()));
+        obj.push_back(Pair("outbound_bloom_filters", thindata.OutBoundBloomFiltersToString()));
+        obj.push_back(Pair("inbound_bloom_filters", thindata.InBoundBloomFiltersToString()));
+        obj.push_back(Pair("rerequested", thindata.ReRequestedTxToString()));
     }
     return obj;
 }


### PR DESCRIPTION
This is a port of #547 to the `release` branch. Orginal
commits list:

ca0e7ca Fix getnetworkinfo XThinBlock statistics (awemany)
eaed868 qa/rpc-tests/thinblocks.py: Test some thinblocks stuff (awemany)