### PR TITLE
[CDoSManager] Clean up use of cs_setBanned locks and standardize internal use of member variables instead of public methods

### DIFF
--- a/src/dosman.cpp
+++ b/src/dosman.cpp
@@ -280,3 +280,20 @@ void CDoSManager::Misbehaving(NodeId pnode, int howmuch)
     else
         LogPrintf("%s: %s (%d -> %d)\n", __func__, state->name, state->nMisbehavior - howmuch, state->nMisbehavior);
 }
+
+
+/**
+* Write in-memory banmap to disk
+*/
+void CDoSManager::DumpBanlist()
+{
+    int64_t nStart = GetTimeMillis();
+
+    CBanDB bandb;
+    banmap_t banmap;
+    GetBanned(banmap);
+    bandb.Write(banmap);
+
+    LogPrint(
+        "net", "Flushed %d banned node ips/subnets to banlist.dat  %dms\n", banmap.size(), GetTimeMillis() - nStart);
+}

--- a/src/dosman.cpp
+++ b/src/dosman.cpp
@@ -302,3 +302,27 @@ void CDoSManager::DumpBanlist()
     LogPrint(
         "net", "Flushed %d banned node ips/subnets to banlist.dat  %dms\n", banmap.size(), GetTimeMillis() - nStart);
 }
+
+/**
+* Read banmap from disk into memory
+*/
+void CDoSManager::LoadBanlist()
+{
+    uiInterface.InitMessage(_("Loading banlist..."));
+
+    // Load addresses from banlist.dat
+    int64_t nStart = GetTimeMillis();
+    CBanDB bandb;
+    banmap_t banmap;
+    if (bandb.Read(banmap))
+    {
+        SetBanned(banmap); // thread safe setter
+        SetBannedSetDirty(false); // no need to write down, just read data
+        SweepBanned(); // sweep out expired entries
+
+        LogPrint("net", "Loaded %d banned node ips/subnets from banlist.dat  %dms\n", banmap.size(),
+            GetTimeMillis() - nStart);
+    }
+    else
+        LogPrintf("Invalid or missing banlist.dat; recreating\n");
+}

--- a/src/dosman.cpp
+++ b/src/dosman.cpp
@@ -287,6 +287,10 @@ void CDoSManager::Misbehaving(NodeId pnode, int howmuch)
 */
 void CDoSManager::DumpBanlist()
 {
+    // If setBanned is not dirty, don't waste time on disk i/o
+    if (!BannedSetIsDirty())
+        return;
+
     int64_t nStart = GetTimeMillis();
 
     CBanDB bandb;
@@ -294,6 +298,7 @@ void CDoSManager::DumpBanlist()
     GetBanned(banmap);
     bandb.Write(banmap);
 
+    SetBannedSetDirty(false);
     LogPrint(
         "net", "Flushed %d banned node ips/subnets to banlist.dat  %dms\n", banmap.size(), GetTimeMillis() - nStart);
 }

