### PR TITLE
Increase the default min-xthin-nodes to 8 and outbound nodes total to 12

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -74,9 +74,9 @@ static const size_t SETASKFOR_MAX_SZ = 2 * MAX_INV_SZ;
 /** The maximum number of peer connections to maintain. */
 static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 /** BU: The maximum numer of outbound peer connections */
-static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 8;
+static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 12;
 /** BU: The minimum number of xthin nodes to connect */
-static const uint8_t MIN_XTHIN_NODES = 4;
+static const uint8_t MIN_XTHIN_NODES = 8;
 /** BU: The daily maximum disconnects while searching for xthin nodes to connect */
 static const unsigned int MAX_DISCONNECTS = 200;
 /** The default for -maxuploadtarget. 0 = Unlimited */


### PR DESCRIPTION
By increasing the min-xthin-nodes count from 4 to 8 we can increase
the connectivity of the XTHIN network significantly and further
protect against any attempt to partition the BU network of nodes by
some sort of sybil attack.  Furthermore we also increase the default
outbound nodes to 12 to ensure we also keep the current value of 4
for other types of nodes.  In short we increase the number of XTHIN
outbound nodes by 4 but keep other outbound nodes with the same count as before.

NOTE:  I only increased the outbound to 12 rather than to 16 to keep bandwidth down as low as
possible for marginal users (without affecting the current connectivity to non-XTHIN nodes) who either don't want inbound connections or run with a low number of max connections.  I think this will work well, but it's of course up for discussion.