### PR TITLE
Fully encapsulate load and save of banlist to disk in DoS Manager

### DIFF
--- a/src/dosman.cpp
+++ b/src/dosman.cpp
@@ -280,3 +280,20 @@ void CDoSManager::Misbehaving(NodeId pnode, int howmuch)
     else
         LogPrintf("%s: %s (%d -> %d)\n", __func__, state->name, state->nMisbehavior - howmuch, state->nMisbehavior);
 }
+
+
+/**
+* Write in-memory banmap to disk
+*/
+void CDoSManager::DumpBanlist()
+{
+    int64_t nStart = GetTimeMillis();
+
+    CBanDB bandb;
+    banmap_t banmap;
+    GetBanned(banmap);
+    bandb.Write(banmap);
+
+    LogPrint(
+        "net", "Flushed %d banned node ips/subnets to banlist.dat  %dms\n", banmap.size(), GetTimeMillis() - nStart);
+}

--- a/src/dosman.cpp
+++ b/src/dosman.cpp
@@ -302,3 +302,27 @@ void CDoSManager::DumpBanlist()
     LogPrint(
         "net", "Flushed %d banned node ips/subnets to banlist.dat  %dms\n", banmap.size(), GetTimeMillis() - nStart);
 }
+
+/**
+* Read banmap from disk into memory
+*/
+void CDoSManager::LoadBanlist()
+{
+    uiInterface.InitMessage(_("Loading banlist..."));
+
+    // Load addresses from banlist.dat
+    int64_t nStart = GetTimeMillis();
+    CBanDB bandb;
+    banmap_t banmap;
+    if (bandb.Read(banmap))
+    {
+        SetBanned(banmap); // thread safe setter
+        SetBannedSetDirty(false); // no need to write down, just read data
+        SweepBanned(); // sweep out expired entries
+
+        LogPrint("net", "Loaded %d banned node ips/subnets from banlist.dat  %dms\n", banmap.size(),
+            GetTimeMillis() - nStart);
+    }
+    else
+        LogPrintf("Invalid or missing banlist.dat; recreating\n");
+}

--- a/src/dosman.cpp
+++ b/src/dosman.cpp
@@ -287,6 +287,10 @@ void CDoSManager::Misbehaving(NodeId pnode, int howmuch)
 */
 void CDoSManager::DumpBanlist()
 {
+    // If setBanned is not dirty, don't waste time on disk i/o
+    if (!BannedSetIsDirty())
+        return;
+
     int64_t nStart = GetTimeMillis();
 
     CBanDB bandb;
@@ -294,6 +298,7 @@ void CDoSManager::DumpBanlist()
     GetBanned(banmap);
     bandb.Write(banmap);
 
+    SetBannedSetDirty(false);
     LogPrint(
         "net", "Flushed %d banned node ips/subnets to banlist.dat  %dms\n", banmap.size(), GetTimeMillis() - nStart);
 }

--- a/src/dosman.h
+++ b/src/dosman.h
@@ -76,6 +76,9 @@ public:
 
     /** Increase a node's misbehavior score. */
     void Misbehaving(NodeId nodeid, int howmuch);
+
+    //! save banlist to disk
+    void DumpBanlist();
 };
 
 // actual definition should be in globals.cpp for ordered construction/destruction

--- a/src/dosman.h
+++ b/src/dosman.h
@@ -79,6 +79,8 @@ public:
 
     //! save banlist to disk
     void DumpBanlist();
+    //! load banlist from disk
+    void LoadBanlist();
 };
 
 // actual definition should be in globals.cpp for ordered construction/destruction

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1631,26 +1631,13 @@ void DumpAddresses()
     LogPrint("net", "Flushed %d addresses to peers.dat  %dms\n", addrman.size(), GetTimeMillis() - nStart);
 }
 
-void DumpBanlist()
-{
-    int64_t nStart = GetTimeMillis();
-
-    CBanDB bandb;
-    banmap_t banmap;
-    dosMan.GetBanned(banmap);
-    bandb.Write(banmap);
-
-    LogPrint(
-        "net", "Flushed %d banned node ips/subnets to banlist.dat  %dms\n", banmap.size(), GetTimeMillis() - nStart);
-}
-
 void DumpData()
 {
     DumpAddresses();
 
     if (dosMan.BannedSetIsDirty())
     {
-        DumpBanlist();
+        dosMan.DumpBanlist();
         dosMan.SetBannedSetDirty(false);
     }
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1635,11 +1635,8 @@ void DumpData()
 {
     DumpAddresses();
 
-    if (dosMan.BannedSetIsDirty())
-    {
-        dosMan.DumpBanlist();
-        dosMan.SetBannedSetDirty(false);
-    }
+    // Request dos manager to write it's ban list to disk
+    dosMan.DumpBanlist();
 }
 
 void static ProcessOneShot()

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -11,7 +11,6 @@
 #include "net.h"
 
 #include "addrman.h"
-#include "bandb.h"
 #include "chainparams.h"
 #include "clientversion.h"
 #include "connmgr.h"
@@ -2290,22 +2289,8 @@ void StartNode(boost::thread_group &threadGroup, CScheduler &scheduler)
         }
     }
 
