### PR TITLE
Request Manager fix for a not yet requested thinblock

### DIFF
--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -338,7 +338,7 @@ bool CUnknownObj::AddSource(CNode *from)
   return false;
 }
 
-void RequestBlock(CNode *pfrom, CInv obj)
+bool RequestBlock(CNode *pfrom, CInv obj)
 {
     const CChainParams &chainParams = Params();
 
@@ -390,6 +390,7 @@ void RequestBlock(CNode *pfrom, CInv obj)
                     pfrom->PushMessage(NetMsgType::GET_XTHIN, ss);
                     LogPrint("thin", "Requesting Thinblock %s from peer %s (%d)\n", inv2.hash.ToString(),
                         pfrom->addrName.c_str(), pfrom->id);
+                    return true;
                 }
             }
             else
@@ -427,6 +428,7 @@ void RequestBlock(CNode *pfrom, CInv obj)
                     vToFetch.push_back(inv2);
                     pfrom->PushMessage(NetMsgType::GETDATA, vToFetch);
                 }
+                return true;
             }
         }
         else
@@ -438,7 +440,9 @@ void RequestBlock(CNode *pfrom, CInv obj)
             pfrom->PushMessage(NetMsgType::GETDATA, vToFetch);
             LogPrint("thin", "Requesting Regular Block %s from peer %s (%d)\n", inv2.hash.ToString(),
                 pfrom->addrName.c_str(), pfrom->id);
+            return true;
         }
+        return false; // no block was requested
         // BUIP010 Xtreme Thinblocks: end section
     }
 }
@@ -531,10 +535,11 @@ void CRequestManager::SendRequests()
 
                     CInv obj = item.obj;
                     cs_objDownloader.unlock();
-
-                    RequestBlock(next.node, obj);
-                    item.outstandingReqs++;
-                    item.lastRequestTime = now;
+                    if (RequestBlock(next.node, obj))
+                    {
+                        item.outstandingReqs++;
+                        item.lastRequestTime = now;
+                    }
 
                     cs_objDownloader.lock();
 


### PR DESCRIPTION
This fixes an issue issue with blocks not getting requested right away and having to wait for the first request manager re-request, which could be up to 30 seconds if rate limiting is turned on.  What was happening was that because we use the 10 second thintimer, we won't request a block for 10 seconds unless it's an xthin but however sometimes the first blocksource is from a non XTHIN node and so we end up not making the request and since no other sources were yet available we would wait until the re-request before getting our xthin.  Now as soon as block sources arrive (either headers or INV) we check again if we can make the request.