### PR TITLE
[Refactor] (2 of 4) Move CBanEntry from net.h|.cpp to banentry.h|.cpp

### DIFF
--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -23,3 +23,5 @@ qt/unlimiteddialog.cpp
 qt/unlimiteddialog.h
 qt/unlimitedmodel.cpp
 qt/unlimitedmodel.h
+nodestate.cpp
+nodestate.h

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -25,3 +25,5 @@ qt/unlimitedmodel.cpp
 qt/unlimitedmodel.h
 nodestate.cpp
 nodestate.h
+banentry.cpp
+banentry.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,6 +109,7 @@ BITCOIN_CORE_H = \
   merkleblock.h \
   miner.h \
   net.h \
+  nodestate.h \
   leakybucket.h \
   netbase.h \
   noui.h \
@@ -188,6 +189,7 @@ libbitcoin_server_a_SOURCES = \
   merkleblock.cpp \
   miner.cpp \
   net.cpp \
+  nodestate.cpp \
   noui.cpp \
   parallel.cpp \
   policy/fees.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,6 +76,7 @@ BITCOIN_CORE_H = \
   addrman.h \
   allowed_args.h \
   base58.h \
+  banentry.h \
   bitnodes.h \
   bloom.h \
   chain.h \
@@ -175,6 +176,7 @@ libbitcoin_server_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_server_a_SOURCES = \
   globals.cpp \
   addrman.cpp \
+  banentry.cpp \
   bitnodes.cpp \
   bloom.cpp \
   chain.cpp \

--- a/src/banentry.cpp
+++ b/src/banentry.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "banentry.h"
+
+/**
+* Default constructor initializes all member variables to "null" equivalents
+*/
+CBanEntry::CBanEntry()
+{
+    // set all member variables to null equivalents
+    SetNull();
+}
+
+/**
+* This constructor initializes all member variables to "null" equivalents,
+* except for the ban creation time, which is set to the value passed in.
+*
+* @param[in] nCreateTimeIn Creation time to initialize this CBanEntry to
+*/
+CBanEntry::CBanEntry(int64_t nCreateTimeIn)
+{
+    // set all member variables to null equivalents
+    SetNull();
+    nCreateTime = nCreateTimeIn;
+}
+
+/**
+* Set all member variables to their "null" equivalent values
+*/
+void CBanEntry::SetNull()
+{
+    nVersion = CBanEntry::CURRENT_VERSION;
+    nCreateTime = 0;
+    nBanUntil = 0;
+    banReason = BanReasonUnknown;
+}
+
+/**
+* Converts the BanReason to a human readable string representation.
+*
+* @return Human readable string representation of the BanReason
+*/
+std::string CBanEntry::banReasonToString()
+{
+    switch (banReason)
+    {
+    case BanReasonNodeMisbehaving:
+        return "node misbehaving";
+    case BanReasonManuallyAdded:
+        return "manually added";
+    default:
+        return "unknown";
+    }
+}

--- a/src/banentry.h
+++ b/src/banentry.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_BANENTRY_H
+#define BITCOIN_BANENTRY_H
+
+// NOTE: netbase.h includes serialize.h which is required for serialization macros
+#include "netbase.h" // for CSubNet
+
+typedef enum BanReason { BanReasonUnknown = 0, BanReasonNodeMisbehaving = 1, BanReasonManuallyAdded = 2 } BanReason;
+
+class CBanEntry
+{
+public:
+    static const int CURRENT_VERSION = 1;
+    int nVersion;
+    int64_t nCreateTime;
+    int64_t nBanUntil;
+    uint8_t banReason;
+
+    CBanEntry();
+    CBanEntry(int64_t nCreateTimeIn);
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action, int nType, int nVersion)
+    {
+        READWRITE(this->nVersion);
+        nVersion = this->nVersion;
+        READWRITE(nCreateTime);
+        READWRITE(nBanUntil);
+        READWRITE(banReason);
+    }
+
+    void SetNull();
+
+    std::string banReasonToString();
+};
+
+typedef std::map<CSubNet, CBanEntry> banmap_t;
+
+#endif // BITCOIN_BANENTRY_H

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -19,6 +19,7 @@
 #include "main.h"
 #include "miner.h"
 #include "net.h"
+#include "nodestate.h"
 #include "parallel.h"
 #include "policy/policy.h"
 #include "primitives/block.h"
@@ -74,6 +75,10 @@ CConditionVariable cvBlockChange;
 proxyType proxyInfo[NET_MAX];
 proxyType nameProxy;
 CCriticalSection cs_proxyInfos;
+
+// moved from main.cpp (now part of nodestate.h)
+std::map<uint256, pair<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight;
+std::map<NodeId, CNodeState> mapNodeState;
 
 set<uint256> setPreVerifiedTxHash;
 set<uint256> setUnVerifiedOrphanTxHash;

--- a/src/net.h
+++ b/src/net.h
@@ -29,6 +29,7 @@
 #include <boost/foreach.hpp>
 #include <boost/signals2/signal.hpp>
 
+#include "banentry.h"
 #include "stat.h"
 #include "unlimited.h"
 
@@ -276,60 +277,6 @@ public:
     int readData(const char *pch, unsigned int nBytes);
 };
 
