### PR TITLE
[Refactor] (3 of 4) Move CBanDB from net.h|.cpp to bandb.h|.cpp

### DIFF
--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -23,3 +23,5 @@ qt/unlimiteddialog.cpp
 qt/unlimiteddialog.h
 qt/unlimitedmodel.cpp
 qt/unlimitedmodel.h
+nodestate.cpp
+nodestate.h

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -27,3 +27,5 @@ nodestate.cpp
 nodestate.h
 banentry.cpp
 banentry.h
+bandb.cpp
+bandb.h

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -25,3 +25,5 @@ qt/unlimitedmodel.cpp
 qt/unlimitedmodel.h
 nodestate.cpp
 nodestate.h
+banentry.cpp
+banentry.h

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -29,3 +29,4 @@ banentry.cpp
 banentry.h
 bandb.cpp
 bandb.h
+test/bandb_tests.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,6 +109,7 @@ BITCOIN_CORE_H = \
   merkleblock.h \
   miner.h \
   net.h \
+  nodestate.h \
   leakybucket.h \
   netbase.h \
   noui.h \
@@ -188,6 +189,7 @@ libbitcoin_server_a_SOURCES = \
   merkleblock.cpp \
   miner.cpp \
   net.cpp \
+  nodestate.cpp \
   noui.cpp \
   parallel.cpp \
   policy/fees.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,6 +76,7 @@ BITCOIN_CORE_H = \
   addrman.h \
   allowed_args.h \
   base58.h \
+  banentry.h \
   bitnodes.h \
   bloom.h \
   chain.h \
@@ -175,6 +176,7 @@ libbitcoin_server_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_server_a_SOURCES = \
   globals.cpp \
   addrman.cpp \
+  banentry.cpp \
   bitnodes.cpp \
   bloom.cpp \
   chain.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,6 +76,7 @@ BITCOIN_CORE_H = \
   addrman.h \
   allowed_args.h \
   base58.h \
+  bandb.h \
   banentry.h \
   bitnodes.h \
   bloom.h \
@@ -176,6 +177,7 @@ libbitcoin_server_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_server_a_SOURCES = \
   globals.cpp \
   addrman.cpp \
+  bandb.cpp \
   banentry.cpp \
   bitnodes.cpp \
   bloom.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -42,6 +42,7 @@ BITCOIN_TESTS =\
   test/addrman_tests.cpp \
   test/alert_tests.cpp \
   test/allocator_tests.cpp \
+  test/bandb_tests.cpp \
   test/base32_tests.cpp \
   test/base58_tests.cpp \
   test/base64_tests.cpp \

