### PR TITLE
Preventing node isolation after hard fork

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -116,7 +116,24 @@ public:
         assert(consensus.hashGenesisBlock == uint256S("0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"));
         assert(genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 
-        // BITCOINUNLIMITED START
+#ifdef BITCOIN_CASH
+        // List of Bitcoin Cash compatible seeders
+        vSeeds.push_back(
+CDNSSeedData("bitcoinunlimited.info", "btccash-seeder.bitcoinunlimited.info", true));
+        vSeeds.push_back(
+CDNSSeedData("bitcoinabc.org", "seed.bitcoinabc.org", true));
+
+        vSeeds.push_back(CDNSSeedData("bitcoinforks.org", "seed-abc.bitcoinforks.org", true));
+        vSeeds.push_back(CDNSSeedData("bitcoinunlimited.info",
+ "seed.bitcoinunlimited.info", true));
+        vSeeds.push_back(CDNSSeedData("bitprim.org", "seed.bitprim.org", true));
+ // Bitprim
+
+        vSeeds.push_back(
+CDNSSeedData("deadalnix.me", "seed.deadalnix.me", true)); // Amaury SÉCHET
+
+#else
+        // List of BitcoinUnlimited seeders
         vSeeds.push_back(CDNSSeedData("bitcoinunlimited.info", "seed.bitcoinunlimited.info", true)); // BU seeder
         vSeeds.push_back(CDNSSeedData("bitnodes.io", "seed.bitnodes.io"));      // Bitnodes (Addy Yeow)
         vSeeds.push_back(CDNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be", true)); // Pieter Wuille, only supports x1, x5, x9, and xd
@@ -124,7 +141,7 @@ public:
         vSeeds.push_back(CDNSSeedData("dashjr.org", "dnsseed.bitcoin.dashjr.org")); // Luke Dashjr
         vSeeds.push_back(CDNSSeedData("bitcoinstats.com", "seed.bitcoinstats.com", true)); // Christian Decker, supports x1 - xf
         vSeeds.push_back(CDNSSeedData("bitcoin.jonasschnelli.ch", "seed.bitcoin.jonasschnelli.ch", true)); // Jonas Schnelli, only supports x1, x5, x9, and xd
-        // BITCOINUNLIMITED END
+#endif
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,0);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,5);

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -197,6 +197,9 @@ CTweakRef<int> maxConnectionsTweak("net.maxConnections", "Maximum number of conn
 CTweakRef<int> minXthinNodesTweak("net.minXthinNodes",
     "Minimum number of outbound xthin capable nodes to connect to",
     &nMinXthinNodes);
+CTweakRef<int> minUAHFNodesTweak("net.minUAHFNodes",
+    "Minimum number of outbound UAHF capable nodes to connect to",
+    &nMinUAHFNodes);
 // When should I request a tx from someone else (in microseconds). cmdline/bitcoin.conf: -txretryinterval
 CTweakRef<unsigned int> triTweak("net.txRetryInterval",
     "How long to wait in microseconds before requesting a transaction from another source",

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -197,9 +197,9 @@ CTweakRef<int> maxConnectionsTweak("net.maxConnections", "Maximum number of conn
 CTweakRef<int> minXthinNodesTweak("net.minXthinNodes",
     "Minimum number of outbound xthin capable nodes to connect to",
     &nMinXthinNodes);
-CTweakRef<int> minUAHFNodesTweak("net.minUAHFNodes",
-    "Minimum number of outbound UAHF capable nodes to connect to",
-    &nMinUAHFNodes);
+CTweakRef<int> minBitcoinCashNodesTweak("net.minBitcoinCashNodes",
+    "Minimum number of outbound BitcoinCash capable nodes to connect to",
+    &nMinBitcoinCashNodes);
 // When should I request a tx from someone else (in microseconds). cmdline/bitcoin.conf: -txretryinterval
 CTweakRef<unsigned int> triTweak("net.txRetryInterval",
     "How long to wait in microseconds before requesting a transaction from another source",

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -772,9 +772,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         nLocalServices |= NODE_XTHIN;
     // BUIP010 Xtreme Thinblocks: end section
 
-    // BUIP055 - UAHF
-    // this can later be removed after the hardfork has happened
+    // BUIP055 - BitcoinCash
+#ifdef BITCOIN_CASH
     nLocalServices |= NODE_BITCOIN_CASH;
+#endif
 
     nMaxTipAge = GetArg("-maxtipage", DEFAULT_MAX_TIP_AGE);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -774,7 +774,7 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
 
     // BUIP055 - UAHF
     // this can later be removed after the hardfork has happened
-    nLocalServices |= NODE_UAHF;
+    nLocalServices |= NODE_BITCOIN_CASH;
 
     nMaxTipAge = GetArg("-maxtipage", DEFAULT_MAX_TIP_AGE);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -772,6 +772,10 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
         nLocalServices |= NODE_XTHIN;
     // BUIP010 Xtreme Thinblocks: end section
 
+    // BUIP055 - UAHF
+    // this can later be removed after the hardfork has happened
+    nLocalServices |= NODE_UAHF;
+
     nMaxTipAge = GetArg("-maxtipage", DEFAULT_MAX_TIP_AGE);
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -97,7 +97,7 @@ static std::vector<ListenSocket> vhListenSocket;
 extern CAddrMan addrman;
 int nMaxConnections = DEFAULT_MAX_PEER_CONNECTIONS;
 int nMinXthinNodes = MIN_XTHIN_NODES;
-int nMinUAHFNodes = MIN_UAHF_NODES;
+int nMinBitcoinCashNodes = MIN_BITCOIN_CASH_NODES;
 
 bool fAddressesInitialized = false;
 std::string strSubVersion;
@@ -1712,7 +1712,7 @@ void ThreadOpenConnections()
         // we don't have enough connections to XTHIN capable nodes yet.
         int nOutbound = 0;
         int nThinBlockCapable = 0;
-        int nUAHF = 0;
+        int nBitcoinCash = 0;
         set<vector<unsigned char> > setConnected;
         CNode *ptemp = nullptr;
         bool fDisconnected = false;
@@ -1727,8 +1727,8 @@ void ThreadOpenConnections()
 
                     if (pnode->ThinBlockCapable())
                         nThinBlockCapable++;
-                    else if (pnode->UAHFCapable())
-                        nUAHF++;
+                    else if (pnode->BitcoinCashCapable())
+                        nBitcoinCash++;
                     else
                         ptemp = pnode;
                 }
@@ -1736,7 +1736,7 @@ void ThreadOpenConnections()
             // Disconnect a node that is not XTHIN capable if all outbound slots are full and we
             // have not yet connected to enough XTHIN nodes.
             nMinXthinNodes = GetArg("-min-xthin-nodes", MIN_XTHIN_NODES);
-            nMinUAHFNodes = GetArg("-min-uahf-nodes", MIN_UAHF_NODES);
+            nMinBitcoinCashNodes = GetArg("-min-bitcoin-cash-nodes", MIN_BITCOIN_CASH_NODES);
             if (nOutbound >= nMaxOutConnections && nThinBlockCapable <= min(nMinXthinNodes, nMaxOutConnections) &&
                 nDisconnects < MAX_DISCONNECTS && IsThinBlocksEnabled() && IsChainNearlySyncd())
             {
@@ -1747,9 +1747,10 @@ void ThreadOpenConnections()
                     nDisconnects++;
                 }
             }
-            // Disconnect a node that is not UAHF capable if all outbound slots are full and we
-            // have not yet connected to enough UAHF nodes.
-            else if (nOutbound >= nMaxOutConnections && nUAHF <= min(nMinUAHFNodes, nMaxOutConnections) &&
+#ifdef BITCOIN_CASH
+            // Disconnect a node that is not BitcoinCash capable if all outbound slots are full and we
+            // have not yet connected to enough BitcoinCash nodes.
+            else if (nOutbound >= nMaxOutConnections && nBitcoinCash <= min(nMinBitcoinCashNodes, nMaxOutConnections) &&
                      nDisconnects < MAX_DISCONNECTS && IsChainNearlySyncd())
             {
                 if (ptemp != nullptr)
@@ -1759,6 +1760,7 @@ void ThreadOpenConnections()
                     nDisconnects++;
                 }
             }
+#endif
 
             // In the event that outbound nodes restart or drop off the network over time we need to
             // replenish the number of disconnects allowed once per day.

--- a/src/net.h
+++ b/src/net.h
@@ -80,6 +80,8 @@ static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 12;
 /** BU: The minimum number of xthin nodes to connect */
 static const uint8_t MIN_XTHIN_NODES = 8;
+/** BU: The minimum number of uahf nodes to connect */
+static const uint8_t MIN_UAHF_NODES = 4;
 /** BU: The daily maximum disconnects while searching for xthin nodes to connect */
 static const unsigned int MAX_DISCONNECTS = 200;
 /** The default for -maxuploadtarget. 0 = Unlimited */
@@ -186,6 +188,8 @@ extern CAddrMan addrman;
 extern int nMaxConnections;
 /** The minimum number of xthin nodes to connect to */
 extern int nMinXthinNodes;
+/** The minimum number of UAHF nodes to connect to */
+extern int nMinUAHFNodes;
 extern std::vector<CNode *> vNodes;
 extern CCriticalSection cs_vNodes;
 extern std::map<CInv, CDataStream> mapRelay;
@@ -508,6 +512,14 @@ public:
     bool ThinBlockCapable()
     {
         if (nServices & NODE_XTHIN)
+            return true;
+        return false;
+    }
+
+    // BUIP055:
+    bool UAHFCapable()
+    {
+        if (nServices & NODE_UAHF)
             return true;
         return false;
     }

--- a/src/net.h
+++ b/src/net.h
@@ -80,8 +80,8 @@ static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 12;
 /** BU: The minimum number of xthin nodes to connect */
 static const uint8_t MIN_XTHIN_NODES = 8;
-/** BU: The minimum number of uahf nodes to connect */
-static const uint8_t MIN_UAHF_NODES = 4;
+/** BU: The minimum number of BitcoinCash nodes to connect */
+static const uint8_t MIN_BITCOIN_CASH_NODES = 4;
 /** BU: The daily maximum disconnects while searching for xthin nodes to connect */
 static const unsigned int MAX_DISCONNECTS = 200;
 /** The default for -maxuploadtarget. 0 = Unlimited */
@@ -188,8 +188,8 @@ extern CAddrMan addrman;
 extern int nMaxConnections;
 /** The minimum number of xthin nodes to connect to */
 extern int nMinXthinNodes;
-/** The minimum number of UAHF nodes to connect to */
-extern int nMinUAHFNodes;
+/** The minimum number of BitcoinCash nodes to connect to */
+extern int nMinBitcoinCashNodes;
 extern std::vector<CNode *> vNodes;
 extern CCriticalSection cs_vNodes;
 extern std::map<CInv, CDataStream> mapRelay;
@@ -517,9 +517,9 @@ public:
     }
 
     // BUIP055:
-    bool UAHFCapable()
+    bool BitcoinCashCapable()
     {
-        if (nServices & NODE_UAHF)
+        if (nServices & NODE_BITCOIN_CASH)
             return true;
         return false;
     }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -300,7 +300,6 @@ enum {
     // a temporary service bit until the fork actually happens.  After the for it can be 
     // removed.
     // If this is turned off then the node will not follow the UAHF hardfork
-    // make xthin requests
     NODE_UAHF = (1 << 5),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -300,7 +300,7 @@ enum {
     // a temporary service bit until the fork actually happens.  After the for it can be 
     // removed.
     // If this is turned off then the node will not follow the UAHF hardfork
-    NODE_UAHF = (1 << 5),
+    NODE_BITCOIN_CASH = (1 << 5),
 
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -295,6 +295,14 @@ enum {
     NODE_XTHIN = (1 << 4),
     // BUIP010 - Xtreme Thinblocks - end section
 
+    // BUIP055 - UAHF
+    // NODE_UAHF means the node supports the UAHF hard fork.  This is intended to be just
+    // a temporary service bit until the fork actually happens.  After the for it can be 
+    // removed.
+    // If this is turned off then the node will not follow the UAHF hardfork
+    // make xthin requests
+    NODE_UAHF = (1 << 5),
+
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the
     // bitcoin-development mailing list. Remember that service bits are just

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -927,9 +927,11 @@ QString formatServicesStr(quint64 mask)
             case NODE_XTHIN:
                 strList.append("XTHIN");
                 break;
-            case NODE_UAHF:
-                strList.append("UAHF");
+#ifdef BITCOIN_CASH
+            case NODE_BITCOIN_CASH:
+                strList.append("CASH");
                 break;
+#endif
             default:
                 strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
             }

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -927,6 +927,9 @@ QString formatServicesStr(quint64 mask)
             case NODE_XTHIN:
                 strList.append("XTHIN");
                 break;
+            case NODE_UAHF:
+                strList.append("UAHF");
+                break;
             default:
                 strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
             }


### PR DESCRIPTION
Here we use a UAHF service bit and connect to a min number of UAHF nodes and maintain those levels of connectivity in the same manner we do for XTHIN nodes.  Then after the fork when most mainchain nodes end up banning the UAHF nodes , there will still be a well connected UAHF network.
