### PR TITLE
Fix bip68-sequence test failure

### DIFF
--- a/qa/rpc-tests/bip68-sequence.py
+++ b/qa/rpc-tests/bip68-sequence.py
@@ -27,8 +27,8 @@ class BIP68Test(BitcoinTestFramework):
 
     def setup_network(self):
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-blockprioritysize=0"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug", "-blockprioritysize=0", "-acceptnonstdtxn=0"]))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-whitelist=127.0.0.1", "-debug", "-blockprioritysize=0"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-whitelist=127.0.0.1", "-debug", "-blockprioritysize=0", "-acceptnonstdtxn=0"]))
         self.is_network_split = False
         self.relayfee = self.nodes[0].getnetworkinfo()["relayfee"]
         connect_nodes(self.nodes[0], 1)

--- a/qa/rpc-tests/test_framework/nodemessages.py
+++ b/qa/rpc-tests/test_framework/nodemessages.py
@@ -6,6 +6,7 @@ from binascii import hexlify, unhexlify
 import time
 from codecs import encode
 from threading import RLock
+from io import BytesIO
 MY_VERSION = 60001  # past bip-31 for ping/pong
 MY_SUBVERSION = b"/python-mininode-tester:0.0.3/"
 


### PR DESCRIPTION
Fixes test crashing due to lack of BytesIO method import, and thereafter going into loop due to node0 banning node1 "because initial headers were either not received or not received before the timeout".

Test plan:
- run qa/pull-tester/rpc-tests.py bip68-sequence

EDIT: during initial testing, the test failed if I didn't also add `-use-thinblocks=0` to the client arguments. This problem somehow resolved itself, so I updated this PR to remove the thinblocks args.

NOTE: this contains an overlapping commit (88a9af6) with #630 . Since that's a single line fix, merging should not be problematic regardless of the order.