--- a/src/bandb.cpp
+++ b/src/bandb.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bandb.h"
+#include "chainparams.h"
+#include "clientversion.h"
+#include "hash.h"
+#include "random.h"
+#include "streams.h"
+
+/**
+* Default constructor initializes CBanDB file path based on user specified
+* data directory.
+*/
+CBanDB::CBanDB()
+{
+    // initialize the CBanDB file path based on user specified data directory
+    pathBanlist = GetDataDir() / "banlist.dat";
+}
+
+/**
+* Writes the the passed in banmap_t to disk
+*
+* @param[in] banSet  The banmap_t to write to disk
+* @return true if banlist successfully written to disk, otherwise false
+*/
+bool CBanDB::Write(const banmap_t &banSet)
+{
+    // Generate random temporary filename
+    unsigned short randv = 0;
+    GetRandBytes((unsigned char *)&randv, sizeof(randv));
+    std::string tmpfn = strprintf("banlist.dat.%04x", randv);
+
+    // serialize banlist, checksum data up to that point, then append csum
+    CDataStream ssBanlist(SER_DISK, CLIENT_VERSION);
+    ssBanlist << FLATDATA(Params().MessageStart());
+    ssBanlist << banSet;
+    uint256 hash = Hash(ssBanlist.begin(), ssBanlist.end());
+    ssBanlist << hash;
+
+    // open temp output file, and associate with CAutoFile
+    boost::filesystem::path pathTmp = GetDataDir() / tmpfn;
+    FILE *file = fopen(pathTmp.string().c_str(), "wb");
+    CAutoFile fileout(file, SER_DISK, CLIENT_VERSION);
+    if (fileout.IsNull())
+        return error("%s: Failed to open file %s", __func__, pathTmp.string());
+
+    // Write and commit header, data
+    try
+    {
+        fileout << ssBanlist;
+    }
+    catch (const std::exception &e)
+    {
+        return error("%s: Serialize or I/O error - %s", __func__, e.what());
+    }
+    FileCommit(fileout.Get());
+    fileout.fclose();
+
+    // replace existing banlist.dat, if any, with new banlist.dat.XXXX
+    if (!RenameOver(pathTmp, pathBanlist))
+        return error("%s: Rename-into-place failed", __func__);
+
+    return true;
+}
+
+/**
+* Reads the banlist from disk and stores in the passed in banmap_t
+*
+* @param[in,out] banSet  The banmap_t to which ban entries are added
+* @return true if banlist successfully read from disk, otherwise false
+*/
+bool CBanDB::Read(banmap_t &banSet)
+{
+    // open input file, and associate with CAutoFile
+    FILE *file = fopen(pathBanlist.string().c_str(), "rb");
+    CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
+    if (filein.IsNull())
+        return error("%s: Failed to open file %s", __func__, pathBanlist.string());
+
+    // use file size to size memory buffer
+    uint64_t fileSize = boost::filesystem::file_size(pathBanlist);
+    uint64_t dataSize = 0;
+    // Don't try to resize to a negative number if file is small
+    if (fileSize >= sizeof(uint256))
+        dataSize = fileSize - sizeof(uint256);
+    std::vector<unsigned char> vchData;
+    vchData.resize(dataSize);
+    uint256 hashIn;
+
+    // read data and checksum from file
+    try
+    {
+        filein.read((char *)&vchData[0], dataSize);
+        filein >> hashIn;
+    }
+    catch (const std::exception &e)
+    {
+        return error("%s: Deserialize or I/O error - %s", __func__, e.what());
+    }
+    filein.fclose();
+
+    CDataStream ssBanlist(vchData, SER_DISK, CLIENT_VERSION);
+
+    // verify stored checksum matches input data
+    uint256 hashTmp = Hash(ssBanlist.begin(), ssBanlist.end());
+    if (hashIn != hashTmp)
+        return error("%s: Checksum mismatch, data corrupted", __func__);
+
+    unsigned char pchMsgTmp[4];
+    try
+    {
+        // de-serialize file header (network specific magic number) and ..
+        ssBanlist >> FLATDATA(pchMsgTmp);
+
+        // ... verify the network matches ours
+        if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp)))
+            return error("%s: Invalid network magic number", __func__);
+
+        // de-serialize banlist data into one banmap_t object
+        ssBanlist >> banSet;
+    }
+    catch (const std::exception &e)
+    {
+        return error("%s: Deserialize or I/O error - %s", __func__, e.what());
+    }
+
+    return true;
+}

--- a/src/bandb.h
+++ b/src/bandb.h
@@ -21,6 +21,9 @@ public:
     CBanDB();
     bool Write(const banmap_t &banSet);
     bool Read(banmap_t &banSet);
+
+    // NOTE: Added for use in unit testing
+    boost::filesystem::path GetDatabasePath() const { return pathBanlist; }
 };
 
 #endif // BITCOIN_BANDB_H

--- a/src/bandb.h
+++ b/src/bandb.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_BANDB_H
+#define BITCOIN_BANDB_H
+
+#include "banentry.h" // for banmap_t
+
+#include <boost/filesystem.hpp>
+
+/** Access to the banlist database (banlist.dat) */
+class CBanDB
+{
+private:
+    boost::filesystem::path pathBanlist;
+
+public:
+    CBanDB();
+    bool Write(const banmap_t &banSet);
+    bool Read(banmap_t &banSet);
+};
+
+#endif // BITCOIN_BANDB_H

--- a/src/banentry.cpp
+++ b/src/banentry.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "banentry.h"
+
+/**
+* Default constructor initializes all member variables to "null" equivalents
+*/
+CBanEntry::CBanEntry()
+{
+    // set all member variables to null equivalents
+    SetNull();
+}
+
+/**
+* This constructor initializes all member variables to "null" equivalents,
+* except for the ban creation time, which is set to the value passed in.
+*
+* @param[in] nCreateTimeIn Creation time to initialize this CBanEntry to
+*/
+CBanEntry::CBanEntry(int64_t nCreateTimeIn)
+{
+    // set all member variables to null equivalents
+    SetNull();
+    nCreateTime = nCreateTimeIn;
+}
+
+/**
+* Set all member variables to their "null" equivalent values
+*/
+void CBanEntry::SetNull()
+{
+    nVersion = CBanEntry::CURRENT_VERSION;
+    nCreateTime = 0;
+    nBanUntil = 0;
+    banReason = BanReasonUnknown;
+}
+
+/**
+* Converts the BanReason to a human readable string representation.
+*
+* @return Human readable string representation of the BanReason
+*/
+std::string CBanEntry::banReasonToString()
+{
+    switch (banReason)
+    {
+    case BanReasonNodeMisbehaving:
+        return "node misbehaving";
+    case BanReasonManuallyAdded:
+        return "manually added";
+    default:
+        return "unknown";
+    }
+}

