### PR TITLE
Better encapsulation of CParallelValidation (part 1)

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -248,10 +248,6 @@ CTweak<uint64_t> checkScriptDays("blockchain.checkScriptDays",
 
 CRequestManager requester; // after the maps nodes and tweaks
 
-// Parallel Validation Variables
-CParallelValidation PV; // Singleton class
-CAllScriptCheckQueues allScriptCheckQueues; // Singleton class
-
 CStatHistory<unsigned int> txAdded; //"memPool/txAdded");
 CStatHistory<uint64_t, MinValMax<uint64_t> > poolSize; // "memPool/size",STAT_OP_AVE);
 CStatHistory<uint64_t> recvAmt;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -164,8 +164,8 @@ static boost::scoped_ptr<ECCVerifyHandle> globalVerifyHandle;
 void Interrupt(boost::thread_group& threadGroup)
 {
     // Interrupt Parallel Block Validation threads if there are any running.
-    PV.StopAllValidationThreads();
-    PV.WaitForAllValidationThreadsToStop();
+    PV->StopAllValidationThreads();
+    PV->WaitForAllValidationThreadsToStop();
 
     InterruptHTTPServer();
     InterruptHTTPRPC();
@@ -680,15 +680,6 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     if (nMempoolSizeMax < 0 || nMempoolSizeMax < nMempoolSizeMin)
         return InitError(strprintf(_("-maxmempool must be at least %d MB"), std::ceil(nMempoolSizeMin / 1000000.0)));
 
-    // -par=0 means autodetect, but nScriptCheckThreads==0 means no concurrency
-    nScriptCheckThreads = GetArg("-par", DEFAULT_SCRIPTCHECK_THREADS);
-    if (nScriptCheckThreads <= 0)
-        nScriptCheckThreads += GetNumCores();
-    if (nScriptCheckThreads <= 1)
-        nScriptCheckThreads = 0;
-    else if (nScriptCheckThreads > MAX_SCRIPTCHECK_THREADS)
-        nScriptCheckThreads = MAX_SCRIPTCHECK_THREADS;
-
     fServer = GetBoolArg("-server", false);
 
     // block pruning; get the amount of disk space (in MiB) to allot for block & undo files
@@ -821,10 +812,13 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     LogPrintf("Using at most %i connections (%i file descriptors available)\n", nMaxConnections, nFD);
     std::ostringstream strErrors;
 
-    LogPrintf("Using %u threads for script verification\n", nScriptCheckThreads);
-    // BU: parallel block validation - begin
-    AddAllScriptCheckQueuesAndThreads(nScriptCheckThreads, &threadGroup); // This initializes and creates 4 separate script thread queues and thread pools.
-    // BU: parallel block validation - end
+    // -par=0 means autodetect, but passing 0 to the CParallelValidation constructor means no concurrency
+    int nPVThreads = GetArg("-par", DEFAULT_SCRIPTCHECK_THREADS);
+    if (nPVThreads <= 0)
+        nPVThreads += GetNumCores();
+
+    // BU: create the parallel block validator
+    PV.reset(new CParallelValidation(nPVThreads, &threadGroup));
 
     // Start the lightweight task scheduler thread
     CScheduler::Function serviceLoop = boost::bind(&CScheduler::serviceQueue, &scheduler);

--- a/src/main.h
+++ b/src/main.h
@@ -149,7 +149,6 @@ extern CWaitableCriticalSection csBestBlock;
 extern CConditionVariable cvBlockChange;
 extern bool fImporting;
 extern bool fReindex;
-extern int nScriptCheckThreads;
 extern bool fTxIndex;
 extern bool fIsBareMultisigStd;
 extern bool fRequireStandard;

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -17,17 +17,14 @@
 
 #include <boost/thread/thread.hpp>
 
-#define MAX_SCRIPT_CHECK_QUEUES 4
-
-static CCheckQueue<CScriptCheck> scriptcheckqueue1(128);
-static CCheckQueue<CScriptCheck> scriptcheckqueue2(128);
-static CCheckQueue<CScriptCheck> scriptcheckqueue3(128);
-static CCheckQueue<CScriptCheck> scriptcheckqueue4(128);
-
 using namespace std;
 
+static const unsigned int nScriptCheckQueues = 4;
+std::unique_ptr<CParallelValidation> PV;
 
-void AddScriptCheckThreads(int i, CCheckQueue<CScriptCheck> *pqueue)
+static void HandleBlockMessageThread(CNode *pfrom, const std::string strCommand, const CBlock block, const CInv inv);
+
+static void AddScriptCheckThreads(int i, CCheckQueue<CScriptCheck> *pqueue)
 {
     ostringstream tName;
     tName << "bitcoin-scriptchk" << i;
@@ -35,20 +32,33 @@ void AddScriptCheckThreads(int i, CCheckQueue<CScriptCheck> *pqueue)
     pqueue->Thread();
 }
 
-void AddAllScriptCheckQueuesAndThreads(int nScriptCheckThreads, boost::thread_group *threadGroup)
+CParallelValidation::CParallelValidation(int threadCount, boost::thread_group *threadGroup)
 {
-    CCheckQueue<CScriptCheck> *pqueue[MAX_SCRIPT_CHECK_QUEUES] = {
-        &scriptcheckqueue1, &scriptcheckqueue2, &scriptcheckqueue3, &scriptcheckqueue4};
+    if (threadCount <= 1)
+        threadCount = 0;
+    else if (threadCount > MAX_SCRIPTCHECK_THREADS)
+        threadCount = MAX_SCRIPTCHECK_THREADS;
+    nThreads = threadCount;
 
-    for (int i = 0; i < MAX_SCRIPT_CHECK_QUEUES; i++)
+    LogPrintf("Using %d threads for script verification\n", threadCount);
+
+    while (QueueCount() < nScriptCheckQueues)
     {
-        allScriptCheckQueues.Add(pqueue[i]);
-        for (int j = 0; j < nScriptCheckThreads; j++)
-            threadGroup->create_thread(boost::bind(&AddScriptCheckThreads, i + 1, pqueue[i]));
+        std::unique_ptr<CCheckQueue<CScriptCheck> > queue(new CCheckQueue<CScriptCheck>(128));
+
+        for (unsigned int i = 0; i < nThreads; i++)
+            threadGroup->create_thread(boost::bind(&AddScriptCheckThreads, i + 1, queue.get()));
+
+        vQueues.push_back(std::move(queue));
     }
 }
 
-CParallelValidation::CParallelValidation() { mapBlockValidationThreads.clear(); }
+unsigned int CParallelValidation::QueueCount()
+{
+    // Only modified in constructor so no lock currently needed
+    return vQueues.size();
+}
+
 bool CParallelValidation::Initialize(const boost::thread::id this_id, const CBlockIndex *pindex, const bool fParallel)
 {
     AssertLockHeld(cs_main);
@@ -391,7 +401,6 @@ void CParallelValidation::HandleBlockMessage(CNode *pfrom,
     const CInv &inv)
 {
     uint64_t nBlockSize = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
-    uint8_t nScriptCheckQueues = allScriptCheckQueues.Size();
 
     /** Initialize Semaphores used to limit the total number of concurrent validation threads. */
     if (semPV == NULL)
@@ -479,7 +488,7 @@ void CParallelValidation::HandleBlockMessage(CNode *pfrom,
     }
 
     // only launch block validation in a separate thread if PV is enabled.
-    if (PV.Enabled())
+    if (PV->Enabled())
     {
         boost::thread thread(boost::bind(&HandleBlockMessageThread, pfrom, strCommand, block, inv));
         thread.detach(); // Separate actual thread from the "thread" object so its fine to fall out of scope
@@ -507,7 +516,7 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, const CBloc
 
 
     boost::thread::id this_id(boost::this_thread::get_id());
-    PV.InitThread(this_id, pfrom, block, inv); // initialize the mapBlockValidationThread entries
+    PV->InitThread(this_id, pfrom, block, inv); // initialize the mapBlockValidationThread entries
 
     // Process all blocks from whitelisted peers, even if not requested,
     // unless we're still syncing with the network.
@@ -515,7 +524,7 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, const CBloc
     // conditions in AcceptBlock().
     bool forceProcessing = pfrom->fWhitelisted && !IsInitialBlockDownload();
     const CChainParams &chainparams = Params();
-    if (PV.Enabled())
+    if (PV->Enabled())
     {
         ProcessNewBlock(state, chainparams, pfrom, &block, forceProcessing, NULL, true);
     }
@@ -595,11 +604,11 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, const CBloc
     }
 
     // Erase any txns from the orphan cache that are no longer needed
-    PV.ClearOrphanCache(block);
+    PV->ClearOrphanCache(block);
 
     // Clear thread data - this must be done before the thread completes or else some other new
     // thread may grab the same thread id and we would end up deleting the entry for the new thread instead.
-    PV.Erase(this_id);
+    PV->Erase(this_id);
 
     // release semaphores depending on whether this was IBD or not.  We can not use IsChainNearlySyncd()
     // because the return value will switch over when IBD is nearly finished and we may end up not releasing
@@ -617,54 +626,51 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, const CBloc
 }
 
 
-CCheckQueue<CScriptCheck> *CAllScriptCheckQueues::GetScriptCheckQueue()
+// for newly mined block validation, return the first queue not in use.
+CCheckQueue<CScriptCheck> *CParallelValidation::GetScriptCheckQueue()
 {
-    // for newly mined block validation, return the first queue not in use.
-    CCheckQueue<CScriptCheck> *pqueue = NULL;
-    if (Size() > 0)
+    while (true)
     {
-        while (true)
         {
+            LOCK(cs_blockvalidationthread);
+
+            for (unsigned int i = 0; i < vQueues.size(); i++)
             {
-                LOCK2(PV.cs_blockvalidationthread, cs);
-                for (unsigned int i = 0; i < vScriptCheckQueues.size(); i++)
+                auto pqueue(vQueues[i].get());
+
+                if (pqueue->IsIdle())
                 {
-                    if (vScriptCheckQueues[i]->IsIdle())
+                    bool inUse = false;
+                    map<boost::thread::id, CParallelValidation::CHandleBlockMsgThreads>::iterator iter =
+                        mapBlockValidationThreads.begin();
+                    while (iter != mapBlockValidationThreads.end())
                     {
-                        bool inUse = false;
-                        map<boost::thread::id, CParallelValidation::CHandleBlockMsgThreads>::iterator iter =
-                            PV.mapBlockValidationThreads.begin();
-                        while (iter != PV.mapBlockValidationThreads.end())
+                        if ((*iter).second.pScriptQueue == pqueue)
                         {
-                            if ((*iter).second.pScriptQueue == vScriptCheckQueues[i])
-                            {
-                                inUse = true;
-                                break;
-                            }
-                            iter++;
+                            inUse = true;
+                            break;
                         }
-                        if (!inUse)
-                        {
-                            pqueue = vScriptCheckQueues[i];
-                            pqueue->Quit(false); // set to false because it still may be set to true from last run.
+                        iter++;
+                    }
+                    if (!inUse)
+                    {
+                        pqueue->Quit(false); // set to false because it still may be set to true from last run.
 
-                            // Only assign a pqueue to a validation thread if a validation thread is actually running.
-                            // When mining or when bitcoin is first starting there will be no validation threads so we
-                            // don't want to assign a pqueue here if that is the case.
-                            boost::thread::id this_id(boost::this_thread::get_id());
-                            if (PV.mapBlockValidationThreads.count(this_id))
-                                PV.mapBlockValidationThreads[this_id].pScriptQueue = pqueue;
+                        // Only assign a pqueue to a validation thread if a validation thread is actually running.
+                        // When mining or when bitcoin is first starting there will be no validation threads so we
+                        // don't want to assign a pqueue here if that is the case.
+                        boost::thread::id this_id(boost::this_thread::get_id());
+                        if (mapBlockValidationThreads.count(this_id))
+                            mapBlockValidationThreads[this_id].pScriptQueue = pqueue;
 
-                            LogPrint("parallel", "next scriptqueue not in use is %d\n", i);
-                            return pqueue;
-                        }
+                        LogPrint("parallel", "next scriptqueue not in use is %d\n", i);
+                        return pqueue;
                     }
                 }
             }
-            LogPrint("parallel", "Sleeping 50 millis\n");
-            MilliSleep(50);
         }
+
+        LogPrint("parallel", "Sleeping 50 millis\n");
+        MilliSleep(50);
     }
-    assert(pqueue != NULL);
-    return pqueue;
 }

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -18,18 +18,7 @@
 
 #include <boost/thread.hpp>
 
-
-// The number of script check queues we have available.  For every script check queue we can run an
-// additional parallel block validation.
-
 extern CCriticalSection cs_blockvalidationthread;
-
-// adds all the script check queues into the "allScriptCheckQueues" global variable and creates nScriptCheckThreads per
-// check queue
-void AddAllScriptCheckQueuesAndThreads(int nScriptCheckThreads, boost::thread_group *threadGroup);
-// Entry point for the script check queue threads.
-void AddScriptCheckThreads(int i, CCheckQueue<CScriptCheck> *pqueue);
-
 extern CCriticalSection cs_semPV;
 extern CSemaphore *semPV; // semaphore for parallel validation threads
 
@@ -80,43 +69,16 @@ public:
     ScriptError GetScriptError() const { return error; }
 };
 
-/**
- * Hold pointers to all script check queues in one vector
- */
-class CAllScriptCheckQueues
-{
-private:
-    std::vector<CCheckQueue<CScriptCheck> *> vScriptCheckQueues;
-
-    CCriticalSection cs;
-
-public:
-    CAllScriptCheckQueues() {}
-    void Add(CCheckQueue<CScriptCheck> *pqueueIn)
-    {
-        LOCK(cs);
-        vScriptCheckQueues.push_back(pqueueIn);
-    }
-
-    uint8_t Size()
-    {
-        LOCK(cs);
-        return vScriptCheckQueues.size();
-    }
-
-    CCheckQueue<CScriptCheck> *GetScriptCheckQueue();
-};
-extern CAllScriptCheckQueues allScriptCheckQueues; // Singleton class
-
 class CParallelValidation
 {
 private:
     // txn hashes that are in the previous block
     CCriticalSection cs_previousblock;
     std::vector<uint256> vPreviousBlock;
+    // Vector of script check queues
+    std::vector<std::unique_ptr<CCheckQueue<CScriptCheck> > > vQueues;
+    unsigned int nThreads;
 
-
-public:
     struct CHandleBlockMsgThreads
     {
         CCheckQueue<CScriptCheck> *pScriptQueue;
@@ -136,8 +98,13 @@ public:
 
 
 public:
-    CParallelValidation();
-
+    /**
+     * Construct a parallel validator.
+     * @param[in] threadCount   The number of script validation threads.  If <= 1 then no separate validation threads
+     *                          are created.
+     * @param[in] threadGroup   The thread group threads will be created in
+     */
+    CParallelValidation(int threadCount, boost::thread_group *threadGroup);
 
     /* Initialize mapBlockValidationThreads*/
     void InitThread(const boost::thread::id this_id, const CNode *pfrom, const CBlock &block, const CInv &inv);
@@ -185,10 +152,16 @@ public:
 
     /* Process a block message */
     void HandleBlockMessage(CNode *pfrom, const std::string &strCommand, const CBlock &block, const CInv &inv);
+
+    // The number of script validation threads
+    unsigned int ThreadCount() { return nThreads; }
+    // The number of script check queues
+    unsigned int QueueCount();
+
+    // For newly mined block validation, return the first queue not in use.
+    CCheckQueue<CScriptCheck> *GetScriptCheckQueue();
 };
-extern CParallelValidation PV; // Singleton class
 
-
-void HandleBlockMessageThread(CNode *pfrom, const std::string strCommand, const CBlock block, const CInv inv);
+extern std::unique_ptr<CParallelValidation> PV; // Singleton class
 
 #endif // BITCOIN_PARALLEL_H

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -467,7 +467,7 @@ void CRequestManager::SendRequests()
     }
 
     // Get Blocks if we are not in the middle of a re-org
-    while (sendBlkIter != mapBlkInfo.end() && !PV.IsReorgInProgress())
+    while (sendBlkIter != mapBlkInfo.end() && !PV->IsReorgInProgress())
     {
         now = GetTimeMicros();
         OdMap::iterator itemIter = sendBlkIter;

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -135,15 +135,15 @@ UniValue generateBlocks(boost::shared_ptr<CReserveScript> coinbaseScript, int nG
 
 
         // We take a cs_main lock here even though it will also be aquired in ProcessNewBlock.  We want
-        // to make sure we give priority to our own blocks.  This is in order to prevent any other Parallel 
+        // to make sure we give priority to our own blocks.  This is in order to prevent any other Parallel
         // Blocks to validate when we've just mined one of our own blocks.
         LOCK(cs_main);
 
-        // In we are mining our own block or not running in parallel for any reason 
+        // In we are mining our own block or not running in parallel for any reason
         // we must terminate any block validation threads that are currently running,
         // Unless they have more work than our own block.
         // TODO: we need a better way to determine if a reorg is in progress.
-        PV.StopAllValidationThreads(pblock->GetBlockHeader().nBits);
+        PV->StopAllValidationThreads(pblock->GetBlockHeader().nBits);
 
         CValidationState state;
         if (!ProcessNewBlock(state, Params(), NULL, pblock, true, NULL, false))
@@ -222,7 +222,7 @@ UniValue generatetoaddress(const UniValue& params, bool fHelp)
     CBitcoinAddress address(params[1].get_str());
     if (!address.IsValid())
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Error: Invalid address");
-    
+
     boost::shared_ptr<CReserveScript> coinbaseScript(new CReserveScript());
     coinbaseScript->reserveScript = GetScriptForDestination(address.Get());
 
@@ -745,15 +745,15 @@ UniValue submitblock(const UniValue& params, bool fHelp)
 
 
     // We take a cs_main lock here even though it will also be aquired in ProcessNewBlock.  We want
-    // to make sure we give priority to our own blocks.  This is in order to prevent any other Parallel 
+    // to make sure we give priority to our own blocks.  This is in order to prevent any other Parallel
     // Blocks to validate when we've just mined one of our own blocks.
     LOCK(cs_main);
 
-    // In we are mining our own block or not running in parallel for any reason 
+    // In we are mining our own block or not running in parallel for any reason
     // we must terminate any block validation threads that are currently running,
     // Unless they have more work than our own block.
     // TODO: we need a better way to determine if a reorg is in progress.
-    PV.StopAllValidationThreads(block.GetBlockHeader().nBits);
+    PV->StopAllValidationThreads(block.GetBlockHeader().nBits);
 
     bool fAccepted = ProcessNewBlock(state, Params(), NULL, &block, true, NULL, false);
     UnregisterValidationInterface(&sc);

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -64,8 +64,7 @@ TestingSetup::TestingSetup(const std::string& chainName) : BasicTestingSetup(cha
         pcoinsTip = new CCoinsViewCache(pcoinsdbview);
         InitBlockIndex(chainparams);
 
-        nScriptCheckThreads = 3;
-        AddAllScriptCheckQueuesAndThreads(nScriptCheckThreads, &threadGroup);
+        PV.reset(new CParallelValidation(3, &threadGroup));
         RegisterNodeSignals(GetNodeSignals());
 }
 

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -198,7 +198,7 @@ bool CThinBlock::process(CNode *pfrom, int nSizeThinBlock)
         thindata.UpdateInBound(nSizeThinBlock, blockSize);
         LogPrint("thin", "thin block stats: %s\n", thindata.ToString());
 
-        PV.HandleBlockMessage(pfrom, NetMsgType::THINBLOCK, pfrom->thinBlock, GetInv());
+        PV->HandleBlockMessage(pfrom, NetMsgType::THINBLOCK, pfrom->thinBlock, GetInv());
     }
     else if (pfrom->thinBlockWaitingForTxns > 0)
     {
@@ -428,7 +428,7 @@ bool CXThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
         thindata.UpdateInBound(nSizeThinBlockTx + pfrom->nSizeThinBlock, blockSize);
         LogPrint("thin", "thin block stats: %s\n", thindata.ToString());
 
-        PV.HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, inv);
+        PV->HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, inv);
     }
 
     return true;
@@ -661,7 +661,7 @@ bool CXThinBlock::process(CNode *pfrom,
     // In PV we must prevent two thinblocks from simulaneously processing from that were recieved from the
     // same peer. This would only happen as in the example of an expedited block coming in
     // after an xthin request, because we would never explicitly request two xthins from the same peer.
-    if (PV.IsAlreadyValidating(pfrom->id))
+    if (PV->IsAlreadyValidating(pfrom->id))
         return false;
 
     // Xpress Validation - only perform xval if the chaintip matches the last blockhash in the thinblock
@@ -844,7 +844,7 @@ bool CXThinBlock::process(CNode *pfrom,
     LogPrint("thin", "thin block stats: %s\n", thindata.ToString().c_str());
 
     // Process the full block
-    PV.HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, GetInv());
+    PV->HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, GetInv());
 
     return true;
 }

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -560,7 +560,7 @@ static bool ProcessBlockFound(const CBlock *pblock, const CChainParams &chainpar
         // we must terminate any block validation threads that are currently running,
         // Unless they have more work than our own block.
         // TODO: we need a better way to determine if a reorg is in progress.
-        PV.StopAllValidationThreads(pblock->GetBlockHeader().nBits);
+        PV->StopAllValidationThreads(pblock->GetBlockHeader().nBits);
 
         // Process this block the same as if we had received it from another node
         CValidationState state;


### PR DESCRIPTION
- make PV a global unique_ptr rather than the object itself.  This gives
  us more control over the timing of construction.  This allows us to
  do more initialization in the constructor and allows us to encapsulate
  other globals (more to come).
- in particular the globals nScriptCheckThreads and allScriptCheckQueues
  are now encapsulated in CParallelValidation
- this permits making mapBlockValidationThreads private rather than public
- move HandleBlockMessageThread declaration out of header; make static