--- a/src/dosman.cpp
+++ b/src/dosman.cpp
@@ -60,19 +60,19 @@ void CDoSManager::ClearBanned()
 */
 bool CDoSManager::IsBanned(CNetAddr ip)
 {
-    bool fResult = false;
+    LOCK(cs_setBanned);
+    for (banmap_t::iterator it = setBanned.begin(); it != setBanned.end(); it++)
     {
-        LOCK(cs_setBanned);
-        for (banmap_t::iterator it = setBanned.begin(); it != setBanned.end(); it++)
-        {
-            CSubNet subNet = (*it).first;
-            CBanEntry banEntry = (*it).second;
+        CSubNet subNet = (*it).first;
+        CBanEntry banEntry = (*it).second;
 
-            if (subNet.Match(ip) && GetTime() < banEntry.nBanUntil)
-                fResult = true;
-        }
+        // As soon as we find a matching ban that isn't expired return immediately
+        if (subNet.Match(ip) && GetTime() < banEntry.nBanUntil)
+            return true;
     }
-    return fResult;
+
+    // If we got here, we traversed the list and didn't find any non-expired bans for this IP
+    return false;
 }
 
 /**
@@ -83,18 +83,18 @@ bool CDoSManager::IsBanned(CNetAddr ip)
 */
 bool CDoSManager::IsBanned(CSubNet subnet)
 {
-    bool fResult = false;
+    LOCK(cs_setBanned);
+    banmap_t::iterator i = setBanned.find(subnet);
+    if (i != setBanned.end())
     {
-        LOCK(cs_setBanned);
-        banmap_t::iterator i = setBanned.find(subnet);
-        if (i != setBanned.end())
-        {
-            CBanEntry banEntry = (*i).second;
-            if (GetTime() < banEntry.nBanUntil)
-                fResult = true;
-        }
+        CBanEntry banEntry = (*i).second;
+        // As soon as we find a matching ban that isn't expired return immediately
+        if (GetTime() < banEntry.nBanUntil)
+            return true;
     }
-    return fResult;
+
+    // If we got here, we traversed the list and didn't find any non-expired bans for this exact subnet
+    return false;
 }
 
 /**
@@ -167,7 +167,7 @@ bool CDoSManager::Unban(const CSubNet &subNet)
     {
         setBannedIsDirty = true;
 
-        SweepBanned();
+        SweepBannedInternal();
         uiInterface.BannedListChanged();
         return true;
     }
@@ -183,21 +183,23 @@ bool CDoSManager::Unban(const CSubNet &subNet)
 void CDoSManager::GetBanned(banmap_t &banMap)
 {
     LOCK(cs_setBanned);
-    SweepBanned();
-    banMap = setBanned; // create a thread safe copy
+    SweepBannedInternal();
+    GetBannedInternal(banMap); // create a thread safe copy
 }
 
 /**
-* Overwrite the current in-memory banlist with the passed in banmap_t
-* Marks the in-memory banlist as dirty
+* Copies current in-memory banlist to the passed in banmap_t
+* Intended to allow read-only actions on the banlist without holding the lock
 *
-* @param[in] banMap  The new banlist to copy over in-memory banmap_t
+* @param[in,out] banMap  The banlist copy
 */
