### PR TITLE
Use NodeRef to avoid nodes disappearing from underneath us

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -895,22 +895,11 @@ void RPCConsole::disconnectSelectedNode()
     // Get currently selected peer address
     QString strNode = GUIUtil::getEntryData(ui->peerWidget, 0, PeerTableModel::Address);
 
-    //BU: Enforce cs_vNodes lock held external to FindNode function calls to prevent use-after-free errors
-    CNode* bannedNode = NULL;
-    {
-        LOCK(cs_vNodes);
-        bannedNode = FindNode(strNode.toStdString());
-
-        //BU: Since we are making UI update calls below, we want to protect bannedNode from deletion
-        //    while still being able to release the lock on cs_vNodes to not block on a UI update
-        if (bannedNode) bannedNode->AddRef();
-    }
-
     // Find the node, disconnect it and clear the selected node
-    if (bannedNode) {
-        bannedNode->fDisconnect = true;
-        //BU: Remember to release the reference we took on bannedNode to protect from use-after-free
-        bannedNode->Release();
+    CNodeRef node = FindNodeRef(strNode.toStdString());
+    if (node)
+    {
+        node->fDisconnect = true;
         clearSelectedNode();
     }
 }
@@ -923,19 +912,10 @@ void RPCConsole::banSelectedNode(int bantime)
     // Get currently selected peer address
     QString strNode = GUIUtil::getEntryData(ui->peerWidget, 0, PeerTableModel::Address);
 
-    //BU: Enforce cs_vNodes lock held external to FindNode function calls to prevent use-after-free errors
-    CNode* bannedNode = NULL;
+    // Find the node, ban it and clear the selected node
+    CNodeRef bannedNode = FindNodeRef(strNode.toStdString());
+    if (bannedNode)
     {
-        LOCK(cs_vNodes);
-        bannedNode = FindNode(strNode.toStdString());
-
-        //BU: Since we are making UI update calls below, we want to protect bannedNode from deletion
-        //    while still being able to release the lock on cs_vNodes to not block on a UI update
-        if (bannedNode) bannedNode->AddRef();
-    }
-
-    // Find possible nodes, ban it and clear the selected node
-    if (bannedNode) {
         std::string nStr = strNode.toStdString();
         std::string addr;
         int port = 0;
@@ -943,8 +923,6 @@ void RPCConsole::banSelectedNode(int bantime)
 
         CNode::Ban(CNetAddr(addr), BanReasonManuallyAdded, bantime);
         bannedNode->fDisconnect = true;
-        //BU: Remember to release the reference we took on bannedNode to protect from use-after-free
-        bannedNode->Release();
 
         clearSelectedNode();
     }

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -162,6 +162,52 @@ BOOST_AUTO_TEST_CASE(cnode_simple_test)
     std::unique_ptr<CNode> pnode2(new CNode(hSocket, addr, pszDest, fInboundIn));
     BOOST_CHECK(pnode2->fInbound == true);
     BOOST_CHECK(pnode2->fFeeler == false);