--- a/src/banentry.h
+++ b/src/banentry.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_BANENTRY_H
+#define BITCOIN_BANENTRY_H
+
+// NOTE: netbase.h includes serialize.h which is required for serialization macros
+#include "netbase.h" // for CSubNet
+
+typedef enum BanReason { BanReasonUnknown = 0, BanReasonNodeMisbehaving = 1, BanReasonManuallyAdded = 2 } BanReason;
+
+class CBanEntry
+{
+public:
+    static const int CURRENT_VERSION = 1;
+    int nVersion;
+    int64_t nCreateTime;
+    int64_t nBanUntil;
+    uint8_t banReason;
+
+    CBanEntry();
+    CBanEntry(int64_t nCreateTimeIn);
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action, int nType, int nVersion)
+    {
+        READWRITE(this->nVersion);
+        nVersion = this->nVersion;
+        READWRITE(nCreateTime);
+        READWRITE(nBanUntil);
+        READWRITE(banReason);
+    }
+
+    void SetNull();
+
+    std::string banReasonToString();
+};
+
+typedef std::map<CSubNet, CBanEntry> banmap_t;
+
+#endif // BITCOIN_BANENTRY_H

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -19,6 +19,7 @@
 #include "main.h"
 #include "miner.h"
 #include "net.h"
+#include "nodestate.h"
 #include "parallel.h"
 #include "policy/policy.h"
 #include "primitives/block.h"
@@ -74,6 +75,10 @@ CConditionVariable cvBlockChange;
 proxyType proxyInfo[NET_MAX];
 proxyType nameProxy;
 CCriticalSection cs_proxyInfos;
+
+// moved from main.cpp (now part of nodestate.h)
+std::map<uint256, pair<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight;
+std::map<NodeId, CNodeState> mapNodeState;
 
 set<uint256> setPreVerifiedTxHash;
 set<uint256> setUnVerifiedOrphanTxHash;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -11,6 +11,7 @@
 #include "net.h"
 
 #include "addrman.h"
+#include "bandb.h"
 #include "chainparams.h"
 #include "clientversion.h"
 #include "connmgr.h"
@@ -3145,109 +3146,6 @@ void CNode::EndMessage() UNLOCK_FUNCTION(cs_vSend)
         SocketSendData(this);
 
     LEAVE_CRITICAL_SECTION(cs_vSend);
