### PR TITLE
Limit orphan pool size by total number of txns as well as by total pool bytes

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4881,6 +4881,7 @@ void UnloadBlockIndex()
         LOCK(cs_orphancache);
         mapOrphanTransactions.clear();
         mapOrphanTransactionsByPrev.clear();
+        nBytesOrphanPool = 0;
     }
 
     LOCK(cs_main);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -799,7 +799,6 @@ bool AddOrphanTx(const CTransaction &tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(c
     if (sz > MAX_STANDARD_TX_SIZE)
     {
         LogPrint("mempool", "ignoring large orphan tx (size: %u, hash: %s)\n", sz, hash.ToString());
-        printf("ignoring large orphan tx (size: %u, hash: %s)\n", sz, hash.ToString().c_str());
         return false;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,6 +96,7 @@ extern std::map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(cs_orphanca
 extern std::map<uint256, std::set<uint256> > mapOrphanTransactionsByPrev GUARDED_BY(cs_orphancache);
 
 int64_t nLastOrphanCheck = GetTime(); // Used in EraseOrphansByTime()
+static uint64_t nBytesOrphanPool = 0; // Current in memory size of the orphan pool.
 
 // BU: start block download at low numbers in case our peers are slow when we start
 /** Number of blocks that can be requested at any given time from a single peer. */
@@ -793,35 +794,26 @@ bool AddOrphanTx(const CTransaction &tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(c
     if (mapOrphanTransactions.count(hash))
         return false;
 
-    // Ignore big transactions, to avoid a
-    // send-big-orphans memory exhaustion attack. If a peer has a legitimate
-    // large transaction with a missing parent then we assume
-    // it will rebroadcast it later, after the parent transaction(s)
-    // have been mined or received.
-    // 10,000 orphans, each of which is at most 5,000 bytes big is
-    // at most 500 megabytes of orphans:
-
-    // BU - Xtreme Thinblocks - begin section
-    // BU - we do not limit the size of orphans.  There is no danger to having memory overrun since the
-    //      orphan cache is limited to only 5000 entries by default. Only 500MB of memory could be consumed
-    //      if there were some kind of orphan memory exhaustion attack.
-    //      Dropping any tx means they need to be included in the thin block when it it mined, which is inefficient.
+    // Ignore orphans larger than the largest txn size allowed.
     unsigned int sz = tx.GetSerializeSize(SER_NETWORK, CTransaction::CURRENT_VERSION);
     if (sz > MAX_STANDARD_TX_SIZE)
     {
         LogPrint("mempool", "ignoring large orphan tx (size: %u, hash: %s)\n", sz, hash.ToString());
+        printf("ignoring large orphan tx (size: %u, hash: %s)\n", sz, hash.ToString().c_str());
         return false;
     }
-    // BU - Xtreme Thinblocks - end section
 
+    uint64_t txSize = RecursiveDynamicUsage(tx);
     mapOrphanTransactions[hash].tx = tx;
     mapOrphanTransactions[hash].fromPeer = peer;
     mapOrphanTransactions[hash].nEntryTime = GetTime(); // BU - Xtreme Thinblocks;
+    mapOrphanTransactions[hash].nOrphanTxSize = txSize;
     BOOST_FOREACH (const CTxIn &txin, tx.vin)
         mapOrphanTransactionsByPrev[txin.prevout.hash].insert(hash);
 
-    LogPrint("mempool", "stored orphan tx %s (mapsz %u prevsz %u)\n", hash.ToString(), mapOrphanTransactions.size(),
-        mapOrphanTransactionsByPrev.size());
+    nBytesOrphanPool += txSize;
+    LogPrint("mempool", "stored orphan tx %s bytes:%ld (mapsz %u prevsz %u), orphan pool bytes:%ld\n", hash.ToString(),
+        txSize, mapOrphanTransactions.size(), mapOrphanTransactionsByPrev.size(), nBytesOrphanPool);
     return true;
 }
 
@@ -841,6 +833,10 @@ void EraseOrphanTx(uint256 hash) EXCLUSIVE_LOCKS_REQUIRED(cs_orphancache)
         if (itPrev->second.empty())
             mapOrphanTransactionsByPrev.erase(itPrev);
     }
+
+    nBytesOrphanPool -= it->second.nOrphanTxSize;
+    LogPrint("mempool", "Erased orphan tx %s of size %ld bytes, orphan pool bytes:%ld\n",
+        it->second.tx.GetHash().ToString(), it->second.nOrphanTxSize, nBytesOrphanPool);
     mapOrphanTransactions.erase(it);
 }
 
@@ -862,9 +858,9 @@ void EraseOrphansByTime() EXCLUSIVE_LOCKS_REQUIRED(cs_orphancache)
         if (nEntryTime < nOrphanTxCutoffTime)
         {
             uint256 txHash = mi->second.tx.GetHash();
-            EraseOrphanTx(txHash);
             LogPrint(
                 "mempool", "Erased old orphan tx %s of age %d seconds\n", txHash.ToString(), GetTime() - nEntryTime);
+            EraseOrphanTx(txHash);
         }
     }
 
@@ -872,12 +868,15 @@ void EraseOrphansByTime() EXCLUSIVE_LOCKS_REQUIRED(cs_orphancache)
 }
 // BU - Xtreme Thinblocks: end
 
-unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans) EXCLUSIVE_LOCKS_REQUIRED(cs_orphancache)
+unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans, uint64_t nMaxBytes) EXCLUSIVE_LOCKS_REQUIRED(cs_orphancache)
 {
     AssertLockHeld(cs_orphancache);
 
+    // Limit the orphan pool size by either number of transactions or the max orphan pool size allowed.
+    // Limiting by pool size to 1/10th the size of the maxmempool alone is not enough because the total number
+    // of txns in the pool can adversely effect the size of the bloom filter in a get_xthin message.
     unsigned int nEvicted = 0;
-    while (mapOrphanTransactions.size() > nMaxOrphans)
+    while (mapOrphanTransactions.size() > nMaxOrphans || nBytesOrphanPool > nMaxBytes)
     {
         // Evict a random orphan:
         uint256 randomhash = GetRandHash();
@@ -6350,9 +6349,11 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             AddOrphanTx(tx, pfrom->GetId());
 
             // DoS prevention: do not allow mapOrphanTransactions to grow unbounded
-            unsigned int nMaxOrphanTx =
+            static unsigned int nMaxOrphanTx =
                 (unsigned int)std::max((int64_t)0, GetArg("-maxorphantx", DEFAULT_MAX_ORPHAN_TRANSACTIONS));
-            unsigned int nEvicted = LimitOrphanTxSize(nMaxOrphanTx);
+            static uint64_t nMaxOrphanPoolSize =
+                (uint64_t)std::max((int64_t)0, (GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000 / 10));
+            unsigned int nEvicted = LimitOrphanTxSize(nMaxOrphanTx, nMaxOrphanPoolSize);
             if (nEvicted > 0)
                 LogPrint("mempool", "mapOrphan overflow, removed %u tx\n", nEvicted);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -790,6 +790,9 @@ bool AddOrphanTx(const CTransaction &tx, NodeId peer) EXCLUSIVE_LOCKS_REQUIRED(c
 {
     AssertLockHeld(cs_orphancache);
 
+    if (mapOrphanTransactions.empty())
+        nBytesOrphanPool = 0;
+
     uint256 hash = tx.GetHash();
     if (mapOrphanTransactions.count(hash))
         return false;

--- a/src/main.h
+++ b/src/main.h
@@ -652,6 +652,7 @@ struct COrphanTx
     CTransaction tx;
     NodeId fromPeer;
     int64_t nEntryTime; // BU - Xtreme Thinblocks: used for aging orphans out of the cache
+    uint64_t nOrphanTxSize;
 };
 // BU: begin creating separate critical section for orphan cache and untangling from cs_main.
 extern CCriticalSection cs_orphancache;

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -27,7 +27,7 @@
 extern bool AddOrphanTx(const CTransaction& tx, NodeId peer);
 extern void EraseOrphansFor(NodeId peer);
 extern void EraseOrphansByTime();
-extern unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans);
+extern unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans, uint64_t nMaxBytes);
 
 CService ip(uint32_t i)
 {
@@ -117,6 +117,35 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
     CBasicKeyStore keystore;
     keystore.AddKey(key);
 
+    // Test LimitOrphanTxSize() function: limit by orphan pool bytes
+    // add 50 orphan transactions:
+    for (int i = 0; i < 50; i++)
+    {
+        CMutableTransaction tx;
+        tx.vin.resize(1);
+        tx.vin[0].prevout.n = 0;
+        tx.vin[0].prevout.hash = GetRandHash();
+        tx.vin[0].scriptSig << OP_1;
+        tx.vout.resize(1);
+        tx.vout[0].nValue = 1*CENT;
+        tx.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
+      
+        LOCK(cs_orphancache);
+        AddOrphanTx(tx, i);
+    }
+
+    {
+        LOCK(cs_orphancache);
+        LimitOrphanTxSize(50, 8000);
+        BOOST_CHECK_EQUAL(mapOrphanTransactions.size(), 50);
+        LimitOrphanTxSize(50, 6300);
+        BOOST_CHECK(mapOrphanTransactions.size() <= 49);
+        LimitOrphanTxSize(50, 1000);
+        BOOST_CHECK(mapOrphanTransactions.size() <= 8);
+        LimitOrphanTxSize(50, 0);
+        BOOST_CHECK(mapOrphanTransactions.empty());
+    }
+
     // 50 orphan transactions:
     for (int i = 0; i < 50; i++)
     {
@@ -176,14 +205,14 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         BOOST_CHECK(AddOrphanTx(tx, i));  // BU, we keep orphans up to the configured memory limit to help xthin compression so this should succeed whereas it fails in other clients
     }
 
-    // Test LimitOrphanTxSize() function:
+    // Test LimitOrphanTxSize() function: limit by number of txns
     {
         LOCK(cs_orphancache);
-        LimitOrphanTxSize(40);
-        BOOST_CHECK(mapOrphanTransactions.size() <= 40);
-        LimitOrphanTxSize(10);
-        BOOST_CHECK(mapOrphanTransactions.size() <= 10);
-        LimitOrphanTxSize(0);
+        LimitOrphanTxSize(40, 10000000);
+        BOOST_CHECK_EQUAL(mapOrphanTransactions.size(), 40);
+        LimitOrphanTxSize(10, 10000000);
+        BOOST_CHECK_EQUAL(mapOrphanTransactions.size(), 10);
+        LimitOrphanTxSize(0, 10000000);
         BOOST_CHECK(mapOrphanTransactions.empty());
         BOOST_CHECK(mapOrphanTransactionsByPrev.empty());
     }

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -176,15 +176,6 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         BOOST_CHECK(AddOrphanTx(tx, i));  // BU, we keep orphans up to the configured memory limit to help xthin compression so this should succeed whereas it fails in other clients
     }
 
-    // Test EraseOrphansFor:
-    for (NodeId i = 0; i < 3; i++)
-    {
-        size_t sizeBefore = mapOrphanTransactions.size();
-        LOCK(cs_orphancache);
-        EraseOrphansFor(i);
-        BOOST_CHECK(mapOrphanTransactions.size() < sizeBefore);
-    }
-
     // Test LimitOrphanTxSize() function:
     {
         LOCK(cs_orphancache);


### PR DESCRIPTION
Keep track of the orphan pool bytes so we can limit by bytes as well as the limiting by number of txns, whichever limit is hit first. (We still want to keep the limiting by number of txns in place because that keeps the bloom filters used in xthins from getting too large.)