### PR TITLE
add custom output scripts to createrawtransaction and understand a new output script type that allows you to embed data in the script

### DIFF
--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -40,8 +40,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
     def wastefulOutput(self, btcAddress):
         data = b"""this is junk data."""
-        # for long data: ret = CScript([OP_PUSHDATA1, len(data), data, OP_DROP, OP_DUP, OP_HASH160, bitcoinAddress2bin(btcAddress), OP_EQUALVERIFY, OP_CHECKSIG])
-        ret = CScript([len(data), data, OP_DROP, OP_DUP, OP_HASH160, bitcoinAddress2bin(btcAddress), OP_EQUALVERIFY, OP_CHECKSIG])
+        ret = CScript([data, OP_NOP, OP_DROP, OP_DUP, OP_HASH160, bitcoinAddress2bin(btcAddress), OP_EQUALVERIFY, OP_CHECKSIG])
         # ret = CScript([OP_DUP, OP_HASH160, bitcoinAddress2bin(btcAddress), OP_EQUALVERIFY, OP_CHECKSIG])
         return ret
 
@@ -193,16 +192,18 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.sync_all()
         self.nodes[1].generate(1)
         bal = self.nodes[1].getbalance()
-        assert(bal == 0)  # Even though I spent to myself, bitcoind is not smart enough to notice this balance
+        #assert(bal == 0)  # Even though I spent to myself, bitcoind is not smart enough to notice this balance
+        assert(bal == amt) # unless the script is added to standard.cpp...
+        print ("balance: ", bal)
 
-        # bitcoind can't spend the weird output, because it can't understand the output script.
-        if 0:
+        # Unless the output script is added to standard.cpp bitcoind can't spend the weird output, because it can't
+        # understand the output script.
+        if 1:
             newAddr3 = self.nodes[1].getnewaddress()
             # txn3 = self.nodes[1].createrawtransaction([{"txid":txhash2,"vout":0,"scriptPubKey":"" }], {newAddr:amt})
             txn3 = self.nodes[1].createrawtransaction([{"txid":txhash2,"vout":0,}], {newAddr:amt})
-            pdb.set_trace()
             signedtxn3 = self.nodes[1].signrawtransaction(txn3)
-            # assert(signedtxn3["complete"])
+            assert(signedtxn3["complete"])
             txhash3 = self.nodes[1].sendrawtransaction(signedtxn3["hex"])
             self.nodes[1].generate(1)
             self.sync_all()

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -755,3 +755,36 @@ def create_lots_of_big_transactions(node, txouts, utxos, fee):
 def get_bip9_status(node, key):
     info = node.getblockchaininfo()
     return info['bip9_softforks'][key]
+
+def bitcoinAddress2bin(btcAddress):
+    """convert a bitcoin address to binary data capable of being put in a CScript"""
+    # chop the version and checksum out of the bytes of the address
+    return decodeBase58(btcAddress)[1:-4]
+
+B58_DIGITS = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+def decodeBase58(s):
+    """Decode a base58-encoding string, returning bytes"""
+    if not s:
+        return b''
+
+    # Convert the string to an integer
+    n = 0
+    for c in s:
+        n *= 58
+        if c not in B58_DIGITS:
+            raise InvalidBase58Error('Character %r is not a valid base58 character' % c)
+        digit = B58_DIGITS.index(c)
+        n += digit
+
+    # Convert the integer to bytes
+    h = '%x' % n
+    if len(h) % 2:
+        h = '0' + h
+    res = binascii.unhexlify(h.encode('utf8'))
+
+    # Add padding back.
+    pad = 0
+    for c in s[:-1]:
+        if c == B58_DIGITS[0]: pad += 1
+        else: break
+    return b'\x00' * pad + res

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -177,6 +177,8 @@ enum opcodetype
 
 
     // template matching params
+    OP_ANY_NOP = 0xf8,
+    OP_DATA = 0xf9,
     OP_SMALLINTEGER = 0xfa,
     OP_PUBKEYS = 0xfb,
     OP_PUBKEYHASH = 0xfd,

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -53,6 +53,9 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
 
         // Sender provides N pubkeys, receivers provides M signatures
         mTemplates.insert(make_pair(TX_MULTISIG, CScript() << OP_SMALLINTEGER << OP_PUBKEYS << OP_SMALLINTEGER << OP_CHECKMULTISIG));
+
+        // Bitcoin address tx, sender provides hash of pubkey, receiver provides signature and pubkey with data
+        mTemplates.insert(make_pair(TX_PUBKEYHASH, CScript() << OP_DATA << OP_ANY_NOP << OP_DROP << OP_DUP << OP_HASH160 << OP_PUBKEYHASH << OP_EQUALVERIFY << OP_CHECKSIG));
     }
 
     vSolutionsRet.clear();
@@ -147,6 +150,17 @@ bool Solver(const CScript& scriptPubKey, txnouttype& typeRet, vector<vector<unsi
                     vSolutionsRet.push_back(valtype(1, n));
                 }
                 else
+                    break;
+            }
+            else if (opcode2 == OP_DATA)  // If the template has data here
+            {
+                // Expect that there is some data in the script
+                if (vch1.size() == 0)
+                    break;
+            }
+            else if (opcode2 == OP_ANY_NOP)  // allow any unknown instruction here (presumably an extension)
+            {
+                if ((opcode1 != OP_NOP)&&((opcode1 < OP_NOP4) || (opcode1 > OP_NOP10)))
                     break;
             }
             else if (opcode1 != opcode2 || vch1 != vch2)


### PR DESCRIPTION
Allow users to supply an output spend script rather than an address to createrawtransaction.

Also accept scripts as standard that push and pop data (with a possible addtl operation) like this:
OP_DATA << OP_ANY_NOP << OP_DROP << OP_DUP << OP_HASH160 << OP_PUBKEYHASH << OP_EQUALVERIFY << OP_CHECKSIG

This allows tests to generate large transactions that require very little validation time.  This will speed up our tests that need > 1MB blocks dramatically.

Use of this type of transaction also could enable a lot of interesting blockchain layer 2, esp. colored coins, since it allows you to tag outputs with data rather than only tag transactions like OP_RETURN.
 
At this point I think that its clear to most that the fee market is sufficient to deter spam, even with larger blocks, since miner code has been changed to price transactions per-byte.  And (of course) miners have always been able to include these (or any) transactions in blocks -- this change only affects whether BU can understand and spend transactions of this format.