-}
-
-//
-// CBanDB
-//
-
-CBanDB::CBanDB() { pathBanlist = GetDataDir() / "banlist.dat"; }
-bool CBanDB::Write(const banmap_t &banSet)
-{
-    // Generate random temporary filename
-    unsigned short randv = 0;
-    GetRandBytes((unsigned char *)&randv, sizeof(randv));
-    std::string tmpfn = strprintf("banlist.dat.%04x", randv);
-
-    // serialize banlist, checksum data up to that point, then append csum
-    CDataStream ssBanlist(SER_DISK, CLIENT_VERSION);
-    ssBanlist << FLATDATA(Params().MessageStart());
-    ssBanlist << banSet;
-    uint256 hash = Hash(ssBanlist.begin(), ssBanlist.end());
-    ssBanlist << hash;
-
-    // open temp output file, and associate with CAutoFile
-    boost::filesystem::path pathTmp = GetDataDir() / tmpfn;
-    FILE *file = fopen(pathTmp.string().c_str(), "wb");
-    CAutoFile fileout(file, SER_DISK, CLIENT_VERSION);
-    if (fileout.IsNull())
-        return error("%s: Failed to open file %s", __func__, pathTmp.string());
-
-    // Write and commit header, data
-    try
-    {
-        fileout << ssBanlist;
-    }
-    catch (const std::exception &e)
-    {
-        return error("%s: Serialize or I/O error - %s", __func__, e.what());
-    }
-    FileCommit(fileout.Get());
-    fileout.fclose();
-
-    // replace existing banlist.dat, if any, with new banlist.dat.XXXX
-    if (!RenameOver(pathTmp, pathBanlist))
-        return error("%s: Rename-into-place failed", __func__);
-
-    return true;
-}
-
-bool CBanDB::Read(banmap_t &banSet)
-{
-    // open input file, and associate with CAutoFile
-    FILE *file = fopen(pathBanlist.string().c_str(), "rb");
-    CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
-    if (filein.IsNull())
-        return error("%s: Failed to open file %s", __func__, pathBanlist.string());
-
-    // use file size to size memory buffer
-    uint64_t fileSize = boost::filesystem::file_size(pathBanlist);
-    uint64_t dataSize = 0;
-    // Don't try to resize to a negative number if file is small
-    if (fileSize >= sizeof(uint256))
-        dataSize = fileSize - sizeof(uint256);
-    vector<unsigned char> vchData;
-    vchData.resize(dataSize);
-    uint256 hashIn;
-
-    // read data and checksum from file
-    try
-    {
-        filein.read((char *)&vchData[0], dataSize);
-        filein >> hashIn;
-    }
-    catch (const std::exception &e)
-    {
-        return error("%s: Deserialize or I/O error - %s", __func__, e.what());
-    }
-    filein.fclose();
-
-    CDataStream ssBanlist(vchData, SER_DISK, CLIENT_VERSION);
-
-    // verify stored checksum matches input data
-    uint256 hashTmp = Hash(ssBanlist.begin(), ssBanlist.end());
-    if (hashIn != hashTmp)
-        return error("%s: Checksum mismatch, data corrupted", __func__);
-
-    unsigned char pchMsgTmp[4];
-    try
-    {
-        // de-serialize file header (network specific magic number) and ..
-        ssBanlist >> FLATDATA(pchMsgTmp);
-
-        // ... verify the network matches ours
-        if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp)))
-            return error("%s: Invalid network magic number", __func__);
-
-        // de-serialize address data into one CAddrMan object
-        ssBanlist >> banSet;
-    }
-    catch (const std::exception &e)
-    {
-        return error("%s: Deserialize or I/O error - %s", __func__, e.what());
-    }
-
-    return true;
 }
 
 int64_t PoissonNextSend(int64_t nNow, int average_interval_seconds)

--- a/src/net.h
+++ b/src/net.h
@@ -917,19 +917,6 @@ public:
     bool Read(CAddrMan &addr, CDataStream &ssPeers);
 };
 
-/** Access to the banlist database (banlist.dat) */
-class CBanDB
-{
-private:
-    boost::filesystem::path pathBanlist;
-
-public:
-    CBanDB();
-    bool Write(const banmap_t &banSet);
-    bool Read(banmap_t &banSet);
-};
-
-
 /** Return a timestamp in the future (in microseconds) for exponentially distributed events. */
 int64_t PoissonNextSend(int64_t nNow, int average_interval_seconds);
 

--- a/src/net.h
+++ b/src/net.h
@@ -29,6 +29,7 @@
 #include <boost/foreach.hpp>
 #include <boost/signals2/signal.hpp>
 
+#include "banentry.h"
 #include "stat.h"
 #include "unlimited.h"
 
@@ -276,60 +277,6 @@ public:
     int readData(const char *pch, unsigned int nBytes);
 };
 
