### PR TITLE
[wip] Backport Core #10344:Fix abandonconflict.py intermittency (jnewbery)

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -755,3 +755,15 @@ def create_lots_of_big_transactions(node, txouts, utxos, fee):
 def get_bip9_status(node, key):
     info = node.getblockchaininfo()
     return info['bip9_softforks'][key]
+
+def disconnect_nodes(from_connection, node_num):
+    for peer_id in [peer['id'] for peer in from_connection.getpeerinfo() if "testnode%d" % node_num in peer['subver']]:
+        from_connection.disconnectnode(nodeid=peer_id)
+
+    for _ in range(50):
+        if [peer['id'] for peer in from_connection.getpeerinfo() if "testnode%d" % node_num in peer['subver']] == []:
+            break
+        time.sleep(0.1)
+    else:
+        raise AssertionError("timed out waiting for disconnect")
+

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -332,7 +332,7 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     if binary is None:
         binary = os.getenv("BITCOIND", "bitcoind")
     # RPC tests still depend on free transactions
-    args = [ binary, "-datadir="+datadir, "-rest", "-mocktime="+str(get_mocktime()) ] # // BU removed, "-keypool=1","-blockprioritysize=50000" ]
+    args = [binary, "-datadir=" + datadir, "-server", "-keypool=1", "-discover=0", "-rest", "-logtimemicros", "-debug", "-mocktime=" + str(get_mocktime()), "-uacomment=testnode%d" % i]
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args)
     if os.getenv("PYTHON_DEBUG", ""):
@@ -354,6 +354,8 @@ def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, binary=None,t
     """
     if extra_args is None: extra_args = [ None for i in range(num_nodes) ]
     if binary is None: binary = [ None for i in range(num_nodes) ]
+    assert_equal(len(extra_args), num_nodes)
+    assert_equal(len(binary), num_nodes)
     rpcs = []
     try:
         for i in range(num_nodes):


### PR DESCRIPTION
Had to add the new disconnect_nodes() method in util.py .
According to https://github.com/bitcoin/bitcoin/pull/10344/ :

"abandonconflict.py intermittently fails (about 1 time out of 25 for me). The failure is caused by a race between shutting down node0 and a transaction being INV'ed from node0 and getting into node1's mempool.

The original intent was that node0 and node1 should be disconnected before sending the transaction in node0. However, the call to disconnectnode() doesn't actually disconnect the nodes because there are two P2P connections between node0 and node1 (connect_nodes_bi() madness).

This PR change the direct call to disconnectnode() into a call to the test_framework/util function disconnect_nodes() which fully disconnects the nodes. It also asserts that node1's mempool is empty after stop-starting node0."