### PR TITLE
[Refactor] (4 of 4) Create DoS Manager class and move DoS functionality from net and main

### DIFF
--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -23,3 +23,5 @@ qt/unlimiteddialog.cpp
 qt/unlimiteddialog.h
 qt/unlimitedmodel.cpp
 qt/unlimitedmodel.h
+nodestate.cpp
+nodestate.h

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -27,3 +27,5 @@ nodestate.cpp
 nodestate.h
 banentry.cpp
 banentry.h
+bandb.cpp
+bandb.h

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -25,3 +25,5 @@ qt/unlimitedmodel.cpp
 qt/unlimitedmodel.h
 nodestate.cpp
 nodestate.h
+banentry.cpp
+banentry.h

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -30,3 +30,5 @@ banentry.h
 bandb.cpp
 bandb.h
 test/bandb_tests.cpp
+dosman.cpp
+dosman.h

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -29,3 +29,4 @@ banentry.cpp
 banentry.h
 bandb.cpp
 bandb.h
+test/bandb_tests.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -109,6 +109,7 @@ BITCOIN_CORE_H = \
   merkleblock.h \
   miner.h \
   net.h \
+  nodestate.h \
   leakybucket.h \
   netbase.h \
   noui.h \
@@ -188,6 +189,7 @@ libbitcoin_server_a_SOURCES = \
   merkleblock.cpp \
   miner.cpp \
   net.cpp \
+  nodestate.cpp \
   noui.cpp \
   parallel.cpp \
   policy/fees.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,6 +76,7 @@ BITCOIN_CORE_H = \
   addrman.h \
   allowed_args.h \
   base58.h \
+  banentry.h \
   bitnodes.h \
   bloom.h \
   chain.h \
@@ -175,6 +176,7 @@ libbitcoin_server_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_server_a_SOURCES = \
   globals.cpp \
   addrman.cpp \
+  banentry.cpp \
   bitnodes.cpp \
   bloom.cpp \
   chain.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -76,6 +76,7 @@ BITCOIN_CORE_H = \
   addrman.h \
   allowed_args.h \
   base58.h \
+  bandb.h \
   banentry.h \
   bitnodes.h \
   bloom.h \
@@ -176,6 +177,7 @@ libbitcoin_server_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_server_a_SOURCES = \
   globals.cpp \
   addrman.cpp \
+  bandb.cpp \
   banentry.cpp \
   bitnodes.cpp \
   bloom.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -98,6 +98,7 @@ BITCOIN_CORE_H = \
   consensus/consensus.h \
   core_io.h \
   core_memusage.h \
+  dosman.h \
   expedited.h \
   httprpc.h \
   httpserver.h \
@@ -184,6 +185,7 @@ libbitcoin_server_a_SOURCES = \
   chain.cpp \
   checkpoints.cpp \
   connmgr.cpp \
+  dosman.cpp \
   expedited.cpp \
   httprpc.cpp \
   httpserver.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -42,6 +42,7 @@ BITCOIN_TESTS =\
   test/addrman_tests.cpp \
   test/alert_tests.cpp \
   test/allocator_tests.cpp \
+  test/bandb_tests.cpp \
   test/base32_tests.cpp \
   test/base58_tests.cpp \
   test/base64_tests.cpp \

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -7,6 +7,7 @@
 
 #include "allowed_args.h"
 #include "chainparams.h"
+#include "dosman.h"
 #include "httpserver.h"
 #include "init.h"
 #include "main.h"

--- a/src/bandb.cpp
+++ b/src/bandb.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bandb.h"
+#include "chainparams.h"
+#include "clientversion.h"
+#include "hash.h"
+#include "random.h"
+#include "streams.h"
+
+/**
+* Default constructor initializes CBanDB file path based on user specified
+* data directory.
+*/
+CBanDB::CBanDB()
+{
+    // initialize the CBanDB file path based on user specified data directory
+    pathBanlist = GetDataDir() / "banlist.dat";
+}
+
+/**
+* Writes the the passed in banmap_t to disk
+*
+* @param[in] banSet  The banmap_t to write to disk
+* @return true if banlist successfully written to disk, otherwise false
+*/
+bool CBanDB::Write(const banmap_t &banSet)
+{
+    // Generate random temporary filename
+    unsigned short randv = 0;
+    GetRandBytes((unsigned char *)&randv, sizeof(randv));
+    std::string tmpfn = strprintf("banlist.dat.%04x", randv);
+
+    // serialize banlist, checksum data up to that point, then append csum
+    CDataStream ssBanlist(SER_DISK, CLIENT_VERSION);
+    ssBanlist << FLATDATA(Params().MessageStart());
+    ssBanlist << banSet;
+    uint256 hash = Hash(ssBanlist.begin(), ssBanlist.end());
+    ssBanlist << hash;
+
+    // open temp output file, and associate with CAutoFile
+    boost::filesystem::path pathTmp = GetDataDir() / tmpfn;
+    FILE *file = fopen(pathTmp.string().c_str(), "wb");
+    CAutoFile fileout(file, SER_DISK, CLIENT_VERSION);
+    if (fileout.IsNull())
+        return error("%s: Failed to open file %s", __func__, pathTmp.string());
+
+    // Write and commit header, data
+    try
+    {
+        fileout << ssBanlist;
+    }
+    catch (const std::exception &e)
+    {
+        return error("%s: Serialize or I/O error - %s", __func__, e.what());
+    }
+    FileCommit(fileout.Get());
+    fileout.fclose();
+
+    // replace existing banlist.dat, if any, with new banlist.dat.XXXX
+    if (!RenameOver(pathTmp, pathBanlist))
+        return error("%s: Rename-into-place failed", __func__);
+
+    return true;
+}
+
+/**
+* Reads the banlist from disk and stores in the passed in banmap_t
+*
+* @param[in,out] banSet  The banmap_t to which ban entries are added
+* @return true if banlist successfully read from disk, otherwise false
+*/
+bool CBanDB::Read(banmap_t &banSet)
+{
+    // open input file, and associate with CAutoFile
+    FILE *file = fopen(pathBanlist.string().c_str(), "rb");
+    CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
+    if (filein.IsNull())
+        return error("%s: Failed to open file %s", __func__, pathBanlist.string());
+
+    // use file size to size memory buffer
+    uint64_t fileSize = boost::filesystem::file_size(pathBanlist);
+    uint64_t dataSize = 0;
+    // Don't try to resize to a negative number if file is small
+    if (fileSize >= sizeof(uint256))
+        dataSize = fileSize - sizeof(uint256);
+    std::vector<unsigned char> vchData;
+    vchData.resize(dataSize);
+    uint256 hashIn;
+
+    // read data and checksum from file
+    try
+    {
+        filein.read((char *)&vchData[0], dataSize);
+        filein >> hashIn;
+    }
+    catch (const std::exception &e)
+    {
+        return error("%s: Deserialize or I/O error - %s", __func__, e.what());
+    }
+    filein.fclose();
+
+    CDataStream ssBanlist(vchData, SER_DISK, CLIENT_VERSION);
+
+    // verify stored checksum matches input data
+    uint256 hashTmp = Hash(ssBanlist.begin(), ssBanlist.end());
+    if (hashIn != hashTmp)
+        return error("%s: Checksum mismatch, data corrupted", __func__);
+
+    unsigned char pchMsgTmp[4];
+    try
+    {
+        // de-serialize file header (network specific magic number) and ..
+        ssBanlist >> FLATDATA(pchMsgTmp);
+
+        // ... verify the network matches ours
+        if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp)))
+            return error("%s: Invalid network magic number", __func__);
+
+        // de-serialize banlist data into one banmap_t object
+        ssBanlist >> banSet;
+    }
+    catch (const std::exception &e)
+    {
+        return error("%s: Deserialize or I/O error - %s", __func__, e.what());
+    }
+
+    return true;
+}

--- a/src/bandb.h
+++ b/src/bandb.h
@@ -21,6 +21,9 @@ public:
     CBanDB();
     bool Write(const banmap_t &banSet);
     bool Read(banmap_t &banSet);
+
+    // NOTE: Added for use in unit testing
+    boost::filesystem::path GetDatabasePath() const { return pathBanlist; }
 };
 
 #endif // BITCOIN_BANDB_H

--- a/src/bandb.h
+++ b/src/bandb.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_BANDB_H
+#define BITCOIN_BANDB_H
+
+#include "banentry.h" // for banmap_t
+
+#include <boost/filesystem.hpp>
+
+/** Access to the banlist database (banlist.dat) */
+class CBanDB
+{
+private:
+    boost::filesystem::path pathBanlist;
+
+public:
+    CBanDB();
+    bool Write(const banmap_t &banSet);
+    bool Read(banmap_t &banSet);
+};
+
+#endif // BITCOIN_BANDB_H

--- a/src/banentry.cpp
+++ b/src/banentry.cpp
@@ -1,0 +1,58 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "banentry.h"
+
+/**
+* Default constructor initializes all member variables to "null" equivalents
+*/
+CBanEntry::CBanEntry()
+{
+    // set all member variables to null equivalents
+    SetNull();
+}
+
+/**
+* This constructor initializes all member variables to "null" equivalents,
+* except for the ban creation time, which is set to the value passed in.
+*
+* @param[in] nCreateTimeIn Creation time to initialize this CBanEntry to
+*/
+CBanEntry::CBanEntry(int64_t nCreateTimeIn)
+{
+    // set all member variables to null equivalents
+    SetNull();
+    nCreateTime = nCreateTimeIn;
+}
+
+/**
+* Set all member variables to their "null" equivalent values
+*/
+void CBanEntry::SetNull()
+{
+    nVersion = CBanEntry::CURRENT_VERSION;
+    nCreateTime = 0;
+    nBanUntil = 0;
+    banReason = BanReasonUnknown;
+}
+
+/**
+* Converts the BanReason to a human readable string representation.
+*
+* @return Human readable string representation of the BanReason
+*/
+std::string CBanEntry::banReasonToString()
+{
+    switch (banReason)
+    {
+    case BanReasonNodeMisbehaving:
+        return "node misbehaving";
+    case BanReasonManuallyAdded:
+        return "manually added";
+    default:
+        return "unknown";
+    }
+}

--- a/src/banentry.h
+++ b/src/banentry.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_BANENTRY_H
+#define BITCOIN_BANENTRY_H
+
+// NOTE: netbase.h includes serialize.h which is required for serialization macros
+#include "netbase.h" // for CSubNet
+
+typedef enum BanReason { BanReasonUnknown = 0, BanReasonNodeMisbehaving = 1, BanReasonManuallyAdded = 2 } BanReason;
+
+class CBanEntry
+{
+public:
+    static const int CURRENT_VERSION = 1;
+    int nVersion;
+    int64_t nCreateTime;
+    int64_t nBanUntil;
+    uint8_t banReason;
+
+    CBanEntry();
+    CBanEntry(int64_t nCreateTimeIn);
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action, int nType, int nVersion)
+    {
+        READWRITE(this->nVersion);
+        nVersion = this->nVersion;
+        READWRITE(nCreateTime);
+        READWRITE(nBanUntil);
+        READWRITE(banReason);
+    }
+
+    void SetNull();
+
+    std::string banReasonToString();
+};
+
+typedef std::map<CSubNet, CBanEntry> banmap_t;
+
+#endif // BITCOIN_BANENTRY_H

--- a/src/dosman.cpp
+++ b/src/dosman.cpp
@@ -5,6 +5,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "dosman.h"
+#include "bandb.h"
+#include "ui_interface.h"
 
 #include <boost/foreach.hpp>
 
