### PR TITLE
Move 3 members of CNodeState to CNode

### DIFF
--- a/src/connmgr.cpp
+++ b/src/connmgr.cpp
@@ -62,6 +62,22 @@ NodeId CConnMgr::NextNodeId()
     return ++next;
 }
 
+/**
+ * Given a node ID, return a node reference to the node.
+ */
+CNodeRef CConnMgr::FindNodeFromId(NodeId id)
+{
+    LOCK(cs_vNodes);
+
+    for (CNode *pNode : vNodes)
+    {
+        if (pNode->GetId() == id)
+            return CNodeRef(pNode);
+    }
+
+    return CNodeRef();
+}
+
 void CConnMgr::EnableExpeditedSends(CNode *pNode, bool fBlocks, bool fTxs, bool fForceIfFull)
 {
     LOCK(cs_expedited);

--- a/src/connmgr.h
+++ b/src/connmgr.h
@@ -42,6 +42,13 @@ public:
     NodeId NextNodeId();
 
     /**
+     * Given a node ID, return a node reference to the node.
+     * @param[in] id     The node ID
+     * @return A CNodeRef.  Will be a null CNodeRef if the node was not found.
+     */
+    CNodeRef FindNodeFromId(NodeId id);
+
+    /**
      * Enable expedited sends to a node.  Ignored if already enabled.
      * @param[in] pNode         The node
      * @param[in] fBlocks       True to enable expedited block sends

--- a/src/dosman.h
+++ b/src/dosman.h
@@ -39,7 +39,35 @@ protected:
     mutable CCriticalSection cs_setBanned;
     bool setBannedIsDirty;
 
+    // If a node's misbehaving count reaches this value, it is flagged for banning.
+    int nBanThreshold;
+
 public:
+    CDoSManager();
+
+    /**
+     * Call once the command line is parsed so dosman configures itself appropriately.
+     */
+    void HandleCommandLine();
+
+    /**
+     * Increment the misbehaving score for this node.  If the ban threshold is reached, flag the node to be
+     * banned.  No locks are needed to call this function.
+     *
+     * @param[in] pNode    The node which is misbehaving.  No effect if nullptr.
+     * @param[in] howmuch  Incremental misbehaving score for the latest infraction by this node.
+     */
+    void Misbehaving(CNode *pNode, int howmuch);
+
+    /**
+     * Increment the misbehaving score for this node.  If the ban threshold is reached, flag the node to be
+     * banned.  No locks are needed to call this function.
+     *
+     * @param[in] nodeid   The ID of the misbehaving node.  No effect if the CNode is no longer present.
+     * @param[in] howmuch  Incremental misbehaving score for the latest infraction by this node.
+     */
+    void Misbehaving(NodeId nodeid, int howmuch);
+
     bool IsWhitelistedRange(const CNetAddr &ip);
     void AddWhitelistedRange(const CSubNet &subnet);
 
@@ -70,9 +98,6 @@ public:
     bool BannedSetIsDirty();
     //! clean unused entries (if bantime has expired)
     void SweepBanned();
-
-    /** Increase a node's misbehavior score. */
-    void Misbehaving(NodeId nodeid, int howmuch);
 
     //! save banlist to disk
     void DumpBanlist();

--- a/src/expedited.cpp
+++ b/src/expedited.cpp
@@ -67,8 +67,7 @@ bool HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom)
 
     if (!pfrom->ThinBlockCapable() || !IsThinBlocksEnabled())
     {
-        LOCK(cs_main);
-        dosMan.Misbehaving(pfrom->GetId(), 5);
+        dosMan.Misbehaving(pfrom, 5);
         return false;
     }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -676,6 +676,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     fCheckpointsEnabled = GetBoolArg("-checkpoints", DEFAULT_CHECKPOINTS_ENABLED);
 
     connmgr->HandleCommandLine();
+    dosMan.HandleCommandLine();
 
     // mempool limits
     int64_t nMempoolSizeMax = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -327,7 +327,6 @@ bool IsReachable(const CNetAddr &addr)
     return IsReachable(net);
 }
 
