### PR TITLE
Clean up handling of expedited nodes

### DIFF
--- a/src/connmgr.cpp
+++ b/src/connmgr.cpp
@@ -2,17 +2,187 @@
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 // Copyright (c) 2016-2017 The Bitcoin Unlimited developers
 
-#include <atomic>
-
 #include "connmgr.h"
+#include "expedited.h"
 
+std::unique_ptr<CConnMgr> connmgr(new CConnMgr);
 
-NodeId CConnMgr::nextNodeId()
+/**
+ * Find a node in a vector.  Just calls std::find.  Split out for cleanliness and also because std:find won't be
+ * enough if we switch to vectors of noderefs.  Requires any lock for vector traversal to be held.
+ */
+static std::vector<CNode *>::iterator FindNode(std::vector<CNode *> &vNodes, CNode *pNode)
 {
-    static std::atomic<NodeId> next;
+    return std::find(vNodes.begin(), vNodes.end(), pNode);
+}
 
+/**
+ * Add a node to a vector, and take a reference.  This function does NOT prevent adding duplicates.
+ * Requires any lock for vector traversal to be held.
+ * @param[in] vNodes      The vector of nodes.
+ * @param[in] pNode       The node to add.
+ */
+static void AddNode(std::vector<CNode *> &vNodes, CNode *pNode)
+{
+    pNode->AddRef();
+    vNodes.push_back(pNode);
+}
+
+/**
+ * If a node is present in a vector, remove it and drop a reference.
+ * Requires any lock for vector traversal to be held.
+ * @param[in] vNodes      The vector of nodes.
+ * @param[in] pNode       The node to remove.
+ * @return  True if the node was originally present, false if not.
+ */
+static bool RemoveNode(std::vector<CNode *> &vNodes, CNode *pNode)
+{
+    auto Node = FindNode(vNodes, pNode);
+
+    if (Node != vNodes.end())
+    {
+        pNode->Release();
+        vNodes.erase(Node);
+        return true;
+    }
+
+    return false;
+}
+
+CConnMgr::CConnMgr() : nExpeditedBlocksMax(32), nExpeditedTxsMax(32), next(0)
+{
+    vSendExpeditedBlocks.reserve(256);
+    vSendExpeditedTxs.reserve(256);
+    vExpeditedUpstream.reserve(256);
+}
+
+NodeId CConnMgr::NextNodeId()
+{
     // Pre-increment; do not use zero
     return ++next;
 }
 
