### PR TITLE
[cherry pick of PR 707] include clientversion.h

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -7,6 +7,7 @@
 
 #include "bitcoinaddressvalidator.h"
 #include "bitcoinunits.h"
+#include "clientversion.h"
 #include "qvalidatedlineedit.h"
 #include "walletmodel.h"
 


### PR DESCRIPTION
We need this so we can pick up the define BITCOIN_CASH which
we use in guiutil.cpp