-
-typedef enum BanReason { BanReasonUnknown = 0, BanReasonNodeMisbehaving = 1, BanReasonManuallyAdded = 2 } BanReason;
-
-class CBanEntry
-{
-public:
-    static const int CURRENT_VERSION = 1;
-    int nVersion;
-    int64_t nCreateTime;
-    int64_t nBanUntil;
-    uint8_t banReason;
-
-    CBanEntry() { SetNull(); }
-    CBanEntry(int64_t nCreateTimeIn)
-    {
-        SetNull();
-        nCreateTime = nCreateTimeIn;
-    }
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action, int nType, int nVersion)
-    {
-        READWRITE(this->nVersion);
-        nVersion = this->nVersion;
-        READWRITE(nCreateTime);
-        READWRITE(nBanUntil);
-        READWRITE(banReason);
-    }
-
-    void SetNull()
-    {
-        nVersion = CBanEntry::CURRENT_VERSION;
-        nCreateTime = 0;
-        nBanUntil = 0;
-        banReason = BanReasonUnknown;
-    }
-
-    std::string banReasonToString()
-    {
-        switch (banReason)
-        {
-        case BanReasonNodeMisbehaving:
-            return "node misbehaving";
-        case BanReasonManuallyAdded:
-            return "manually added";
-        default:
-            return "unknown";
-        }
-    }
-};
-
-typedef std::map<CSubNet, CBanEntry> banmap_t;
 
 // BU cleaning up nodes as a global destructor creates many global destruction dependencies.  Instead use a function
 // call.

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "nodestate.h"
+
+/**
+* Default constructor initializing all local member variables to "null" values
+*/
+CNodeState::CNodeState()
+{
+    fCurrentlyConnected = false;
+    nMisbehavior = 0;
+    fShouldBan = false;
+    pindexBestKnownBlock = NULL;
+    hashLastUnknownBlock.SetNull();
+    pindexLastCommonBlock = NULL;
+    pindexBestHeaderSent = NULL;
+    fSyncStarted = false;
+    nDownloadingSince = 0;
+    nBlocksInFlight = 0;
+    nBlocksInFlightValidHeaders = 0;
+    fPreferredDownload = false;
+    fPreferHeaders = false;
+}
+
+/**
+* Gets the CNodeState for the specified NodeId.
+*
+* @param[in] pnode  The NodeId to return CNodeState* for
+* @return CNodeState* matching the NodeId, or NULL if NodeId is not matched
+*/
+CNodeState *State(NodeId pnode)
+{
+    std::map<NodeId, CNodeState>::iterator it = mapNodeState.find(pnode);
+    if (it == mapNodeState.end())
+        return NULL;
+    return &it->second;
+}

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -1,0 +1,85 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODESTATE_H
+#define BITCOIN_NODESTATE_H
+
+#include "net.h" // For NodeId
+
+/** Blocks that are in flight, and that are in the queue to be downloaded. Protected by cs_main. */
+struct QueuedBlock
+{
+    uint256 hash;
+    CBlockIndex *pindex; //!< Optional.
+    int64_t nTime; //! Time of "getdata" request in microseconds.
+    bool fValidatedHeaders; //!< Whether this block has validated headers at the time of request.
+};
+
+extern std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight;
+
+
+struct CBlockReject
+{
+    unsigned char chRejectCode;
+    std::string strRejectReason;
+    uint256 hashBlock;
+};
+
+/**
+* Maintain validation-specific state about nodes, protected by cs_main, instead
+* by CNode's own locks. This simplifies asynchronous operation, where
+* processing of incoming data is done after the ProcessMessage call returns,
+* and we're no longer holding the node's locks.
+*/
+struct CNodeState
+{
+    //! The peer's address
+    CService address;
+    //! Whether we have a fully established connection.
+    bool fCurrentlyConnected;
+    //! Accumulated misbehaviour score for this peer.
+    int nMisbehavior;
+    //! Whether this peer should be disconnected and banned (unless whitelisted).
+    bool fShouldBan;
+    //! String name of this peer (debugging/logging purposes).
+    std::string name;
+    //! List of asynchronously-determined block rejections to notify this peer about.
+    std::vector<CBlockReject> rejects;
+    //! The best known block we know this peer has announced.
+    CBlockIndex *pindexBestKnownBlock;
+    //! The hash of the last unknown block this peer has announced.
+    uint256 hashLastUnknownBlock;
+    //! The last full block we both have.
+    CBlockIndex *pindexLastCommonBlock;
+    //! The best header we have sent our peer.
+    CBlockIndex *pindexBestHeaderSent;
+    //! Whether we've started headers synchronization with this peer.
+    bool fSyncStarted;
+    //! The start time of the sync
+    int64_t fSyncStartTime;
+    //! Were the first headers requested in a sync received
+    bool fFirstHeadersReceived;
+
+    std::list<QueuedBlock> vBlocksInFlight;
+    //! When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.
+    int64_t nDownloadingSince;
+    int nBlocksInFlight;
+    int nBlocksInFlightValidHeaders;
+    //! Whether we consider this a preferred download peer.
+    bool fPreferredDownload;
+    //! Whether this peer wants invs or headers (when possible) for block announcements.
+    bool fPreferHeaders;
+
+    CNodeState();
+};
+
+/** Map maintaining per-node state. Requires cs_main. */
+extern std::map<NodeId, CNodeState> mapNodeState;
+
+// Requires cs_main.
+extern CNodeState *State(NodeId pnode);
+
+#endif // BITCOIN_NODESTATE_H


### PR DESCRIPTION
This is a precursor refactor leading up to creation of a DoS manager class to encapsulate all of the DoS related functionality.  This builds on #616 and should be merged second.

This PR moves `CBanEntry` declaration/definition and `banmap_t` typedef from net.h|.cpp to it's own banentry.h|.cpp files.  This allows selective inclusion of banentry.h where needed instead of including net.h everywhere.

This PR:
1. Moves `CBanEntry` and `banmap_t` from net.h|.cpp to banentry.h|.cpp
2. Moves all non-template method definitions to banentry.cpp instead of polluting the header.
3. Add doxygen comments for all method definitions in banentry.cpp
4. Add banentry.h|.cpp to clang format list.