-std::unique_ptr<CConnMgr> connmgr(new CConnMgr);
+void CConnMgr::EnableExpeditedSends(CNode *pNode, bool fBlocks, bool fTxs, bool fForceIfFull)
+{
+    LOCK(cs_expedited);
+
+    if (fBlocks && FindNode(vSendExpeditedBlocks, pNode) == vSendExpeditedBlocks.end())
+    {
+        if (fForceIfFull || vSendExpeditedBlocks.size() < nExpeditedBlocksMax)
+        {
+            AddNode(vSendExpeditedBlocks, pNode);
+            LogPrint("thin", "Enabled expedited blocks to peer %s (%u peers total)\n", pNode->GetLogName(),
+                vSendExpeditedBlocks.size());
+        }
+        else
+        {
+            LogPrint("thin", "Cannot enable expedited blocks to peer %s, I am full (%u peers total)\n",
+                pNode->GetLogName(), vSendExpeditedBlocks.size());
+        }
+    }
+
+    if (fTxs && FindNode(vSendExpeditedTxs, pNode) == vSendExpeditedTxs.end())
+    {
+        if (fForceIfFull || vSendExpeditedTxs.size() < nExpeditedTxsMax)
+        {
+            AddNode(vSendExpeditedTxs, pNode);
+            LogPrint("thin", "Enabled expedited txs to peer %s (%u peers total)\n", pNode->GetLogName(),
+                vSendExpeditedTxs.size());
+        }
+        else
+        {
+            LogPrint("thin", "Cannot enable expedited txs to peer %s, I am full (%u peers total)\n",
+                pNode->GetLogName(), vSendExpeditedTxs.size());
+        }
+    }
+}
+
+void CConnMgr::DisableExpeditedSends(CNode *pNode, bool fBlocks, bool fTxs)
+{
+    LOCK(cs_expedited);
+
+    if (fBlocks && RemoveNode(vSendExpeditedBlocks, pNode))
+        LogPrint("thin", "Disabled expedited blocks to peer %s (%u peers total)\n", pNode->GetLogName(),
+            vSendExpeditedBlocks.size());
+
+    if (fTxs && RemoveNode(vSendExpeditedTxs, pNode))
+        LogPrint("thin", "Disabled expedited txs to peer %s (%u peers total)\n", pNode->GetLogName(),
+            vSendExpeditedTxs.size());
+}
+
+void CConnMgr::HandleCommandLine()
+{
+    nExpeditedBlocksMax = GetArg("-maxexpeditedblockrecipients", nExpeditedBlocksMax);
+    nExpeditedTxsMax = GetArg("-maxexpeditedtxrecipients", nExpeditedTxsMax);
+}
+
+// Called after a node is removed from the node list.
+void CConnMgr::RemovedNode(CNode *pNode)
+{
+    LOCK(cs_expedited);
+
+    RemoveNode(vSendExpeditedBlocks, pNode);
+    RemoveNode(vSendExpeditedTxs, pNode);
+    RemoveNode(vExpeditedUpstream, pNode);
+}
+
+void CConnMgr::ExpeditedNodeCounts(uint32_t &nBlocks, uint32_t &nTxs, uint32_t &nUpstream)
+{
+    LOCK(cs_expedited);
+
+    nBlocks = vSendExpeditedBlocks.size();
+    nTxs = vSendExpeditedTxs.size();
+    nUpstream = vExpeditedUpstream.size();
+}
+
+VNodeRefs CConnMgr::ExpeditedBlockNodes()
+{
+    LOCK(cs_expedited);
+
+    VNodeRefs vRefs;
+
+    BOOST_FOREACH (CNode *pNode, vExpeditedUpstream)
+        vRefs.push_back(CNodeRef(pNode));
+
+    return vRefs;
+}
+
+bool CConnMgr::PushExpeditedRequest(CNode *pNode, uint64_t flags)
+{
+    if (!IsThinBlocksEnabled())
+        return error("Thinblocks is not enabled so cannot request expedited blocks from peer %s", pNode->GetLogName());
+
+    if (!pNode->ThinBlockCapable())
+        return error("Remote peer has not enabled Thinblocks so you cannot request expedited blocks from %s",
+            pNode->GetLogName());
+
+    if (flags & EXPEDITED_BLOCKS)
+    {
+        LOCK(cs_expedited);
+
+        // Add or remove this node as an upstream node
+        if (flags & EXPEDITED_STOP)
+        {
+            RemoveNode(vExpeditedUpstream, pNode);
+            LogPrintf("Requesting a stop of expedited blocks from peer %s\n", pNode->GetLogName());
+        }
+        else
+        {
+            if (FindNode(vExpeditedUpstream, pNode) == vExpeditedUpstream.end())
+                AddNode(vExpeditedUpstream, pNode);
+            LogPrintf("Requesting expedited blocks from peer %s\n", pNode->GetLogName());
+        }
+    }
+
+    // Push even if its a repeat to allow the operator to use the CLI or GUI to force another message.
+    pNode->PushMessage(NetMsgType::XPEDITEDREQUEST, flags);
+
+    return true;
+}
+
+bool CConnMgr::IsExpeditedUpstream(CNode *pNode)
+{
+    LOCK(cs_expedited);
+
+    return FindNode(vExpeditedUpstream, pNode) != vExpeditedUpstream.end();
+}

--- a/src/connmgr.h
+++ b/src/connmgr.h
@@ -5,12 +5,92 @@
 #ifndef BITCOIN_CONNMGR_H
 #define BITCOIN_CONNMGR_H
 