-void CDoSManager::SetBanned(const banmap_t &banMap)
+void CDoSManager::GetBannedInternal(banmap_t &banMap) EXCLUSIVE_LOCKS_REQUIRED(cs_setBanned)
 {
-    LOCK(cs_setBanned);
-    setBanned = banMap;
-    setBannedIsDirty = true;
+    // Ensure lock is held externally as it is required for this internal version of the method
+    AssertLockHeld(cs_setBanned);
+
+    SweepBannedInternal();
+    banMap = setBanned; // create a thread safe copy
 }
 
 /**
@@ -206,9 +208,23 @@ void CDoSManager::SetBanned(const banmap_t &banMap)
 */
 void CDoSManager::SweepBanned()
 {
-    int64_t now = GetTime();
-
     LOCK(cs_setBanned);
+    SweepBannedInternal();
+}
+
+/**
+* Iterates the in-memory banlist and removes any ban entries where the ban has expired
+* Marks the in-memory banlist as dirty if any entries were removed
+*
+* This is the internal version of the function which requres a lock is held externally
+* This helps avoid taking recursive locks internally
+*/
+void CDoSManager::SweepBannedInternal() EXCLUSIVE_LOCKS_REQUIRED(cs_setBanned)
+{
+    // Ensure lock is held externally as it is required for this internal version of the method
+    AssertLockHeld(cs_setBanned);
+
+    int64_t now = GetTime();
     banmap_t::iterator it = setBanned.begin();
     while (it != setBanned.end())
     {
@@ -234,17 +250,6 @@ bool CDoSManager::BannedSetIsDirty()
 {
     LOCK(cs_setBanned);
     return setBannedIsDirty;
-}
-
-/**
-* Set flag indicating the in-memory banlist has changes not written to disk
-*
-* @param[in] dirty  Flag indicating if in-memory banlist has changes not written to disk
-*/
-void CDoSManager::SetBannedSetDirty(bool dirty)
-{
-    LOCK(cs_setBanned); // reuse setBanned lock for the isDirty flag
-    setBannedIsDirty = dirty;
 }
 
 /**
@@ -287,20 +292,35 @@ void CDoSManager::Misbehaving(NodeId pnode, int howmuch)
 */
 void CDoSManager::DumpBanlist()
 {
-    // If setBanned is not dirty, don't waste time on disk i/o
-    if (!BannedSetIsDirty())
-        return;
-
     int64_t nStart = GetTimeMillis();
-
-    CBanDB bandb;
     banmap_t banmap;
-    GetBanned(banmap);
-    bandb.Write(banmap);
+    {
+        LOCK(cs_setBanned);
+        // If setBanned is not dirty, don't waste time on disk i/o
+        if (!setBannedIsDirty)
+            return;
 
-    SetBannedSetDirty(false);
-    LogPrint(
-        "net", "Flushed %d banned node ips/subnets to banlist.dat  %dms\n", banmap.size(), GetTimeMillis() - nStart);
+        // Get thread-safe copy of the current banlist
+        GetBannedInternal(banmap);
+
+        // Set the dirty flag to false in anticipation of successful flush to disk
+        // In the event that the flush fails, we will set the flag back to true below
+        // This needs to be done before the current lock is released in case another thread
+        // dirties the banlist between now and completion of the write to disk
+        setBannedIsDirty = false;
+    }
+
+    // Don't hold the lock while performing disk I/O
+    CBanDB bandb;
+    if (!bandb.Write(banmap))
+    {
+        // If the write to disk failed we need to set the dirty flag to true
+        LOCK(cs_setBanned);
+        setBannedIsDirty = true;
+    }
+    else
+        LogPrint("net", "Flushed %d banned node ips/subnets to banlist.dat  %dms\n", banmap.size(),
+            GetTimeMillis() - nStart);
 }
 
 /**
@@ -316,9 +336,12 @@ void CDoSManager::LoadBanlist()
     banmap_t banmap;
     if (bandb.Read(banmap))
     {
-        SetBanned(banmap); // thread safe setter
-        SetBannedSetDirty(false); // no need to write down, just read data
-        SweepBanned(); // sweep out expired entries
+        LOCK(cs_setBanned);
+        setBanned = banmap;
+        // We just set the in memory banlist to the values from disk, so indicate banlist is not dirty
+        setBannedIsDirty = false;
+        // Remove any ban entries that were persisted to disk but have since expired
+        SweepBannedInternal();
 
         LogPrint("net", "Loaded %d banned node ips/subnets from banlist.dat  %dms\n", banmap.size(),
             GetTimeMillis() - nStart);

--- a/src/dosman.h
+++ b/src/dosman.h
@@ -76,6 +76,9 @@ public:
 
     /** Increase a node's misbehavior score. */
     void Misbehaving(NodeId nodeid, int howmuch);
+
+    //! save banlist to disk
+    void DumpBanlist();
 };
 
 // actual definition should be in globals.cpp for ordered construction/destruction

--- a/src/dosman.h
+++ b/src/dosman.h
@@ -65,12 +65,9 @@ public:
     bool Unban(const CNetAddr &ip);
     bool Unban(const CSubNet &ip);
     void GetBanned(banmap_t &banmap);
-    void SetBanned(const banmap_t &banmap);
 
-    //! check is the banlist has unwritten changes
+    //! check if the banlist has unwritten changes
     bool BannedSetIsDirty();
-    //! set the "dirty" flag for the banlist
-    void SetBannedSetDirty(bool dirty = true);
     //! clean unused entries (if bantime has expired)
     void SweepBanned();
 
@@ -81,6 +78,10 @@ public:
     void DumpBanlist();
     //! load banlist from disk
     void LoadBanlist();
+
+protected:
+    void SweepBannedInternal() EXCLUSIVE_LOCKS_REQUIRED(cs_setBanned);
+    void GetBannedInternal(banmap_t &banmap) EXCLUSIVE_LOCKS_REQUIRED(cs_setBanned);
 };
 
 // actual definition should be in globals.cpp for ordered construction/destruction

