### PR TITLE
bug fix for -min-xthin-nodes

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1832,6 +1832,14 @@ void ThreadOpenConnections()
                     nDisconnects++;
                 }
             }
+
+            // In the event that outbound nodes restart or drop off the network over time we need to 
+            // replenish the number of disconnects allowed once per day.
+            if (GetTime() - nStart > 86400)
+            {
+                nDisconnects = 0;
+                nStart = GetTime();
+            }
         }
 
         // If disconnected then wait for disconnection completion

--- a/src/net.h
+++ b/src/net.h
@@ -74,8 +74,8 @@ static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 8;
 /** BU: The minimum number of xthin nodes to connect */
 static const uint8_t MIN_XTHIN_NODES = 4;
-/** BU: The maximum disconnects while searching for xthin nodes to connect */
-static const unsigned int MAX_DISCONNECTS = 500;
+/** BU: The daily maximum disconnects while searching for xthin nodes to connect */
+static const unsigned int MAX_DISCONNECTS = 200;
 /** The default for -maxuploadtarget. 0 = Unlimited */
 static const uint64_t DEFAULT_MAX_UPLOAD_TARGET = 0;
 /** Default for blocks only*/


### PR DESCRIPTION
Over timer outbound xthin nodes may disconnect from the network or one reason or another and eventually our MAX_DISCONNECTS value will be hit causing us to possibly not be able to maintain
enough connections to xthin nodes set by -min-xthin-nodes.  Here we simply replenish the nDisconnections and reset to zero once per day while also reducing the MAX_DISCONNECTS from 500 to 200.