+
+    // NodeRef checks and refcount checks.
+    BOOST_CHECK_EQUAL(pnode1->nRefCount, 0);
+
+    // Check null pointers are good
+    {
+        CNodeRef ref;       // Default constructor
+        BOOST_CHECK(!ref);  // operator bool
+        ref = 0;
+        BOOST_CHECK(!ref);
+    }
+
+    // get()
+    {
+        CNodeRef ref1(pnode1.get());
+        CNodeRef ref2;
+        BOOST_CHECK(ref1.get() == pnode1.get());
+        BOOST_CHECK(ref2.get() == nullptr);
+    }
+
+    // Plain constructor and copy constructor
+    {
+        CNodeRef ref1(pnode1.get());
+        BOOST_CHECK_EQUAL(pnode1->nRefCount, 1);
+
+        {
+            CNodeRef ref2(ref1);
+            BOOST_CHECK_EQUAL(pnode1->nRefCount, 2);
+        }
+
+        BOOST_CHECK_EQUAL(pnode1->nRefCount, 1);
+    }
+    BOOST_CHECK_EQUAL(pnode1->nRefCount, 0);
+
+    // Assignment operator
+    {
+        CNodeRef ref1;
+
+        ref1 = pnode1.get();
+        BOOST_CHECK_EQUAL(pnode1->nRefCount, 1);
+        ref1 = ref1;
+        BOOST_CHECK_EQUAL(pnode1->nRefCount, 1);
+        ref1 = nullptr;
+        BOOST_CHECK_EQUAL(pnode1->nRefCount, 0);
+    }
+    BOOST_CHECK_EQUAL(pnode1->nRefCount, 0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(json_parse_errors)
 BOOST_AUTO_TEST_CASE(rpc_ban)
 {
     BOOST_CHECK_NO_THROW(CallRPC(string("clearbanned")));
-    
+
     UniValue r;
     BOOST_CHECK_NO_THROW(r = CallRPC(string("setban 127.0.0.0 add")));
     BOOST_CHECK_THROW(r = CallRPC(string("setban 127.0.0.0:8334")), runtime_error); //portnumber for setban not allowed
@@ -323,16 +323,16 @@ BOOST_AUTO_TEST_CASE(findlikelynode)
   vNodes.push_back(&n2);
 
   // Test prefix matching
-  BOOST_CHECK(FindLikelyNode("169.254.1.2") == &n1);
-  BOOST_CHECK(FindLikelyNode("169.254.1.2:1234") == NULL);
-  BOOST_CHECK(FindLikelyNode("169.254.1") == &n1);
+  BOOST_CHECK(FindLikelyNode("169.254.1.2").get() == &n1);
+  BOOST_CHECK(FindLikelyNode("169.254.1.2:1234").get() == NULL);
+  BOOST_CHECK(FindLikelyNode("169.254.1").get() == &n1);
 
   // Test wildcard matching
-  BOOST_CHECK(FindLikelyNode("169.254.1*") == &n1);
-  BOOST_CHECK(FindLikelyNode("169.254.2*") == &n2);
-  BOOST_CHECK(FindLikelyNode("169.254.2.3*") == &n2);
-  BOOST_CHECK(FindLikelyNode("169.254.2.?:?") == &n2);
-  BOOST_CHECK(FindLikelyNode("169.254.1.?:*") == &n1);
+  BOOST_CHECK(FindLikelyNode("169.254.1*").get() == &n1);
+  BOOST_CHECK(FindLikelyNode("169.254.2*").get() == &n2);
+  BOOST_CHECK(FindLikelyNode("169.254.2.3*").get() == &n2);
+  BOOST_CHECK(FindLikelyNode("169.254.2.?:?").get() == &n2);
+  BOOST_CHECK(FindLikelyNode("169.254.1.?:*").get() == &n1);
 
   vNodes.clear();
 }

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -1530,19 +1530,15 @@ void CheckNodeSupportForThinBlocks()
 {
     if (IsThinBlocksEnabled())
     {
-        // BU: Enforce cs_vNodes lock held external to FindNode function calls to prevent use-after-free errors
-        LOCK(cs_vNodes);
         // Check that a nodes pointed to with connect-thinblock actually supports thinblocks
         BOOST_FOREACH (string &strAddr, mapMultiArgs["-connect-thinblock"])
         {
-            if (CNode *pnode = FindNode(strAddr))
+            CNodeRef node = FindNodeRef(strAddr);
+            if (node && !node->ThinBlockCapable())
             {
-                if (!pnode->ThinBlockCapable())
-                {
-                    LogPrintf("ERROR: You are trying to use connect-thinblocks but to a node that does not support it "
-                              "- Protocol Version: %d peer=%d\n",
-                        pnode->nVersion, pnode->id);
-                }
+                LogPrintf("ERROR: You are trying to use connect-thinblocks but to a node that does not support it "
+                          "- Protocol Version: %d peer=%s\n",
+                    node->nVersion, node->GetLogName());
             }
         }
     }

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -44,6 +44,7 @@ class CBlockIndex;
 class CValidationState;
 struct CDiskBlockPos;
 class CNode;
+class CNodeRef;
 class CChainParams;
 
 
@@ -84,7 +85,7 @@ int32_t UnlimitedComputeBlockVersion(const CBlockIndex *pindexPrev, const Consen
 // The function also allows * or ? wildcards.
 // This is useful for the RPC calls.
 // Returns the first node that matches.
-extern CNode *FindLikelyNode(const std::string &addrName);
+extern CNodeRef FindLikelyNode(const std::string &addrName);
 
 // Convert the BUComments to the string client's "subversion" string
 extern void settingsToUserAgentString();


### PR DESCRIPTION
- move NodeRef from net.cpp to net.h, add handy methods
- add tests to net_tests that it works as expected
- make FindNode static in net.cpp; use FindNodeRef as the external interface
- remove unused overloaded instance of FindNode function taking a subnet
- use FindNodeRef in rpc/ and unlimited.cpp
- have FindLikelyNode return a NodeRef