### PR TITLE
Relax ban for Initial Header download

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6353,7 +6353,25 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
 
         bool fCanDirectFetch = CanDirectFetch(chainparams.GetConsensus());
         CNodeState *nodestate = State(pfrom->GetId());
-        nodestate->fFirstHeadersReceived = true;
+
+        // During the initial peer handshake we must receive the initial headers which should be greater
+        // than or equal to our block height at the time of requesting GETHEADERS. This is because the peer has
+        // advertised a height >= to our own. Furthermore, because the headers max returned is as much as 2000 this
+        // could not be a mainnet re-org.
+        if (!nodestate->fFirstHeadersReceived)
+        {
+            // We want to make sure that the peer doesn't just send us any old valid header. The block height of the
+            // last header they send us should be equal to our block height at the time we made the GETHEADERS request.
+            if (pindexLast && nodestate->nFirstHeadersExpectedHeight <= pindexLast->nHeight)
+            {
+                nodestate->fFirstHeadersReceived = true;
+                LogPrint("net", "Initial headers received for peer=%s\n", pfrom->GetLogName());
+            }
+
+            // Allow for very large reorgs (> 2000 blocks) on the nol test chain or other test net.
+            if (Params().NetworkIDString() != "main" && Params().NetworkIDString() != "regtest")
+                nodestate->fFirstHeadersReceived = true;
+        }
 
         // update the syncd status.  This should come before we make calls to requester.AskFor().
         IsChainNearlySyncdInit();
@@ -7190,6 +7208,7 @@ bool SendMessages(CNode *pto)
                     state.fSyncStarted = true;
                     state.fSyncStartTime = GetTime();
                     state.fFirstHeadersReceived = false;
+                    state.nFirstHeadersExpectedHeight = pindexBestHeader->nHeight;
                     nSyncStarted++;
 
                     LogPrint("net", "initial getheaders (%d) to peer=%d (startheight:%d)\n", pindexStart->nHeight,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7159,10 +7159,9 @@ bool SendMessages(CNode *pto)
             (!state.fFirstHeadersReceived) && !pto->fWhitelisted)
         {
             pto->fDisconnect = true;
-            dosMan.Ban(pto->addr, BanReasonNodeMisbehaving, 4 * 60 * 60); // ban for 4 hours
             LogPrintf(
-                "Banning %s because initial headers were either not received or not received before the timeout\n",
-                pto->addr.ToString());
+                "Initial headers were either not received or not received before the timeout - disconnecting peer=%s\n",
+                pto->GetLogName());
         }
 
         // Start block sync

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -62,6 +62,8 @@ struct CNodeState
     int64_t fSyncStartTime;
     //! Were the first headers requested in a sync received
     bool fFirstHeadersReceived;
+    //! Our current block height at the time we requested GETHEADERS
+    int nFirstHeadersExpectedHeight;
 
     std::list<QueuedBlock> vBlocksInFlight;
     //! When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.


### PR DESCRIPTION
Also, be more stringent on checking the initial header to make sure it is not just any valid header but is equal to or greater than our header at the time of the request to GETHEADERS.