### PR TITLE
thinblocksinflight timer updates

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7211,8 +7211,7 @@ bool SendMessages(CNode *pto)
                     {
                         LogPrint("thin", "ERROR: Disconnecting peer=%d due to download timeout exceeded "
                                          "(%d secs)\n",
-                            pto->GetId(),
-                            (GetTime() - (*iter).second.nRequestTime));
+                            pto->GetId(), (GetTime() - (*iter).second.nRequestTime));
                         pto->fDisconnect = true;
                         break;
                     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7204,16 +7204,16 @@ bool SendMessages(CNode *pto)
             if (pto->mapThinBlocksInFlight.size() > 0)
             {
                 LOCK(pto->cs_mapthinblocksinflight);
-                std::map<uint256, int64_t>::iterator iter = pto->mapThinBlocksInFlight.begin();
+                std::map<uint256, CNode::CThinBlockInFlight>::iterator iter = pto->mapThinBlocksInFlight.begin();
                 while (iter != pto->mapThinBlocksInFlight.end())
                 {
-                    if ((*iter).second != -1 && (GetTime() - (*iter).second) > THINBLOCK_DOWNLOAD_TIMEOUT)
+                    if (!(*iter).second.fReceived && (GetTime() - (*iter).second.nRequestTime) > THINBLOCK_DOWNLOAD_TIMEOUT)
                     {
                         if (!pto->fWhitelisted && Params().NetworkIDString() != "regtest")
                         {
                             LogPrint("thin", "ERROR: Disconnecting peer=%d due to download timeout exceeded "
                                              "(%d secs)\n",
-                                pto->GetId(), (GetTime() - (*iter).second));
+                                pto->GetId(), (GetTime() - (*iter).second.nRequestTime));
                             pto->fDisconnect = true;
                             break;
                         }

--- a/src/net.h
+++ b/src/net.h
@@ -350,11 +350,16 @@ public:
 class CNode
 {
 public:
-
     struct CThinBlockInFlight
     {
         int64_t nRequestTime;
         bool fReceived;
+
+        CThinBlockInFlight()
+        {
+            nRequestTime = GetTime();
+            fReceived = false;
+        }
     };
 
     // socket

--- a/src/net.h
+++ b/src/net.h
@@ -350,6 +350,13 @@ public:
 class CNode
 {
 public:
+
+    struct CThinBlockInFlight
+    {
+        int64_t nRequestTime;
+        bool fReceived;
+    };
+
     // socket
     uint64_t nServices;
     SOCKET hSocket;
@@ -417,7 +424,7 @@ public:
     int nSizeThinBlock; // Original on-wire size of the block. Just used for reporting
     int thinBlockWaitingForTxns; // if -1 then not currently waiting
     CCriticalSection cs_mapthinblocksinflight; // lock mapThinBlocksInFlight
-    std::map<uint256, int64_t> mapThinBlocksInFlight; // thin blocks in flight and the time requested.
+    std::map<uint256, CThinBlockInFlight> mapThinBlocksInFlight; // thin blocks in flight and the time requested.
     double nGetXBlockTxCount; // Count how many get_xblocktx requests are made
     uint64_t nGetXBlockTxLastTime; // The last time a get_xblocktx request was made
     double nGetXthinCount; // Count how many get_xthin requests are made

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -496,15 +496,13 @@ void HandleBlockMessageThread(CNode *pfrom, const string &strCommand, const CBlo
     CValidationState state;
     uint64_t nSizeBlock = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
 
-    // At this point we have either a block or a fully reconstructed thinblock but we still need to
-    // maintain a mapThinBlocksInFlight entry so that we don't re-request a full block from
-    // the same node while the block is processing. Furthermore by setting the time = -1 we prevent
-    // the timeout from triggering and inadvertently disconnecting the node in the event that the block
-    // takes a longer time to process than the THINBLOCK_DOWNLOAD_TIMEOUT interval.
+    // Indicate that the thinblock was fully received. At this point we have either a block or a fully reconstructed
+    // thinblock but we still need to maintain a mapThinBlocksInFlight entry so that we don't re-request a full block
+    // from the same node while the block is processing.
     {
         LOCK(pfrom->cs_mapthinblocksinflight);
         if (pfrom->mapThinBlocksInFlight.count(inv.hash))
-            pfrom->mapThinBlocksInFlight[inv.hash] = -1;
+            pfrom->mapThinBlocksInFlight[inv.hash].fReceived = true;
     }
 
 

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -373,7 +373,8 @@ void RequestBlock(CNode *pfrom, CInv obj)
                 { // We can only send one thinblock per peer at a time
                     {
                         LOCK(pfrom->cs_mapthinblocksinflight);
-                        pfrom->mapThinBlocksInFlight[inv2.hash].nRequestTime = GetTime();
+                        pfrom->mapThinBlocksInFlight.insert(
+                            std::pair<uint256, CNode::CThinBlockInFlight>(inv2.hash, CNode::CThinBlockInFlight()));
                     }
                     inv2.type = MSG_XTHINBLOCK;
                     std::vector<uint256> vOrphanHashes;
@@ -401,7 +402,8 @@ void RequestBlock(CNode *pfrom, CInv obj)
                 {
                     {
                         LOCK(pfrom->cs_mapthinblocksinflight);
-                        pfrom->mapThinBlocksInFlight[inv2.hash].nRequestTime = GetTime();
+                        pfrom->mapThinBlocksInFlight.insert(
+                            std::pair<uint256, CNode::CThinBlockInFlight>(inv2.hash, CNode::CThinBlockInFlight()));
                     }
                     inv2.type = MSG_XTHINBLOCK;
                     std::vector<uint256> vOrphanHashes;

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -373,7 +373,7 @@ void RequestBlock(CNode *pfrom, CInv obj)
                 { // We can only send one thinblock per peer at a time
                     {
                         LOCK(pfrom->cs_mapthinblocksinflight);
-                        pfrom->mapThinBlocksInFlight[inv2.hash] = GetTime();
+                        pfrom->mapThinBlocksInFlight[inv2.hash].nRequestTime = GetTime();
                     }
                     inv2.type = MSG_XTHINBLOCK;
                     std::vector<uint256> vOrphanHashes;
@@ -401,7 +401,7 @@ void RequestBlock(CNode *pfrom, CInv obj)
                 {
                     {
                         LOCK(pfrom->cs_mapthinblocksinflight);
-                        pfrom->mapThinBlocksInFlight[inv2.hash] = GetTime();
+                        pfrom->mapThinBlocksInFlight[inv2.hash].nRequestTime = GetTime();
                     }
                     inv2.type = MSG_XTHINBLOCK;
                     std::vector<uint256> vOrphanHashes;

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -704,7 +704,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     excessiveBlockSize = 234;
 
     // Add the node to vNodes and also we need a thinblockinflight entry
-    dummyNode6.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    dummyNode6.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
     vNodes.push_back(&dummyNode6);
 
     // Process an xthinblock
@@ -755,13 +755,13 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     excessiveBlockSize = 234;
 
     // Add the node to vNodes and also we need a thinblockinflight entry
-    dummyNode6.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    dummyNode6.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
     vNodes.push_back(&dummyNode6);
-    dummyNode7.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    dummyNode7.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
     vNodes.push_back(&dummyNode7);
-    dummyNode8.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    dummyNode8.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
     vNodes.push_back(&dummyNode8);
-    dummyNode9.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    dummyNode9.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
     vNodes.push_back(&dummyNode9);
 
     // manually set the nLocalThinBlockBytes to be lower than the actual bytes of the thinblock that we will
@@ -816,13 +816,13 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     excessiveBlockSize = 234;
 
     // Add the node to vNodes and also we need a thinblockinflight entry
-    dummyNode6.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    dummyNode6.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
     vNodes.push_back(&dummyNode6);
-    dummyNode7.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    dummyNode7.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
     vNodes.push_back(&dummyNode7);
-    dummyNode8.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    dummyNode8.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
     vNodes.push_back(&dummyNode8);
-    dummyNode9.mapThinBlocksInFlight[TestBlock1().GetHash()] = GetTime();
+    dummyNode9.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
     vNodes.push_back(&dummyNode9);
 
     // manually set two of the nLocalThinBlockBytes to be higher than the actual bytes of the thinblock that we will


### PR DESCRIPTION
The first commit about creating a bool to track if we've received the thinblock or not, rather than trying to use the RequestTime for two separate purposes.  Makes the code easier to follow.

The second commit is just a one liner ... main.cpp line 6346 was taken out and the rest of what looks like a lot of change is just indentation.