-    uiInterface.InitMessage(_("Loading banlist..."));
-    // Load addresses from banlist.dat
-    nStart = GetTimeMillis();
-    CBanDB bandb;
-    banmap_t banmap;
-    if (bandb.Read(banmap))
-    {
-        dosMan.SetBanned(banmap); // thread save setter
-        dosMan.SetBannedSetDirty(false); // no need to write down, just read data
-        dosMan.SweepBanned(); // sweep out unused entries
-
-        LogPrint("net", "Loaded %d banned node ips/subnets from banlist.dat  %dms\n", banmap.size(),
-            GetTimeMillis() - nStart);
-    }
-    else
-        LogPrintf("Invalid or missing banlist.dat; recreating\n");
+    // ask dos manager to load banlist from disk (or recreate if missing/corrupt)
+    dosMan.LoadBanlist();
 
     fAddressesInitialized = true;
 

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -21,6 +21,7 @@
 
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'
 #include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -46,6 +47,108 @@ size_t GetNumberBanEntries()
     return banmap.size();
 }
 
+bool DoesBanlistFileExist()
+{
+    return boost::filesystem::exists(boost::filesystem::path(GetDataDir() / "banlist.dat"));
+}
+
+bool RemoveBanlistFile()
+{
+    boost::filesystem::path path(GetDataDir() / "banlist.dat");
+    try
+    {
+        if (boost::filesystem::exists(path))
+        {
+            // if the file already exists, remove it
+            boost::filesystem::remove(path);
+        }
+
+        // if we get here, we either successfully deleted the file, or it didn't exist
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        // there was an error deleting the file
+        return false;
+    }
+}
+
+void SetKnownBanlistContents()
+{
+    // empty out any current entries
+    dosMan.ClearBanned();
+
+    // Add test ban of specific IP
+    dosMan.Ban(CNetAddr("192.168.1.1"), BanReasonNodeMisbehaving, DEFAULT_MISBEHAVING_BANTIME, false);
+
+    // Add test ban of specific subnet
+    dosMan.Ban(CSubNet("10.168.1.0/28"), BanReasonManuallyAdded, DEFAULT_MISBEHAVING_BANTIME, false);
+}
+
+BOOST_AUTO_TEST_CASE(DoS_persistence_tests)
+{
+    // 1. Test handling when banlist cannot be loaded from disk (reason doesn't matter)
+    // Ensure we don't have a banlist on the file system currently
+    BOOST_CHECK(RemoveBanlistFile());
+
+    // Initialize banlist to have 2 specific known entries
+    SetKnownBanlistContents();
+
+    // The current implementation does not touch the in-memory banlist if load from disk fails
+    dosMan.LoadBanlist();
+    // Verify that since we couldn't load from disk, the in-memory values weren't overridden
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+    // Also ensure we didn't write a file to disk
+    BOOST_CHECK(!DoesBanlistFileExist());
+
+    // 2. Test handling when banlist can be loaded from disk
+    dosMan.ClearBanned();
+    // write an empty banlist file to disk
+    dosMan.DumpBanlist();
+    // Initialize banlist to have 2 specific known entries
+    SetKnownBanlistContents();
+    // Ensure that before load, we have 2 ban entries in the banlist
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+    // Read from file, this should succeed and overwrite the in-memory banlist
+    // NOTE: LoadBanlist calls SweepBanned, which will clear out any expired ban entries so ensure
+    //       that the test ban entries expire far enough in the future that it doesn't break this test
+    dosMan.LoadBanlist();
+    // Ensure that we overwrote the in-memory banlist and now have no entries
+    BOOST_CHECK(GetNumberBanEntries() == 0);
+
+    // 3. Test handling when reading from disk a second time without writing out changes
+    // Initialize banlist to have 2 specific known entries
+    SetKnownBanlistContents();
+    // Ensure that before load, we have 2 ban entries in the banlist
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+    // Read from file, this should succeed and overwrite the in-memory banlist
+    dosMan.LoadBanlist();
+    // Ensure that we overwrote the in-memory banlist and now have no entries
+    BOOST_CHECK(GetNumberBanEntries() == 0);
+
+    // 4. Test writing out to file then reading back in
+    // Initialize banlist to have 2 specific known entries
+    SetKnownBanlistContents();
+    // Ensure that before load, we have 2 ban entries in the banlist
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+    // Now write out to file
+    dosMan.DumpBanlist();
+    // Verify the contents in-memory haven't changed
+    // NOTE: GetBanned calls SweepBanned, this will clear out any expired ban entries so ensure
+    //       that the test ban entries expire far enough in the future that it doesn't break this test
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+    // Clear in-memory banlist, then load from file and ensure we the 2 entries back
+    dosMan.ClearBanned();
+    BOOST_CHECK(GetNumberBanEntries() == 0);
+    dosMan.LoadBanlist();
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+
+    // Clean up in-memory banlist
+    dosMan.ClearBanned();
+    // Clean up on-disk banlist
+    RemoveBanlistFile();
+}
+
 BOOST_AUTO_TEST_CASE(DoS_basic_ban_tests)
 {
     // Ensure in-memory banlist is empty
@@ -53,9 +156,11 @@ BOOST_AUTO_TEST_CASE(DoS_basic_ban_tests)
     BOOST_CHECK(GetNumberBanEntries() == 0);
 
     // Add a CNetAddr entry to banlist
-    dosMan.Ban(CNetAddr("192.168.1.1"), BanReasonManuallyAdded, DEFAULT_MISBEHAVING_BANTIME, false);
+    dosMan.Ban(CNetAddr("192.168.1.1"), BanReasonNodeMisbehaving, DEFAULT_MISBEHAVING_BANTIME, false);
+    // Ensure we have exactly 1 entry in our banlist
+    BOOST_CHECK(GetNumberBanEntries() == 1);
     // Add a CSubNet entry to banlist
-    dosMan.Ban(CSubNet("10.168.1.0/28"), BanReasonNodeMisbehaving, DEFAULT_MISBEHAVING_BANTIME, false);
+    dosMan.Ban(CSubNet("10.168.1.0/28"), BanReasonManuallyAdded, DEFAULT_MISBEHAVING_BANTIME, false);
     // Ensure we have exactly 2 entries in our banlist
     BOOST_CHECK(GetNumberBanEntries() == 2);
 
@@ -109,8 +214,7 @@ BOOST_AUTO_TEST_CASE(DoS_basic_ban_tests)
     BOOST_CHECK(GetNumberBanEntries() == 0);
 
     // Re-add ban entries so we can test ClearBanned()
-    dosMan.Ban(CNetAddr("192.168.1.1"), BanReasonManuallyAdded, DEFAULT_MISBEHAVING_BANTIME, false);
-    dosMan.Ban(CSubNet("10.168.1.0/28"), BanReasonNodeMisbehaving, DEFAULT_MISBEHAVING_BANTIME, false);
+    SetKnownBanlistContents();
     // Ensure we have exactly 2 entries in our banlist
     BOOST_CHECK(GetNumberBanEntries() == 2);
 


### PR DESCRIPTION
This builds on top of #619 to fully encapsulate banlist functionality related to saving to and loading from disk.  This allows removal of dependency on CBanDB in net.cpp.

This PR:
1. Moves `DumpBanlist()` from net.cpp to the DoS manager class, including the checks to see if the in-memory banlist is marked as dirty inside `DumpData()`.  Replaces this functionality with a single call to the DoS Manager.
2. Creates a `LoadBanlist()` method in the DoS manager class and moves this functionality from `StartNode` in net.cpp.  Replaces this functionality with a single call to the DoS Manager.
3. Remove bandb.h dependency/include from net.cpp
4. Corrects an issue where the dirty flag was cleared even if the banlist failed to write to disk.
5. Adds additional unit tests related to `DumpBanlist()` and `LoadBanlist()` functionality.

Potential clean-ups:
dff576b is actually a fix to a potential bug I found while moving this functionality from net.cpp and may warrant a separate PR rather than just a separate commit.

Future Tasks:
1. `SetBanned()`, `BannedSetIsDirty()`, and `SetBannedSetDirty()` are now no longer used externally from the DoS manager and can potentially be removed.  This is beneficial as the current implementation (as pulled from net.cpp) takes and releases the `cs_setBanned` lock several times in quick succession by making multiple calls to these methods from within `DumpBanlist()` and `LoadBanlist()`.