### PR TITLE
bitcoin-cli should accept config-file tweaks

### DIFF
--- a/src/allowed_args.h
+++ b/src/allowed_args.h
@@ -48,6 +48,10 @@ class AllowedArgs
 protected:
     std::map<std::string, CheckValueFunc> m_args;
     std::list<HelpComponent> m_helpList;
+    // If true, unrecognized switches are ignored.
+    bool m_permit_unrecognized;
+
+    AllowedArgs(bool permit_unrecognized);
 
 public:
     /**


### PR DESCRIPTION
bitcoin-cli is not aware of tweaks as it is not linked against the
files that contain them.  bitcoin-cli should not reject something that
looks like a tweak as it may have come from the config file.

Add testcases.