### PR TITLE
stat.h: Fix missing inits and wrong type init

### DIFF
--- a/src/stat.h
+++ b/src/stat.h
@@ -79,7 +79,10 @@ protected:
     std::string name;
 
 public:
-    CStat() {}
+    CStat()
+    {
+        value = RecordType(); // = 0;
+    }
     CStat(const char *namep) : name(namep)
     {
         LOCK(cs_statMap);
@@ -182,7 +185,10 @@ protected:
     RecordType total;
 
 public:
-    CStatHistory() : CStat<DataType, RecordType>(), timer(stat_io_service) { Clear(); }
+    CStatHistory() : CStat<DataType, RecordType>(), op(STAT_OP_SUM | STAT_KEEP_COUNT), timer(stat_io_service)
+    {
+        Clear();
+    }
     CStatHistory(const char *name, unsigned int operation = STAT_OP_SUM)
         : CStat<DataType, RecordType>(name), op(operation), timer(stat_io_service)
     {
@@ -212,6 +218,7 @@ public:
     void Clear(void)
     {
         timerCount = 0;
+        sampleCount = 0;
         for (int i = 0; i < STATISTICS_NUM_RANGES; i++)
             loc[i] = 0;
         for (int i = 0; i < STATISTICS_NUM_RANGES; i++)
@@ -221,7 +228,7 @@ public:
             {
                 history[i][j] = RecordType();
             }
-        total = DataType();
+        total = RecordType();
         this->value = RecordType();
         Start();
     }


### PR DESCRIPTION
I feel there's some further fixing that should be done on the stats stuff:

- the decaying ring-buffer history as implemented in CStatsHistory is a nice feature, but it appears to be duplicated  in thinblocks.cpp with the same goal but a std::map.

- conversely, the CStatsHistory in thinblock.cpp seems to be used basically just as fancy counters right now, only extracting the last value when putting it into the getnetworkinfo stats or debug.log? Or am I missing something here?

- a lot more thought should IMO go into the defaults for CStatHistory construction. Right now, the default constructor has different values for `op` than the rest, however this is exactly what fixes #614. Also: Should it even be possible to create unnamed stats? Or should they always be named and registered?

This closes #614.