+#include <atomic>
+#include <vector>
+
 #include "net.h"
 
 class CConnMgr
 {
+    // This critical section protects the vectors
+    CCriticalSection cs_expedited;
+    // We send expedited blocks to these nodes
+    std::vector<CNode *> vSendExpeditedBlocks;
+    // We send expedited txs to these nodes
+    std::vector<CNode *> vSendExpeditedTxs;
+    // We requested expedited blocks from these nodes
+    std::vector<CNode *> vExpeditedUpstream;
+
+    // Maximum number of nodes to send expedited blocks and txs to.
+    uint32_t nExpeditedBlocksMax;
+    uint32_t nExpeditedTxsMax;
+
+    std::atomic<NodeId> next;
+
 public:
-    static NodeId nextNodeId();
+    CConnMgr();
+
+    /**
+     * Call once the command line is parsed so the connection manager configures itself appropriately.
+     */
+    void HandleCommandLine();
+
+    /**
+     * Return and consume the next node identifier.  Guaranteed positive and monotonically increasing.
+     * @return The node ID.
+     */
+    NodeId NextNodeId();
+
+    /**
+     * Enable expedited sends to a node.  Ignored if already enabled.
+     * @param[in] pNode         The node
+     * @param[in] fBlocks       True to enable expedited block sends
+     * @param[in] fTxs          True to enable expedited tx sends
+     * @param[in] fForceIfFull  True to add the node even if the expedited send list is at its maximum
+     */
+    void EnableExpeditedSends(CNode *pNode, bool fBlocks, bool fTxs, bool fForceIfFull);
+
+    /**
+     * Disable expedited sends to a node.  Ignored if not enabled.
+     * @param[in] pNode         The node
+     * @param[in] fBlocks       True to disable expedited block sends
+     * @param[in] fTxs          True to disnable expedited tx sends
+     */
+    void DisableExpeditedSends(CNode *pNode, bool fBlocks, bool fTxs);
+
+    /**
+     * Return expedited node counts.
+     * @param[out] nBlocks       Number of nodes to which we send expedited blocks to
+     * @param[out] nTxs          Number of nodes to which we send expedited txs to
+     * @param[out] nUpstream     Number of nodes we requested expedited blocks from
+     */
+    void ExpeditedNodeCounts(uint32_t &nBlocks, uint32_t &nTxs, uint32_t &nUpstream);
+
+    /**
+     * Return a vector of node refs to which we send expedited blocks.  A lock is held only briefly.
+     * @return A vector of node references.
+     */
+    VNodeRefs ExpeditedBlockNodes();
+
+    /**
+     * Must be called after a node is removed from the vNodes list.
+     * @param[in] pNode         The node
+     */
+    void RemovedNode(CNode *pNode);
+
+    /**
+     * Call to request a node to send, or stop sending, expedited blocks or transactions to us.
+     * @param[in] pNode         The node
+     * @param[in] flags         EXPEDITED_STOP, EXPEDITED_BLOCKS, EXPEDITED_TXS
+     * @return True if the request was sent.  False if thin blocks are disabled for us or the peer.
+     */
+    bool PushExpeditedRequest(CNode *pNode, uint64_t flags);
+
+    /**
+     * @param[in] pNode         The node
+     * @return True if we have requested expedited blocks from the node.
+     */
+    bool IsExpeditedUpstream(CNode *pNode);
 };
 
 extern std::unique_ptr<CConnMgr> connmgr;

--- a/src/expedited.cpp
+++ b/src/expedited.cpp
@@ -2,17 +2,14 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "expedited.h"
-#include "dosman.h"
-#include "main.h"
-#include "rpc/server.h"
-#include "thinblock.h"
-#include "tweak.h"
-#include "unlimited.h"
-
 #include <sstream>
 #include <string>
-#include <univalue.h>
+
+#include "connmgr.h"
+#include "dosman.h"
+#include "expedited.h"
+#include "main.h" // Misbehaving, cs_main
+
 
 #define NUM_XPEDITED_STORE 10
 
