### PR TITLE
[Refactor] (1 of 4) Move CNodeState, related structs and State function to nodestate.h|.cpp

### DIFF
--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -23,3 +23,5 @@ qt/unlimiteddialog.cpp
 qt/unlimiteddialog.h
 qt/unlimitedmodel.cpp
 qt/unlimitedmodel.h
+nodestate.cpp
+nodestate.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,6 +109,7 @@ BITCOIN_CORE_H = \
   merkleblock.h \
   miner.h \
   net.h \
+  nodestate.h \
   leakybucket.h \
   netbase.h \
   noui.h \
@@ -188,6 +189,7 @@ libbitcoin_server_a_SOURCES = \
   merkleblock.cpp \
   miner.cpp \
   net.cpp \
+  nodestate.cpp \
   noui.cpp \
   parallel.cpp \
   policy/fees.cpp \

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -19,6 +19,7 @@
 #include "main.h"
 #include "miner.h"
 #include "net.h"
+#include "nodestate.h"
 #include "parallel.h"
 #include "policy/policy.h"
 #include "primitives/block.h"
@@ -74,6 +75,10 @@ CConditionVariable cvBlockChange;
 proxyType proxyInfo[NET_MAX];
 proxyType nameProxy;
 CCriticalSection cs_proxyInfos;
+
+// moved from main.cpp (now part of nodestate.h)
+std::map<uint256, pair<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight;
+std::map<NodeId, CNodeState> mapNodeState;
 
 set<uint256> setPreVerifiedTxHash;
 set<uint256> setUnVerifiedOrphanTxHash;

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "nodestate.h"
+
+/**
+* Default constructor initializing all local member variables to "null" values
+*/
+CNodeState::CNodeState()
+{
+    fCurrentlyConnected = false;
+    nMisbehavior = 0;
+    fShouldBan = false;
+    pindexBestKnownBlock = NULL;
+    hashLastUnknownBlock.SetNull();
+    pindexLastCommonBlock = NULL;
+    pindexBestHeaderSent = NULL;
+    fSyncStarted = false;
+    nDownloadingSince = 0;
+    nBlocksInFlight = 0;
+    nBlocksInFlightValidHeaders = 0;
+    fPreferredDownload = false;
+    fPreferHeaders = false;
+}
+
+/**
+* Gets the CNodeState for the specified NodeId.
+*
+* @param[in] pnode  The NodeId to return CNodeState* for
+* @return CNodeState* matching the NodeId, or NULL if NodeId is not matched
+*/
+CNodeState *State(NodeId pnode)
+{
+    std::map<NodeId, CNodeState>::iterator it = mapNodeState.find(pnode);
+    if (it == mapNodeState.end())
+        return NULL;
+    return &it->second;
+}

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -1,0 +1,85 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODESTATE_H
+#define BITCOIN_NODESTATE_H
+
+#include "net.h" // For NodeId
+
+/** Blocks that are in flight, and that are in the queue to be downloaded. Protected by cs_main. */
+struct QueuedBlock
+{
+    uint256 hash;
+    CBlockIndex *pindex; //!< Optional.
+    int64_t nTime; //! Time of "getdata" request in microseconds.
+    bool fValidatedHeaders; //!< Whether this block has validated headers at the time of request.
+};
+
+extern std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight;
+
+
+struct CBlockReject
+{
+    unsigned char chRejectCode;
+    std::string strRejectReason;
+    uint256 hashBlock;
+};
+
+/**
+* Maintain validation-specific state about nodes, protected by cs_main, instead
+* by CNode's own locks. This simplifies asynchronous operation, where
+* processing of incoming data is done after the ProcessMessage call returns,
+* and we're no longer holding the node's locks.
+*/
+struct CNodeState
+{
+    //! The peer's address
+    CService address;
+    //! Whether we have a fully established connection.
+    bool fCurrentlyConnected;
+    //! Accumulated misbehaviour score for this peer.
+    int nMisbehavior;
+    //! Whether this peer should be disconnected and banned (unless whitelisted).
+    bool fShouldBan;
+    //! String name of this peer (debugging/logging purposes).
+    std::string name;
+    //! List of asynchronously-determined block rejections to notify this peer about.
+    std::vector<CBlockReject> rejects;
+    //! The best known block we know this peer has announced.
+    CBlockIndex *pindexBestKnownBlock;
+    //! The hash of the last unknown block this peer has announced.
+    uint256 hashLastUnknownBlock;
+    //! The last full block we both have.
+    CBlockIndex *pindexLastCommonBlock;
+    //! The best header we have sent our peer.
+    CBlockIndex *pindexBestHeaderSent;
+    //! Whether we've started headers synchronization with this peer.
+    bool fSyncStarted;
+    //! The start time of the sync
+    int64_t fSyncStartTime;
+    //! Were the first headers requested in a sync received
+    bool fFirstHeadersReceived;
+
+    std::list<QueuedBlock> vBlocksInFlight;
+    //! When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.
+    int64_t nDownloadingSince;
+    int nBlocksInFlight;
+    int nBlocksInFlightValidHeaders;
+    //! Whether we consider this a preferred download peer.
+    bool fPreferredDownload;
+    //! Whether this peer wants invs or headers (when possible) for block announcements.
+    bool fPreferHeaders;
+
+    CNodeState();
+};
+
+/** Map maintaining per-node state. Requires cs_main. */
+extern std::map<NodeId, CNodeState> mapNodeState;
+
+// Requires cs_main.
+extern CNodeState *State(NodeId pnode);
+
+#endif // BITCOIN_NODESTATE_H


### PR DESCRIPTION
This is a precursor refactor leading up to creation of a DoS manager class to encapsulate all of the DoS related functionality.  As part of that I will be moving the `Misbehaving` functionality from main.h|.cpp to the DoS manager.  `Misbehaving` relies on the `State` function and `CNodeState` entries.  In order to not have to rely on including main.h in the manager, I am splitting out the relevant structs and functions to their own source file.

This PR:
1. Moves `CNodeState`, `QueuedBlock`, and `CBlockReject` from main.cpp to nodestate.h|.cpp.
2. Moves global collections `mapBlocksInFlight` and `mapNodeState` from main.cpp to instantiate in globals.cpp with extern references in nodestate.h.
3. Moves the `State` function from main.cpp to new nodestate.h|.cpp
4. Add doxygen comments for all method definitions in nodestate.cpp
5. Add nodestate.h|.cpp to clang format list.