### PR TITLE
Bug Fix - Request Manager: Always add every block source during IBD

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -629,7 +629,7 @@ void FindNextBlocksToDownload(NodeId nodeid,
                 if (pindex->nChainTx)
                     state->pindexLastCommonBlock = pindex;
             }
-            else if (mapBlocksInFlight.count(pindex->GetBlockHash()) == 0)
+            else
             {
                 // The block is not already downloaded, and not yet in flight.
                 if (pindex->nHeight > nWindowEnd)
@@ -647,11 +647,6 @@ void FindNextBlocksToDownload(NodeId nodeid,
                 {
                     return;
                 }
-            }
-            else if (waitingfor == -1)
-            {
-                // This is the first already-in-flight block.
-                waitingfor = mapBlocksInFlight[pindex->GetBlockHash()].first;
             }
         }
     }

--- a/src/main.h
+++ b/src/main.h
@@ -218,7 +218,7 @@ void UnregisterNodeSignals(CNodeSignals &nodeSignals);
  */
 bool ProcessNewBlock(CValidationState &state,
     const CChainParams &chainparams,
-    const CNode *pfrom,
+    CNode *pfrom,
     const CBlock *pblock,
     bool fForceProcessing,
     CDiskBlockPos *dbp,

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -126,13 +126,13 @@ public:
     void AskFor(const std::vector<CInv> &objArray, CNode *from, unsigned int priority = 0);
 
     // Indicate that we got this object, from and bytes are optional (for node performance tracking)
-    void Received(const CInv &obj, CNode *from = NULL, int bytes = 0);
+    void Received(const CInv &obj, CNode *from, int bytes = 0);
 
     // Indicate that we previously got this object
     void AlreadyReceived(const CInv &obj);
 
     // Indicate that getting this object was rejected
-    void Rejected(const CInv &obj, CNode *from = NULL, unsigned char reason = 0);
+    void Rejected(const CInv &obj, CNode *from, unsigned char reason = 0);
 
     void SendRequests();
 

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -245,7 +245,6 @@ bool CThinBlock::process(CNode *pfrom, int nSizeThinBlock)
     if (pfrom->thinBlockWaitingForTxns == 0)
     {
         // We have all the transactions now that are in this block: try to reassemble and process.
-        requester.Received(GetInv(), pfrom, nSizeThinBlock);
         pfrom->thinBlockWaitingForTxns = -1;
         int blockSize = pfrom->thinBlock.GetSerializeSize(SER_NETWORK, CBlock::CURRENT_VERSION);
         LogPrint("thin", "Reassembled thin block for %s (%d bytes). Message was %d bytes, compression ratio %3.2f\n",
@@ -386,7 +385,6 @@ bool CXThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
             LogPrint("thin",
                 "xblocktx received but it was either not requested or it was beaten by another block %s  peer=%d\n",
                 inv.hash.ToString(), pfrom->id);
-            requester.Received(inv, pfrom, msgSize); // record the bytes received from the message
             return true;
         }
     }
@@ -428,7 +426,6 @@ bool CXThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     {
         // We have all the transactions now that are in this block: try to reassemble and process.
         pfrom->thinBlockWaitingForTxns = -1;
-        requester.Received(inv, pfrom, msgSize);
 
         // for compression statistics, we have to add up the size of xthinblock and the re-requested thinBlockTx.
         int nSizeThinBlockTx = ::GetSerializeSize(thinBlockTx, SER_NETWORK, PROTOCOL_VERSION);
@@ -893,7 +890,6 @@ bool CXThinBlock::process(CNode *pfrom,
         thindata.UpdateInBound(pfrom->nSizeThinBlock, blockSize);
         string ss = thindata.ToString();
         LogPrint("thin", "thin block stats: %s\n", ss.c_str());
-        requester.Received(GetInv(), pfrom, pfrom->nSizeThinBlock);
 
         PV.HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, GetInv());
     }


### PR DESCRIPTION
In the past we were only adding a block source if there was no
block currently in flight.  We want to always add more block
sources in the event that a block in flight is delayed. This way
we give the request manager the ability to re-request the block
from another source.

I believe this may fix issue #575...I noticed this problem during my last chain sync and was seeing
that if i started to download from a very slow node then I would get stuck for 10 or 20 minutes before IBD would continue.  We were never re-requesting another block because there were no additional block sources being added.