### PR TITLE
Reboot nolnet.

### DIFF
--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -121,4 +121,8 @@ CChainParams& Params(const std::string& chain);
  */
 void SelectParams(const std::string& chain);
 
+CBlock CreateGenesisBlock(CScript prefix, const std::string &comment, const CScript& genesisOutputScript,
+                          uint32_t nTime, uint32_t nNonce, uint32_t nBits, int32_t nVersion,
+                          const CAmount& genesisReward);
+
 #endif // BITCOIN_CHAINPARAMS_H


### PR DESCRIPTION
- New genesis block to force a new chain
- New network bytes so we don't interfere with old nolnet nodes
- After 20 minutes difficulty resets to 1 like on testnet3
- P2PKH addresses begin with B and P2SH with U
- BIP32 xprv and xpub prefixes are "Big " and "Blks".

Exports CreateGenesisBlock for use in an as yet uncommited script
by thezerg for adding an RPC call to create genesis blocks.