### PR TITLE
[Backport to Release PR627] Move bitnodes seeding to be after DNS seeding.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1741,46 +1741,6 @@ void MapPort(bool)
 }
 #endif
 
-// BITCOINUNLIMITED START
-void ThreadBitnodesAddressSeed()
-{
-    // Get nodes from websites offering Bitnodes API
-    if ((addrman.size() > 0) && (!GetBoolArg("-forcebitnodes", DEFAULT_FORCEBITNODES)))
-    {
-        MilliSleep(11 * 1000);
-        LOCK(cs_vNodes);
-        if (vNodes.size() >= 2)
-        {
-            LogPrintf("P2P peers available. Skipped Bitnodes seeding.\n");
-            return;
-        }
-    }
-
-    LogPrintf("Loading addresses from Bitnodes API\n");
-
-    vector<string> vIPs;
-    vector<CAddress> vAdd;
-    bool success = GetLeaderboardFromBitnodes(vIPs);
-    if (success)
-    {
-        int portOut;
-        std::string hostOut = "";
-        BOOST_FOREACH (const string &seed, vIPs)
-        {
-            SplitHostPort(seed, portOut, hostOut);
-            CNetAddr ip(hostOut, false);
-            CAddress addr = CAddress(CService(ip, portOut));
-            addr.nTime = GetTime();
-            vAdd.push_back(addr);
-        }
-        addrman.Add(vAdd, CNetAddr("bitnodes.21.co", true));
-    }
-
-    LogPrintf("%d addresses found from Bitnodes API\n", vAdd.size());
-}
-// BITCOINUNLIMITED END
-
-
 static std::string GetDNSHost(const CDNSSeedData &data, uint64_t requiredServiceBits)
 {
     // use default host for non-filter-capable seeds or if we use the default service bits (NODE_NETWORK)
@@ -1793,8 +1753,7 @@ static std::string GetDNSHost(const CDNSSeedData &data, uint64_t requiredService
     return strprintf("x%x.%s", requiredServiceBits, data.host);
 }
 
-
-void ThreadDNSAddressSeed()
+static void DNSAddressSeed()
 {
     // goal: only query DNS seeds if address need is acute
     if ((addrman.size() > 0) && (!GetBoolArg("-forcednsseed", DEFAULT_FORCEDNSSEED)))
@@ -1863,6 +1822,65 @@ void ThreadDNSAddressSeed()
     }
 
     LogPrintf("%d addresses found from DNS seeds\n", found);
+}
+
+// BITCOINUNLIMITED START
+static void BitnodesAddressSeed()
+{
+    // Get nodes from websites offering Bitnodes API
+    if ((addrman.size() > 0) && (!GetBoolArg("-forcebitnodes", DEFAULT_FORCEBITNODES)))
+    {
+        MilliSleep(11 * 1000);
+        LOCK(cs_vNodes);
+        if (vNodes.size() >= 2)
+        {
+            LogPrintf("P2P peers available. Skipped Bitnodes seeding.\n");
+            return;
+        }
+    }
+
+    LogPrintf("Loading addresses from Bitnodes API\n");
+
+    vector<string> vIPs;
+    vector<CAddress> vAdd;
+    bool success = GetLeaderboardFromBitnodes(vIPs);
+    if (success)
+    {
+        int portOut;
+        std::string hostOut = "";
+        BOOST_FOREACH (const string &seed, vIPs)
+        {
+            SplitHostPort(seed, portOut, hostOut);
+            CNetAddr ip(hostOut);
+            CAddress addr = CAddress(CService(ip, portOut));
+            addr.nTime = GetTime();
+            vAdd.push_back(addr);
+        }
+        CService bitnodes;
+        if (Lookup("bitnodes.21.co", bitnodes, 0, true))
+            addrman.Add(vAdd, bitnodes);
+    }
+
+    LogPrintf("%d addresses found from Bitnodes API\n", vAdd.size());
+}
+// BITCOINUNLIMITED END
+
+void ThreadAddressSeeding()
+{
+    if (!GetBoolArg("-dnsseed", true))
+        LogPrintf("DNS seeding disabled\n");
+    else
+    {
+        DNSAddressSeed();
+    }
+
+    // Bitnodes seeding is intended as a backup in the event that DNS seeding fails and a such is run after.
+    if ((!GetBoolArg("-bitnodes", true)) || (Params().NetworkIDString() != "main"))
+        LogPrintf("Bitnodes API seeding disabled\n");
+    else
+    {
+        BitnodesAddressSeed();
+    }
 }
 
 
@@ -2539,17 +2557,7 @@ void StartNode(boost::thread_group &threadGroup, CScheduler &scheduler)
     // Start threads
     //
 
-    // BITCOINUNLIMITED START
-    if ((!GetBoolArg("-bitnodes", true)) || (Params().NetworkIDString() != "main"))
-        LogPrintf("Bitnodes API seeding disabled\n");
-    else
-        threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "bitnodes", &ThreadBitnodesAddressSeed));
-    // BITCOINUNLIMITED END
-
-    if (!GetBoolArg("-dnsseed", true))
-        LogPrintf("DNS seeding disabled\n");
-    else
-        threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "dnsseed", &ThreadDNSAddressSeed));
+    threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "dnsseed", &ThreadAddressSeeding));
 
     // Map ports with UPnP
     MapPort(GetBoolArg("-upnp", DEFAULT_UPNP));


### PR DESCRIPTION
By removing the bitnodes seeding thread and moving the bitnodes
seeding to run after DNS seeding we prevent the problem on first
startup where binodes seeding finishes first and we end up with
100 entries from the leaderboard at the beginning of our address
list.  Whereas what we wanted is for the first entries to be coming
from our on BU seed list. And if no seeds could be found then and
only then get them from the bitnodes leader board.