-
-typedef enum BanReason { BanReasonUnknown = 0, BanReasonNodeMisbehaving = 1, BanReasonManuallyAdded = 2 } BanReason;
-
-class CBanEntry
-{
-public:
-    static const int CURRENT_VERSION = 1;
-    int nVersion;
-    int64_t nCreateTime;
-    int64_t nBanUntil;
-    uint8_t banReason;
-
-    CBanEntry() { SetNull(); }
-    CBanEntry(int64_t nCreateTimeIn)
-    {
-        SetNull();
-        nCreateTime = nCreateTimeIn;
-    }
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action, int nType, int nVersion)
-    {
-        READWRITE(this->nVersion);
-        nVersion = this->nVersion;
-        READWRITE(nCreateTime);
-        READWRITE(nBanUntil);
-        READWRITE(banReason);
-    }
-
-    void SetNull()
-    {
-        nVersion = CBanEntry::CURRENT_VERSION;
-        nCreateTime = 0;
-        nBanUntil = 0;
-        banReason = BanReasonUnknown;
-    }
-
-    std::string banReasonToString()
-    {
-        switch (banReason)
-        {
-        case BanReasonNodeMisbehaving:
-            return "node misbehaving";
-        case BanReasonManuallyAdded:
-            return "manually added";
-        default:
-            return "unknown";
-        }
-    }
-};
-
-typedef std::map<CSubNet, CBanEntry> banmap_t;
 
 // BU cleaning up nodes as a global destructor creates many global destruction dependencies.  Instead use a function
 // call.

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "nodestate.h"
+
+/**
+* Default constructor initializing all local member variables to "null" values
+*/
+CNodeState::CNodeState()
+{
+    fCurrentlyConnected = false;
+    nMisbehavior = 0;
+    fShouldBan = false;
+    pindexBestKnownBlock = NULL;
+    hashLastUnknownBlock.SetNull();
+    pindexLastCommonBlock = NULL;
+    pindexBestHeaderSent = NULL;
+    fSyncStarted = false;
+    nDownloadingSince = 0;
+    nBlocksInFlight = 0;
+    nBlocksInFlightValidHeaders = 0;
+    fPreferredDownload = false;
+    fPreferHeaders = false;
+}
+
+/**
+* Gets the CNodeState for the specified NodeId.
+*
+* @param[in] pnode  The NodeId to return CNodeState* for
+* @return CNodeState* matching the NodeId, or NULL if NodeId is not matched
+*/
+CNodeState *State(NodeId pnode)
+{
+    std::map<NodeId, CNodeState>::iterator it = mapNodeState.find(pnode);
+    if (it == mapNodeState.end())
+        return NULL;
+    return &it->second;
+}

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -1,0 +1,85 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODESTATE_H
+#define BITCOIN_NODESTATE_H
+
+#include "net.h" // For NodeId
+
+/** Blocks that are in flight, and that are in the queue to be downloaded. Protected by cs_main. */
+struct QueuedBlock
+{
+    uint256 hash;
+    CBlockIndex *pindex; //!< Optional.
+    int64_t nTime; //! Time of "getdata" request in microseconds.
+    bool fValidatedHeaders; //!< Whether this block has validated headers at the time of request.
+};
+
+extern std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight;
+
+
+struct CBlockReject
+{
+    unsigned char chRejectCode;
+    std::string strRejectReason;
+    uint256 hashBlock;
+};
+
+/**
+* Maintain validation-specific state about nodes, protected by cs_main, instead
+* by CNode's own locks. This simplifies asynchronous operation, where
+* processing of incoming data is done after the ProcessMessage call returns,
+* and we're no longer holding the node's locks.
+*/
+struct CNodeState
+{
+    //! The peer's address
+    CService address;
+    //! Whether we have a fully established connection.
+    bool fCurrentlyConnected;
+    //! Accumulated misbehaviour score for this peer.
+    int nMisbehavior;
+    //! Whether this peer should be disconnected and banned (unless whitelisted).
+    bool fShouldBan;
+    //! String name of this peer (debugging/logging purposes).
+    std::string name;
+    //! List of asynchronously-determined block rejections to notify this peer about.
+    std::vector<CBlockReject> rejects;
+    //! The best known block we know this peer has announced.
+    CBlockIndex *pindexBestKnownBlock;
+    //! The hash of the last unknown block this peer has announced.
+    uint256 hashLastUnknownBlock;
+    //! The last full block we both have.
+    CBlockIndex *pindexLastCommonBlock;
+    //! The best header we have sent our peer.
+    CBlockIndex *pindexBestHeaderSent;
+    //! Whether we've started headers synchronization with this peer.
+    bool fSyncStarted;
+    //! The start time of the sync
+    int64_t fSyncStartTime;
+    //! Were the first headers requested in a sync received
+    bool fFirstHeadersReceived;
+
+    std::list<QueuedBlock> vBlocksInFlight;
+    //! When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.
+    int64_t nDownloadingSince;
+    int nBlocksInFlight;
+    int nBlocksInFlightValidHeaders;
+    //! Whether we consider this a preferred download peer.
+    bool fPreferredDownload;
+    //! Whether this peer wants invs or headers (when possible) for block announcements.
+    bool fPreferHeaders;
+
+    CNodeState();
+};
+
+/** Map maintaining per-node state. Requires cs_main. */
+extern std::map<NodeId, CNodeState> mapNodeState;
+
+// Requires cs_main.
+extern CNodeState *State(NodeId pnode);
+
+#endif // BITCOIN_NODESTATE_H