@@ -57,30 +54,7 @@ bool CheckAndRequestExpeditedBlocks(CNode *pfrom)
                 strListeningPeerIP = strPeerIP;
 
             if (strAddr == strListeningPeerIP)
-            {
-                if (!IsThinBlocksEnabled())
-                {
-                    return error("You do not have Thinblocks enabled.  You can not request expedited blocks from "
-                                 "peer %s (%d)",
-                        strListeningPeerIP, pfrom->id);
-                }
-                else if (!pfrom->ThinBlockCapable())
-                {
-                    return error("Thinblocks is not enabled on remote peer.  You can not request expedited blocks "
-                                 "from peer %s (%d)",
-                        strListeningPeerIP, pfrom->id);
-                }
-                else
-                {
-                    LogPrintf("Requesting expedited blocks from peer %s (%d).\n", strListeningPeerIP, pfrom->id);
-                    pfrom->PushMessage(NetMsgType::XPEDITEDREQUEST, ((uint64_t)EXPEDITED_BLOCKS));
-
-                    LOCK(cs_xpedited);
-                    xpeditedBlkUp.push_back(pfrom);
-
-                    return true;
-                }
-            }
+                connmgr->PushExpeditedRequest(pfrom, EXPEDITED_BLOCKS);
         }
     }
     return false;
@@ -90,7 +64,6 @@ bool HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom)
 {
     uint64_t options;
     vRecv >> options;
-    bool stop = ((options & EXPEDITED_STOP) != 0); // Indicates started or stopped expedited service
 
     if (!pfrom->ThinBlockCapable() || !IsThinBlocksEnabled())
     {
@@ -99,86 +72,10 @@ bool HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom)
         return false;
     }
 
-    if (options & EXPEDITED_BLOCKS)
-    {
-        LOCK(cs_xpedited);
-
-        if (stop) // If stopping, find the array element and clear it.
-        {
-            LogPrint("blk", "Stopping expedited blocks to peer %s\n", pfrom->GetLogName());
-            std::vector<CNode *>::iterator it = std::find(xpeditedBlk.begin(), xpeditedBlk.end(), pfrom);
-            if (it != xpeditedBlk.end())
-            {
-                *it = NULL;
-                pfrom->Release();
-            }
-        }
-        else // Otherwise, add the new node to the end
-        {
-            std::vector<CNode *>::iterator it1 = std::find(xpeditedBlk.begin(), xpeditedBlk.end(), pfrom);
-            if (it1 == xpeditedBlk.end()) // don't add it twice
-            {
-                unsigned int maxExpedited = GetArg("-maxexpeditedblockrecipients", 32);
-                if (xpeditedBlk.size() < maxExpedited)
-                {
-                    LogPrint("blk", "Starting expedited blocks to peer %s\n", pfrom->GetLogName());
-
-                    // find an empty array location
-                    std::vector<CNode *>::iterator it =
-                        std::find(xpeditedBlk.begin(), xpeditedBlk.end(), ((CNode *)NULL));
-                    if (it != xpeditedBlk.end())
-                        *it = pfrom;
-                    else
-                        xpeditedBlk.push_back(pfrom);
-                    pfrom->AddRef(); // add a reference because we have added this pointer into the expedited array
-                }
-                else
-                {
-                    LogPrint("blk", "Expedited blocks requested from peer %s but I am full\n", pfrom->GetLogName());
-                }
-            }
-        }
-    }
-    if (options & EXPEDITED_TXNS)
-    {
-        LOCK(cs_xpedited);
-
-        if (stop) // If stopping, find the array element and clear it.
-        {
-            LogPrint("blk", "Stopping expedited transactions to peer %s\n", pfrom->GetLogName());
-            std::vector<CNode *>::iterator it = std::find(xpeditedTxn.begin(), xpeditedTxn.end(), pfrom);
-            if (it != xpeditedTxn.end())
-            {
-                *it = NULL;
-                pfrom->Release();
-            }
-        }
-        else // Otherwise, add the new node to the end
-        {
-            std::vector<CNode *>::iterator it1 = std::find(xpeditedTxn.begin(), xpeditedTxn.end(), pfrom);
-            if (it1 == xpeditedTxn.end()) // don't add it twice
-            {
-                unsigned int maxExpedited = GetArg("-maxexpeditedtxrecipients", 32);
-                if (xpeditedTxn.size() < maxExpedited)
-                {
-                    LogPrint("blk", "Starting expedited transactions to peer %s\n", pfrom->GetLogName());
-
-                    std::vector<CNode *>::iterator it =
-                        std::find(xpeditedTxn.begin(), xpeditedTxn.end(), ((CNode *)NULL));
-                    if (it != xpeditedTxn.end())
-                        *it = pfrom;
-                    else
-                        xpeditedTxn.push_back(pfrom);
-                    pfrom->AddRef();
-                }
-                else
-                {
-                    LogPrint(
-                        "blk", "Expedited transactions requested from peer %s but I am full\n", pfrom->GetLogName());
-                }
-            }
-        }
-    }
+    if (options & EXPEDITED_STOP)
+        connmgr->DisableExpeditedSends(pfrom, options & EXPEDITED_BLOCKS, options & EXPEDITED_TXNS);
+    else
+        connmgr->EnableExpeditedSends(pfrom, options & EXPEDITED_BLOCKS, options & EXPEDITED_TXNS, false);
 
     return true;
 }