--- a/src/dosman.h
+++ b/src/dosman.h
@@ -79,6 +79,8 @@ public:
 
     //! save banlist to disk
     void DumpBanlist();
+    //! load banlist from disk
+    void LoadBanlist();
 };
 
 // actual definition should be in globals.cpp for ordered construction/destruction

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1631,26 +1631,13 @@ void DumpAddresses()
     LogPrint("net", "Flushed %d addresses to peers.dat  %dms\n", addrman.size(), GetTimeMillis() - nStart);
 }
 
-void DumpBanlist()
-{
-    int64_t nStart = GetTimeMillis();
-
-    CBanDB bandb;
-    banmap_t banmap;
-    dosMan.GetBanned(banmap);
-    bandb.Write(banmap);
-
-    LogPrint(
-        "net", "Flushed %d banned node ips/subnets to banlist.dat  %dms\n", banmap.size(), GetTimeMillis() - nStart);
-}
-
 void DumpData()
 {
     DumpAddresses();
 
     if (dosMan.BannedSetIsDirty())
     {
-        DumpBanlist();
+        dosMan.DumpBanlist();
         dosMan.SetBannedSetDirty(false);
     }
 }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1635,11 +1635,8 @@ void DumpData()
 {
     DumpAddresses();
 
-    if (dosMan.BannedSetIsDirty())
-    {
-        dosMan.DumpBanlist();
-        dosMan.SetBannedSetDirty(false);
-    }
+    // Request dos manager to write it's ban list to disk
+    dosMan.DumpBanlist();
 }
 
 void static ProcessOneShot()

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -11,7 +11,6 @@
 #include "net.h"
 
 #include "addrman.h"
-#include "bandb.h"
 #include "chainparams.h"
 #include "clientversion.h"
 #include "connmgr.h"
@@ -2290,22 +2289,8 @@ void StartNode(boost::thread_group &threadGroup, CScheduler &scheduler)
         }
     }
 
-    uiInterface.InitMessage(_("Loading banlist..."));
-    // Load addresses from banlist.dat
-    nStart = GetTimeMillis();
-    CBanDB bandb;
-    banmap_t banmap;
-    if (bandb.Read(banmap))
-    {
-        dosMan.SetBanned(banmap); // thread save setter
-        dosMan.SetBannedSetDirty(false); // no need to write down, just read data
-        dosMan.SweepBanned(); // sweep out unused entries
-
-        LogPrint("net", "Loaded %d banned node ips/subnets from banlist.dat  %dms\n", banmap.size(),
-            GetTimeMillis() - nStart);
-    }
-    else
-        LogPrintf("Invalid or missing banlist.dat; recreating\n");
+    // ask dos manager to load banlist from disk (or recreate if missing/corrupt)
+    dosMan.LoadBanlist();
 
     fAddressesInitialized = true;
 

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -21,6 +21,7 @@
 
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'
 #include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
 #include <boost/test/unit_test.hpp>
 
@@ -46,6 +47,108 @@ size_t GetNumberBanEntries()
     return banmap.size();
 }
 