--- a/src/test/bandb_tests.cpp
+++ b/src/test/bandb_tests.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) 2012-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bandb.h"
+#include "test/test_bitcoin.h"
+
+#include <string>
+
+#include <boost/assign/list_of.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+
+
+BOOST_FIXTURE_TEST_SUITE(bandb_tests, TestingSetup)
+
+bool RemoveLocalDatabase(const boost::filesystem::path &path)
+{
+    try
+    {
+        if (boost::filesystem::exists(path))
+        {
+            // if the file already exists, remove it
+            boost::filesystem::remove(path);
+        }
+
+        // if we get here, we either successfully deleted the file, or it didn't exist
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        // there was an error deleting the file
+        return false;
+    }
+}
+
+BOOST_AUTO_TEST_CASE(bandb_no_database)
+{
+    // create the CBanDB object
+    CBanDB db;
+
+    // Ensure local bandlist.dat has been removed
+    BOOST_CHECK(RemoveLocalDatabase(db.GetDatabasePath()));
+
+    // Try to read non-existent file (this shoudl fail)
+    banmap_t banset;
+    BOOST_CHECK(!db.Read(banset));
+}
+
+BOOST_AUTO_TEST_CASE(bandb_read_write_empty_database)
+{
+    // create the CBanDB object
+    CBanDB db;
+
+    // Ensure local bandlist.db has been removed
+    BOOST_CHECK(RemoveLocalDatabase(db.GetDatabasePath()));
+
+    // Write an empty banset_t to file
+    banmap_t banset_write;
+    BOOST_CHECK(db.Write(banset_write));
+
+    // Read an empty banset_t from file
+    banmap_t banset_read;
+    BOOST_CHECK(db.Read(banset_read));
+    // And ensure after reading in the banset is still empty
+    BOOST_CHECK(banset_read.size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(bandb_read_write_non_empty_database)
+{
+    // create the CBanDB object
+    CBanDB db;
+
+    // Ensure local bandlist.db has been removed
+    BOOST_CHECK(RemoveLocalDatabase(db.GetDatabasePath()));
+
+    // Create sub-nets
+    CSubNet singleIP("192.168.1.1/32");
+    CSubNet subNet("10.168.1.1/24");
+
+    // Write a non-empty banset_t to file
+    banmap_t banset_write;
+    // Add single IP
+    CBanEntry write1(GetTime());
+    write1.banReason = BanReasonNodeMisbehaving;
+    write1.nBanUntil = GetTime() + 14400; // Ban 4 hours
+    banset_write[singleIP] = write1;
+    // Add subnet
+    CBanEntry write2(GetTime());
+    write2.banReason = BanReasonManuallyAdded;
+    write2.nBanUntil = GetTime() + 28800; // Ban 8 hours
+    banset_write[subNet] = write2;
+    // Ensure we can succesfully write to the banlist.dat file
+    BOOST_CHECK(db.Write(banset_write));
+
+    // Read a non-empty banset_t from file
+    banmap_t banset_read;
+    BOOST_CHECK(db.Read(banset_read));
+    // And ensure after reading in the banset contains 2 entries
+    BOOST_CHECK(banset_read.size() == 2);
+
+    // Ensure entry 1 matches the pre-write entry
+    CBanEntry *read1 = &banset_read[singleIP];
+    BOOST_CHECK(read1 != NULL);
+    BOOST_CHECK(read1->banReason == write1.banReason);
+    BOOST_CHECK(read1->nBanUntil == write1.nBanUntil);
+    BOOST_CHECK(read1->nCreateTime == write1.nCreateTime);
+
+    // Ensure entry 2 matches the pre-write entry
+    CBanEntry *read2 = &banset_read[subNet];
+    BOOST_CHECK(read2 != NULL);
+    BOOST_CHECK(read2->banReason == write2.banReason);
+    BOOST_CHECK(read2->nBanUntil == write2.nBanUntil);
+    BOOST_CHECK(read2->nCreateTime == write2.nCreateTime);
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is a precursor refactor leading up to creation of a DoS manager class to encapsulate all of the DoS related functionality. This builds on #617 and should be merged third.

This PR moves `CBanDB` declaration/definition from net.h|.cpp to it's own bandb.h|.cpp files. This allows inclusion of bandb.h only where needed, which should eventually be only in the DoS manager and unit test source files.  Final goal is full encapsulation of the ban DB within the DoS manager.

This PR:
1. Moves `CBanDB` from net.h|.cpp to bandb.h|.cpp
2. Add doxygen comments for all method definitions in bandb.cpp
3. Add helper function `GetDatabasePath` for use in unit tests
4. Add some basic unit tests around reading and writing the ban database.
5. Add bandb.h|.cpp and bandb_tests.cpp to clang format list.