### PR TITLE
Fix bipdersig-p2p test failure

### DIFF
--- a/qa/rpc-tests/bipdersig-p2p.py
+++ b/qa/rpc-tests/bipdersig-p2p.py
@@ -50,7 +50,7 @@ class BIP66Test(ComparisonTestFramework):
     def setup_network(self):
         # Must set the blockversion for this test
         self.nodes = start_nodes(1, self.options.tmpdir, 
-                                 extra_args=[['-debug', '-whitelist=127.0.0.1', '-blockversion=2']],
+                                 extra_args=[['-use-thinblocks=0', '-debug', '-whitelist=127.0.0.1', '-blockversion=2']],
                                  binary=[self.options.testbinary])
 
     def run_test(self):
@@ -102,7 +102,7 @@ class BIP66Test(ComparisonTestFramework):
             self.last_block_time += 1
             self.tip = block.sha256
             height += 1
-        yield TestInstance(test_blocks, sync_every_block=False)
+        yield TestInstance(test_blocks, sync_every_block=True)
 
         ''' 
         Check that the new DERSIG rules are not enforced in the 750th

--- a/qa/rpc-tests/test_framework/nodemessages.py
+++ b/qa/rpc-tests/test_framework/nodemessages.py
@@ -6,6 +6,7 @@ from binascii import hexlify, unhexlify
 import time
 from codecs import encode
 from threading import RLock
+from io import BytesIO
 MY_VERSION = 60001  # past bip-31 for ping/pong
 MY_SUBVERSION = b"/python-mininode-tester:0.0.3/"
 


### PR DESCRIPTION
Until we sort out the issues with thinblocks / RM / test framework interactions, disabling thinblocks and syncing on every block at least allow this test to pass, which means other defects are not so easily introduced.

Test plan:
- run qa/pull-tester/rpc-tests.py bipdersig-p2p

NOTE: this contains an overlapping commit (88a9af6) with https://github.com/BitcoinUnlimited/BitcoinUnlimited/pull/628 . Since that's a single line fix, merging should not be problematic regardless of the order.