@@ -201,46 +98,41 @@ bool HandleExpeditedBlock(CDataStream &vRecv, CNode *pfrom)
 {
     unsigned char hops;
     unsigned char msgType;
-    vRecv >> msgType >> hops;
 
-    if (!pfrom->ThinBlockCapable() || !IsThinBlocksEnabled() || !IsExpeditedNode(pfrom))
-    {
+    if (!connmgr->IsExpeditedUpstream(pfrom))
         return false;
-    }
 
+    vRecv >> msgType >> hops;
     if (msgType == EXPEDITED_MSG_XTHIN)
     {
         return CXThinBlock::HandleMessage(vRecv, pfrom, NetMsgType::XPEDITEDBLK, hops + 1);
     }
     else
     {
-        return error("Received unknown (0x%x) expedited message from peer %s (%d). Hop %d.\n", msgType,
-            pfrom->addrName.c_str(), pfrom->id, hops);
+        return error(
+            "Received unknown (0x%x) expedited message from peer %s hop %d\n", msgType, pfrom->GetLogName(), hops);
     }
 }
 
 void SendExpeditedBlock(CXThinBlock &thinBlock, unsigned char hops, const CNode *skip)
 {
-    LOCK(cs_xpedited);
-    std::vector<CNode *>::iterator end = xpeditedBlk.end();
-    for (std::vector<CNode *>::iterator it = xpeditedBlk.begin(); it != end; it++)
-    {
-        CNode *n = *it;
-        if ((n != skip) && (n != NULL)) // Don't send it back in case there is a forwarding loop
-        {
-            if (n->fDisconnect)
-            {
-                *it = NULL;
-                n->Release();
-            }
-            else
-            {
-                LogPrint("thin", "Sending expedited block %s to %s.\n", thinBlock.header.GetHash().ToString(),
-                    n->addrName.c_str());
+    VNodeRefs vNodeRefs(connmgr->ExpeditedBlockNodes());
 
-                n->PushMessage(NetMsgType::XPEDITEDBLK, (unsigned char)EXPEDITED_MSG_XTHIN, hops, thinBlock);
-                n->blocksSent += 1;
-            }
+    BOOST_FOREACH (CNodeRef &nodeRef, vNodeRefs)
+    {
+        CNode *n = nodeRef.get();
+
+        if (n->fDisconnect)
+        {
+            connmgr->RemovedNode(n);
+        }
+        else if (n != skip) // Don't send back to the sending node to avoid looping
+        {
+            LogPrint(
+                "thin", "Sending expedited block %s to %s\n", thinBlock.header.GetHash().ToString(), n->GetLogName());
+
+            n->PushMessage(NetMsgType::XPEDITEDBLK, (unsigned char)EXPEDITED_MSG_XTHIN, hops, thinBlock);
+            n->blocksSent += 1;
         }
     }
 }
@@ -253,15 +145,4 @@ void SendExpeditedBlock(const CBlock &block, const CNode *skip)
         SendExpeditedBlock(thinBlock, 0, skip);
     }
     // else, nothing to do
-}
-
-bool IsExpeditedNode(const CNode *pfrom)
-{
-    // xpeditedBlkUp keeps track of the nodes that we have requested expedited blocks from.  If the node
-    // is not in this list then it is not expedited node.
-    LOCK(cs_xpedited);
-    if (std::find(xpeditedBlkUp.begin(), xpeditedBlkUp.end(), pfrom) == xpeditedBlkUp.end())
-        return false;
-
-    return true;
 }

