### PR TITLE
Accept tweaks in the config file.

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -710,7 +710,7 @@ BitcoinTx::BitcoinTx()
         .addDebugArg("", optionalBool, "Read hex-encoded bitcoin transaction from stdin.");
 }
 
-ConfigFile::ConfigFile()
+ConfigFile::ConfigFile(CTweakMap *pTweaks)
 {
     // Merges all allowed args from BitcoinCli, Bitcoind, and BitcoinQt.
     // Excludes args from BitcoinTx, because bitcoin-tx does not read
@@ -718,7 +718,7 @@ ConfigFile::ConfigFile()
     // program does not output a config file help message anywhere.
 
     BitcoinCli bitcoinCli;
-    Bitcoind bitcoind;
+    Bitcoind bitcoind(pTweaks);
     BitcoinQt bitcoinQt;
 
     m_args.insert(bitcoinCli.getArgs().begin(), bitcoinCli.getArgs().end());

--- a/src/allowed_args.h
+++ b/src/allowed_args.h
@@ -136,7 +136,7 @@ public:
 class ConfigFile : public AllowedArgs
 {
 public:
-    ConfigFile();
+    ConfigFile(CTweakMap *pTweaks);
 };
 
 } // namespace AllowedArgs

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -95,7 +95,7 @@ static int AppInitRPC(int argc, char* argv[])
         return EXIT_FAILURE;
     }
     try {
-        ReadConfigFile(mapArgs, mapMultiArgs);
+        ReadConfigFile(mapArgs, mapMultiArgs, nullptr);
     } catch (const std::exception& e) {
         fprintf(stderr,"Error reading configuration file: %s\n", e.what());
         return EXIT_FAILURE;

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -112,7 +112,7 @@ bool AppInit(int argc, char* argv[])
         }
         try
         {
-            ReadConfigFile(mapArgs, mapMultiArgs);
+            ReadConfigFile(mapArgs, mapMultiArgs, &tweaks);
         } catch (const std::exception& e) {
             fprintf(stderr,"Error reading configuration file: %s\n", e.what());
             return false;

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -732,7 +732,7 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
     try {
-        ReadConfigFile(mapArgs, mapMultiArgs);
+        ReadConfigFile(mapArgs, mapMultiArgs, &tweaks);
     } catch (const std::exception& e) {
         QMessageBox::critical(0, QObject::tr(PACKAGE_NAME),
                               QObject::tr("Error: Cannot parse configuration file: %1. Only use key=value syntax.").arg(e.what()));

--- a/src/test/getarg_tests.cpp
+++ b/src/test/getarg_tests.cpp
@@ -15,7 +15,7 @@
 
 BOOST_FIXTURE_TEST_SUITE(getarg_tests, BasicTestingSetup)
 
-static void ResetArgs(const std::string& strArg)
+static void ResetArgs(const std::string& strArg, bool fConfigFile=false)
 {
     std::vector<std::string> vecArg;
     if (strArg.size())
@@ -29,7 +29,10 @@ static void ResetArgs(const std::string& strArg)
     BOOST_FOREACH(std::string& s, vecArg)
         vecChar.push_back(s.c_str());
 
-    ParseParameters(vecChar.size(), &vecChar[0], AllowedArgs::Bitcoind(&tweaks));
+    if (fConfigFile)
+        ParseParameters(vecChar.size(), &vecChar[0], AllowedArgs::ConfigFile(&tweaks));
+    else
+        ParseParameters(vecChar.size(), &vecChar[0], AllowedArgs::Bitcoind(&tweaks));
 }
 
 BOOST_AUTO_TEST_CASE(boolarg)
@@ -172,6 +175,12 @@ BOOST_AUTO_TEST_CASE(boolargno)
 BOOST_AUTO_TEST_CASE(tweakArgs)
 {
     ResetArgs("-mining.comment=I_Am_A_Meat_Popsicle -mining.coinbaseReserve=250 -wallet.maxTxFee=0.001");
+    BOOST_CHECK_EQUAL(GetArg("-mining.comment", "foo"), "I_Am_A_Meat_Popsicle");
+    BOOST_CHECK_EQUAL(GetArg("-mining.coinbaseReserve", 100), 250);
+    BOOST_CHECK_EQUAL(GetArg("-wallet.maxTxFee", ""), "0.001");
+
+    // Test ConfigFile accepts tweaks
+    ResetArgs("-mining.comment=I_Am_A_Meat_Popsicle -mining.coinbaseReserve=250 -wallet.maxTxFee=0.001", true);
     BOOST_CHECK_EQUAL(GetArg("-mining.comment", "foo"), "I_Am_A_Meat_Popsicle");
     BOOST_CHECK_EQUAL(GetArg("-mining.coinbaseReserve", 100), 250);
     BOOST_CHECK_EQUAL(GetArg("-wallet.maxTxFee", ""), "0.001");

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -537,7 +537,8 @@ boost::filesystem::path GetConfigFile()
 }
 
 void ReadConfigFile(map<string, string>& mapSettingsRet,
-                    map<string, vector<string> >& mapMultiSettingsRet)
+                    map<string, vector<string> >& mapMultiSettingsRet,
+                    CTweakMap *pTweaks)
 {
     boost::filesystem::ifstream streamConfig(GetConfigFile());
     if (!streamConfig.good())
@@ -545,7 +546,7 @@ void ReadConfigFile(map<string, string>& mapSettingsRet,
 
     set<string> setOptions;
     setOptions.insert("*");
-    AllowedArgs::ConfigFile allowedArgs;
+    AllowedArgs::ConfigFile allowedArgs(pTweaks);
 
     for (boost::program_options::detail::config_file_iterator it(streamConfig, setOptions), end; it != end; ++it)
     {

--- a/src/util.h
+++ b/src/util.h
@@ -156,7 +156,9 @@ boost::filesystem::path GetConfigFile();
 boost::filesystem::path GetPidFile();
 void CreatePidFile(const boost::filesystem::path &path, pid_t pid);
 #endif
-void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet, std::map<std::string, std::vector<std::string> >& mapMultiSettingsRet);
+void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet,
+                    std::map<std::string, std::vector<std::string> >& mapMultiSettingsRet,
+                    CTweakMap *pTweaks);
 #ifdef WIN32
 boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif


### PR DESCRIPTION
Previously an oversight meant they were only accepted on the command line.
Fixes #637