### PR TITLE
Disconnect instead of banning nodes for VERSION VERACK inconsistencies

### DIFF
--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -622,8 +622,7 @@ class SendHeadersTest(BitcoinTestFramework):
             assert_equal(int(self.nodes[0].getbestblockhash(), 16), blocks[1].sha256)
 
 
-        # Check that multiple unconnecting headers don't cause an immediate ban.
-        # Do this four times only which will give a DOS misbeviour of 80.
+        # Check that multiple unconnecting headers don't cause any issues.
         for i in range(2):
             test_node.last_getdata = []
             blocks = []
@@ -669,7 +668,7 @@ class SendHeadersTest(BitcoinTestFramework):
             assert_equal(int(self.nodes[0].getbestblockhash(), 16), blocks[4].sha256)
 
 
-        # Send one more out of order header which should result in a DOS 100 with subsequent ban and disconnect
+        # Send one more out of order header which should not cause any problems
         test_node.last_getdata = []
         blocks = []
         # Create two more blocks
@@ -681,9 +680,6 @@ class SendHeadersTest(BitcoinTestFramework):
             height += 1
         # Send the header of the second block -> this won't connect.
         test_node.send_header_for_blocks([blocks[1]])
-
-        # Should get disconnected
-        test_node.wait_for_disconnect()
 
         # Finally, check that the inv node never received a getdata request,
         # throughout the test

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5747,7 +5747,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         // Must have version message before anything else (Although we may send our VERSION before
         // we receive theirs, it would not be possible to receive their VERACK before their VERSION).
         pfrom->fDisconnect = true;
-        return error("VERSION was not received before other messages - disconnecting peer=%s", pfrom->GetLogName());
+        return error("%s receieved before VERSION message - disconnecting peer=%s", strCommand, pfrom->GetLogName());
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6322,7 +6322,6 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
 
             if (header.hashPrevBlock != hashLastBlock)
             {
-                dosMan.Misbehaving(pfrom->GetId(), 20);
                 return error("non-continuous headers sequence");
             }
             hashLastBlock = header.GetHash();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5746,10 +5746,6 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
     {
         // Must have version message before anything else (Although we may send our VERSION before
         // we receive theirs, it would not be possible to receive their VERACK before their VERSION).
-        // NOTE:  we MUST explicitly ban the peer here.  If we only indicate a misbehaviour then the peer
-        //        may never be banned since the banning process requires that messages be sent back. If an
-        //        attacker sends us messages that do not require a response coupled with an nVersion of zero
-        //        then they can continue unimpeded even though they have exceeded the misbehaving threshold.
         pfrom->fDisconnect = true;
         return error("VERSION was not received before other messages - disconnecting peer=%s", pfrom->GetLogName());
     }

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(version_tests)
     BOOST_CHECK(dummyNode1a.nVersion);
     BOOST_CHECK(dosMan.IsBanned(addr1));
 
-    // Receive duplicate VERSION, nVersion will not be zero and should result in a ban
+    // Receive duplicate VERSION, nVersion will not be zero and should result in a disconnect
     vRecv1.clear();
     dosMan.ClearBanned();
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
@@ -126,9 +126,9 @@ BOOST_AUTO_TEST_CASE(version_tests)
     ProcessMessage(&dummyNode2, NetMsgType::VERSION, vRecv1, GetTime());
     SendMessages(&dummyNode2);
     BOOST_CHECK(dummyNode2.nVersion);
-    BOOST_CHECK(dosMan.IsBanned(addr2));
+    BOOST_CHECK(dummyNode2.fDisconnect);
 
-    // Receive any message without receiving the version message first - this should cause a ban
+    // Receive any message without receiving the version message first - this should cause a disconnect
     vRecv1.clear();
     dosMan.ClearBanned();
     CNode dummyNode3(INVALID_SOCKET, addr3, "", true);
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(version_tests)
     ProcessMessage(&dummyNode3, NetMsgType::PING, vRecv1, GetTime());
     SendMessages(&dummyNode3);
     BOOST_CHECK(!dummyNode3.nVersion);
-    BOOST_CHECK(dosMan.IsBanned(addr3));
+    BOOST_CHECK(dummyNode3.fDisconnect);
 }
 
 BOOST_AUTO_TEST_CASE(verack_tests)
@@ -155,23 +155,23 @@ BOOST_AUTO_TEST_CASE(verack_tests)
 
     // Receive VERACK but no VERSION sent
     dummyNode1.fSuccessfullyConnected = false;
-    dummyNode1.tVersionSent = -1; // should cause ban
+    dummyNode1.tVersionSent = -1; // should cause disconnect
     ProcessMessage(&dummyNode1, NetMsgType::VERACK, vRecv1, GetTime());
     SendMessages(&dummyNode1);
     BOOST_CHECK(dummyNode1.tVersionSent < 0);
-    BOOST_CHECK(dosMan.IsBanned(addr1));
+    BOOST_CHECK(dummyNode1.fDisconnect);
 
     // Receive duplicate VERACK after VERSION sent. fSuccessfullyConnected will already be true.
     vRecv1.clear();
     dosMan.ClearBanned();
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
     dummyNode2.nVersion = MIN_PEER_PROTO_VERSION;
-    dummyNode2.fSuccessfullyConnected = true; // should cause ban if VERSION was already sent
+    dummyNode2.fSuccessfullyConnected = true; // should cause disconnect if VERSION was already sent
     dummyNode2.tVersionSent = GetTime();
     ProcessMessage(&dummyNode2, NetMsgType::VERACK, vRecv1, GetTime());
     SendMessages(&dummyNode2);
     BOOST_CHECK(dummyNode2.fSuccessfullyConnected);
-    BOOST_CHECK(dosMan.IsBanned(addr2));
+    BOOST_CHECK(dummyNode2.fDisconnect);
 
     // Test the disconnect of a peer if the VERACK_TIMEOUT is exceeded
     int64_t nStartTime = GetTime();


### PR DESCRIPTION
Also, do not assign misbehavior for headers received that can not immediately be connected.