@@ -24,4 +26,137 @@ void CDoSManager::AddWhitelistedRange(const CSubNet &subnet)
 {
     LOCK(cs_vWhitelistedRange);
     vWhitelistedRange.push_back(subnet);
+}
+
+void CDoSManager::ClearBanned()
+{
+    LOCK(cs_setBanned);
+    setBanned.clear();
+    setBannedIsDirty = true;
+    uiInterface.BannedListChanged();
+}
+
+bool CDoSManager::IsBanned(CNetAddr ip)
+{
+    bool fResult = false;
+    {
+        LOCK(cs_setBanned);
+        for (banmap_t::iterator it = setBanned.begin(); it != setBanned.end(); it++)
+        {
+            CSubNet subNet = (*it).first;
+            CBanEntry banEntry = (*it).second;
+
+            if (subNet.Match(ip) && GetTime() < banEntry.nBanUntil)
+                fResult = true;
+        }
+    }
+    return fResult;
+}
+
+bool CDoSManager::IsBanned(CSubNet subnet)
+{
+    bool fResult = false;
+    {
+        LOCK(cs_setBanned);
+        banmap_t::iterator i = setBanned.find(subnet);
+        if (i != setBanned.end())
+        {
+            CBanEntry banEntry = (*i).second;
+            if (GetTime() < banEntry.nBanUntil)
+                fResult = true;
+        }
+    }
+    return fResult;
+}
+
+void CDoSManager::Ban(const CNetAddr &addr, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch)
+{
+    CSubNet subNet(addr);
+    Ban(subNet, banReason, bantimeoffset, sinceUnixEpoch);
+}
+
+void CDoSManager::Ban(const CSubNet &subNet, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch)
+{
+    CBanEntry banEntry(GetTime());
+    banEntry.banReason = banReason;
+    if (bantimeoffset <= 0)
+    {
+        bantimeoffset = GetArg("-bantime", DEFAULT_MISBEHAVING_BANTIME);
+        sinceUnixEpoch = false;
+    }
+    banEntry.nBanUntil = (sinceUnixEpoch ? 0 : GetTime()) + bantimeoffset;
+
+    LOCK(cs_setBanned);
+    if (setBanned[subNet].nBanUntil < banEntry.nBanUntil)
+        setBanned[subNet] = banEntry;
+
+    setBannedIsDirty = true;
+    uiInterface.BannedListChanged();
+}
+
+bool CDoSManager::Unban(const CNetAddr &addr)
+{
+    CSubNet subNet(addr);
+    return Unban(subNet);
+}
+
+bool CDoSManager::Unban(const CSubNet &subNet)
+{
+    LOCK(cs_setBanned);
+    if (setBanned.erase(subNet))
+    {
+        setBannedIsDirty = true;
+
+        SweepBanned();
+        uiInterface.BannedListChanged();
+        return true;
+    }
+    return false;
+}
+
+void CDoSManager::GetBanned(banmap_t &banMap)
+{
+    LOCK(cs_setBanned);
+    SweepBanned();
+    banMap = setBanned; // create a thread safe copy
+}
+
+void CDoSManager::SetBanned(const banmap_t &banMap)
+{
+    LOCK(cs_setBanned);
+    setBanned = banMap;
+    setBannedIsDirty = true;
+}
+
+void CDoSManager::SweepBanned()
+{
+    int64_t now = GetTime();
+
+    LOCK(cs_setBanned);
+    banmap_t::iterator it = setBanned.begin();
+    while (it != setBanned.end())
+    {
+        CSubNet subNet = (*it).first;
+        CBanEntry banEntry = (*it).second;
+        if (now > banEntry.nBanUntil)
+        {
+            setBanned.erase(it++);
+            setBannedIsDirty = true;
+            LogPrint("net", "%s: Removed banned node ip/subnet from banlist.dat: %s\n", __func__, subNet.ToString());
+        }
+        else
+            ++it;
+    }
+}
+
+bool CDoSManager::BannedSetIsDirty()
+{
+    LOCK(cs_setBanned);
+    return setBannedIsDirty;
+}
+
+void CDoSManager::SetBannedSetDirty(bool dirty)
+{
+    LOCK(cs_setBanned); // reuse setBanned lock for the isDirty flag
+    setBannedIsDirty = dirty;
 }

--- a/src/dosman.cpp
+++ b/src/dosman.cpp
@@ -1,0 +1,7 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "dosman.h"

--- a/src/dosman.cpp
+++ b/src/dosman.cpp
@@ -5,3 +5,23 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "dosman.h"
+
+#include <boost/foreach.hpp>
+
+
+bool CDoSManager::IsWhitelistedRange(const CNetAddr &addr)
+{
+    LOCK(cs_vWhitelistedRange);
+    BOOST_FOREACH (const CSubNet &subnet, vWhitelistedRange)
+    {
+        if (subnet.Match(addr))
+            return true;
+    }
+    return false;
+}
+
+void CDoSManager::AddWhitelistedRange(const CSubNet &subnet)
+{
+    LOCK(cs_vWhitelistedRange);
+    vWhitelistedRange.push_back(subnet);
+}

--- a/src/dosman.h
+++ b/src/dosman.h
@@ -8,6 +8,7 @@
 #define BITCOIN_DOSMANAGER_H
 
 #include "banentry.h" // for banmap_t
+#include "net.h" // for NodeId
 #include "netbase.h" // for CSubNet
 #include "sync.h" // for CCritalSection
 
@@ -17,6 +18,7 @@
 
 // NOTE: When adjusting this, update rpcnet:setban's help ("24h")
 static const unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24; // Default 24-hour ban
+static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 
 
 class CDoSManager
@@ -71,6 +73,9 @@ public:
     void SetBannedSetDirty(bool dirty = true);
     //! clean unused entries (if bantime has expired)
     void SweepBanned();
+
+    /** Increase a node's misbehavior score. */
+    void Misbehaving(NodeId nodeid, int howmuch);
 };
 
 // actual definition should be in globals.cpp for ordered construction/destruction

--- a/src/dosman.h
+++ b/src/dosman.h
@@ -7,12 +7,16 @@
 #ifndef BITCOIN_DOSMANAGER_H
 #define BITCOIN_DOSMANAGER_H
 
+#include "banentry.h" // for banmap_t
 #include "netbase.h" // for CSubNet
 #include "sync.h" // for CCritalSection
 
 #ifdef DEBUG
 #include <univalue.h>
 #endif
+
+// NOTE: When adjusting this, update rpcnet:setban's help ("24h")
+static const unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24; // Default 24-hour ban
 
 
 class CDoSManager
@@ -27,9 +31,46 @@ protected:
     std::vector<CSubNet> vWhitelistedRange;
     mutable CCriticalSection cs_vWhitelistedRange;
 
+    // Denial-of-service detection/prevention
+    // Key is IP address, value is banned-until-time
+    banmap_t setBanned;
+    mutable CCriticalSection cs_setBanned;
+    bool setBannedIsDirty;
+
 public:
     bool IsWhitelistedRange(const CNetAddr &ip);
     void AddWhitelistedRange(const CSubNet &subnet);
+
+    // Denial-of-service detection/prevention
+    // The idea is to detect peers that are behaving
+    // badly and disconnect/ban them, but do it in a
+    // one-coding-mistake-won't-shatter-the-entire-network
+    // way.
+    // IMPORTANT:  There should be nothing I can give a
+    // node that it will forward on that will make that
+    // node's peers drop it. If there is, an attacker
+    // can isolate a node and/or try to split the network.
+    // Dropping a node for sending stuff that is invalid
+    // now but might be valid in a later version is also
+    // dangerous, because it can cause a network split
+    // between nodes running old code and nodes running
+    // new code.
+    void ClearBanned(); // needed for unit testing
+    bool IsBanned(CNetAddr ip);
+    bool IsBanned(CSubNet subnet);
+    void Ban(const CNetAddr &ip, const BanReason &banReason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
+    void Ban(const CSubNet &subNet, const BanReason &banReason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
+    bool Unban(const CNetAddr &ip);
+    bool Unban(const CSubNet &ip);
+    void GetBanned(banmap_t &banmap);
+    void SetBanned(const banmap_t &banmap);
+
+    //! check is the banlist has unwritten changes
+    bool BannedSetIsDirty();
+    //! set the "dirty" flag for the banlist
+    void SetBannedSetDirty(bool dirty = true);
+    //! clean unused entries (if bantime has expired)
+    void SweepBanned();
 };
 
 // actual definition should be in globals.cpp for ordered construction/destruction

--- a/src/dosman.h
+++ b/src/dosman.h
@@ -1,0 +1,17 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_DOSMANAGER_H
+#define BITCOIN_DOSMANAGER_H
+
+class CDoSManager
+{
+};
+
+// actual definition should be in globals.cpp for ordered construction/destruction
+extern CDoSManager dosMan;
+
+#endif // BITCOIN_DOSMANAGER_H

--- a/src/dosman.h
+++ b/src/dosman.h
@@ -7,8 +7,29 @@
 #ifndef BITCOIN_DOSMANAGER_H
 #define BITCOIN_DOSMANAGER_H
 
+#include "netbase.h" // for CSubNet
+#include "sync.h" // for CCritalSection
+
+#ifdef DEBUG
+#include <univalue.h>
+#endif
+
+
 class CDoSManager
 {
+protected:
+#ifdef DEBUG
+    friend UniValue getstructuresizes(const UniValue &params, bool fHelp);
+#endif
+
+    // Whitelisted ranges. Any node connecting from these is automatically
+    // whitelisted (as well as those connecting to whitelisted binds).
+    std::vector<CSubNet> vWhitelistedRange;
+    mutable CCriticalSection cs_vWhitelistedRange;
+
+public:
+    bool IsWhitelistedRange(const CNetAddr &ip);
+    void AddWhitelistedRange(const CSubNet &subnet);
 };
 
 // actual definition should be in globals.cpp for ordered construction/destruction

--- a/src/expedited.cpp
+++ b/src/expedited.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "expedited.h"
+#include "dosman.h"
 #include "main.h"
 #include "rpc/server.h"
 #include "thinblock.h"
@@ -94,7 +95,7 @@ bool HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom)
     if (!pfrom->ThinBlockCapable() || !IsThinBlocksEnabled())
     {
         LOCK(cs_main);
-        Misbehaving(pfrom->GetId(), 5);
+        dosMan.Misbehaving(pfrom->GetId(), 5);
         return false;
     }
 

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -19,6 +19,7 @@
 #include "main.h"
 #include "miner.h"
 #include "net.h"
+#include "nodestate.h"
 #include "parallel.h"
 #include "policy/policy.h"
 #include "primitives/block.h"
@@ -74,6 +75,10 @@ CConditionVariable cvBlockChange;
 proxyType proxyInfo[NET_MAX];
 proxyType nameProxy;
 CCriticalSection cs_proxyInfos;
+
+// moved from main.cpp (now part of nodestate.h)
+std::map<uint256, pair<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight;
+std::map<NodeId, CNodeState> mapNodeState;
 
 set<uint256> setPreVerifiedTxHash;
 set<uint256> setUnVerifiedOrphanTxHash;

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -15,6 +15,7 @@
 #include "consensus/consensus.h"
 #include "consensus/params.h"
 #include "consensus/validation.h"
+#include "dosman.h"
 #include "leakybucket.h"
 #include "main.h"
 #include "miner.h"
@@ -156,6 +157,7 @@ CSemaphore *semOutbound = NULL;
 CSemaphore *semOutboundAddNode = NULL; // BU: separate semaphore for -addnodes
 CNodeSignals g_signals;
 CAddrMan addrman;
+CDoSManager dosMan;
 
 // BU: change locking of orphan map from using cs_main to cs_orphancache.  There is too much dependance on cs_main locks
 // which are generally too broad in scope.

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -87,7 +87,6 @@ CCriticalSection cs_xval;
 CCriticalSection cs_vNodes;
 CCriticalSection cs_mapLocalHost;
 map<CNetAddr, LocalServiceInfo> mapLocalHost;
-CCriticalSection CNode::cs_setBanned;
 uint64_t CNode::nTotalBytesRecv = 0;
 uint64_t CNode::nTotalBytesSent = 0;
 CCriticalSection CNode::cs_totalBytesRecv;

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -87,8 +87,6 @@ CCriticalSection cs_xval;
 CCriticalSection cs_vNodes;
 CCriticalSection cs_mapLocalHost;
 map<CNetAddr, LocalServiceInfo> mapLocalHost;
-std::vector<CSubNet> CNode::vWhitelistedRange;
-CCriticalSection CNode::cs_vWhitelistedRange;
 CCriticalSection CNode::cs_setBanned;
 uint64_t CNode::nTotalBytesRecv = 0;
 uint64_t CNode::nTotalBytesSent = 0;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -18,6 +18,7 @@
 #include "checkpoints.h"
 #include "compat/sanity.h"
 #include "consensus/validation.h"
