### PR TITLE
Simplify wild card matching

### DIFF
--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -767,4 +767,26 @@ BOOST_AUTO_TEST_CASE(util_Logging)
     }
 }
 
+BOOST_AUTO_TEST_CASE(util_wildmatch)
+{
+    BOOST_CHECK(wildmatch("123", "123"));
+    BOOST_CHECK(wildmatch("", ""));
+    BOOST_CHECK(wildmatch("?", "?"));
+    BOOST_CHECK(wildmatch("?", "x"));
+    BOOST_CHECK(wildmatch("*", "123"));
+    BOOST_CHECK(!wildmatch("456", "123"));
+
+    // multi-star pattern is not allowed
+    BOOST_CHECK(!wildmatch("**", "123"));
+    BOOST_CHECK(!wildmatch("************************************", "123"));
+    BOOST_CHECK(!wildmatch("?*?*?*?*?*?*?*?*?*?*?*?*?*?*?*?*?*?", "123"));
+
+    BOOST_CHECK(wildmatch("????", "1234"));
+    BOOST_CHECK(wildmatch("????a?b?", "1234a5b6"));
+    BOOST_CHECK(!wildmatch("????a?b?", "1234a5c6"));
+    BOOST_CHECK(wildmatch("123*", "123456"));
+    BOOST_CHECK(wildmatch("123*456", "123acdef456"));
+    BOOST_CHECK(wildmatch("*123", "abcdef123"));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -787,6 +787,10 @@ BOOST_AUTO_TEST_CASE(util_wildmatch)
     BOOST_CHECK(wildmatch("123*", "123456"));
     BOOST_CHECK(wildmatch("123*456", "123acdef456"));
     BOOST_CHECK(wildmatch("*123", "abcdef123"));
+
+    // length limit check
+    BOOST_CHECK(!wildmatch(std::string("*", 10000), ""));
+    BOOST_CHECK(!wildmatch("*", std::string("x", 10000)));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/tweak.h
+++ b/src/tweak.h
@@ -90,9 +90,6 @@ inline void fill(const UniValue &v, bool &output)
         output = v.get_bool();
 }
 
-// Checks if two given strings match. The first string may contain wildcard characters
-bool match(const char *first, const char *second);
-
 /** A configuration parameter that is automatically hooked up to
  * bitcoin.conf, bitcoin-cli, and is available as a command line argument
  */

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -231,17 +231,13 @@ std::string FormatCoinbaseMessage(const std::vector<std::string> &comments, cons
 CNodeRef FindLikelyNode(const std::string &addrName)
 {
     LOCK(cs_vNodes);
-    bool wildcard = (addrName.find_first_of("*?") != std::string::npos);
-
+    // always match any beginning part of string to be
+    // compatible with old implementation of FindLikelyNode(..)
+    std::string match_str = (addrName[addrName.size() - 1] == '*') ? addrName : addrName + "*";
     for (CNode *pnode : vNodes)
     {
-        if (wildcard)
-        {
-            if (match(addrName.c_str(), pnode->addrName.c_str()))
-                return (pnode);
-        }
-        else if (pnode->addrName.find(addrName) != std::string::npos)
-            return (pnode);
+        if (wildmatch(match_str, pnode->addrName))
+            return pnode;
     }
     return nullptr;
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -928,3 +928,61 @@ bool IsStringTrue(const std::string &str)
 
     return false;
 }
+
+static const int wildmatch_max_length = 100;
+
+bool wildmatch(const string &pattern, const string &test)
+{
+    // stack overflow prevention
+    if (test.size() > wildmatch_max_length || pattern.size() > wildmatch_max_length)
+    {
+        return false;
+    }
+
+    // handle empty strings
+    if (!test.size() && !pattern.size())
+        return true;
+
+    // handle trailing chars in test str
+    if (test.size() && !pattern.size())
+        return false;
+
+    // handle trailing chars in  pattern str. Needs to be a single asterisk to match.
+    if (!test.size() && pattern.size())
+    {
+        return pattern == "*";
+    }
+
+    // test.size() && pattern.size() holds when reaching here
+
+    if (pattern[0] == '?')
+        return wildmatch(pattern.substr(1), test.substr(1));
+    if (pattern[0] == '*')
+    {
+        if (pattern.size() > 1)
+        {
+            // Will not try multiple ways to match to avoid the potential
+            // for path explosion, like matching "*-*-*-*" to "------------" and the like
+            // Just eat up the test string until the first char mismatches
+            if (pattern[1] == '?' || pattern[1] == '*')
+            {
+                // ** or *? patterns are disallowed in the midst of a matching expression
+                return false;
+            }
+            size_t i = 0;
+            while (i < test.size())
+            {
+                if (test[i] != pattern[1])
+                    i++;
+                else
+                    break;
+            }
+            if (i == test.size())
+                return true;
+            return wildmatch(pattern.substr(1), test.substr(i));
+        }
+        else
+            return true;
+    }
+    return (test[0] == pattern[0]) && wildmatch(pattern.substr(1), test.substr(1));
+}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -929,9 +929,9 @@ bool IsStringTrue(const std::string &str)
     return false;
 }
 
