### PR TITLE
HandleBlockMessageThread cannot take references

### DIFF
--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -490,7 +490,7 @@ void CParallelValidation::HandleBlockMessage(CNode *pfrom,
     }
 }
 
-void HandleBlockMessageThread(CNode *pfrom, const string &strCommand, const CBlock &block, const CInv &inv)
+void HandleBlockMessageThread(CNode *pfrom, const string strCommand, const CBlock block, const CInv inv)
 {
     int64_t startTime = GetTimeMicros();
     CValidationState state;

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -189,6 +189,6 @@ public:
 extern CParallelValidation PV; // Singleton class
 
 
-void HandleBlockMessageThread(CNode *pfrom, const std::string &strCommand, const CBlock &block, const CInv &inv);
+void HandleBlockMessageThread(CNode *pfrom, const std::string strCommand, const CBlock block, const CInv inv);
 
 #endif // BITCOIN_PARALLEL_H


### PR DESCRIPTION
They might be to stack objects.
Until object lifetime management is cleaned up for the various code paths calling
this function this is the best short-term fix, at the cost of some performance.