-void AddressCurrentlyConnected(const CService &addr) { addrman.Connected(addr); }
 // BU moved to globals.cpp
 // uint64_t CNode::nTotalBytesRecv = 0;
 // uint64_t CNode::nTotalBytesSent = 0;
@@ -2765,6 +2764,10 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
     addrFromPort = 0; // BU
     nLocalThinBlockBytes = 0;
 
+    nMisbehavior = 0;
+    fShouldBan = false;
+    fCurrentlyConnected = false;
+
     // BU instrumentation
     std::string xmledName;
     if (addrNameIn != "")
@@ -2825,6 +2828,10 @@ CNode::~CNode()
     // BUIP010 - Xtreme Thinblocks - end section
 
     addrFromPort = 0;
+
+    // Update addrman timestamp
+    if (nMisbehavior == 0 && fCurrentlyConnected)
+        addrman.Connected(addr);
 
     GetNodeSignals().FinalizeNode(GetId());
 }

--- a/src/net.h
+++ b/src/net.h
@@ -98,7 +98,6 @@ unsigned int ReceiveFloodSize();
 unsigned int SendBufferSize();
 
 void AddOneShot(const std::string &strDest);
-void AddressCurrentlyConnected(const CService &addr);
 CNodeRef FindNodeRef(const std::string &addrName);
 int DisconnectSubNetNodes(const CSubNet &subNet);
 bool OpenNetworkConnection(const CAddress &addrConnect,
@@ -361,6 +360,13 @@ public:
     CBloomFilter *pThinBlockFilter;
     std::atomic<int> nRefCount;
     NodeId id;
+
+    //! Accumulated misbehaviour score for this peer.
+    std::atomic<int> nMisbehavior;
+    //! Whether this peer should be disconnected and banned (unless whitelisted).
+    bool fShouldBan;
+    //! Whether we have a fully established connection.
+    bool fCurrentlyConnected;
 
     // BUIP010 Xtreme Thinblocks: begin section
     CBlock thinBlock;

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -11,9 +11,6 @@
 */
 CNodeState::CNodeState()
 {
-    fCurrentlyConnected = false;
-    nMisbehavior = 0;
-    fShouldBan = false;
     pindexBestKnownBlock = NULL;
     hashLastUnknownBlock.SetNull();
     pindexLastCommonBlock = NULL;

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -38,12 +38,6 @@ struct CNodeState
 {
     //! The peer's address
     CService address;
-    //! Whether we have a fully established connection.
-    bool fCurrentlyConnected;
-    //! Accumulated misbehaviour score for this peer.
-    int nMisbehavior;
-    //! Whether this peer should be disconnected and banned (unless whitelisted).
-    bool fShouldBan;
     //! String name of this peer (debugging/logging purposes).
     std::string name;
     //! List of asynchronously-determined block rejections to notify this peer about.

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -547,10 +547,7 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, const CBloc
             pfrom->PushMessage("reject", strCommand, state.GetRejectCode(),
                 state.GetRejectReason().substr(0, MAX_REJECT_MESSAGE_LENGTH), inv.hash);
             if (nDoS > 0)
-            {
-                LOCK(cs_main);
-                dosMan.Misbehaving(pfrom->GetId(), nDoS);
-            }
+                dosMan.Misbehaving(pfrom, nDoS);
         }
     }
     else

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1279,7 +1279,7 @@ void LoadFilter(CNode *pfrom, CBloomFilter *filter)
 {
     if (!filter->IsWithinSizeConstraints())
         // There is no excuse for sending a too-large filter
-        dosMan.Misbehaving(pfrom->GetId(), 100);
+        dosMan.Misbehaving(pfrom, 100);
     else
     {
         LOCK(pfrom->cs_filter);


### PR DESCRIPTION
- permits Misbehaving to be lock-free, by making nMisbehavior atomic.
- reduce number of places grabbing cs_main (and frequently forgetting to)
  in order to bump Misbehaving of a node.
- one or two places only had a NodeId not a CNode *, so add a function
  FindNodeFromId to connmgr to look up a node from its ID.
- update addrMan timestamp directly from the destructor of CNode, rather
  than indirectly in FinalizeNode