### PR TITLE
[backport to Release] Renable the check IsInitialBlockDownload() for txns during IBD

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6016,7 +6016,7 @@ bool ProcessMessage(CNode *pfrom, string strCommand, CDataStream &vRecv, int64_t
                 if (fBlocksOnly)
                     LogPrint("net", "transaction (%s) inv sent in violation of protocol peer=%d\n", inv.hash.ToString(),
                         pfrom->id);
-                else if (!fAlreadyHave && !fImporting && !fReindex) // BU removed && !IsInitialBlockDownload())
+                else if (!fAlreadyHave && !fImporting && !fReindex && !IsInitialBlockDownload())
                     requester.AskFor(inv, pfrom); // BU manage outgoing requests.  was: pfrom->AskFor(inv);
             }
 


### PR DESCRIPTION
We want to ensure we don't unnecessarily download txns during IBD
until the chain is approaching a sync'd state.  This will be more
important as txn rates rise further.