### PR TITLE
[Nit] Put "advertising address" log message under the "net" debug category.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5831,13 +5831,13 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                 CAddress addr = GetLocalAddress(&pfrom->addr);
                 if (addr.IsRoutable())
                 {
-                    LogPrintf("ProcessMessages: advertising address %s\n", addr.ToString());
+                    LogPrint("net", "ProcessMessages: advertising address %s\n", addr.ToString());
                     pfrom->PushAddress(addr);
                 }
                 else if (IsPeerAddrLocalGood(pfrom))
                 {
                     addr.SetIP(pfrom->addrLocal);
-                    LogPrintf("ProcessMessages: advertising address %s\n", addr.ToString());
+                    LogPrint("net", "ProcessMessages: advertising address %s\n", addr.ToString());
                     pfrom->PushAddress(addr);
                 }
             }


### PR DESCRIPTION
Log file currently quickly accumulates many log lines advertising node local address (>50 lines in the first 10 minutes after startup on my node).  These log messages properly belong in the network category so as not to bloat the log file if we aren't interested in net debugging log messages.

`ProcessMessages: advertising address xxx.xxx.xxx.xxx:8333`