+#include "dosman.h"
 #include "httpserver.h"
 #include "httprpc.h"
 #include "key.h"
@@ -1112,7 +1113,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
             CSubNet subnet(net);
             if (!subnet.IsValid())
                 return InitError(strprintf(_("Invalid netmask specified in -whitelist: '%s'"), net));
-            CNode::AddWhitelistedRange(subnet);
+            dosMan.AddWhitelistedRange(subnet);
         }
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@
 #include "consensus/consensus.h"
 #include "consensus/merkle.h"
 #include "consensus/validation.h"
+#include "dosman.h"
 #include "expedited.h"
 #include "hash.h"
 #include "init.h"
@@ -5780,7 +5781,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         //        attacker sends us messages that do not require a response coupled with an nVersion of zero
         //        then they can continue unimpeded even though they have exceeded the misbehaving threshold.
         pfrom->fDisconnect = true;
-        CNode::Ban(pfrom->addr, BanReasonNodeMisbehaving);
+        dosMan.Ban(pfrom->addr, BanReasonNodeMisbehaving);
         return error("VERSION was not received before other messages - banning peer=%d ip=%s", pfrom->GetId(),
             pfrom->addrName.c_str());
     }
@@ -6968,7 +6969,7 @@ bool ProcessMessages(CNode *pfrom)
                 pfrom->id, pfrom->addrName.c_str());
             if (!pfrom->fWhitelisted)
             {
-                CNode::Ban(pfrom->addr, BanReasonNodeMisbehaving, 4 * 60 * 60); // ban for 4 hours
+                dosMan.Ban(pfrom->addr, BanReasonNodeMisbehaving, 4 * 60 * 60); // ban for 4 hours
             }
             fOk = false;
             break;
@@ -7183,7 +7184,7 @@ bool SendMessages(CNode *pto)
                     LogPrintf("Warning: not banning local peer %s!\n", pto->addr.ToString());
                 else
                 {
-                    CNode::Ban(pto->addr, BanReasonNodeMisbehaving);
+                    dosMan.Ban(pto->addr, BanReasonNodeMisbehaving);
                 }
             }
             state.fShouldBan = false;
@@ -7202,7 +7203,7 @@ bool SendMessages(CNode *pto)
             (!state.fFirstHeadersReceived) && !pto->fWhitelisted)
         {
             pto->fDisconnect = true;
-            CNode::Ban(pto->addr, BanReasonNodeMisbehaving, 4 * 60 * 60); // ban for 4 hours
+            dosMan.Ban(pto->addr, BanReasonNodeMisbehaving, 4 * 60 * 60); // ban for 4 hours
             LogPrintf(
                 "Banning %s because initial headers were either not received or not received before the timeout\n",
                 pto->addr.ToString());

--- a/src/main.h
+++ b/src/main.h
@@ -124,7 +124,6 @@ static const bool DEFAULT_PERMIT_BAREMULTISIG = true;
 static const unsigned int DEFAULT_BYTES_PER_SIGOP = 20;
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
 static const bool DEFAULT_TXINDEX = false;
-static const unsigned int DEFAULT_BANSCORE_THRESHOLD = 100;
 
 static const bool DEFAULT_TESTSAFEMODE = false;
 
@@ -316,8 +315,6 @@ void UnlinkPrunedFiles(std::set<int> &setFilesToPrune);
 CBlockIndex *InsertBlockIndex(uint256 hash);
 /** Get statistics from node state */
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
-/** Increase a node's misbehavior score. */
-void Misbehaving(NodeId nodeid, int howmuch);
 /** Flush all state, indexes and buffers to disk. */
 void FlushStateToDisk();
 /** Prune block files and flush state to disk. */

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -11,6 +11,7 @@
 #include "net.h"
 
 #include "addrman.h"
+#include "bandb.h"
 #include "chainparams.h"
 #include "clientversion.h"
 #include "connmgr.h"
@@ -3145,109 +3146,6 @@ void CNode::EndMessage() UNLOCK_FUNCTION(cs_vSend)
         SocketSendData(this);
 
     LEAVE_CRITICAL_SECTION(cs_vSend);
-}
-
-//
-// CBanDB
-//
-
-CBanDB::CBanDB() { pathBanlist = GetDataDir() / "banlist.dat"; }
-bool CBanDB::Write(const banmap_t &banSet)
-{
-    // Generate random temporary filename
-    unsigned short randv = 0;
-    GetRandBytes((unsigned char *)&randv, sizeof(randv));
-    std::string tmpfn = strprintf("banlist.dat.%04x", randv);
-
-    // serialize banlist, checksum data up to that point, then append csum
-    CDataStream ssBanlist(SER_DISK, CLIENT_VERSION);
-    ssBanlist << FLATDATA(Params().MessageStart());
-    ssBanlist << banSet;
-    uint256 hash = Hash(ssBanlist.begin(), ssBanlist.end());
-    ssBanlist << hash;
-
-    // open temp output file, and associate with CAutoFile
-    boost::filesystem::path pathTmp = GetDataDir() / tmpfn;
-    FILE *file = fopen(pathTmp.string().c_str(), "wb");
-    CAutoFile fileout(file, SER_DISK, CLIENT_VERSION);
-    if (fileout.IsNull())
-        return error("%s: Failed to open file %s", __func__, pathTmp.string());
-
-    // Write and commit header, data
-    try
-    {
-        fileout << ssBanlist;
-    }
-    catch (const std::exception &e)
-    {
-        return error("%s: Serialize or I/O error - %s", __func__, e.what());
-    }
-    FileCommit(fileout.Get());
-    fileout.fclose();
-
-    // replace existing banlist.dat, if any, with new banlist.dat.XXXX
-    if (!RenameOver(pathTmp, pathBanlist))
-        return error("%s: Rename-into-place failed", __func__);
-
-    return true;
-}
-
-bool CBanDB::Read(banmap_t &banSet)
-{
-    // open input file, and associate with CAutoFile
-    FILE *file = fopen(pathBanlist.string().c_str(), "rb");
-    CAutoFile filein(file, SER_DISK, CLIENT_VERSION);
-    if (filein.IsNull())
-        return error("%s: Failed to open file %s", __func__, pathBanlist.string());
-
-    // use file size to size memory buffer
-    uint64_t fileSize = boost::filesystem::file_size(pathBanlist);
-    uint64_t dataSize = 0;
-    // Don't try to resize to a negative number if file is small
-    if (fileSize >= sizeof(uint256))
-        dataSize = fileSize - sizeof(uint256);
-    vector<unsigned char> vchData;
-    vchData.resize(dataSize);
-    uint256 hashIn;
-
-    // read data and checksum from file
-    try
-    {
-        filein.read((char *)&vchData[0], dataSize);
-        filein >> hashIn;
-    }
-    catch (const std::exception &e)
-    {
-        return error("%s: Deserialize or I/O error - %s", __func__, e.what());
-    }
-    filein.fclose();
-
-    CDataStream ssBanlist(vchData, SER_DISK, CLIENT_VERSION);
-
-    // verify stored checksum matches input data
-    uint256 hashTmp = Hash(ssBanlist.begin(), ssBanlist.end());
-    if (hashIn != hashTmp)
-        return error("%s: Checksum mismatch, data corrupted", __func__);
-
-    unsigned char pchMsgTmp[4];
-    try
-    {
-        // de-serialize file header (network specific magic number) and ..
-        ssBanlist >> FLATDATA(pchMsgTmp);
-
-        // ... verify the network matches ours
-        if (memcmp(pchMsgTmp, Params().MessageStart(), sizeof(pchMsgTmp)))
-            return error("%s: Invalid network magic number", __func__);
-
-        // de-serialize address data into one CAddrMan object
-        ssBanlist >> banSet;
-    }
-    catch (const std::exception &e)
-    {
-        return error("%s: Deserialize or I/O error - %s", __func__, e.what());
-    }
-
-    return true;
 }
 
 int64_t PoissonNextSend(int64_t nNow, int average_interval_seconds)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -17,7 +17,7 @@
 #include "connmgr.h"
 #include "consensus/consensus.h"
 #include "crypto/common.h"
-#include "crypto/common.h"
+#include "dosman.h"
 #include "hash.h"
 #include "primitives/transaction.h"
 #include "requestManager.h"
@@ -631,26 +631,6 @@ void CNode::SetBannedSetDirty(bool dirty)
 }
 
 
-// BU moved: std::vector<CSubNet> CNode::vWhitelistedRange;
-// BU moved: CCriticalSection CNode::cs_vWhitelistedRange;
-
-bool CNode::IsWhitelistedRange(const CNetAddr &addr)
-{
-    LOCK(cs_vWhitelistedRange);
-    BOOST_FOREACH (const CSubNet &subnet, vWhitelistedRange)
-    {
-        if (subnet.Match(addr))
-            return true;
-    }
-    return false;
-}
-
-void CNode::AddWhitelistedRange(const CSubNet &subnet)
-{
-    LOCK(cs_vWhitelistedRange);
-    vWhitelistedRange.push_back(subnet);
-}
-
 #undef X
 #define X(name) stats.name = name
 void CNode::copyStats(CNodeStats &stats)
@@ -1054,7 +1034,7 @@ static void AcceptConnection(const ListenSocket &hListenSocket)
         if (!addr.SetSockAddr((const struct sockaddr *)&sockaddr))
             LogPrintf("Warning: Unknown socket family\n");
 
-    bool whitelisted = hListenSocket.whitelisted || CNode::IsWhitelistedRange(addr);
+    bool whitelisted = hListenSocket.whitelisted || dosMan.IsWhitelistedRange(addr);
     if (hSocket == INVALID_SOCKET)
     {
         int nErr = WSAGetLastError();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -493,144 +493,6 @@ void CNode::PushVersion()
 }
 
 
-banmap_t CNode::setBanned;
-// CCriticalSection CNode::cs_setBanned;
-bool CNode::setBannedIsDirty;
-
-void CNode::ClearBanned()
-{
-    LOCK(cs_setBanned);
-    setBanned.clear();
-    setBannedIsDirty = true;
-    uiInterface.BannedListChanged();
-}
-
-bool CNode::IsBanned(CNetAddr ip)
-{
-    bool fResult = false;
-    {
-        LOCK(cs_setBanned);
-        for (banmap_t::iterator it = setBanned.begin(); it != setBanned.end(); it++)
-        {
-            CSubNet subNet = (*it).first;
-            CBanEntry banEntry = (*it).second;
-
-            if (subNet.Match(ip) && GetTime() < banEntry.nBanUntil)
-                fResult = true;
-        }
-    }
-    return fResult;
-}
-
-bool CNode::IsBanned(CSubNet subnet)
-{
-    bool fResult = false;
-    {
-        LOCK(cs_setBanned);
-        banmap_t::iterator i = setBanned.find(subnet);
-        if (i != setBanned.end())
-        {
-            CBanEntry banEntry = (*i).second;
-            if (GetTime() < banEntry.nBanUntil)
-                fResult = true;
-        }
-    }
-    return fResult;
-}
-
-void CNode::Ban(const CNetAddr &addr, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch)
-{
-    CSubNet subNet(addr);
-    Ban(subNet, banReason, bantimeoffset, sinceUnixEpoch);
-}
-
-void CNode::Ban(const CSubNet &subNet, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch)
-{
-    CBanEntry banEntry(GetTime());
-    banEntry.banReason = banReason;
-    if (bantimeoffset <= 0)
-    {
-        bantimeoffset = GetArg("-bantime", DEFAULT_MISBEHAVING_BANTIME);
-        sinceUnixEpoch = false;
-    }
-    banEntry.nBanUntil = (sinceUnixEpoch ? 0 : GetTime()) + bantimeoffset;
-
-    LOCK(cs_setBanned);
-    if (setBanned[subNet].nBanUntil < banEntry.nBanUntil)
-        setBanned[subNet] = banEntry;
-
-    setBannedIsDirty = true;
-    uiInterface.BannedListChanged();
-}
-
-bool CNode::Unban(const CNetAddr &addr)
-{
-    CSubNet subNet(addr);
-    return Unban(subNet);
-}
-
-bool CNode::Unban(const CSubNet &subNet)
-{
-    LOCK(cs_setBanned);
-    if (setBanned.erase(subNet))
-    {
-        setBannedIsDirty = true;
-
-        SweepBanned();
-        uiInterface.BannedListChanged();
-        return true;
-    }
-    return false;
-}
-
-void CNode::GetBanned(banmap_t &banMap)
-{
-    LOCK(cs_setBanned);
-    SweepBanned();
-    banMap = setBanned; // create a thread safe copy
-}
-
-void CNode::SetBanned(const banmap_t &banMap)
-{
-    LOCK(cs_setBanned);
-    setBanned = banMap;
-    setBannedIsDirty = true;
-}
-
-void CNode::SweepBanned()
-{
-    int64_t now = GetTime();
-
-    LOCK(cs_setBanned);
-    banmap_t::iterator it = setBanned.begin();
-    while (it != setBanned.end())
-    {
-        CSubNet subNet = (*it).first;
-        CBanEntry banEntry = (*it).second;
-        if (now > banEntry.nBanUntil)
-        {
-            setBanned.erase(it++);
-            setBannedIsDirty = true;
-            LogPrint("net", "%s: Removed banned node ip/subnet from banlist.dat: %s\n", __func__, subNet.ToString());
-        }
-        else
-            ++it;
-    }
-}
-
-bool CNode::BannedSetIsDirty()
-{
-    LOCK(cs_setBanned);
-    return setBannedIsDirty;
-}
-
-void CNode::SetBannedSetDirty(bool dirty)
-{
-    LOCK(cs_setBanned); // reuse setBanned lock for the isDirty flag
-    setBannedIsDirty = dirty;
-}
-
-
 #undef X
 #define X(name) stats.name = name
 void CNode::copyStats(CNodeStats &stats)
