### PR TITLE
[Backport to Release] Also check pindexBestHeader when determining fScriptChecks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2697,7 +2697,10 @@ bool ConnectBlock(const CBlock &block,
     // real online nodes have checked the scripts.  Therefore, during initial block
     // download we don't need to check most of those scripts except for the most
     // recent ones.
-    bool fScriptChecks = !fCheckpointsEnabled || block.nTime > timeBarrier;
+    bool fScriptChecks = true;
+    if (pindexBestHeader)
+        fScriptChecks = !fCheckpointsEnabled || block.nTime > timeBarrier ||
+                        pindex->nHeight > pindexBestHeader->nHeight - (144 * DEFAULT_CHECKPOINT_DAYS);
 
     int64_t nTime1 = GetTimeMicros();
     nTimeCheck += nTime1 - nTimeStart;


### PR DESCRIPTION
Since we can be reasonable sure we have all the headers when we
do IBD or receive new blocks then we can also check if we are
within approx 30 days of the chain tip by block height.  We still
keep the check that timeBarrier is also within 30 days but by
having both checks it makes it more difficult to attack in some
way.