### PR TITLE
Update seeders list.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -137,9 +137,14 @@ public:
         assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 
         // BITCOINUNLIMITED START
-        vSeeds.push_back(CDNSSeedData("btcc.com", "seed.btcc.com"));    // BTCC
+        vSeeds.push_back(CDNSSeedData("bitcoinunlimited.info", "seed.bitcoinunlimited.info")); // BU seeder
         vSeeds.push_back(CDNSSeedData("bitnodes.io", "seed.bitnodes.io"));      // Bitnodes (Addy Yeow)
-        vSeeds.push_back(CDNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be")); // Pieter Wuille
+        vSeeds.push_back(CDNSSeedData("bitcoinstats.com", "seed.bitcoinstats.com")); // Christian Decker
+        vSeeds.push_back(CDNSSeedData("bitcoin.jonasschnelli.ch", "seed.bitcoin.jonasschnelli.ch")); // Jonas Schnelli
+        vSeeds.push_back(CDNSSeedData("dashjr.org", "dnsseed.bitcoin.dashjr.org")); // Luke Dashjr
+        vSeeds.push_back(CDNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be")); // Pieter Wiulle
+        vSeeds.push_back(CDNSSeedData("bluematt.me", "dnsseed.bluematt.me")); // Matt Corallo
+
         // BITCOINUNLIMITED END
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,0);


### PR DESCRIPTION
Since we are going to maintain `release` branch longer that we supposed
adding BU managed seeder seems a usefull tihng todo.

Contextually the seeders list have been updated removing btcc's,
add Schnelli's, Decker's, Luke-jr's, Wiulle's and Corallo's.

Now we are in sync with XT and Core (modulo ptodd's).