### PR TITLE
Create connection manager

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -90,6 +90,7 @@ BITCOIN_CORE_H = \
   compat/endian.h \
   compat/sanity.h \
   compressor.h \
+  connmgr.h \
   consensus/consensus.h \
   core_io.h \
   core_memusage.h \
@@ -175,6 +176,7 @@ libbitcoin_server_a_SOURCES = \
   bloom.cpp \
   chain.cpp \
   checkpoints.cpp \
+  connmgr.cpp \
   expedited.cpp \
   httprpc.cpp \
   httpserver.cpp \

--- a/src/connmgr.cpp
+++ b/src/connmgr.cpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2016-2017 The Bitcoin Unlimited developers
+
+#include <atomic>
+
+#include "connmgr.h"
+
+
+NodeId CConnMgr::nextNodeId()
+{
+    static std::atomic<NodeId> next;
+
+    // Pre-increment; do not use zero
+    return ++next;
+}
+
+std::unique_ptr<CConnMgr> connmgr(new CConnMgr);

--- a/src/connmgr.h
+++ b/src/connmgr.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2016-2017 The Bitcoin Unlimited developers
+
+#ifndef BITCOIN_CONNMGR_H
+#define BITCOIN_CONNMGR_H
+
+#include "net.h"
+
+class CConnMgr
+{
+public:
+    static NodeId nextNodeId();
+};
+
+extern std::unique_ptr<CConnMgr> connmgr;
+
+#endif

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -93,7 +93,6 @@ CCriticalSection CNode::cs_totalBytesSent;
 CCriticalSection cs_setservAddNodeAddresses;
 CCriticalSection cs_vAddedNodes;
 CCriticalSection cs_vUseDNSSeeds;
-CCriticalSection cs_nLastNodeId;
 CCriticalSection cs_mapInboundConnectionTracker;
 CCriticalSection cs_vOneShots;
 

--- a/src/net.h
+++ b/src/net.h
@@ -118,6 +118,8 @@ void StartNode(boost::thread_group &threadGroup, CScheduler &scheduler);
 bool StopNode();
 int SocketSendData(CNode *pnode);
 
+// Node IDs are currently signed but only values greater than zero are returned.  Zero or negative can be used as a
+// sentinel value.
 typedef int NodeId;
 
 struct CombinerAll
@@ -197,9 +199,6 @@ extern limitedmap<uint256, int64_t> mapAlreadyAskedFor;
 
 extern std::vector<std::string> vAddedNodes;
 extern CCriticalSection cs_vAddedNodes;
-
-extern NodeId nLastNodeId;
-extern CCriticalSection cs_nLastNodeId;
 
 /** Subversion as sent to the P2P network in `version` messages */
 extern std::string strSubVersion;


### PR DESCRIPTION
Intended to handle and hide low-level node and connection handling details, and associated locking.
Currently just provides node IDs using C++11 atomic rather than critical sections.

Wondering what others think of this; I think it's a useful abstraction and we can gradually move bits of logic here as I just did with the nodeID counter.