--- a/src/expedited.h
+++ b/src/expedited.h
@@ -5,12 +5,7 @@
 #ifndef BITCOIN_EXPEDITED_H
 #define BITCOIN_EXPEDITED_H
 
-#include "net.h"
 #include "thinblock.h"
-
-#include <univalue.h>
-#include <vector>
-
 
 enum
 {
@@ -26,11 +21,6 @@ enum
 };
 
 
-extern CCriticalSection cs_xpedited; // protects xpeditedBlk, xpeditedBlkUp and xpeditedTxn
-extern std::vector<CNode *> xpeditedBlk; // Who requested expedited blocks from us
-extern std::vector<CNode *> xpeditedBlkUp; // Who we requested expedited blocks from
-extern std::vector<CNode *> xpeditedTxn;
-
 // Checks to see if the node is configured in bitcoin.conf to
 extern bool CheckAndRequestExpeditedBlocks(CNode *pfrom);
 
@@ -42,8 +32,5 @@ extern bool IsRecentlyExpeditedAndStore(const uint256 &hash);
 
 // process incoming unsolicited block
 extern bool HandleExpeditedBlock(CDataStream &vRecv, CNode *pfrom);
-
-// is this node an expedited node
-extern bool IsExpeditedNode(const CNode *pfrom);
 
 #endif

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -100,9 +100,6 @@ CCriticalSection cs_vOneShots;
 
 CCriticalSection cs_statMap;
 
-// critical sections from expedited.cpp
-CCriticalSection cs_xpedited;
-
 deque<string> vOneShots;
 std::map<CNetAddr, ConnectionHistory> mapInboundConnectionTracker;
 vector<std::string> vUseDNSSeeds;
@@ -252,8 +249,3 @@ CStatHistory<uint64_t> nBlockValidationTime("blockValidationTime", STAT_OP_MAX |
 CCriticalSection cs_blockvalidationtime;
 
 CThinBlockData thindata; // Singleton class
-
-// Expedited blocks
-std::vector<CNode *> xpeditedBlk; // (256,(CNode*)NULL);    // Who requested expedited blocks from us
-std::vector<CNode *> xpeditedBlkUp; //(256,(CNode*)NULL);  // Who we requested expedited blocks from
-std::vector<CNode *> xpeditedTxn; // (256,(CNode*)NULL);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -17,6 +17,7 @@
 #include "chainparams.h"
 #include "checkpoints.h"
 #include "compat/sanity.h"
+#include "connmgr.h"
 #include "consensus/validation.h"
 #include "dosman.h"
 #include "httpserver.h"
@@ -673,6 +674,8 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     }
     fCheckBlockIndex = GetBoolArg("-checkblockindex", chainparams.DefaultConsistencyChecks());
     fCheckpointsEnabled = GetBoolArg("-checkpoints", DEFAULT_CHECKPOINTS_ENABLED);
+
+    connmgr->HandleCommandLine();
 
     // mempool limits
     int64_t nMempoolSizeMax = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1059,6 +1059,9 @@ void ThreadSocketHandler()
                     // remove from vNodes
                     vNodes.erase(remove(vNodes.begin(), vNodes.end(), pnode), vNodes.end());
 
