### PR TITLE
Avoid using floating point arithmetic to compute EB

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -107,7 +107,7 @@ vector<std::string> vAddedNodes;
 set<CNetAddr> setservAddNodeAddresses;
 
 uint64_t maxGeneratedBlock = DEFAULT_MAX_GENERATED_BLOCK_SIZE;
-unsigned int excessiveBlockSize = DEFAULT_EXCESSIVE_BLOCK_SIZE;
+uint64_t excessiveBlockSize = DEFAULT_EXCESSIVE_BLOCK_SIZE;
 unsigned int excessiveAcceptDepth = DEFAULT_EXCESSIVE_ACCEPT_DEPTH;
 unsigned int maxMessageSizeMultiplier = DEFAULT_MAX_MESSAGE_SIZE_MULTIPLIER;
 int nMaxOutConnections = DEFAULT_MAX_OUTBOUND_CONNECTIONS;
@@ -154,7 +154,7 @@ CCriticalSection cs_orphancache;
 map<uint256, COrphanTx> mapOrphanTransactions GUARDED_BY(cs_orphancache);
 map<uint256, set<uint256> > mapOrphanTransactionsByPrev GUARDED_BY(cs_orphancache);
 
-CTweakRef<unsigned int> ebTweak("net.excessiveBlock",
+CTweakRef<uint64_t> ebTweak("net.excessiveBlock",
     "Excessive block size in bytes",
     &excessiveBlockSize,
     &ExcessiveBlockValidator);

--- a/src/qt/unlimitedmodel.cpp
+++ b/src/qt/unlimitedmodel.cpp
@@ -131,9 +131,9 @@ QVariant UnlimitedModel::data(const QModelIndex &index, int role) const
         switch (index.row())
         {
         case MaxGeneratedBlock:
-            return QVariant((uint64_t)maxGeneratedBlock);
+            return QVariant((qulonglong)maxGeneratedBlock);
         case ExcessiveBlockSize:
-            return QVariant((uint64_t)excessiveBlockSize);
+            return QVariant((qulonglong)excessiveBlockSize);
         case ExcessiveAcceptDepth:
             return QVariant(excessiveAcceptDepth);
         case UseReceiveShaping:

--- a/src/qt/unlimitedmodel.cpp
+++ b/src/qt/unlimitedmodel.cpp
@@ -31,7 +31,7 @@
 #include <QStringList>
 
 extern CTweakRef<uint64_t> miningBlockSize;
-extern CTweakRef<unsigned int> ebTweak;
+extern CTweakRef<uint64_t> ebTweak;
 
 UnlimitedModel::UnlimitedModel(QObject *parent) : QAbstractListModel(parent) { Init(); }
 void UnlimitedModel::addOverriddenOption(const std::string &option)
@@ -133,7 +133,7 @@ QVariant UnlimitedModel::data(const QModelIndex &index, int role) const
         case MaxGeneratedBlock:
             return QVariant((unsigned int)maxGeneratedBlock);
         case ExcessiveBlockSize:
-            return QVariant(excessiveBlockSize);
+            return QVariant((unsigned int)excessiveBlockSize);
         case ExcessiveAcceptDepth:
             return QVariant(excessiveAcceptDepth);
         case UseReceiveShaping:

--- a/src/qt/unlimitedmodel.cpp
+++ b/src/qt/unlimitedmodel.cpp
@@ -131,9 +131,9 @@ QVariant UnlimitedModel::data(const QModelIndex &index, int role) const
         switch (index.row())
         {
         case MaxGeneratedBlock:
-            return QVariant((unsigned int)maxGeneratedBlock);
+            return QVariant((uint64_t)maxGeneratedBlock);
         case ExcessiveBlockSize:
-            return QVariant((unsigned int)excessiveBlockSize);
+            return QVariant((uint64_t)excessiveBlockSize);
         case ExcessiveAcceptDepth:
             return QVariant(excessiveAcceptDepth);
         case UseReceiveShaping:

--- a/src/test/excessiveblock_test.cpp
+++ b/src/test/excessiveblock_test.cpp
@@ -72,8 +72,8 @@ BOOST_AUTO_TEST_CASE(buip005)
     BOOST_CHECK_MESSAGE(BUComments.front() == exceptedEB,
                         "EB ought to have been " << exceptedEB << " when excessiveBlockSize = "
                         << excessiveBlockSize << " but was " << BUComments.front());
-    excessiveBlockSize = 150000;
-    exceptedEB = "EB0.1";
+    excessiveBlockSize = 1670000;
+    exceptedEB = "EB1.6";
     settingsToUserAgentString();
     BOOST_CHECK_MESSAGE(BUComments.front() == exceptedEB,
                         "EB ought to have been rounded to " << exceptedEB << " when excessiveBlockSize = "
@@ -84,7 +84,24 @@ BOOST_AUTO_TEST_CASE(buip005)
     BOOST_CHECK_MESSAGE(BUComments.front() == exceptedEB,
                         "EB ought to have been rounded to " << exceptedEB << " when excessiveBlockSize = "
                         << excessiveBlockSize << " but was " << BUComments.front());
-
+    excessiveBlockSize = 0;
+    exceptedEB = "EB0";
+    settingsToUserAgentString();
+    BOOST_CHECK_MESSAGE(BUComments.front() == exceptedEB,
+                        "EB ought to have been rounded to " << exceptedEB << " when excessiveBlockSize = "
+                        << excessiveBlockSize << " but was " << BUComments.front());
+    excessiveBlockSize = 3800000000;
+    exceptedEB = "EB3800";
+    settingsToUserAgentString();
+    BOOST_CHECK_MESSAGE(BUComments.front() == exceptedEB,
+                        "EB ought to have been rounded to " << exceptedEB << " when excessiveBlockSize = "
+                        << excessiveBlockSize << " but was " << BUComments.front());
+    excessiveBlockSize = 49200000000;
+    exceptedEB = "EB49200";
+    settingsToUserAgentString();
+    BOOST_CHECK_MESSAGE(BUComments.front() == exceptedEB,
+                        "EB ought to have been rounded to " << exceptedEB << " when excessiveBlockSize = "
+                        << excessiveBlockSize << " but was " << BUComments.front());
     // set back to defaults
     excessiveBlockSize = 1000000;
     excessiveAcceptDepth = 4;
@@ -164,7 +181,7 @@ BOOST_AUTO_TEST_CASE(check_excessive_validator)
     str = ExcessiveBlockValidator(tmpExcessive, NULL, false);
     BOOST_CHECK(str.empty());
 
-    str = ExcessiveBlockValidator(tmpExcessive, (unsigned int *) 42, true);
+    str = ExcessiveBlockValidator(tmpExcessive, (uint64_t *) 42, true);
     BOOST_CHECK(str.empty());
 
     tmpExcessive = maxGeneratedBlock + 1;
@@ -176,7 +193,7 @@ BOOST_AUTO_TEST_CASE(check_excessive_validator)
     str = ExcessiveBlockValidator(tmpExcessive, NULL, false);
     BOOST_CHECK(str.empty());
 
-    str = ExcessiveBlockValidator(tmpExcessive, (unsigned int *) 42, true);
+    str = ExcessiveBlockValidator(tmpExcessive, (uint64_t *) 42, true);
     BOOST_CHECK(str.empty());
 
     tmpExcessive = maxGeneratedBlock - 1;
@@ -187,7 +204,7 @@ BOOST_AUTO_TEST_CASE(check_excessive_validator)
     str = ExcessiveBlockValidator(tmpExcessive, NULL, false);
     BOOST_CHECK(str.empty());
 
-    str = ExcessiveBlockValidator(tmpExcessive, (unsigned int *) 42, true);
+    str = ExcessiveBlockValidator(tmpExcessive, (uint64_t *) 42, true);
     BOOST_CHECK(! str.empty());
 
     maxGeneratedBlock = c_mgb;

--- a/src/test/excessiveblock_test.cpp
+++ b/src/test/excessiveblock_test.cpp
@@ -164,8 +164,8 @@ BOOST_AUTO_TEST_CASE(check_validator_rule)
 
 BOOST_AUTO_TEST_CASE(check_excessive_validator)
 {
-    unsigned int c_mgb = maxGeneratedBlock;
-    unsigned int c_ebs = excessiveBlockSize;
+    uint64_t c_mgb = maxGeneratedBlock;
+    uint64_t c_ebs = excessiveBlockSize;
 
     // fudge global variables....
     maxGeneratedBlock = 1000000;
@@ -213,8 +213,8 @@ BOOST_AUTO_TEST_CASE(check_excessive_validator)
 
 BOOST_AUTO_TEST_CASE(check_generated_block_validator)
 {
-    unsigned int c_mgb = maxGeneratedBlock;
-    unsigned int c_ebs = excessiveBlockSize;
+    uint64_t c_mgb = maxGeneratedBlock;
+    uint64_t c_ebs = excessiveBlockSize;
 
     // fudge global variables....
     maxGeneratedBlock = 888;

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -52,21 +52,21 @@ static atomic<uint64_t> nLargestBlockSeen{BLOCKSTREAM_CORE_MAX_BLOCK_SIZE}; // t
 static atomic<bool> fIsChainNearlySyncd{false};
 extern atomic<bool> fIsInitialBlockDownload;
 extern CTweakRef<uint64_t> miningBlockSize;
-extern CTweakRef<unsigned int> ebTweak;
+extern CTweakRef<uint64_t> ebTweak;
 
 int64_t nMaxTipAge = DEFAULT_MAX_TIP_AGE;
 
 bool IsTrafficShapingEnabled();
 UniValue validateblocktemplate(const UniValue &params, bool fHelp);
 
-bool MiningAndExcessiveBlockValidatorRule(const unsigned int newExcessiveBlockSize,
-    const unsigned int newMiningBlockSize)
+bool MiningAndExcessiveBlockValidatorRule(const uint64_t newExcessiveBlockSize, const uint64_t newMiningBlockSize)
 {
     // The mined block size must be less then or equal too the excessive block size.
+    LogPrintf("newMiningBlockSizei: %d - newExcessiveBlockSize: %d", newMiningBlockSize, newExcessiveBlockSize);
     return (newMiningBlockSize <= newExcessiveBlockSize);
 }
 
-std::string ExcessiveBlockValidator(const unsigned int &value, unsigned int *item, bool validate)
+std::string ExcessiveBlockValidator(const uint64_t &value, uint64_t *item, bool validate)
 {
     if (validate)
     {
@@ -346,13 +346,16 @@ void settingsToUserAgentString()
 {
     BUComments.clear();
 
-    double ebInMegaBytes = (double)excessiveBlockSize / 1000000;
     std::stringstream ebss;
-    ebss << std::fixed << std::setprecision(1) << ebInMegaBytes;
+    ebss << (excessiveBlockSize / 100000);
     std::string eb = ebss.str();
-    std::string eb_formatted;
-    eb_formatted = (eb.at(eb.size() - 1) == '0' ? eb.substr(0, eb.size() - 2) : eb); // strip zero decimal
-    BUComments.push_back("EB" + eb_formatted);
+    eb.insert(eb.size() - 1, ".", 1);
+    if (eb.substr(0, 1) == ".")
+        eb = "0" + eb;
+    if (eb.at(eb.size() - 1) == '0')
+        eb = eb.substr(0, eb.size() - 2);
+
+    BUComments.push_back("EB" + eb);
 
     int ad_formatted;
     ad_formatted = (excessiveAcceptDepth >= 9999999 ? 9999999 : excessiveAcceptDepth);

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -49,7 +49,7 @@ class CChainParams;
 
 extern uint32_t blockVersion; // Overrides the mined block version if non-zero
 extern uint64_t maxGeneratedBlock;
-extern unsigned int excessiveBlockSize;
+extern uint64_t excessiveBlockSize;
 extern unsigned int excessiveAcceptDepth;
 extern unsigned int maxMessageSizeMultiplier;
 /** BU Default maximum number of Outbound connections to simultaneously allow*/
@@ -229,9 +229,8 @@ extern CStatHistory<unsigned int> txAdded;
 extern CStatHistory<uint64_t, MinValMax<uint64_t> > poolSize;
 
 // Configuration variable validators
-bool MiningAndExcessiveBlockValidatorRule(const unsigned int newExcessiveBlockSize,
-    const unsigned int newMiningBlockSize);
-std::string ExcessiveBlockValidator(const unsigned int &value, unsigned int *item, bool validate);
+bool MiningAndExcessiveBlockValidatorRule(const uint64_t newExcessiveBlockSize, const uint64_t newMiningBlockSize);
+std::string ExcessiveBlockValidator(const uint64_t &value, uint64_t *item, bool validate);
 std::string OutboundConnectionValidator(const int &value, int *item, bool validate);
 std::string SubverValidator(const std::string &value, std::string *item, bool validate);
 std::string MiningBlockSizeValidator(const uint64_t &value, uint64_t *item, bool validate);


### PR DESCRIPTION
Change `excessiveBlockSize` type to uint64_t since has to be
coherent with `maxGeneratedBlock`. Expand also the tests for
EB signaling in subVersion string.