### PR TITLE
[Backport to Release PR#192] Do not check scripts unless blocks are less than 30 days old

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2695,7 +2695,7 @@ bool ConnectBlock(const CBlock &block,
     const int64_t timeBarrier = GetTime() - 24 * 3600 * DEFAULT_CHECKPOINT_DAYS;
     // Blocks that have various days of POW behind them makes them secure in that
     // real online nodes have checked the scripts.  Therefore, during initial block
-    // download we don't need to check most of those scripts except for the most 
+    // download we don't need to check most of those scripts except for the most
     // recent ones.
     bool fScriptChecks = !fCheckpointsEnabled || block.nTime > timeBarrier;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2692,16 +2692,12 @@ bool ConnectBlock(const CBlock &block,
         return true;
     }
 
-    bool fScriptChecks = true;
-    if (fCheckpointsEnabled)
-    {
-        CBlockIndex *pindexLastCheckpoint = Checkpoints::GetLastCheckpoint(chainparams.Checkpoints());
-        if (pindexLastCheckpoint && pindexLastCheckpoint->GetAncestor(pindex->nHeight) == pindex)
-        {
-            // This block is an ancestor of a checkpoint: disable script checks
-            fScriptChecks = false;
-        }
-    }
+    const int64_t timeBarrier = GetTime() - 24 * 3600 * DEFAULT_CHECKPOINT_DAYS;
+    // Blocks that have various days of POW behind them makes them secure in that
+    // real online nodes have checked the scripts.  Therefore, during initial block
+    // download we don't need to check most of those scripts except for the most 
+    // recent ones.
+    bool fScriptChecks = !fCheckpointsEnabled || block.nTime > timeBarrier;
 
     int64_t nTime1 = GetTimeMicros();
     nTimeCheck += nTime1 - nTimeStart;

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -62,6 +62,10 @@ static const unsigned int MAX_BLOCK_SIZE_MULTIPLIER = 3;
 static const unsigned int DEFAULT_MIN_LIMITFREERELAY = 1;
 // BU - Xtreme Thinblocks Auto Mempool Limiter - end section
 
+// The number of days in the past we check scripts during initial block download
+static const uint8_t DEFAULT_CHECKPOINT_DAYS = 30;
+
+
 // print out a configuration warning during initialization
 // bool InitWarning(const std::string &str);
 


### PR DESCRIPTION
This is another one we should add , has been around for almost 6 months.

We still allow one to force the checking of scripts by the use
of fCheckpointsEnabled however in general we only will check the
signatures for the last 30 days of blocks. All other block checks
are still performed for all blocks.