@@ -1006,7 +868,7 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection)
         if (nEvictions > 15)
         {
             int nHoursToBan = 4;
-            CNode::Ban(ipAddress, BanReasonNodeMisbehaving, nHoursToBan * 60 * 60);
+            dosMan.Ban(ipAddress, BanReasonNodeMisbehaving, nHoursToBan * 60 * 60);
             LogPrintf("Banning %s for %d hours: Too many evictions - connection dropped\n",
                 vEvictionCandidatesByActivity[0]->addr.ToString(), nHoursToBan);
         }
@@ -1059,7 +921,7 @@ static void AcceptConnection(const ListenSocket &hListenSocket)
     setsockopt(hSocket, IPPROTO_TCP, TCP_NODELAY, (void *)&set, sizeof(int));
 #endif
 
-    if (CNode::IsBanned(addr) && !whitelisted)
+    if (dosMan.IsBanned(addr) && !whitelisted)
     {
         LogPrint("net", "connection from %s dropped (banned)\n", addr.ToString());
         CloseSocket(hSocket);
@@ -1149,7 +1011,7 @@ static void AcceptConnection(const ListenSocket &hListenSocket)
         if (nConnections > 4 && !whitelisted)
         {
             int nHoursToBan = 4;
-            CNode::Ban((CNetAddr)addr, BanReasonNodeMisbehaving, nHoursToBan * 60 * 60);
+            dosMan.Ban((CNetAddr)addr, BanReasonNodeMisbehaving, nHoursToBan * 60 * 60);
             LogPrintf("Banning %s for %d hours: Too many connection attempts - connection dropped\n", addr.ToString(),
                 nHoursToBan);
             CloseSocket(hSocket);
@@ -1775,7 +1637,7 @@ void DumpBanlist()
 
     CBanDB bandb;
     banmap_t banmap;
-    CNode::GetBanned(banmap);
+    dosMan.GetBanned(banmap);
     bandb.Write(banmap);
 
     LogPrint(
@@ -1786,10 +1648,10 @@ void DumpData()
 {
     DumpAddresses();
 
-    if (CNode::BannedSetIsDirty())
+    if (dosMan.BannedSetIsDirty())
     {
         DumpBanlist();
-        CNode::SetBannedSetDirty(false);
+        dosMan.SetBannedSetDirty(false);
     }
 }
 
@@ -2159,7 +2021,7 @@ bool OpenNetworkConnection(const CAddress &addrConnect,
         LOCK(cs_vNodes);
         if (!pszDest)
         {
-            if (IsLocal(addrConnect) || FindNode((CNetAddr)addrConnect) || CNode::IsBanned(addrConnect) ||
+            if (IsLocal(addrConnect) || FindNode((CNetAddr)addrConnect) || dosMan.IsBanned(addrConnect) ||
                 FindNode(addrConnect.ToStringIPPort()))
                 return false;
         }
@@ -2451,9 +2313,9 @@ void StartNode(boost::thread_group &threadGroup, CScheduler &scheduler)
     banmap_t banmap;
     if (bandb.Read(banmap))
     {
-        CNode::SetBanned(banmap); // thread save setter
-        CNode::SetBannedSetDirty(false); // no need to write down, just read data
-        CNode::SweepBanned(); // sweep out unused entries
+        dosMan.SetBanned(banmap); // thread save setter
+        dosMan.SetBannedSetDirty(false); // no need to write down, just read data
+        dosMan.SweepBanned(); // sweep out unused entries
 
         LogPrint("net", "Loaded %d banned node ips/subnets from banlist.dat  %dms\n", banmap.size(),
             GetTimeMillis() - nStart);

--- a/src/net.h
+++ b/src/net.h
@@ -93,10 +93,6 @@ static const bool DEFAULT_FORCEDNSSEED = false;
 static const size_t DEFAULT_MAXRECEIVEBUFFER = 5 * 1000;
 static const size_t DEFAULT_MAXSENDBUFFER = 1 * 1000;
 
-// NOTE: When adjusting this, update rpcnet:setban's help ("24h")
-static const unsigned int DEFAULT_MISBEHAVING_BANTIME = 60 * 60 * 24; // Default 24-hour ban
-
-
 unsigned int ReceiveFloodSize();
 unsigned int SendBufferSize();
 
@@ -383,12 +379,6 @@ public:
     unsigned short addrFromPort;
 
 protected:
-    // Denial-of-service detection/prevention
-    // Key is IP address, value is banned-until-time
-    static banmap_t setBanned;
-    static CCriticalSection cs_setBanned;
-    static bool setBannedIsDirty;
-
     // Basic fuzz-testing
     void Fuzz(int nChance); // modifies ssSend
 
@@ -778,43 +768,6 @@ public:
         return idstr;
     }
 
-
-    // Denial-of-service detection/prevention
-    // The idea is to detect peers that are behaving
-    // badly and disconnect/ban them, but do it in a
-    // one-coding-mistake-won't-shatter-the-entire-network
-    // way.
-    // IMPORTANT:  There should be nothing I can give a
-    // node that it will forward on that will make that
-    // node's peers drop it. If there is, an attacker
-    // can isolate a node and/or try to split the network.
-    // Dropping a node for sending stuff that is invalid
-    // now but might be valid in a later version is also
-    // dangerous, because it can cause a network split
-    // between nodes running old code and nodes running
-    // new code.
-    static void ClearBanned(); // needed for unit testing
-    static bool IsBanned(CNetAddr ip);
-    static bool IsBanned(CSubNet subnet);
-    static void Ban(const CNetAddr &ip,
-        const BanReason &banReason,
-        int64_t bantimeoffset = 0,
-        bool sinceUnixEpoch = false);
-    static void Ban(const CSubNet &subNet,
-        const BanReason &banReason,
-        int64_t bantimeoffset = 0,
-        bool sinceUnixEpoch = false);
-    static bool Unban(const CNetAddr &ip);
-    static bool Unban(const CSubNet &ip);
-    static void GetBanned(banmap_t &banmap);
-    static void SetBanned(const banmap_t &banmap);
-
-    //! check is the banlist has unwritten changes
-    static bool BannedSetIsDirty();
-    //! set the "dirty" flag for the banlist
-    static void SetBannedSetDirty(bool dirty = true);
-    //! clean unused entries (if bantime has expired)
-    static void SweepBanned();
 
     void copyStats(CNodeStats &stats);
 

--- a/src/net.h
+++ b/src/net.h
@@ -389,11 +389,6 @@ protected:
     static CCriticalSection cs_setBanned;
     static bool setBannedIsDirty;
 
-    // Whitelisted ranges. Any node connecting from these is automatically
-    // whitelisted (as well as those connecting to whitelisted binds).
-    static std::vector<CSubNet> vWhitelistedRange;
-    static CCriticalSection cs_vWhitelistedRange;
-
     // Basic fuzz-testing
     void Fuzz(int nChance); // modifies ssSend
 
@@ -822,9 +817,6 @@ public:
     static void SweepBanned();
 
     void copyStats(CNodeStats &stats);
-
-    static bool IsWhitelistedRange(const CNetAddr &ip);
-    static void AddWhitelistedRange(const CSubNet &subnet);
 
     // Network stats
     static void RecordBytesRecv(uint64_t bytes);

--- a/src/net.h
+++ b/src/net.h
@@ -917,19 +917,6 @@ public:
     bool Read(CAddrMan &addr, CDataStream &ssPeers);
 };
 
-/** Access to the banlist database (banlist.dat) */
-class CBanDB
-{
-private:
-    boost::filesystem::path pathBanlist;
-
-public:
-    CBanDB();
-    bool Write(const banmap_t &banSet);
-    bool Read(banmap_t &banSet);
-};
-
-
 /** Return a timestamp in the future (in microseconds) for exponentially distributed events. */
 int64_t PoissonNextSend(int64_t nNow, int average_interval_seconds);
 

--- a/src/net.h
+++ b/src/net.h
@@ -29,6 +29,7 @@
 #include <boost/foreach.hpp>
 #include <boost/signals2/signal.hpp>
 
+#include "banentry.h"
 #include "stat.h"
 #include "unlimited.h"
 
@@ -276,60 +277,6 @@ public:
     int readData(const char *pch, unsigned int nBytes);
 };
 
-
-typedef enum BanReason { BanReasonUnknown = 0, BanReasonNodeMisbehaving = 1, BanReasonManuallyAdded = 2 } BanReason;
-
-class CBanEntry
-{
-public:
-    static const int CURRENT_VERSION = 1;
-    int nVersion;
-    int64_t nCreateTime;
-    int64_t nBanUntil;
-    uint8_t banReason;
-
-    CBanEntry() { SetNull(); }
-    CBanEntry(int64_t nCreateTimeIn)
-    {
-        SetNull();
-        nCreateTime = nCreateTimeIn;
-    }
-
-    ADD_SERIALIZE_METHODS;
-
-    template <typename Stream, typename Operation>
-    inline void SerializationOp(Stream &s, Operation ser_action, int nType, int nVersion)
-    {
-        READWRITE(this->nVersion);
-        nVersion = this->nVersion;
-        READWRITE(nCreateTime);
-        READWRITE(nBanUntil);
-        READWRITE(banReason);
-    }
-
-    void SetNull()
-    {
-        nVersion = CBanEntry::CURRENT_VERSION;
-        nCreateTime = 0;
-        nBanUntil = 0;
-        banReason = BanReasonUnknown;
-    }
-
-    std::string banReasonToString()
-    {
-        switch (banReason)
-        {
-        case BanReasonNodeMisbehaving:
-            return "node misbehaving";
-        case BanReasonManuallyAdded:
-            return "manually added";
-        default:
-            return "unknown";
-        }
-    }
-};
-
-typedef std::map<CSubNet, CBanEntry> banmap_t;
 
 // BU cleaning up nodes as a global destructor creates many global destruction dependencies.  Instead use a function
 // call.

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "nodestate.h"
+
+/**
+* Default constructor initializing all local member variables to "null" values
+*/
+CNodeState::CNodeState()
+{
+    fCurrentlyConnected = false;
+    nMisbehavior = 0;
+    fShouldBan = false;
+    pindexBestKnownBlock = NULL;
+    hashLastUnknownBlock.SetNull();
+    pindexLastCommonBlock = NULL;
+    pindexBestHeaderSent = NULL;
+    fSyncStarted = false;
+    nDownloadingSince = 0;
+    nBlocksInFlight = 0;
+    nBlocksInFlightValidHeaders = 0;
+    fPreferredDownload = false;
+    fPreferHeaders = false;
+}
+
+/**
+* Gets the CNodeState for the specified NodeId.
+*
+* @param[in] pnode  The NodeId to return CNodeState* for
+* @return CNodeState* matching the NodeId, or NULL if NodeId is not matched
+*/
+CNodeState *State(NodeId pnode)
+{
+    std::map<NodeId, CNodeState>::iterator it = mapNodeState.find(pnode);
+    if (it == mapNodeState.end())
+        return NULL;
+    return &it->second;
+}

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -1,0 +1,85 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_NODESTATE_H
+#define BITCOIN_NODESTATE_H
+
+#include "net.h" // For NodeId
+
+/** Blocks that are in flight, and that are in the queue to be downloaded. Protected by cs_main. */
+struct QueuedBlock
+{
+    uint256 hash;
+    CBlockIndex *pindex; //!< Optional.
+    int64_t nTime; //! Time of "getdata" request in microseconds.
+    bool fValidatedHeaders; //!< Whether this block has validated headers at the time of request.
+};
+
+extern std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight;
+
+
+struct CBlockReject
+{
+    unsigned char chRejectCode;
+    std::string strRejectReason;
+    uint256 hashBlock;
+};
+
+/**
+* Maintain validation-specific state about nodes, protected by cs_main, instead
+* by CNode's own locks. This simplifies asynchronous operation, where
+* processing of incoming data is done after the ProcessMessage call returns,
+* and we're no longer holding the node's locks.
+*/
+struct CNodeState
+{
+    //! The peer's address
+    CService address;
+    //! Whether we have a fully established connection.
+    bool fCurrentlyConnected;
+    //! Accumulated misbehaviour score for this peer.
+    int nMisbehavior;
+    //! Whether this peer should be disconnected and banned (unless whitelisted).
+    bool fShouldBan;
+    //! String name of this peer (debugging/logging purposes).
+    std::string name;
+    //! List of asynchronously-determined block rejections to notify this peer about.
+    std::vector<CBlockReject> rejects;
+    //! The best known block we know this peer has announced.
+    CBlockIndex *pindexBestKnownBlock;
+    //! The hash of the last unknown block this peer has announced.
+    uint256 hashLastUnknownBlock;
+    //! The last full block we both have.
+    CBlockIndex *pindexLastCommonBlock;
+    //! The best header we have sent our peer.
+    CBlockIndex *pindexBestHeaderSent;
+    //! Whether we've started headers synchronization with this peer.
+    bool fSyncStarted;
+    //! The start time of the sync
+    int64_t fSyncStartTime;
+    //! Were the first headers requested in a sync received
+    bool fFirstHeadersReceived;
+
+    std::list<QueuedBlock> vBlocksInFlight;
+    //! When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.
+    int64_t nDownloadingSince;
+    int nBlocksInFlight;
+    int nBlocksInFlightValidHeaders;
+    //! Whether we consider this a preferred download peer.
+    bool fPreferredDownload;
+    //! Whether this peer wants invs or headers (when possible) for block announcements.
+    bool fPreferHeaders;
+
+    CNodeState();
+};
+
+/** Map maintaining per-node state. Requires cs_main. */
+extern std::map<NodeId, CNodeState> mapNodeState;
+
+// Requires cs_main.
+extern CNodeState *State(NodeId pnode);
+
+#endif // BITCOIN_NODESTATE_H

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -4,7 +4,7 @@
 
 #include "parallel.h"
 #include "chainparams.h"
-#include "main.h"
+#include "dosman.h"
 #include "net.h"
 #include "pow.h"
 #include "timedata.h"
@@ -536,7 +536,7 @@ void HandleBlockMessageThread(CNode *pfrom, const string &strCommand, const CBlo
             if (nDoS > 0)
             {
                 LOCK(cs_main);
-                Misbehaving(pfrom->GetId(), nDoS);
+                dosMan.Misbehaving(pfrom->GetId(), nDoS);
             }
         }
     }

--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -6,6 +6,7 @@
 #include "bantablemodel.h"
 
 #include "clientmodel.h"
+#include "dosman.h"
 #include "guiconstants.h"
 #include "guiutil.h"
 
@@ -49,7 +50,7 @@ public:
     void refreshBanlist()
     {
         banmap_t banMap;
-        CNode::GetBanned(banMap);
+        dosMan.GetBanned(banMap);
 
         cachedBanlist.clear();
 #if QT_VERSION >= 0x040700

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -12,6 +12,7 @@
 
 #include "bantablemodel.h"
 #include "clientmodel.h"
+#include "dosman.h"
 #include "guiutil.h"
 #include "platformstyle.h"
 #include "bantablemodel.h"
@@ -921,7 +922,7 @@ void RPCConsole::banSelectedNode(int bantime)
         int port = 0;
         SplitHostPort(nStr, port, addr);
 
-        CNode::Ban(CNetAddr(addr), BanReasonManuallyAdded, bantime);
+        dosMan.Ban(CNetAddr(addr), BanReasonManuallyAdded, bantime);
         bannedNode->fDisconnect = true;
 
         clearSelectedNode();
@@ -939,7 +940,7 @@ void RPCConsole::unbanSelectedNode()
 
     if (possibleSubnet.IsValid())
     {
-        CNode::Unban(possibleSubnet);
+        dosMan.Unban(possibleSubnet);
     }
 }
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -7,6 +7,7 @@
 
 #include "chainparams.h"
 #include "clientversion.h"
+#include "dosman.h"
 #include "main.h"
 #include "net.h"
 #include "netbase.h"
@@ -557,7 +558,7 @@ UniValue setban(const UniValue& params, bool fHelp)
 
     if (strCommand == "add")
     {
-        if (isSubnet ? CNode::IsBanned(subNet) : CNode::IsBanned(netAddr))
+        if (isSubnet ? dosMan.IsBanned(subNet) : dosMan.IsBanned(netAddr))
             throw JSONRPCError(RPC_CLIENT_NODE_ALREADY_ADDED, "Error: IP/Subnet already banned");
 
         int64_t banTime = 0; //use standard bantime if not specified
@@ -568,7 +569,7 @@ UniValue setban(const UniValue& params, bool fHelp)
         if (params.size() == 4 && params[3].isTrue())
             absolute = true;
 
-        isSubnet ? CNode::Ban(subNet, BanReasonManuallyAdded, banTime, absolute) : CNode::Ban(netAddr, BanReasonManuallyAdded, banTime, absolute);
+        isSubnet ? dosMan.Ban(subNet, BanReasonManuallyAdded, banTime, absolute) : dosMan.Ban(netAddr, BanReasonManuallyAdded, banTime, absolute);
 
         //disconnect possible nodes
         if (!isSubnet) subNet = CSubNet(netAddr);
@@ -577,7 +578,7 @@ UniValue setban(const UniValue& params, bool fHelp)
     }
     else if(strCommand == "remove")
     {
-        if (!( isSubnet ? CNode::Unban(subNet) : CNode::Unban(netAddr) ))
+        if (!( isSubnet ? dosMan.Unban(subNet) : dosMan.Unban(netAddr) ))
             throw JSONRPCError(RPC_MISC_ERROR, "Error: Unban failed");
     }
 
@@ -596,7 +597,7 @@ UniValue listbanned(const UniValue& params, bool fHelp)
                             );
 
     banmap_t banMap;
-    CNode::GetBanned(banMap);
+    dosMan.GetBanned(banMap);
 
     UniValue bannedAddresses(UniValue::VARR);
     for (banmap_t::iterator it = banMap.begin(); it != banMap.end(); it++)
@@ -625,7 +626,7 @@ UniValue clearbanned(const UniValue& params, bool fHelp)
                             + HelpExampleRpc("clearbanned", "")
                             );
 
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     return NullUniValue;
 }
 

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -6,6 +6,7 @@
 // Unit tests for denial-of-service detection/prevention code
 
 #include "chainparams.h"
