### PR TITLE
Only add a peer to addrman's tried list if we are sure it is a good peer

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -203,7 +203,8 @@ testScripts = [ RpcTest(t) for t in [
     'abandonconflict',
     'p2p-versionbits-warning',
     'importprunedfunds',
-    'thinblocks'
+    'thinblocks',
+    'ibd'
 ] ]
 
 testScriptsExt = [ RpcTest(t) for t in [

--- a/qa/rpc-tests/ibd.py
+++ b/qa/rpc-tests/ibd.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+# Copyright (c) 2014-2015 The Bitcoin Core developers
+# Copyright (c) 2015-2016 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class IBDTest (BitcoinTestFramework):
+    def __init__(self):
+      self.rep = False
+      BitcoinTestFramework.__init__(self)
+
+    def setup_chain(self):
+        print ("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 3)
+
+    def setup_network(self, split=False):
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug="]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug="]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug=", "-prune=1000"]))
+        interconnect_nodes(self.nodes)
+        self.is_network_split=False
+        self.sync_all()
+
+                    
+    def run_test (self):
+        
+        # Mine a 500 blocks chain.
+        print ("Mining blocks...")
+        self.nodes[0].generate(500)
+
+        # Stop nodes
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+
+        ######################################################################
+        # Verify that pruned and non-pruned nodes can sync from a regular node
+        ######################################################################
+
+        # Start the first node and mine 10 blocks
+        print ("Mining 10 more blocks...")
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug="]))
+        self.nodes[0].generate(10)
+
+        # Connect the first NETWORK_NODE - all nodes should sync
+        print ("Connect NETWORK_NODE...")
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug="]))
+        connect_nodes(self.nodes[1],0)
+        self.sync_all()
+
+        # Connect the second node as non pruned  node (not a network node)- all nodes should sync
+        print ("Connect Pruned node...")
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug=", "-prune=1000"]))
+        connect_nodes(self.nodes[1],2)
+        self.sync_all()
+        
+        #stop nodes
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+
+
+        ######################################################################
+        # Verify that NETWORK_NODE will not sync from pruned nodes
+        ######################################################################
+
+        # Mine blocks on node 0 and sync to the pruned node 2
+        print ("Mining 10 more blocks...")
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug="]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug=", "-prune=1000"]))
+        connect_nodes(self.nodes[0],2)
+        self.nodes[0].generate(10)
+
+        # Connect node1 to pruned node 2 only.  They should not sync.
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug="]))
+        connect_nodes(self.nodes[1],2)
+        time.sleep(5);
+        counts = [ x.getblockcount() for x in self.nodes ]
+        assert_equal(counts, [520, 520, 510])  
+
+        # Now connect the two network nodes 0 and 1 together and they should sync
+        print ("Connecting network nodes...")
+        connect_nodes(self.nodes[0],1)
+        self.sync_all()
+         
+        #stop nodes
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+
+
+
+if __name__ == '__main__':
+    IBDTest ().main ()
+
+    

--- a/qa/rpc-tests/ibd.py
+++ b/qa/rpc-tests/ibd.py
@@ -29,9 +29,10 @@ class IBDTest (BitcoinTestFramework):
                     
     def run_test (self):
         
-        # Mine a 500 blocks chain.
+        # Mine a 2001 blocks chain.  Mining more than 2000 blocks will test the request
+        # of a second GETHEADERS.
         print ("Mining blocks...")
-        self.nodes[0].generate(500)
+        self.nodes[0].generate(2001)
 
         # Stop nodes
         stop_nodes(self.nodes)
@@ -63,33 +64,27 @@ class IBDTest (BitcoinTestFramework):
         wait_bitcoinds()
 
 
-        ######################################################################
-        # Verify that NETWORK_NODE will not sync from pruned nodes
-        ######################################################################
+        ##############################################################################
+        # Verify that NETWORK_NODE will sync from pruned nodes that are close to today
+        ##############################################################################
 