-static const int wildmatch_max_length = 100;
+static const int wildmatch_max_length = 1024;
 
-bool wildmatch(const string &pattern, const string &test)
+bool wildmatch(string pattern, string test)
 {
     // stack overflow prevention
     if (test.size() > wildmatch_max_length || pattern.size() > wildmatch_max_length)
@@ -939,50 +939,65 @@ bool wildmatch(const string &pattern, const string &test)
         return false;
     }
 
-    // handle empty strings
-    if (!test.size() && !pattern.size())
-        return true;
-
-    // handle trailing chars in test str
-    if (test.size() && !pattern.size())
-        return false;
-
-    // handle trailing chars in  pattern str. Needs to be a single asterisk to match.
-    if (!test.size() && pattern.size())
+    while (true)
     {
-        return pattern == "*";
-    }
-
-    // test.size() && pattern.size() holds when reaching here
-
-    if (pattern[0] == '?')
-        return wildmatch(pattern.substr(1), test.substr(1));
-    if (pattern[0] == '*')
-    {
-        if (pattern.size() > 1)
-        {
-            // Will not try multiple ways to match to avoid the potential
-            // for path explosion, like matching "*-*-*-*" to "------------" and the like
-            // Just eat up the test string until the first char mismatches
-            if (pattern[1] == '?' || pattern[1] == '*')
-            {
-                // ** or *? patterns are disallowed in the midst of a matching expression
-                return false;
-            }
-            size_t i = 0;
-            while (i < test.size())
-            {
-                if (test[i] != pattern[1])
-                    i++;
-                else
-                    break;
-            }
-            if (i == test.size())
-                return true;
-            return wildmatch(pattern.substr(1), test.substr(i));
-        }
-        else
+        // handle empty strings
+        if (!test.size() && !pattern.size())
             return true;
+
+        // handle trailing chars in test str
+        if (test.size() && !pattern.size())
+            return false;
+
+        // handle trailing chars in  pattern str. Needs to be a single asterisk to match.
+        if (!test.size() && pattern.size())
+        {
+            return pattern == "*";
+        }
+
+        // test.size() && pattern.size() holds when reaching here
+
+        if (pattern[0] == '?')
+        {
+            pattern = pattern.substr(1);
+            test = test.substr(1);
+            continue;
+        }
+
+        if (pattern[0] == '*')
+        {
+            if (pattern.size() > 1)
+            {
+                // Will not try multiple ways to match to avoid the potential
+                // for path explosion, like matching "*-*-*-*" to "------------" and the like
+                // Just eat up the test string until the first char mismatches
+                if (pattern[1] == '?' || pattern[1] == '*')
+                {
+                    // ** or *? patterns are disallowed in the midst of a matching expression
+                    return false;
+                }
+                size_t i = 0;
+                while (i < test.size())
+                {
+                    if (test[i] != pattern[1])
+                        i++;
+                    else
+                        break;
+                }
+                if (i == test.size())
+                    return true;
+
+                pattern = pattern.substr(1);
+                test = test.substr(i);
+                continue;
+            }
+            else
+                return true;
+        }
+        if (test[0] != pattern[0])
+            return false;
+
+        pattern = pattern.substr(1);
+        test = test.substr(1);
     }
-    return (test[0] == pattern[0]) && wildmatch(pattern.substr(1), test.substr(1));
 }

--- a/src/util.h
+++ b/src/util.h
@@ -478,6 +478,6 @@ std::string CopyrightHolders(const std::string &strPrefix);
 The first argument (the pattern) might contain '?' and '*' wildcards and
 the second argument will be matched to this pattern. Returns true iff the string
 matches pattern. */
-bool wildmatch(const std::string &pattern, const std::string &test);
+bool wildmatch(std::string pattern, std::string test);
 
 #endif // BITCOIN_UTIL_H

--- a/src/util.h
+++ b/src/util.h
@@ -474,4 +474,10 @@ void TraceThread(const char *name, Callable func)
 
 std::string CopyrightHolders(const std::string &strPrefix);
 
+/** Wildcard matching of strings
+The first argument (the pattern) might contain '?' and '*' wildcards and
+the second argument will be matched to this pattern. Returns true iff the string
+matches pattern. */
+bool wildmatch(const std::string &pattern, const std::string &test);
+
 #endif // BITCOIN_UTIL_H


### PR DESCRIPTION
- replace match(..) with libc function fnmatch(..)
- always use fnmatch instead of separate match for no wildcards