+bool DoesBanlistFileExist()
+{
+    return boost::filesystem::exists(boost::filesystem::path(GetDataDir() / "banlist.dat"));
+}
+
+bool RemoveBanlistFile()
+{
+    boost::filesystem::path path(GetDataDir() / "banlist.dat");
+    try
+    {
+        if (boost::filesystem::exists(path))
+        {
+            // if the file already exists, remove it
+            boost::filesystem::remove(path);
+        }
+
+        // if we get here, we either successfully deleted the file, or it didn't exist
+        return true;
+    }
+    catch (const std::exception &e)
+    {
+        // there was an error deleting the file
+        return false;
+    }
+}
+
+void SetKnownBanlistContents()
+{
+    // empty out any current entries
+    dosMan.ClearBanned();
+
+    // Add test ban of specific IP
+    dosMan.Ban(CNetAddr("192.168.1.1"), BanReasonNodeMisbehaving, DEFAULT_MISBEHAVING_BANTIME, false);
+
+    // Add test ban of specific subnet
+    dosMan.Ban(CSubNet("10.168.1.0/28"), BanReasonManuallyAdded, DEFAULT_MISBEHAVING_BANTIME, false);
+}
+
+BOOST_AUTO_TEST_CASE(DoS_persistence_tests)
+{
+    // 1. Test handling when banlist cannot be loaded from disk (reason doesn't matter)
+    // Ensure we don't have a banlist on the file system currently
+    BOOST_CHECK(RemoveBanlistFile());
+
+    // Initialize banlist to have 2 specific known entries
+    SetKnownBanlistContents();
+
+    // The current implementation does not touch the in-memory banlist if load from disk fails
+    dosMan.LoadBanlist();
+    // Verify that since we couldn't load from disk, the in-memory values weren't overridden
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+    // Also ensure we didn't write a file to disk
+    BOOST_CHECK(!DoesBanlistFileExist());
+
+    // 2. Test handling when banlist can be loaded from disk
+    dosMan.ClearBanned();
+    // write an empty banlist file to disk
+    dosMan.DumpBanlist();
+    // Initialize banlist to have 2 specific known entries
+    SetKnownBanlistContents();
+    // Ensure that before load, we have 2 ban entries in the banlist
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+    // Read from file, this should succeed and overwrite the in-memory banlist
+    // NOTE: LoadBanlist calls SweepBanned, which will clear out any expired ban entries so ensure
+    //       that the test ban entries expire far enough in the future that it doesn't break this test
+    dosMan.LoadBanlist();
+    // Ensure that we overwrote the in-memory banlist and now have no entries
+    BOOST_CHECK(GetNumberBanEntries() == 0);
+
+    // 3. Test handling when reading from disk a second time without writing out changes
+    // Initialize banlist to have 2 specific known entries
+    SetKnownBanlistContents();
+    // Ensure that before load, we have 2 ban entries in the banlist
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+    // Read from file, this should succeed and overwrite the in-memory banlist
+    dosMan.LoadBanlist();
+    // Ensure that we overwrote the in-memory banlist and now have no entries
+    BOOST_CHECK(GetNumberBanEntries() == 0);
+
+    // 4. Test writing out to file then reading back in
+    // Initialize banlist to have 2 specific known entries
+    SetKnownBanlistContents();
+    // Ensure that before load, we have 2 ban entries in the banlist
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+    // Now write out to file
+    dosMan.DumpBanlist();
+    // Verify the contents in-memory haven't changed
+    // NOTE: GetBanned calls SweepBanned, this will clear out any expired ban entries so ensure
+    //       that the test ban entries expire far enough in the future that it doesn't break this test
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+    // Clear in-memory banlist, then load from file and ensure we the 2 entries back
+    dosMan.ClearBanned();
+    BOOST_CHECK(GetNumberBanEntries() == 0);
+    dosMan.LoadBanlist();
+    BOOST_CHECK(GetNumberBanEntries() == 2);
+
+    // Clean up in-memory banlist
+    dosMan.ClearBanned();
+    // Clean up on-disk banlist
+    RemoveBanlistFile();
+}
+
 BOOST_AUTO_TEST_CASE(DoS_basic_ban_tests)
 {
     // Ensure in-memory banlist is empty
@@ -53,9 +156,11 @@ BOOST_AUTO_TEST_CASE(DoS_basic_ban_tests)
     BOOST_CHECK(GetNumberBanEntries() == 0);
 
     // Add a CNetAddr entry to banlist
-    dosMan.Ban(CNetAddr("192.168.1.1"), BanReasonManuallyAdded, DEFAULT_MISBEHAVING_BANTIME, false);
+    dosMan.Ban(CNetAddr("192.168.1.1"), BanReasonNodeMisbehaving, DEFAULT_MISBEHAVING_BANTIME, false);
+    // Ensure we have exactly 1 entry in our banlist
+    BOOST_CHECK(GetNumberBanEntries() == 1);
     // Add a CSubNet entry to banlist
-    dosMan.Ban(CSubNet("10.168.1.0/28"), BanReasonNodeMisbehaving, DEFAULT_MISBEHAVING_BANTIME, false);
+    dosMan.Ban(CSubNet("10.168.1.0/28"), BanReasonManuallyAdded, DEFAULT_MISBEHAVING_BANTIME, false);
     // Ensure we have exactly 2 entries in our banlist
     BOOST_CHECK(GetNumberBanEntries() == 2);
 
@@ -109,8 +214,7 @@ BOOST_AUTO_TEST_CASE(DoS_basic_ban_tests)
     BOOST_CHECK(GetNumberBanEntries() == 0);
 
     // Re-add ban entries so we can test ClearBanned()
-    dosMan.Ban(CNetAddr("192.168.1.1"), BanReasonManuallyAdded, DEFAULT_MISBEHAVING_BANTIME, false);
-    dosMan.Ban(CSubNet("10.168.1.0/28"), BanReasonNodeMisbehaving, DEFAULT_MISBEHAVING_BANTIME, false);
+    SetKnownBanlistContents();
     // Ensure we have exactly 2 entries in our banlist
     BOOST_CHECK(GetNumberBanEntries() == 2);
 


### PR DESCRIPTION
This builds on top of #625 to clean up locking and address points raised in the review of 625.

Quick summary:
Remove use of calls to public methods inside of method implementations for `DumpBanlist()` and `LoadBanlist(`) in `CDoSManager`.  This eliminates taking and releasing locks in areas that should be atomic.  This involved creation of some protected internal helper methods which require locks to be held externally and removal of some public methods that should not be publicly exposed now that this functionality is fully encapsulated.