-        # Mine blocks on node 0 and sync to the pruned node 2
+        # Mine blocks on node 0 and sync to the pruned node 1
         print ("Mining 10 more blocks...")
         self.nodes.append(start_node(0, self.options.tmpdir, ["-debug="]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug=", "-prune=1000"]))
-        connect_nodes(self.nodes[0],2)
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug=", "-prune=1000"]))
+        connect_nodes(self.nodes[0],1)
         self.nodes[0].generate(10)
 
-        # Connect node1 to pruned node 2 only.  They should not sync.
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug="]))
-        connect_nodes(self.nodes[1],2)
-        time.sleep(5);
-        counts = [ x.getblockcount() for x in self.nodes ]
-        assert_equal(counts, [520, 520, 510])  
-
-        # Now connect the two network nodes 0 and 1 together and they should sync
-        print ("Connecting network nodes...")
-        connect_nodes(self.nodes[0],1)
+        # Connect node2  only to pruned node 1.  They should sync.
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug="]))
+        connect_nodes(self.nodes[2],1)
         self.sync_all()
+        counts = [ x.getblockcount() for x in self.nodes ]
+        assert_equal(counts, [2021, 2021, 2021])  
          
         #stop nodes
         stop_nodes(self.nodes)
         wait_bitcoinds()
-
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -534,7 +534,7 @@ class SendHeadersTest(BitcoinTestFramework):
 
         test_node.send_header_for_blocks(blocks)
         test_node.sync_with_ping()
-        test_node.wait_for_getdata([x.sha256 for x in blocks], timeout=5)
+        test_node.wait_for_getdata([x.sha256 for x in blocks], timeout=10)
 
         [ test_node.send_message(msg_block(x)) for x in blocks ]
 
@@ -546,7 +546,7 @@ class SendHeadersTest(BitcoinTestFramework):
         blocks = []
 
         # Create extra blocks for later
-        for b in range(20):
+        for b in range(24):
             blocks.append(create_block(tip, create_coinbase(height), block_time))
             blocks[-1].solve()
             tip = blocks[-1].sha256
@@ -565,22 +565,20 @@ class SendHeadersTest(BitcoinTestFramework):
         # both blocks (same work as tip)
         test_node.send_header_for_blocks(blocks[1:2])
         test_node.sync_with_ping()
-        test_node.wait_for_getdata([x.sha256 for x in blocks[0:2]], timeout=5)
+        test_node.wait_for_getdata([x.sha256 for x in blocks[0:2]], timeout=10)
 
-        # Announcing 16 more headers should trigger direct fetch for 14 more
+        # Announcing 20 more headers should trigger direct fetch for 18 more
         # blocks
-        self.nodes[0].set("net.maxBlocksInTransitPerPeer=16")
-        self.nodes[1].set("net.maxBlocksInTransitPerPeer=16")
-        test_node.send_header_for_blocks(blocks[2:18])
+        test_node.send_header_for_blocks(blocks[2:22])
         test_node.sync_with_ping()
-        test_node.wait_for_getdata([x.sha256 for x in blocks[2:16]], timeout=5)
+        test_node.wait_for_getdata([x.sha256 for x in blocks[2:20]], timeout=15)
         with mininode_lock:
             assert_equal(test_node.last_getdata, [])
 
         # Announcing 1 more header should not trigger any response because we
         # already have the maximumum blocks in flight
         test_node.last_getdata = []
-        test_node.send_header_for_blocks(blocks[18:19])
+        test_node.send_header_for_blocks(blocks[22:23])
         test_node.sync_with_ping()
         with mininode_lock:
             assert_equal(test_node.last_getdata, [])

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5705,14 +5705,12 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                 pfrom->PushMessage(NetMsgType::GETADDR);
                 pfrom->fGetAddr = true;
             }
-            addrman.Good(pfrom->addr);
         }
         else
         {
             if (((CNetAddr)pfrom->addr) == (CNetAddr)addrFrom)
             {
                 addrman.Add(addrFrom, addrFrom);
-                addrman.Good(addrFrom);
             }
         }
 
@@ -6369,6 +6367,10 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             {
                 nodestate->fFirstHeadersReceived = true;
                 LogPrint("net", "Initial headers received for peer=%s\n", pfrom->GetLogName());
+
+                // Peers are added to addrman when they first connect, but we only add peers to addrman's
+                // good (tried) list if we're confident this really is a good peer.
+                addrman.Good(pfrom->addr);
             }
 
             // Allow for very large reorgs (> 2000 blocks) on the nol test chain or other test net.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7171,7 +7171,7 @@ bool SendMessages(CNode *pto)
         // period.
         // If not then disconnect and ban the node and a new node will automatically be selected to start the headers
         // download.