+                    // inform connection manager
+                    connmgr->RemovedNode(pnode);
+
                     // release outbound grant (if any)
                     pnode->grantOutbound.Release();
 
@@ -2741,7 +2744,7 @@ bool CAddrDB::Read(CAddrMan &addr, CDataStream &ssPeers)
 unsigned int ReceiveFloodSize() { return 1000 * GetArg("-maxreceivebuffer", DEFAULT_MAXRECEIVEBUFFER); }
 unsigned int SendBufferSize() { return 1000 * GetArg("-maxsendbuffer", DEFAULT_MAXSENDBUFFER); }
 CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNameIn, bool fInboundIn)
-    : ssSend(SER_NETWORK, INIT_PROTO_VERSION), id(CConnMgr::nextNodeId()), addrKnown(5000, 0.001),
+    : ssSend(SER_NETWORK, INIT_PROTO_VERSION), id(connmgr->NextNodeId()), addrKnown(5000, 0.001),
       filterInventoryKnown(50000, 0.000001)
 {
     nServices = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -846,6 +846,8 @@ private:
     CNode *_pnode;
 };
 
+typedef std::vector<CNodeRef> VNodeRefs;
+
 class CTransaction;
 void RelayTransaction(const CTransaction &tx);
 void RelayTransaction(const CTransaction &tx, const CDataStream &ss);

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "chainparams.h"
+#include "connmgr.h"
 #include "consensus/merkle.h"
 #include "dosman.h"
 #include "expedited.h"
@@ -100,7 +101,7 @@ bool CThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     // Ban a node for sending unrequested thinblocks unless from an expedited node.
     {
         LOCK(pfrom->cs_mapthinblocksinflight);
-        if (!pfrom->mapThinBlocksInFlight.count(inv.hash) && !IsExpeditedNode(pfrom))
+        if (!pfrom->mapThinBlocksInFlight.count(inv.hash) && !connmgr->IsExpeditedUpstream(pfrom))
         {
             LOCK(cs_main);
             dosMan.Misbehaving(pfrom->GetId(), 100);
@@ -316,7 +317,7 @@ bool CXThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     {
         // Do not process unrequested xblocktx unless from an expedited node.
         LOCK(pfrom->cs_mapthinblocksinflight);
-        if (!pfrom->mapThinBlocksInFlight.count(inv.hash) && !IsExpeditedNode(pfrom))
+        if (!pfrom->mapThinBlocksInFlight.count(inv.hash) && !connmgr->IsExpeditedUpstream(pfrom))
         {
             dosMan.Misbehaving(pfrom->GetId(), 10);
             return error(
@@ -624,7 +625,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
         }
 
         // If this is an expedited block then add and entry to mapThinBlocksInFlight.
-        if (nHops > 0 && IsExpeditedNode(pfrom))
+        if (nHops > 0 && connmgr->IsExpeditedUpstream(pfrom))
         {
             AddThinBlockInFlight(pfrom, inv.hash);
 
@@ -638,7 +639,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
 
             // Do not process unrequested xthinblocks unless from an expedited node.
             LOCK(pfrom->cs_mapthinblocksinflight);
-            if (!pfrom->mapThinBlocksInFlight.count(inv.hash) && !IsExpeditedNode(pfrom))
+            if (!pfrom->mapThinBlocksInFlight.count(inv.hash) && !connmgr->IsExpeditedUpstream(pfrom))
             {
                 dosMan.Misbehaving(pfrom->GetId(), 10);
                 return error(


### PR DESCRIPTION
This is a follow-up to the node ref patch and connection manager patches, using both ideas to simplify the code.

- use flags on the node rather than node lists for simplicity.  I am fairly sure the old code
  wasn't handling node reference counting robustly.
- move expedited request handling to the connection manager.  Previously there were 2 places.
  A side effect is to implement missing checks (a TODO) in the RPC interface.
- remove obsolete expedited global variables and critical section