Detailed Change Log:
- Remove unnecessary lock isolation level in both `IsBanned()` methods
- Optimize loop logic in both `IsBanned()` methods to return immediately instead of continuing to iterate once it has been determined that the IP/Subnet in question IS in fact banned.
- Remove `SetBanned()` method, this functionality is only ever needed in `LoadBanlist()` and has been moved there.  I don't believe this should be externally accessible, so having as a public method is unnecessary.
- Created protected method `SweepBannedInternal()` which requires a lock on `cs_setBanned` to be held externally and performs the actual sweep functionality.
- Updated public method `SweepBanned()` to simply take the lock on `cs_setBanned` and then call `SweepBannedInternal()`
- Updated internal calls to `SweepBanned()` to now call `SweepBannedInternal()`.  All locations which internally called `SweepBanned()` already held the lock, except Dump/Load banlist which both now take the lock.
- Created protected method `GetBannedInternal()` which requires a lock on `cs_setBanned `to be held externally and performs the actual get banned functionality
- Updated public method `GetBanned()` to simply take the lock on `cs_setBanned` and then call `GetBannedInternal()`
- Updated internal calls to `GetBanned()` to now call `GetBannedInternal()`.  All locations which internally called `GetBanned()` already held the lock, except Dump/Load banlist which both now take the lock.
- Reorganize `DumpBanlist()` method to now treat critical section atomically by taking a single lock and directly reference the internal member variables or use the protected internal versions of method calls which require the lock be held externally (instead of using public method calls).
- - As part of this change, we set the dirty flag to false just before releasing the lock and starting to write to disk.  This allows any other thread that is trying to acquire the lock to make changes to the in-memory banlist and set the dirty flag, without the flag being incorrectly set to false after write to disk succeeds.  In the exceptional case that the write to disk fails, the lock is retaken and we set the dirty flag to true since the write to disk failed, which is accurate even if some other thread dirtied the flag while we were trying to write to disk.
- - NOTE: The locking was split this way so that the lock is not held during the potentially expensive disk I/O operation when we write to disk, and the need to retake the lock and reset the value only occurs in the exceptional case of write to disk failing.
- Reorganize `LoadBanlist()` method to now take a single lock and directly reference the internal member variables or use the protected internal versions of method calls which require the lock be held externally.
- Remove the `SetBannedSetDirty()` method, the state of this flag should only ever be modified internally based on the encapsulated functionality.  NOTE: Prior to this change, this method was no longer called anywhere outside of `dosman.cpp`.
