### PR TITLE
dbcache performance enhancements

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -73,6 +73,23 @@ size_t CCoinsViewCache::DynamicMemoryUsage() const {
     return memusage::DynamicUsage(cacheCoins) + cachedCoinsUsage;
 }
 
+size_t CCoinsViewCache::ResetCachedCoinUsage() const
+{
+
+    LOCK(cs_utxo);
+    assert(!hasModifier);
+    size_t newCachedCoinsUsage = 0;
+    for (CCoinsMap::iterator it = cacheCoins.begin(); it != cacheCoins.end(); it++)
+        newCachedCoinsUsage += it->second.coins.DynamicMemoryUsage();
+    if (cachedCoinsUsage != newCachedCoinsUsage)
+    {
+        error("Resetting: cachedCoinsUsage has drifted - before %lld after %lld", cachedCoinsUsage,
+            newCachedCoinsUsage);
+        cachedCoinsUsage = newCachedCoinsUsage;
+    }
+    return newCachedCoinsUsage;
+}
+
 CCoinsMap::const_iterator CCoinsViewCache::FetchCoins(const uint256 &txid) const {
     // requires cs_utxo
     CCoinsMap::iterator it = cacheCoins.find(txid);

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -255,7 +255,7 @@ void CCoinsViewCache::Trim(size_t nTrimSize) const
 
     LOCK(cs_utxo);
     CCoinsMap::iterator iter = cacheCoins.begin();
-    while (cachedCoinsUsage > nTrimSize)
+    while (DynamicMemoryUsage() > nTrimSize)
     {
         if (iter == cacheCoins.end())
             break;

--- a/src/coins.h
+++ b/src/coins.h
@@ -471,6 +471,9 @@ public:
     //! Calculate the size of the cache (in bytes)
     size_t DynamicMemoryUsage() const;
 
+    //! Recalculate and Reset the size of cachedCoinsUsage
+    size_t ResetCachedCoinUsage() const;
+
     /**
      * Amount of bitcoins coming in to a transaction
      * Note that lightweight clients may not know anything besides the hash of previous transactions,

--- a/src/coins.h
+++ b/src/coins.h
@@ -334,7 +334,7 @@ public:
 
     //! Do a bulk modification (multiple CCoins changes + BestBlock change).
     //! The passed mapCoins can be modified.
-    virtual bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
+    virtual bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, size_t &nChildCachedCoinsUsage);
 
     //! Calculate statistics about the unspent transaction output set
     virtual bool GetStats(CCoinsStats &stats) const;
@@ -356,7 +356,7 @@ public:
     bool HaveCoins(const uint256 &txid) const;
     uint256 GetBestBlock() const;
     void SetBackend(CCoinsView &viewIn);
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
+    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, size_t &nChildCachedCoinsUsage);
     bool GetStats(CCoinsStats &stats) const;
 };
 
@@ -410,7 +410,7 @@ public:
     bool HaveCoins(const uint256 &txid) const;
     uint256 GetBestBlock() const;
     void SetBestBlock(const uint256 &hashBlock);
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
+    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, size_t &nChildCachedCoinsUsage);
 
     /**
      * Check if we have the given tx already loaded in this cache.
@@ -450,6 +450,14 @@ public:
      * If false is returned, the state of this cache (and its backing view) will be undefined.
      */
     bool Flush();
+
+    /** 
+     * Remove excess entries from this cache.
+     * Entries are trimmed starting from the beginning of the map.  In this way if those entries
+     * are needed later they will all be collocated near the the beginning of the leveldb database
+     * and will be faster to retrieve.
+     */
+    void Trim(size_t nTrimSize) const;
 
     /**
      * Removes the transaction with the given hash from the cache, if it is

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2983,6 +2983,12 @@ bool FlushStateToDisk(CValidationState &state, FlushStateMode mode)
             GetMainSignals().SetBestChain(chainActive.GetLocator());
             nLastSetChain = nNow;
         }
+
+        // As a safeguard, periodically check and correct any drift in the value of cachedCoinsUsage.  While a
+        // correction should never be needed, resetting the value allows the node to continue operating, and only
+        // an error is reported if the new and old values do not match.
+        if (fPeriodicFlush)
+            pcoinsTip->ResetCachedCoinUsage();
     }
     catch (const std::runtime_error &e)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2993,6 +2993,8 @@ bool static FlushStateToDisk(CValidationState &state, FlushStateMode mode)
             if (!pcoinsTip->Flush())
                 return AbortNode(state, "Failed to write to coin database");
             nLastFlush = nNow;
+            // Trim any excess entries from the cache if needed
+            pcoinsTip->Trim(nCoinCacheUsage);
         }
         if (fDoFullFlush || ((mode == FLUSH_STATE_ALWAYS || mode == FLUSH_STATE_PERIODIC) &&
                                 nNow > nLastSetChain + (int64_t)DATABASE_WRITE_INTERVAL * 1000000))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3207,17 +3207,19 @@ bool static ConnectTip(CValidationState &state,
         bool result = view.Flush();
         assert(result);
     }
+
     int64_t nTime4 = GetTimeMicros();
     nTimeFlush += nTime4 - nTime3;
     LogPrint("bench", "  - Flush: %.2fms [%.2fs]\n", (nTime4 - nTime3) * 0.001, nTimeFlush * 0.000001);
-    // Write the chain state to disk, if necessary and only during IBD
-    if (!IsChainNearlySyncd())
+    // Write the chain state to disk, if necessary, and only during IBD, reindex, or importing.
+    if (!IsChainNearlySyncd() || fReindex || fImporting)
         if (!FlushStateToDisk(state, FLUSH_STATE_IF_NEEDED))
             return false;
     int64_t nTime5 = GetTimeMicros();
     nTimeChainState += nTime5 - nTime4;
     LogPrint(
         "bench", "  - Writing chainstate: %.2fms [%.2fs]\n", (nTime5 - nTime4) * 0.001, nTimeChainState * 0.000001);
+
     // Remove conflicting transactions from the mempool.
     std::list<CTransaction> txConflicted;
     mempool.removeForBlock(pblock->vtx, pindexNew->nHeight, txConflicted, !IsInitialBlockDownload());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1221,15 +1221,6 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
             CCoinsViewMemPool viewMemPool(pcoinsTip, pool);
             view.SetBackend(viewMemPool);
 
-            // do we already have it?
-            bool fHadTxInCache = pcoinsTip->HaveCoinsInCache(hash);
-            if (view.HaveCoins(hash))
-            {
-                if (!fHadTxInCache)
-                    vHashTxnToUncache.push_back(hash);
-                return state.Invalid(false, REJECT_ALREADY_KNOWN, "txn-already-known");
-            }
-
             // do all inputs exist?
             // Note that this does not check for the presence of actual outputs (see the next check for that),
             // and only helps with filling in pfMissingInputs (to determine missing vs spent).

--- a/src/main.h
+++ b/src/main.h
@@ -47,6 +47,14 @@ class CValidationState;
 struct CNodeStateStats;
 struct LockPoints;
 
+enum FlushStateMode
+{
+    FLUSH_STATE_NONE,
+    FLUSH_STATE_IF_NEEDED,
+    FLUSH_STATE_PERIODIC,
+    FLUSH_STATE_ALWAYS
+};
+
 /** Default for DEFAULT_WHITELISTRELAY. */
 static const bool DEFAULT_WHITELISTRELAY = true;
 /** Default for DEFAULT_WHITELISTFORCERELAY. */
@@ -321,6 +329,7 @@ CBlockIndex *InsertBlockIndex(uint256 hash);
 bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats);
 /** Flush all state, indexes and buffers to disk. */
 void FlushStateToDisk();
+bool FlushStateToDisk(CValidationState &state, FlushStateMode mode);
 /** Prune block files and flush state to disk. */
 void PruneAndFlush();
 

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -664,6 +664,12 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, const CBloc
         LOCK(cs_vNodes);
         pfrom->Release();
     }
+
+    // If chain is nearly caught up then flush the state after a block is finished processing and the
+    // performance timings have been updated.  This way we don't include the flush time in our time to
+    // process the block advance the tip.
+    if (IsChainNearlySyncd())
+        FlushStateToDisk(state, FLUSH_STATE_ALWAYS);
 }
 
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -41,7 +41,7 @@ public:
     bool GetCoins(const uint256 &txid, CCoins &coins) const;
     bool HaveCoins(const uint256 &txid) const;
     uint256 GetBestBlock() const;
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock);
+    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, size_t &nChildCachedCoinsUsage);
     bool GetStats(CCoinsStats &stats) const;
 };
 


### PR DESCRIPTION
This is currently fully functional, I just need to update some of the unit tests and should have this finished in the morning sometime.

I'm seeing very good performance even with a small 100MB dbcache.  Previously the dbcache was just getting cleared entirely every time the max limit was exceeded causing the next few blocks to be quite slow at validating while the cache was rebuilding.  All we do here is, when flushing the chainstate, keep cache entries that are not marked DIRTY and we also trim non-dirty entries if we exceed the max.

If you want to test with it use the following to see the log entries before and after flushing the chainstate.

debug=coindb
debug=thin