-        if ((state.fSyncStarted) && (state.fSyncStartTime < GetTime() - INITIAL_HEADERS_TIMEOUT) &&
+        if ((state.fSyncStarted) && (state.nSyncStartTime < GetTime() - INITIAL_HEADERS_TIMEOUT) &&
             (!state.fFirstHeadersReceived) && !pto->fWhitelisted)
         {
             pto->fDisconnect = true;
@@ -7204,7 +7204,7 @@ bool SendMessages(CNode *pto)
                 if (pindexStart->nHeight < pto->nStartingHeight)
                 {
                     state.fSyncStarted = true;
-                    state.fSyncStartTime = GetTime();
+                    state.nSyncStartTime = GetTime();
                     state.fFirstHeadersReceived = false;
                     state.nFirstHeadersExpectedHeight = pindexBestHeader->nHeight;
                     nSyncStarted++;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -610,8 +610,8 @@ void MarkBlockAsInFlight(NodeId nodeid,
 // Requires cs_main
 bool CanDirectFetch(const Consensus::Params &consensusParams)
 {
-    return chainActive.Tip()->GetBlockTime() > GetAdjustedTime() - consensusParams.nPowTargetSpacing *
-        MAX_CAN_DIRECT_FETCH;
+    return chainActive.Tip()->GetBlockTime() >
+           GetAdjustedTime() - consensusParams.nPowTargetSpacing * MAX_CAN_DIRECT_FETCH;
 }
 
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats)

--- a/src/main.h
+++ b/src/main.h
@@ -114,6 +114,8 @@ static const int64_t BLOCK_DOWNLOAD_TIMEOUT_BASE = 1000000;
 static const int64_t BLOCK_DOWNLOAD_TIMEOUT_PER_PEER = 500000;
 /** Timeout in secs for the initial sync. If we don't receive the first batch of headers */
 static const uint32_t INITIAL_HEADERS_TIMEOUT = 30;
+/** The maximum number of blocks we can do a headers direct fetch **/
+static const uint32_t MAX_CAN_DIRECT_FETCH = 20;
 
 static const unsigned int DEFAULT_LIMITFREERELAY = 15;
 static const bool DEFAULT_RELAYPRIORITY = true;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2732,6 +2732,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
     fWhitelisted = false;
     fOneShot = false;
     fClient = false; // set by version message
+    fPrunedNode = false;
     fFeeler = false;
     fInbound = fInboundIn;
     fAutoOutbound = false;

--- a/src/net.h
+++ b/src/net.h
@@ -340,6 +340,7 @@ public:
     bool fFeeler; // If true this node is being used as a short lived feeler.
     bool fOneShot;
     bool fClient;
+    bool fPrunedNode;
     bool fInbound;
     bool fAutoOutbound; // any outbound node not connected with -addnode, connect-thinblock or -connect
     bool fNetworkNode; // any outbound node

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -34,10 +34,10 @@ CNodeState::CNodeState()
 * @param[in] pnode  The NodeId to return CNodeState* for
 * @return CNodeState* matching the NodeId, or NULL if NodeId is not matched
 */
-CNodeState *State(NodeId pnode)
+CNodeState *State(NodeId id)
 {
-    std::map<NodeId, CNodeState>::iterator it = mapNodeState.find(pnode);
+    std::map<NodeId, CNodeState>::iterator it = mapNodeState.find(id);
     if (it == mapNodeState.end())
-        return NULL;
+        return nullptr;
     return &it->second;
 }

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -6,16 +6,21 @@
 
 #include "nodestate.h"
 
+extern CChain chainActive;
+
 /**
-* Default constructor initializing all local member variables to "null" values
+* Default constructor initializing all local member variables
 */
 CNodeState::CNodeState()
 {
-    pindexBestKnownBlock = NULL;
+    pindexBestKnownBlock = nullptr;
     hashLastUnknownBlock.SetNull();
-    pindexLastCommonBlock = NULL;
-    pindexBestHeaderSent = NULL;
+    pindexLastCommonBlock = nullptr;
+    pindexBestHeaderSent = nullptr;
     fSyncStarted = false;
+    nSyncStartTime = GetTime();
+    fFirstHeadersReceived = false;
+    nFirstHeadersExpectedHeight = chainActive.Height();
     nDownloadingSince = 0;
     nBlocksInFlight = 0;
     nBlocksInFlightValidHeaders = 0;

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -76,6 +76,6 @@ struct CNodeState
 extern std::map<NodeId, CNodeState> mapNodeState;
 
 // Requires cs_main.
-extern CNodeState *State(NodeId pnode);
+extern CNodeState *State(NodeId id);
 
 #endif // BITCOIN_NODESTATE_H

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -53,7 +53,7 @@ struct CNodeState
     //! Whether we've started headers synchronization with this peer.
     bool fSyncStarted;
     //! The start time of the sync
-    int64_t fSyncStartTime;
+    int64_t nSyncStartTime;
     //! Were the first headers requested in a sync received
     bool fFirstHeadersReceived;
     //! Our current block height at the time we requested GETHEADERS


### PR DESCRIPTION
By only adding peers to addrmans good (tried) list after we receive
initial headers, then we can be very confidant this a good peer.

Previously we were adding any peer that would connect to the tried
table.  This allowed sybil nodes to connect and pretend to be
good peers but then just disconnect again and end up filling up
our tried table (Although it would take quite a few sybil nodes
from different ip's to mount an attack). Therefore, this approach
further reduces  any attack that may be mounted to isolate good
nodes from one another.