+#include "dosman.h"
 #include "keystore.h"
 #include "main.h"
 #include "net.h"
@@ -40,49 +41,49 @@ BOOST_FIXTURE_TEST_SUITE(DoS_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(DoS_banning)
 {
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     CAddress addr1(ip(0xa0b0c001));
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100); // Should get banned
     SendMessages(&dummyNode1);
-    BOOST_CHECK(CNode::IsBanned(addr1));
-    BOOST_CHECK(!CNode::IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
+    BOOST_CHECK(dosMan.IsBanned(addr1));
+    BOOST_CHECK(!dosMan.IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
 
     CAddress addr2(ip(0xa0b0c002));
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
     dummyNode2.nVersion = 1;
     Misbehaving(dummyNode2.GetId(), 50);
     SendMessages(&dummyNode2);
-    BOOST_CHECK(!CNode::IsBanned(addr2)); // 2 not banned yet...
-    BOOST_CHECK(CNode::IsBanned(addr1));  // ... but 1 still should be
+    BOOST_CHECK(!dosMan.IsBanned(addr2)); // 2 not banned yet...
+    BOOST_CHECK(dosMan.IsBanned(addr1));  // ... but 1 still should be
     Misbehaving(dummyNode2.GetId(), 50);
     SendMessages(&dummyNode2);
-    BOOST_CHECK(CNode::IsBanned(addr2));
+    BOOST_CHECK(dosMan.IsBanned(addr2));
 }
 
 BOOST_AUTO_TEST_CASE(DoS_banscore)
 {
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     mapArgs["-banscore"] = "111"; // because 11 is my favorite number
     CAddress addr1(ip(0xa0b0c001));
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
     Misbehaving(dummyNode1.GetId(), 100);
     SendMessages(&dummyNode1);
-    BOOST_CHECK(!CNode::IsBanned(addr1));
+    BOOST_CHECK(!dosMan.IsBanned(addr1));
     Misbehaving(dummyNode1.GetId(), 10);
     SendMessages(&dummyNode1);
-    BOOST_CHECK(!CNode::IsBanned(addr1));
+    BOOST_CHECK(!dosMan.IsBanned(addr1));
     Misbehaving(dummyNode1.GetId(), 1);
     SendMessages(&dummyNode1);
-    BOOST_CHECK(CNode::IsBanned(addr1));
+    BOOST_CHECK(dosMan.IsBanned(addr1));
     mapArgs.erase("-banscore");
 }
 
 BOOST_AUTO_TEST_CASE(DoS_bantime)
 {
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     int64_t nStartTime = GetTime();
     SetMockTime(nStartTime); // Overrides future calls to GetTime()
 
@@ -92,13 +93,13 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
 
     Misbehaving(dummyNode.GetId(), 100);
     SendMessages(&dummyNode);
-    BOOST_CHECK(CNode::IsBanned(addr));
+    BOOST_CHECK(dosMan.IsBanned(addr));
 
     SetMockTime(nStartTime+60*60);
-    BOOST_CHECK(CNode::IsBanned(addr));
+    BOOST_CHECK(dosMan.IsBanned(addr));
 
     SetMockTime(nStartTime+60*60*24+1);
-    BOOST_CHECK(!CNode::IsBanned(addr));
+    BOOST_CHECK(!dosMan.IsBanned(addr));
 }
 
 CTransaction RandomOrphan()

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -39,7 +39,88 @@ CService ip(uint32_t i)
 
 BOOST_FIXTURE_TEST_SUITE(DoS_tests, TestingSetup)
 
-BOOST_AUTO_TEST_CASE(DoS_banning)
+size_t GetNumberBanEntries()
+{
+    banmap_t banmap;
+    dosMan.GetBanned(banmap);
+    return banmap.size();
+}
+
+BOOST_AUTO_TEST_CASE(DoS_basic_ban_tests)
+{
+    // Ensure in-memory banlist is empty
+    dosMan.ClearBanned();
+    BOOST_CHECK(GetNumberBanEntries() == 0);
+
+    // Add a CNetAddr entry to banlist
+    dosMan.Ban(CNetAddr("192.168.1.1"), BanReasonManuallyAdded, DEFAULT_MISBEHAVING_BANTIME, false);
+    // Add a CSubNet entry to banlist
+    dosMan.Ban(CSubNet("10.168.1.0/28"), BanReasonNodeMisbehaving, DEFAULT_MISBEHAVING_BANTIME, false);
+    // Ensure we have exactly 2 entries in our banlist
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+
+    // Verify IsBanned works for single IP directly specified
+    BOOST_CHECK(dosMan.IsBanned(CNetAddr("192.168.1.1")));
+    // Verify IsBanned works for single IP not banned
+    BOOST_CHECK(!dosMan.IsBanned(CNetAddr("192.168.1.2")));
+    // Verify IsBanned works for single IP banned as part of subnet
+    BOOST_CHECK(dosMan.IsBanned(CNetAddr("10.168.1.1")));
+    // Verify IsBanned works for single IP not banned as part of subnet
+    BOOST_CHECK(!dosMan.IsBanned(CNetAddr("10.168.1.19")));
+    // Verify IsBanned works for subnet exact match
+    BOOST_CHECK(dosMan.IsBanned(CSubNet("10.168.1.0/28")));
+    // Verify IsBanned works for subnet not banned
+    BOOST_CHECK(!dosMan.IsBanned(CSubNet("10.168.1.64/30")));
+
+    // REVISIT: Currently subnets require EXACT matches, so the encompassed case should return not banned.
+    BOOST_CHECK(!dosMan.IsBanned(CSubNet("10.168.1.4/30")));
+
+    // Verify unbanning an IP not banned doesn't change banlist contents
+    dosMan.Unban(CNetAddr("192.168.10.1"));
+    // Ensure we still have exactly 2 entries in our banlist
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+
+    // Verify unbanning an IP that is within a subnet, but not directly banned, doesn't
+    // change our banlist conents
+    dosMan.Unban(CNetAddr("10.168.1.1"));
+    // Ensure we still have exactly 2 entries in our banlist
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+    // Verify that the IP we just "unbanned" still shows as banned since it still falls within banned subnet
+    BOOST_CHECK(dosMan.IsBanned(CNetAddr("10.168.1.1")));
+
+    // Verify that unbanning an IP that is banned works
+    dosMan.Unban(CNetAddr("192.168.1.1"));
+    // Ensure we now have exactly 1 entry in our banlist
+    BOOST_CHECK(GetNumberBanEntries() == 1);
+
+    // Verify that unbanning a subnet that is inside a banned subnet doesn't change our banlist contents
+    dosMan.Unban(CSubNet("10.168.1.4/30"));
+    // Ensure we still have exactly 1 entry in our banlist
+    BOOST_CHECK(GetNumberBanEntries() == 1);
+
+    // Verify that unbanning a subnet that encompasses a banned subnet doesn't change our banlist conents
+    dosMan.Unban(CSubNet("10.168.1.0/24"));
+    // Ensure we still have exactly 1 entry in our banlist
+    BOOST_CHECK(GetNumberBanEntries() == 1);
+
+    // Verify that unbanning a subnet that exactly matches a banned subnet updates our banlist conents
+    dosMan.Unban(CSubNet("10.168.1.0/28"));
+    // Ensure we now have exactly 0 entries in our banlist
+    BOOST_CHECK(GetNumberBanEntries() == 0);
+
+    // Re-add ban entries so we can test ClearBanned()
+    dosMan.Ban(CNetAddr("192.168.1.1"), BanReasonManuallyAdded, DEFAULT_MISBEHAVING_BANTIME, false);
+    dosMan.Ban(CSubNet("10.168.1.0/28"), BanReasonNodeMisbehaving, DEFAULT_MISBEHAVING_BANTIME, false);
+    // Ensure we have exactly 2 entries in our banlist
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+
+    // Clear the in-memory banlist
+    dosMan.ClearBanned();
+    // Ensure in-memory banlist is now empty
+    BOOST_CHECK(GetNumberBanEntries() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(DoS_misbehaving_ban_tests)
 {
     dosMan.ClearBanned();
     CAddress addr1(ip(0xa0b0c001));
@@ -62,7 +143,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     BOOST_CHECK(dosMan.IsBanned(addr2));
 }
 
-BOOST_AUTO_TEST_CASE(DoS_banscore)
+BOOST_AUTO_TEST_CASE(DoS_non_default_banscore)
 {
     dosMan.ClearBanned();
     mapArgs["-banscore"] = "111"; // because 11 is my favorite number
@@ -81,7 +162,7 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     mapArgs.erase("-banscore");
 }
 
-BOOST_AUTO_TEST_CASE(DoS_bantime)
+BOOST_AUTO_TEST_CASE(DoS_bantime_expiration)
 {
     dosMan.ClearBanned();
     int64_t nStartTime = GetTime();
@@ -95,11 +176,26 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     SendMessages(&dummyNode);
     BOOST_CHECK(dosMan.IsBanned(addr));
 
+    // Verify that SweepBanned does not remove the entry
+    dosMan.SweepBanned();
+    // Ensure we still have exactly 1 entry in our banlist
+    BOOST_CHECK(GetNumberBanEntries() == 1);
+
     SetMockTime(nStartTime+60*60);
     BOOST_CHECK(dosMan.IsBanned(addr));
 
+    // Verify that SweepBanned still does not remove the entry
+    dosMan.SweepBanned();
+    // Ensure we still have exactly 1 entry in our banlist
+    BOOST_CHECK(GetNumberBanEntries() == 1);
+
     SetMockTime(nStartTime+60*60*24+1);
     BOOST_CHECK(!dosMan.IsBanned(addr));
+
+    // Verify that SweepBanned does remove the entry this time as it is expired
+    dosMan.SweepBanned();
+    // Ensure we now have exactly 0 entries in our banlist
+    BOOST_CHECK(GetNumberBanEntries() == 0);
 }
 
 CTransaction RandomOrphan()

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     CAddress addr1(ip(0xa0b0c001));
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
-    Misbehaving(dummyNode1.GetId(), 100); // Should get banned
+    dosMan.Misbehaving(dummyNode1.GetId(), 100); // Should get banned
     SendMessages(&dummyNode1);
     BOOST_CHECK(dosMan.IsBanned(addr1));
     BOOST_CHECK(!dosMan.IsBanned(ip(0xa0b0c001|0x0000ff00))); // Different IP, not banned
@@ -53,11 +53,11 @@ BOOST_AUTO_TEST_CASE(DoS_banning)
     CAddress addr2(ip(0xa0b0c002));
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
     dummyNode2.nVersion = 1;
-    Misbehaving(dummyNode2.GetId(), 50);
+    dosMan.Misbehaving(dummyNode2.GetId(), 50);
     SendMessages(&dummyNode2);
     BOOST_CHECK(!dosMan.IsBanned(addr2)); // 2 not banned yet...
     BOOST_CHECK(dosMan.IsBanned(addr1));  // ... but 1 still should be
-    Misbehaving(dummyNode2.GetId(), 50);
+    dosMan.Misbehaving(dummyNode2.GetId(), 50);
     SendMessages(&dummyNode2);
     BOOST_CHECK(dosMan.IsBanned(addr2));
 }
@@ -69,13 +69,13 @@ BOOST_AUTO_TEST_CASE(DoS_banscore)
     CAddress addr1(ip(0xa0b0c001));
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 1;
-    Misbehaving(dummyNode1.GetId(), 100);
+    dosMan.Misbehaving(dummyNode1.GetId(), 100);
     SendMessages(&dummyNode1);
     BOOST_CHECK(!dosMan.IsBanned(addr1));
-    Misbehaving(dummyNode1.GetId(), 10);
+    dosMan.Misbehaving(dummyNode1.GetId(), 10);
     SendMessages(&dummyNode1);
     BOOST_CHECK(!dosMan.IsBanned(addr1));
-    Misbehaving(dummyNode1.GetId(), 1);
+    dosMan.Misbehaving(dummyNode1.GetId(), 1);
     SendMessages(&dummyNode1);
     BOOST_CHECK(dosMan.IsBanned(addr1));
     mapArgs.erase("-banscore");
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime)
     CNode dummyNode(INVALID_SOCKET, addr, "", true);
     dummyNode.nVersion = 1;
 
-    Misbehaving(dummyNode.GetId(), 100);
+    dosMan.Misbehaving(dummyNode.GetId(), 100);
     SendMessages(&dummyNode);
     BOOST_CHECK(dosMan.IsBanned(addr));
 

--- a/src/test/bandb_tests.cpp
+++ b/src/test/bandb_tests.cpp
@@ -1,0 +1,118 @@
+// Copyright (c) 2012-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bandb.h"
+#include "test/test_bitcoin.h"
+
+#include <string>
+
+#include <boost/assign/list_of.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/test/unit_test.hpp>
+
+
+BOOST_FIXTURE_TEST_SUITE(bandb_tests, TestingSetup)
+
+bool RemoveLocalDatabase(const boost::filesystem::path &path)
+{
+    try
+    {
+        if (boost::filesystem::exists(path))
+        {
+            // if the file already exists, remove it
+            boost::filesystem::remove(path);
+        }
+
+        // if we get here, we either successfully deleted the file, or it didn't exist
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        // there was an error deleting the file
+        return false;
+    }
+}
+
+BOOST_AUTO_TEST_CASE(bandb_no_database)
+{
+    // create the CBanDB object
+    CBanDB db;
+
+    // Ensure local bandlist.dat has been removed
+    BOOST_CHECK(RemoveLocalDatabase(db.GetDatabasePath()));
+
+    // Try to read non-existent file (this shoudl fail)
+    banmap_t banset;
+    BOOST_CHECK(!db.Read(banset));
+}
+
+BOOST_AUTO_TEST_CASE(bandb_read_write_empty_database)
+{
+    // create the CBanDB object
+    CBanDB db;
+
+    // Ensure local bandlist.db has been removed
+    BOOST_CHECK(RemoveLocalDatabase(db.GetDatabasePath()));
+
+    // Write an empty banset_t to file
+    banmap_t banset_write;
+    BOOST_CHECK(db.Write(banset_write));
+
+    // Read an empty banset_t from file
+    banmap_t banset_read;
+    BOOST_CHECK(db.Read(banset_read));
+    // And ensure after reading in the banset is still empty
+    BOOST_CHECK(banset_read.size() == 0);
+}
+
+BOOST_AUTO_TEST_CASE(bandb_read_write_non_empty_database)
+{
+    // create the CBanDB object
+    CBanDB db;
+
+    // Ensure local bandlist.db has been removed
+    BOOST_CHECK(RemoveLocalDatabase(db.GetDatabasePath()));
+
+    // Create sub-nets
+    CSubNet singleIP("192.168.1.1/32");
+    CSubNet subNet("10.168.1.1/24");
+
+    // Write a non-empty banset_t to file
+    banmap_t banset_write;
+    // Add single IP
+    CBanEntry write1(GetTime());
+    write1.banReason = BanReasonNodeMisbehaving;
+    write1.nBanUntil = GetTime() + 14400; // Ban 4 hours
+    banset_write[singleIP] = write1;
+    // Add subnet
+    CBanEntry write2(GetTime());
+    write2.banReason = BanReasonManuallyAdded;
+    write2.nBanUntil = GetTime() + 28800; // Ban 8 hours
+    banset_write[subNet] = write2;
+    // Ensure we can succesfully write to the banlist.dat file
+    BOOST_CHECK(db.Write(banset_write));
+
+    // Read a non-empty banset_t from file
+    banmap_t banset_read;
+    BOOST_CHECK(db.Read(banset_read));
+    // And ensure after reading in the banset contains 2 entries
+    BOOST_CHECK(banset_read.size() == 2);
+
+    // Ensure entry 1 matches the pre-write entry
+    CBanEntry *read1 = &banset_read[singleIP];
+    BOOST_CHECK(read1 != NULL);
+    BOOST_CHECK(read1->banReason == write1.banReason);
+    BOOST_CHECK(read1->nBanUntil == write1.nBanUntil);
+    BOOST_CHECK(read1->nCreateTime == write1.nCreateTime);
+
+    // Ensure entry 2 matches the pre-write entry
+    CBanEntry *read2 = &banset_read[subNet];
+    BOOST_CHECK(read2 != NULL);
+    BOOST_CHECK(read2->banReason == write2.banReason);
+    BOOST_CHECK(read2->nBanUntil == write2.nBanUntil);
+    BOOST_CHECK(read2->nCreateTime == write2.nCreateTime);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -7,6 +7,7 @@
 #include "random.h"
 #include "bloom.h"
 #include "chainparams.h"
+#include "dosman.h"
 #include "streams.h"
 #include "version.h"
 #include "serialize.h"
@@ -92,7 +93,7 @@ BOOST_AUTO_TEST_CASE(version_tests)
 
     // Recieve VERSION with no prior VERSION received yet.  Should not ban
     vRecv1.clear();
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = 0;
     dummyNode1.fSuccessfullyConnected = false;
@@ -101,11 +102,11 @@ BOOST_AUTO_TEST_CASE(version_tests)
     ProcessMessage(&dummyNode1, NetMsgType::VERSION, vRecv1, GetTime());
     SendMessages(&dummyNode1);
     BOOST_CHECK(dummyNode1.nVersion);
-    BOOST_CHECK(!CNode::IsBanned(addr1));
+    BOOST_CHECK(!dosMan.IsBanned(addr1));
 
     // Receive VERSION with no prior VERSION received but invalid protocol version, which should result in ban
     vRecv1.clear();
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     CNode dummyNode1a(INVALID_SOCKET, addr1, "", true);
     dummyNode1a.nVersion = 0;
     dummyNode1a.fSuccessfullyConnected = false;
@@ -114,35 +115,35 @@ BOOST_AUTO_TEST_CASE(version_tests)
     ProcessMessage(&dummyNode1a, NetMsgType::VERSION, vRecv1, GetTime());
     SendMessages(&dummyNode1a);
     BOOST_CHECK(dummyNode1a.nVersion);
-    BOOST_CHECK(CNode::IsBanned(addr1));
+    BOOST_CHECK(dosMan.IsBanned(addr1));
 
     // Receive duplicate VERSION, nVersion will not be zero and should result in a ban
     vRecv1.clear();
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
     dummyNode2.nVersion = MIN_PEER_PROTO_VERSION;
     vRecv1 << nVersion << nServices << nTime << addrMe;
     ProcessMessage(&dummyNode2, NetMsgType::VERSION, vRecv1, GetTime());
     SendMessages(&dummyNode2);
     BOOST_CHECK(dummyNode2.nVersion);
-    BOOST_CHECK(CNode::IsBanned(addr2));
+    BOOST_CHECK(dosMan.IsBanned(addr2));
 
     // Receive any message without receiving the version message first - this should cause a ban
     vRecv1.clear();
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     CNode dummyNode3(INVALID_SOCKET, addr3, "", true);
     dummyNode3.nVersion = 0;
     ProcessMessage(&dummyNode3, NetMsgType::PING, vRecv1, GetTime());
     SendMessages(&dummyNode3);
     BOOST_CHECK(!dummyNode3.nVersion);
-    BOOST_CHECK(CNode::IsBanned(addr3));
+    BOOST_CHECK(dosMan.IsBanned(addr3));
 }
 
 BOOST_AUTO_TEST_CASE(verack_tests)
 {
     // Receive VERACK after VERSION sent
     vRecv1.clear();
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode1.fSuccessfullyConnected = false;
@@ -150,7 +151,7 @@ BOOST_AUTO_TEST_CASE(verack_tests)
     ProcessMessage(&dummyNode1, NetMsgType::VERACK, vRecv1, GetTime());
     SendMessages(&dummyNode1);
     BOOST_CHECK(dummyNode1.tVersionSent >= 0);
-    BOOST_CHECK(!CNode::IsBanned(addr1));
+    BOOST_CHECK(!dosMan.IsBanned(addr1));
 
     // Receive VERACK but no VERSION sent
     dummyNode1.fSuccessfullyConnected = false;
@@ -158,11 +159,11 @@ BOOST_AUTO_TEST_CASE(verack_tests)
     ProcessMessage(&dummyNode1, NetMsgType::VERACK, vRecv1, GetTime());
     SendMessages(&dummyNode1);
     BOOST_CHECK(dummyNode1.tVersionSent < 0);
-    BOOST_CHECK(CNode::IsBanned(addr1));
+    BOOST_CHECK(dosMan.IsBanned(addr1));
 
     // Receive duplicate VERACK after VERSION sent. fSuccessfullyConnected will already be true.
     vRecv1.clear();
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
     dummyNode2.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode2.fSuccessfullyConnected = true; // should cause ban if VERSION was already sent
@@ -170,13 +171,13 @@ BOOST_AUTO_TEST_CASE(verack_tests)
     ProcessMessage(&dummyNode2, NetMsgType::VERACK, vRecv1, GetTime());
     SendMessages(&dummyNode2);
     BOOST_CHECK(dummyNode2.fSuccessfullyConnected);
-    BOOST_CHECK(CNode::IsBanned(addr2));
+    BOOST_CHECK(dosMan.IsBanned(addr2));
 
     // Test the disconnect of a peer if the VERACK_TIMEOUT is exceeded
     int64_t nStartTime = GetTime();
 
     vRecv1.clear();
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     CNode dummyNode3(INVALID_SOCKET, addr3, "", true);
     dummyNode3.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode3.fSuccessfullyConnected = false;
@@ -185,10 +186,10 @@ BOOST_AUTO_TEST_CASE(verack_tests)
     ProcessMessage(&dummyNode3, NetMsgType::VERACK, vRecv1, GetTime());
     SendMessages(&dummyNode3);
     BOOST_CHECK(dummyNode3.tVersionSent >= 0);
-    BOOST_CHECK(!CNode::IsBanned(addr3));
+    BOOST_CHECK(!dosMan.IsBanned(addr3));
 
     vRecv1.clear();
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     CNode dummyNode4(INVALID_SOCKET, addr4, "", true);
     dummyNode4.nVersion = 1;
     dummyNode4.fSuccessfullyConnected = false;
@@ -198,7 +199,7 @@ BOOST_AUTO_TEST_CASE(verack_tests)
     BOOST_CHECK(!dummyNode4.fDisconnect);
 
     vRecv1.clear();
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     CNode dummyNode4a(INVALID_SOCKET, addr4, "", true);
     dummyNode4a.nVersion = 1;
     dummyNode4a.fSuccessfullyConnected = false;
@@ -212,7 +213,7 @@ BOOST_AUTO_TEST_CASE(bu_version_tests)
 {
     // Receive BUVERSION after VERACK sent
     vRecv1.clear();
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     vRecv1 << 8333;
 
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
@@ -223,7 +224,7 @@ BOOST_AUTO_TEST_CASE(bu_version_tests)
     ProcessMessage(&dummyNode1, NetMsgType::BUVERSION, vRecv1, GetTime());
     SendMessages(&dummyNode1);
     BOOST_CHECK(dummyNode1.fVerackSent);
-    BOOST_CHECK(!CNode::IsBanned(addr1));
+    BOOST_CHECK(!dosMan.IsBanned(addr1));
 
     // Receive BUVERSION but no VERACK sent
     dummyNode1.fSuccessfullyConnected = true;
@@ -232,7 +233,7 @@ BOOST_AUTO_TEST_CASE(bu_version_tests)
     ProcessMessage(&dummyNode1, NetMsgType::BUVERACK, vRecv1, GetTime());
     SendMessages(&dummyNode1);
     BOOST_CHECK(!dummyNode1.fVerackSent);
-    BOOST_CHECK(CNode::IsBanned(addr1));
+    BOOST_CHECK(dosMan.IsBanned(addr1));
 
     // Recieve duplicate BUVERSION. addrFromPort will not be zero
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
@@ -243,14 +244,14 @@ BOOST_AUTO_TEST_CASE(bu_version_tests)
     ProcessMessage(&dummyNode2, NetMsgType::BUVERSION, vRecv1, GetTime());
     SendMessages(&dummyNode2);
     BOOST_CHECK(dummyNode2.addrFromPort);
-    BOOST_CHECK(CNode::IsBanned(addr2));
+    BOOST_CHECK(dosMan.IsBanned(addr2));
 }
 
 BOOST_AUTO_TEST_CASE(bu_verack_tests)
 {
     // Receive BUVERACK after BUVERSION sent
     vRecv1.clear();
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
 
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
     dummyNode1.fSuccessfullyConnected = true;
@@ -259,7 +260,7 @@ BOOST_AUTO_TEST_CASE(bu_verack_tests)
     ProcessMessage(&dummyNode1, NetMsgType::BUVERACK, vRecv1, GetTime());
     SendMessages(&dummyNode1);
     BOOST_CHECK(dummyNode1.fBUVersionSent);
-    BOOST_CHECK(!CNode::IsBanned(addr1));
+    BOOST_CHECK(!dosMan.IsBanned(addr1));
 
     // Receive BUVERACK but no BUVERSION sent
     dummyNode1.fSuccessfullyConnected = true;
@@ -267,14 +268,14 @@ BOOST_AUTO_TEST_CASE(bu_verack_tests)
     ProcessMessage(&dummyNode1, NetMsgType::BUVERACK, vRecv1, GetTime());
     SendMessages(&dummyNode1);
     BOOST_CHECK(!dummyNode1.fBUVersionSent);
-    BOOST_CHECK(CNode::IsBanned(addr1));
+    BOOST_CHECK(dosMan.IsBanned(addr1));
 }
 
 BOOST_AUTO_TEST_CASE(inv_tests)
 {
     // send more INV than the limit of MAX_INV_SZ
     vRecv1.clear();
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     std::vector<CInv> vInv;
 
     CInv testINV(MSG_TX, TestBlock1().GetHash());
@@ -301,7 +302,7 @@ BOOST_AUTO_TEST_CASE(inv_tests)
 
     SendMessages(&dummyNode1); // sending five messages below MAX_INV_SZ should not cause ban
     BOOST_CHECK(vInv.size() <= MAX_INV_SZ);
-    BOOST_CHECK(!CNode::IsBanned(addr1));
+    BOOST_CHECK(!dosMan.IsBanned(addr1));
 
 
     vInv.push_back(testINV); // Add one more INV which should cause a ban
@@ -322,19 +323,19 @@ BOOST_AUTO_TEST_CASE(inv_tests)
     ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetTime());
     SendMessages(&dummyNode1); // send four messages should not cause ban
     BOOST_CHECK(vInv.size() > MAX_INV_SZ);
-    BOOST_CHECK(!CNode::IsBanned(addr1));
+    BOOST_CHECK(!dosMan.IsBanned(addr1));
 
     vRecv1 << vInv;
     ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetTime());
     SendMessages(&dummyNode1); // send a fifth message will cause a ban
     BOOST_CHECK(vInv.size() > MAX_INV_SZ);
-    BOOST_CHECK(CNode::IsBanned(addr1));
+    BOOST_CHECK(dosMan.IsBanned(addr1));
 
 
     // INV with invalid type
     vRecv1.clear();
     vInv.clear();
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
 
     CInv txINV(MSG_TX, TestBlock1().GetHash());
     CInv blockINV(MSG_BLOCK, TestBlock1().GetHash());
@@ -362,19 +363,19 @@ BOOST_AUTO_TEST_CASE(inv_tests)
     vRecv1 << vInv;
     ProcessMessage(&dummyNode3, NetMsgType::INV, vRecv1, GetTime());
     SendMessages(&dummyNode3); // send four messages should not cause ban
-    BOOST_CHECK(!CNode::IsBanned(addr3));
+    BOOST_CHECK(!dosMan.IsBanned(addr3));
 
     vRecv1 << vInv;
     ProcessMessage(&dummyNode3, NetMsgType::INV, vRecv1, GetTime());
     SendMessages(&dummyNode3); // send a fifth message should cause ban
-    BOOST_CHECK(CNode::IsBanned(addr3));
+    BOOST_CHECK(dosMan.IsBanned(addr3));
 
 
     // INV with null hash
     vRecv1.clear();
     vInv.clear();
     nullhash.SetNull();
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
 
     CInv nullINV(MSG_BLOCK, nullhash);
     for (unsigned int i = 0; i < 10; i++)
@@ -400,13 +401,13 @@ BOOST_AUTO_TEST_CASE(inv_tests)
     vRecv1 << vInv;
     ProcessMessage(&dummyNode5, NetMsgType::INV, vRecv1, GetTime());
     SendMessages(&dummyNode5); // send four messages should not cause ban
-    BOOST_CHECK(!CNode::IsBanned(addr5));
+    BOOST_CHECK(!dosMan.IsBanned(addr5));
 
     vRecv1.clear();
     vRecv1 << vInv;
     ProcessMessage(&dummyNode5, NetMsgType::INV, vRecv1, GetTime());
     SendMessages(&dummyNode5); // send a fifth message should cause ban
-    BOOST_CHECK(CNode::IsBanned(addr5));
+    BOOST_CHECK(dosMan.IsBanned(addr5));
 }
 
 BOOST_AUTO_TEST_CASE(transaction_tests)
@@ -449,7 +450,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     /** XTHINBLOCK message consistency checks */
 
     // testing empty missingtx vector
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     CXThinBlock xthin = xthinblock;
     xthin.vMissingTx.clear(); // empty the missingtx vector. This should cause an error.
     vRecv1.clear();
@@ -462,10 +463,10 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     ProcessMessage(&dummyNode1, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
     SendMessages(&dummyNode1);
     BOOST_CHECK(xthin.vMissingTx.size() == 0);
-    BOOST_CHECK(CNode::IsBanned(addr1));
+    BOOST_CHECK(dosMan.IsBanned(addr1));
 
     // test invalid or missing coinbase
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     vRecv1.clear();
     xthin = xthinblock;
     xthin.vMissingTx[0] = xthin.vMissingTx[1]; // delete the coinbase. This should cause an error.
@@ -479,10 +480,10 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     ProcessMessage(&dummyNode1a, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
     SendMessages(&dummyNode1a);
     BOOST_CHECK(!xthin.vMissingTx[0].IsCoinBase());
-    BOOST_CHECK(CNode::IsBanned(addr1));
+    BOOST_CHECK(dosMan.IsBanned(addr1));
 
     // test invalid block header
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     vRecv1.clear();
     xthin = xthinblock;
     xthin.header.nBits = 1; // create invalid block header
@@ -497,12 +498,12 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     SendMessages(&dummyNode1b);
     CValidationState state;
     BOOST_CHECK(!CheckBlockHeader(xthin.header, state, true));
-    BOOST_CHECK(CNode::IsBanned(addr1));
+    BOOST_CHECK(dosMan.IsBanned(addr1));
 
     /** THINBLOCK message consistency  checks */
 
     // test empty missingtx vector
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     CThinBlock thin = thinblock;
     thin.vMissingTx.clear(); // empty the missingtx vector. This should cause an error.
     vRecv2 << thin;
@@ -515,10 +516,10 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     ProcessMessage(&dummyNode2, NetMsgType::THINBLOCK, vRecv2, GetTime());
     SendMessages(&dummyNode2);
     BOOST_CHECK(thin.vMissingTx.size() == 0);
-    BOOST_CHECK(CNode::IsBanned(addr2));
+    BOOST_CHECK(dosMan.IsBanned(addr2));
 
     // test invalid or missing coinbase
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     vRecv2.clear();
     thin = thinblock;
     thin.vMissingTx[0] = thin.vMissingTx[1]; // delete the coinbase. This should cause an error.
@@ -532,10 +533,10 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     ProcessMessage(&dummyNode2a, NetMsgType::THINBLOCK, vRecv2, GetTime());
     SendMessages(&dummyNode2a);
     BOOST_CHECK(!thin.vMissingTx[0].IsCoinBase());
-    BOOST_CHECK(CNode::IsBanned(addr2));
+    BOOST_CHECK(dosMan.IsBanned(addr2));
 
     // create invalid block header
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     vRecv2.clear();
     thin = thinblock;
     thin.header.nBits = 1;
@@ -549,7 +550,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     ProcessMessage(&dummyNode2b, NetMsgType::THINBLOCK, vRecv2, GetTime());
     SendMessages(&dummyNode2b);
     BOOST_CHECK(!CheckBlockHeader(thin.header, state, true));
-    BOOST_CHECK(CNode::IsBanned(addr2));
+    BOOST_CHECK(dosMan.IsBanned(addr2));
 
 
     /** XBLOCKTX message consistency checks */
@@ -557,7 +558,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     // test null hash
     CBlock block3 = TestBlock1();
 
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     nullhash.SetNull();
     CXThinBlockTx xblocktx(nullhash, block3.vtx);
     vRecv3 << xblocktx;
@@ -570,10 +571,10 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     ProcessMessage(&dummyNode3, NetMsgType::XBLOCKTX, vRecv3, GetTime());
     SendMessages(&dummyNode3);
     BOOST_CHECK(nullhash.IsNull());
-    BOOST_CHECK(CNode::IsBanned(addr3));
+    BOOST_CHECK(dosMan.IsBanned(addr3));
 
     // test no txns in xblocktx
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     vRecv3.clear();
     std::vector<CTransaction> vTxEmpty;
     CXThinBlockTx xblocktx2(block3.GetHash(), vTxEmpty);
@@ -587,10 +588,10 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     ProcessMessage(&dummyNode3a, NetMsgType::XBLOCKTX, vRecv3, GetTime());
     SendMessages(&dummyNode3a);
     BOOST_CHECK(vTxEmpty.size() == 0);
-    BOOST_CHECK(CNode::IsBanned(addr3));
+    BOOST_CHECK(dosMan.IsBanned(addr3));
 
     // test txns hashes in xblocktx not matching num in pfrom->xThinBlockHashes
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     vRecv3.clear();
     CXThinBlockTx xblocktx3(block3.GetHash(), block3.vtx);
     vRecv3 << xblocktx3;
@@ -604,13 +605,13 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     ProcessMessage(&dummyNode3b, NetMsgType::XBLOCKTX, vRecv3, GetTime());
     SendMessages(&dummyNode3b);
     BOOST_CHECK(dummyNode3b.xThinBlockHashes.size() != dummyNode3b.thinBlock.vtx.size());
-    BOOST_CHECK(CNode::IsBanned(addr3));
+    BOOST_CHECK(dosMan.IsBanned(addr3));
 
 
     /** GET_XBLOCKTX message consistency checks */
 
     // test null hash
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     nullhash.SetNull();
     std::set<uint64_t> setHashesToRequest;
     setHashesToRequest.insert(1); // add a hash so that we are not empty
@@ -625,10 +626,10 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     ProcessMessage(&dummyNode4, NetMsgType::GET_XBLOCKTX, vRecv4, GetTime());
     SendMessages(&dummyNode4);
     BOOST_CHECK(nullhash.IsNull());
-    BOOST_CHECK(CNode::IsBanned(addr4));
+    BOOST_CHECK(dosMan.IsBanned(addr4));
 
     // test empty setHashesToRequest
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     vRecv4.clear();
     setHashesToRequest.clear(); // clear the set
     CXRequestThinBlockTx get_xblocktx2(block3.GetHash(), setHashesToRequest);
@@ -642,13 +643,13 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     ProcessMessage(&dummyNode4a, NetMsgType::GET_XBLOCKTX, vRecv4, GetTime());
     SendMessages(&dummyNode4a);
     BOOST_CHECK(setHashesToRequest.empty());
-    BOOST_CHECK(CNode::IsBanned(addr4));
+    BOOST_CHECK(dosMan.IsBanned(addr4));
 
 
     /** GET_XTHIN message consistency checks */
 
     // test get_xthin with null hash
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     nullhash.SetNull();
     CInv inv(MSG_XTHINBLOCK, nullhash);
     CBloomFilter filterMemPool;
@@ -664,10 +665,10 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     ProcessMessage(&dummyNode5, NetMsgType::GET_XTHIN, vRecv5, GetTime());
     SendMessages(&dummyNode5);
     BOOST_CHECK(nullhash.IsNull());
-    BOOST_CHECK(CNode::IsBanned(addr5));
+    BOOST_CHECK(dosMan.IsBanned(addr5));
 
     // test get_xthin with invalid message type
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     vRecv5.clear();
     CInv inv2(15, block3.GetHash()); // invalid type
     CBloomFilter filterMemPool2;
@@ -683,14 +684,14 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     ProcessMessage(&dummyNode5a, NetMsgType::GET_XTHIN, vRecv5, GetTime());
     SendMessages(&dummyNode5a);
     BOOST_CHECK(inv2.type != MSG_THINBLOCK && inv2.type != MSG_XTHINBLOCK);
-    BOOST_CHECK(CNode::IsBanned(addr5));
+    BOOST_CHECK(dosMan.IsBanned(addr5));
 
 
     /* Thinblock memory exhaustion attack 1 */
 
     // test a single valid thinblock reconstruction that goes over the limit.
     // result: the peer should have it data cleared and node should be disconnected.
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     CXThinBlock xthin2 = xthinblock;
     CThinBlock thin2 = thinblock;
 
@@ -741,7 +742,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     // result: the peer with largest thinblock set of data should have it data cleared
     //         and node should be disconnected.
 
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     CXThinBlock xthin3 = xthinblock;
 
     CNode dummyNode7(INVALID_SOCKET, addr2, "", true);
@@ -808,7 +809,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     // result: the peer with largest thinblock set of data should have it data cleared
     //         and node should be disconnected.
 
-    CNode::ClearBanned();
+    dosMan.ClearBanned();
     CXThinBlock xthin4 = xthinblock;
 
     // This time we don't want the xthinblock to cause an overlimit but have some other node disconnected.

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -11,6 +11,7 @@
 #include "consensus/params.h"
 #include "consensus/validation.h"
 #include "core_io.h"
+#include "dosman.h"
 #include "expedited.h"
 #include "hash.h"
 #include "leakybucket.h"
@@ -1632,7 +1633,7 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
         ret.push_back(Pair("setUnVerifiedOrphanTxHash", setUnVerifiedOrphanTxHash.size()));
     }
     ret.push_back(Pair("mapLocalHost", mapLocalHost.size()));
-    ret.push_back(Pair("CNode::vWhitelistedRange", CNode::vWhitelistedRange.size()));
+    ret.push_back(Pair("CDoSManager::vWhitelistedRange", dosMan.vWhitelistedRange.size()));
     ret.push_back(Pair("mapInboundConnectionTracker", mapInboundConnectionTracker.size()));
     ret.push_back(Pair("vUseDNSSeeds", vUseDNSSeeds.size()));
     ret.push_back(Pair("vAddedNodes", vAddedNodes.size()));

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -15,7 +15,6 @@
 #include "expedited.h"
 #include "hash.h"
 #include "leakybucket.h"
-#include "main.h"
 #include "miner.h"
 #include "net.h"
 #include "parallel.h"
@@ -1305,7 +1304,7 @@ void LoadFilter(CNode *pfrom, CBloomFilter *filter)
 {
     if (!filter->IsWithinSizeConstraints())
         // There is no excuse for sending a too-large filter
-        Misbehaving(pfrom->GetId(), 100);
+        dosMan.Misbehaving(pfrom->GetId(), 100);
     else
     {
         LOCK(pfrom->cs_filter);


### PR DESCRIPTION
This PR creates a `CDoSManager` class which is intended to encapsulate the DoS related functionality currently in net.h|.cpp and main.h|.cpp.  This eliminates several global collections/critical sections which are now fully encapsulated in the manager, consolidates whitelist, banlist, and misbehaving functionality, and will hopefully eliminate the need for some of the includes of main.h and net.h all over the place.

This builds on #618 and should be merged fourth.

This PR:
1. Creates the `CDoSManager` for encapsulating DoS related functionality.
2. Moves whitelist related functionality from `CNode` to the manager
3. Moves banlist related functionality from `CNode` to the manager
4. Moves `Misbehaving` functionality from main.h|.cpp to the manager
5. Adds some additional basic unit tests around the ban functionality (expanding the existing DoS_tests.cpp).
6. Add doxygen comments for all method definitions in dosman.cpp
7. Adds dosman.h|.cpp to the clang format files list.


Still to do in upcoming PRs:
1. Better encapsulation of `CBanDB` functionality by moving `DumpBanlist` and adding a `LoadBanlist` function to the manager.  This will declutter some functionality in net.cpp and allow removal of the bandb.h include there.  This will also allow elimination of several methods ported over from net.h|.cpp as their functionality will be fully handled internally in the manager (`SetBanmap`, `BannedSetIsDirty`, `SetBannedSetDirty`).
2. Find where main.h and/or net.h includes can now be eliminated from source files which only needed DoS functionality.
3. Verify `cs_main` locks are taken correctly around the use of `State` and `Misbehaving` functions.  Add AssertLockHeld to enforce proper use of the cs_main lock.