### PR TITLE
Fixes for bitcoin-cash and general usability

### DIFF
--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -95,7 +95,7 @@ static int AppInitRPC(int argc, char* argv[])
         return EXIT_FAILURE;
     }
     try {
-        ReadConfigFile(mapArgs, mapMultiArgs, nullptr);
+        ReadConfigFile(mapArgs, mapMultiArgs, allowedArgs);
     } catch (const std::exception& e) {
         fprintf(stderr,"Error reading configuration file: %s\n", e.what());
         return EXIT_FAILURE;

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -112,7 +112,7 @@ bool AppInit(int argc, char* argv[])
         }
         try
         {
-            ReadConfigFile(mapArgs, mapMultiArgs, &tweaks);
+            ReadConfigFile(mapArgs, mapMultiArgs, allowedArgs);
         } catch (const std::exception& e) {
             fprintf(stderr,"Error reading configuration file: %s\n", e.what());
             return false;

--- a/src/buip055fork.cpp
+++ b/src/buip055fork.cpp
@@ -7,11 +7,13 @@
 #include "primitives/block.h"
 #include "script/interpreter.h"
 #include "unlimited.h"
+#include "chainparams.h"
 
 #include <inttypes.h>
 #include <vector>
 
 const int REQ_6_1_SUNSET_HEIGHT = 530000;
+const int TESTNET_REQ_6_1_SUNSET_HEIGHT = 1250000;
 
 static const std::string ANTI_REPLAY_MAGIC_VALUE = "Bitcoin: A Peer-to-Peer Electronic Cash System";
 
@@ -37,7 +39,8 @@ bool ValidateBUIP055Block(const CBlock &block, CValidationState &state, int nHei
     // Validate transactions are HF compatible
     for (const CTransaction &tx : block.vtx)
     {
-        if ((nHeight <= REQ_6_1_SUNSET_HEIGHT) && IsTxOpReturnInvalid(tx))
+        int sunsetHeight = (Params().NetworkIDString() == "testnet") ? TESTNET_REQ_6_1_SUNSET_HEIGHT : REQ_6_1_SUNSET_HEIGHT;
+        if ((nHeight <= sunsetHeight) && IsTxOpReturnInvalid(tx))
             return state.DoS(100,
                              error("transaction is invalid on BUIP055 chain"), REJECT_INVALID, "bad-txns-wrong-fork");
     }

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -184,6 +184,10 @@ CTweak<uint64_t> miningForkTime("mining.forkTime",
     0);
 #endif
 
+CTweak<bool> unsafeGetBlockTemplate("mining.unsafeGetBlockTemplate",
+    "Allow getblocktemplate to succeed even if the chain tip is old or this node is not connected to other nodes",
+    false);
+
 CTweak<uint64_t> miningForkEB("mining.forkExcessiveBlock",
     "Set the excessive block to this value at the time of the fork.",
     8000000); // 8MB, uahf-technical-spec.md REQ-4-1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1789,7 +1789,6 @@ void static InvalidChainFound(CBlockIndex *pindexNew)
 }
 
 
-
 void static InvalidBlockFound(CBlockIndex *pindex, const CValidationState &state)
 {
     int nDoS = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1788,6 +1788,8 @@ void static InvalidChainFound(CBlockIndex *pindexNew)
     CheckForkWarningConditions();
 }
 
+
+
 void static InvalidBlockFound(CBlockIndex *pindex, const CValidationState &state)
 {
     int nDoS = 0;
@@ -1816,6 +1818,9 @@ void static InvalidBlockFound(CBlockIndex *pindex, const CValidationState &state
         setDirtyBlockIndex.insert(pindex);
         setBlockIndexCandidates.erase(pindex);
         InvalidChainFound(pindex);
+
+        // Now mark every block index on every chain that contains pindex as child of invalid
+        MarkAllContainingChainsInvalid(pindex);
     }
 }
 
@@ -3768,6 +3773,8 @@ bool InvalidateBlock(CValidationState &state, const Consensus::Params &consensus
     }
 
     InvalidChainFound(pindex);
+    // Now mark every block index on every chain that contains pindex as child of invalid
+    MarkAllContainingChainsInvalid(pindex);
     mempool.removeForReorg(pcoinsTip, chainActive.Tip()->nHeight + 1, STANDARD_LOCKTIME_VERIFY_FLAGS);
     uiInterface.NotifyBlockTip(IsInitialBlockDownload(), pindex->pprev);
     return true;
@@ -4336,6 +4343,8 @@ static bool AcceptBlock(const CBlock &block,
         {
             pindex->nStatus |= BLOCK_FAILED_VALID;
             setDirtyBlockIndex.insert(pindex);
+            // Now mark every block index on every chain that contains pindex as child of invalid
+            MarkAllContainingChainsInvalid(pindex);
         }
         return false;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4246,7 +4246,7 @@ bool AcceptBlockHeader(const CBlockHeader &block,
             if (ppindex)
                 *ppindex = pindex;
             if (pindex->nStatus & BLOCK_FAILED_MASK)
-                return state.Invalid(error("%s: block is marked invalid", __func__), 0, "duplicate");
+                return state.Invalid(error("%s: block %s height %d is marked invalid", __func__, hash.ToString(), pindex->nHeight), 0, "duplicate");
             return true;
         }
 
@@ -6254,6 +6254,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         uint256 hashStop;
         vRecv >> locator >> hashStop;
 
+
         if (IsInitialBlockDownload() && !pfrom->fWhitelisted)
         {
             LogPrint("net", "Ignoring getheaders from peer=%d because node is in initial block download\n", pfrom->id);
@@ -7421,9 +7422,10 @@ bool SendMessages(CNode *pto)
         if (!state.fSyncStarted && !pto->fClient && !fImporting && !fReindex)
         {
             // Only actively request headers from a single peer, unless we're close to today.
-            if ((nSyncStarted == 0 && fFetch) || pindexBestHeader->GetBlockTime() > GetAdjustedTime() - 24 * 60 * 60)
+            if ((nSyncStarted == 0 && fFetch) ||
+                chainActive.Tip()->GetBlockTime() > GetAdjustedTime() - SINGLE_PEER_REQUEST_MODE_AGE)
             {
-                const CBlockIndex *pindexStart = pindexBestHeader;
+                const CBlockIndex *pindexStart = chainActive.Tip(); // pindexBestHeader;
                 /* If possible, start at the block preceding the currently
                    best known header.  This ensures that we always get a
                    non-empty list of headers back as long as the peer

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -681,8 +681,9 @@ int main(int argc, char *argv[])
     qRegisterMetaType< CAmount >("CAmount");
 
     /// 2. Parse command-line options. Command-line options take precedence:
+    AllowedArgs::BitcoinQt allowedArgs(&tweaks);
     try {
-        ParseParameters(argc, argv, AllowedArgs::BitcoinQt(&tweaks));
+        ParseParameters(argc, argv, allowedArgs);
     } catch (const std::exception& e) {
         QMessageBox::critical(0, QObject::tr("Bitcoin Classic"),
                               QObject::tr("Error: Cannot parse program options: %1.").arg(e.what()));
@@ -732,7 +733,7 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
     try {
-        ReadConfigFile(mapArgs, mapMultiArgs, &tweaks);
+        ReadConfigFile(mapArgs, mapMultiArgs, allowedArgs);
     } catch (const std::exception& e) {
         QMessageBox::critical(0, QObject::tr(PACKAGE_NAME),
                               QObject::tr("Error: Cannot parse configuration file: %1. Only use key=value syntax.").arg(e.what()));

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -470,11 +470,14 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     if (strMode != "template")
         throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid mode");
 
-    if (vNodes.empty())
-        throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Bitcoin is not connected!");
+    if (!unsafeGetBlockTemplate.value)
+    {
+        if (vNodes.empty())
+            throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Bitcoin is not connected!");
 
-    if (IsInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Bitcoin is downloading blocks...");
+        if (IsInitialBlockDownload())
+            throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Bitcoin is downloading blocks...");
+    }
 
     static unsigned int nTransactionsUpdatedLast;
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1744,41 +1744,43 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
 /** Comparison function for sorting the getchaintips heads.  */
 struct CompareBlocksByHeight
 {
-    bool operator()(const CBlockIndex* a, const CBlockIndex* b) const
+    bool operator()(const CBlockIndex *a, const CBlockIndex *b) const
     {
         /* Make sure that unequal blocks with the same height do not compare
            equal. Use the pointers themselves to make a distinction. */
 
         if (a->nHeight != b->nHeight)
-          return (a->nHeight > b->nHeight);
+            return (a->nHeight > b->nHeight);
 
         return a < b;
     }
 };
 
-void MarkAllContainingChainsInvalid(CBlockIndex* invalidBlock)
+void MarkAllContainingChainsInvalid(CBlockIndex *invalidBlock)
 {
     LOCK(cs_main);
 
     bool dirty = false;
-    DbgAssert(invalidBlock->nStatus&BLOCK_FAILED_MASK, return);
+    DbgAssert(invalidBlock->nStatus & BLOCK_FAILED_MASK, return );
 
     // Find all the chain tips:
-    std::set<CBlockIndex*, CompareBlocksByHeight> setTips;
-    std::set<CBlockIndex*> setOrphans;
-    std::set<CBlockIndex*> setPrevs;
+    std::set<CBlockIndex *, CompareBlocksByHeight> setTips;
+    std::set<CBlockIndex *> setOrphans;
+    std::set<CBlockIndex *> setPrevs;
 
-    BOOST_FOREACH(const PAIRTYPE(const uint256, CBlockIndex*)& item, mapBlockIndex)
+    BOOST_FOREACH (const PAIRTYPE(const uint256, CBlockIndex *) & item, mapBlockIndex)
     {
-        if (!chainActive.Contains(item.second)) {
+        if (!chainActive.Contains(item.second))
+        {
             setOrphans.insert(item.second);
             setPrevs.insert(item.second->pprev);
         }
     }
 
-    for (std::set<CBlockIndex*>::iterator it = setOrphans.begin(); it != setOrphans.end(); ++it)
+    for (std::set<CBlockIndex *>::iterator it = setOrphans.begin(); it != setOrphans.end(); ++it)
     {
-        if (setPrevs.erase(*it) == 0) {
+        if (setPrevs.erase(*it) == 0)
+        {
             setTips.insert(*it);
         }
     }
@@ -1786,21 +1788,22 @@ void MarkAllContainingChainsInvalid(CBlockIndex* invalidBlock)
     // Always report the currently active tip.
     setTips.insert(chainActive.Tip());
 
-    BOOST_FOREACH(CBlockIndex* tip, setTips)
+    BOOST_FOREACH (CBlockIndex *tip, setTips)
     {
         if (tip->GetAncestor(invalidBlock->nHeight) == invalidBlock)
         {
-            for(CBlockIndex* blk = tip; blk != invalidBlock; blk=blk->pprev)
+            for (CBlockIndex *blk = tip; blk != invalidBlock; blk = blk->pprev)
             {
-                if ((blk->nStatus&BLOCK_FAILED_CHILD)==0)
+                if ((blk->nStatus & BLOCK_FAILED_CHILD) == 0)
                 {
                     blk->nStatus |= BLOCK_FAILED_CHILD;
                     setDirtyBlockIndex.insert(blk);
-                    dirty=true;
+                    dirty = true;
                 }
             }
         }
     }
 
-    if (dirty) FlushStateToDisk();
+    if (dirty)
+        FlushStateToDisk();
 }

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1740,3 +1740,67 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
     return ret;
 }
 #endif
+
+/** Comparison function for sorting the getchaintips heads.  */
+struct CompareBlocksByHeight
+{
+    bool operator()(const CBlockIndex* a, const CBlockIndex* b) const
+    {
+        /* Make sure that unequal blocks with the same height do not compare
+           equal. Use the pointers themselves to make a distinction. */
+
+        if (a->nHeight != b->nHeight)
+          return (a->nHeight > b->nHeight);
+
+        return a < b;
+    }
+};
+
+void MarkAllContainingChainsInvalid(CBlockIndex* invalidBlock)
+{
+    LOCK(cs_main);
+
+    bool dirty = false;
+    DbgAssert(invalidBlock->nStatus&BLOCK_FAILED_MASK, return);
+
+    // Find all the chain tips:
+    std::set<CBlockIndex*, CompareBlocksByHeight> setTips;
+    std::set<CBlockIndex*> setOrphans;
+    std::set<CBlockIndex*> setPrevs;
+
+    BOOST_FOREACH(const PAIRTYPE(const uint256, CBlockIndex*)& item, mapBlockIndex)
+    {
+        if (!chainActive.Contains(item.second)) {
+            setOrphans.insert(item.second);
+            setPrevs.insert(item.second->pprev);
+        }
+    }
+
+    for (std::set<CBlockIndex*>::iterator it = setOrphans.begin(); it != setOrphans.end(); ++it)
+    {
+        if (setPrevs.erase(*it) == 0) {
+            setTips.insert(*it);
+        }
+    }
+
+    // Always report the currently active tip.
+    setTips.insert(chainActive.Tip());
+
+    BOOST_FOREACH(CBlockIndex* tip, setTips)
+    {
+        if (tip->GetAncestor(invalidBlock->nHeight) == invalidBlock)
+        {
+            for(CBlockIndex* blk = tip; blk != invalidBlock; blk=blk->pprev)
+            {
+                if ((blk->nStatus&BLOCK_FAILED_CHILD)==0)
+                {
+                    blk->nStatus |= BLOCK_FAILED_CHILD;
+                    setDirtyBlockIndex.insert(blk);
+                    dirty=true;
+                }
+            }
+        }
+    }
+
+    if (dirty) FlushStateToDisk();
+}

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -58,6 +58,7 @@ int64_t nMaxTipAge = DEFAULT_MAX_TIP_AGE;
 
 bool IsTrafficShapingEnabled();
 UniValue validateblocktemplate(const UniValue &params, bool fHelp);
+UniValue validatechainhistory(const UniValue &params, bool fHelp);
 
 bool MiningAndExcessiveBlockValidatorRule(const uint64_t newExcessiveBlockSize, const uint64_t newMiningBlockSize)
 {
@@ -1476,6 +1477,7 @@ static const CRPCCommand commands[] =
     { "util",               "getstat",                &getstat,                true  },
     { "util",               "get",                    &gettweak,               true  },
     { "util",               "set",                    &settweak,               true  },
+    { "util",               "validatechainhistory",   &validatechainhistory,   true  },
 #ifdef DEBUG
     { "util",               "getstructuresizes",      &getstructuresizes,      true  },  // BU
 #endif
@@ -1490,6 +1492,67 @@ void RegisterUnlimitedRPCCommands(CRPCTable &tableRPC)
 {
     for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
         tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
+}
+
+
+UniValue validatechainhistory(const UniValue &params, bool fHelp)
+{
+    if (fHelp)
+        throw runtime_error("validatechainhistory [hash]\n"
+                            "\nUpdates a chain's valid/invalid status based on parent blocks.\n");
+
+    std::stack<CBlockIndex *> stk;
+    CBlockIndex *pos = pindexBestHeader;
+    bool failedChain = false;
+    UniValue ret = NullUniValue;
+
+    LOCK(cs_main);
+
+    if (params.size() >= 1)
+    {
+        std::string strHash = params[0].get_str();
+        uint256 hash(uint256S(strHash));
+
+        if (mapBlockIndex.count(hash) == 0)
+            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+
+        CBlock block;
+        pos = mapBlockIndex[hash];
+    }
+
+    LogPrintf("validatechainhistory starting at %d %s\n", pos->nHeight, pos->phashBlock->ToString());
+    while (pos && !failedChain)
+    {
+        // LogPrintf("validate %d %s\n", pos->nHeight, pos->phashBlock->ToString());
+        failedChain = pos->nStatus & BLOCK_FAILED_MASK;
+        if (!failedChain)
+        {
+            stk.push(pos);
+        }
+        pos = pos->pprev;
+    }
+    if (failedChain)
+    {
+        ret = UniValue("Chain has a bad ancestor");
+        while (!stk.empty())
+        {
+            pos = stk.top();
+            if (pos)
+            {
+                pos->nStatus |= BLOCK_FAILED_CHILD;
+            }
+            setDirtyBlockIndex.insert(pos);
+            stk.pop();
+        }
+        FlushStateToDisk();
+        pindexBestHeader = FindMostWorkChain();
+    }
+    else
+    {
+        ret = UniValue("Chain is ok");
+    }
+
+    return ret;
 }
 
 

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -12,6 +12,7 @@
 #include "coins.h"
 #include "consensus/params.h"
 #include "consensus/validation.h"
+#include "clientversion.h"
 #include "leakybucket.h"
 #include "net.h"
 #include "script/script_error.h"
@@ -37,6 +38,15 @@ enum
     EXCESSIVE_BLOCK_CHAIN_RESET = 6 * 24, // After 1 day of non-excessive blocks, reset the checker
     DEFAULT_CHECKPOINT_DAYS =
         30, // Default for the number of days in the past we check scripts during initial block download
+
+    // if the blockchain is this far (in seconds) behind the current time, only request headers from a single
+    // peer.  This makes IBD more efficient.  We make BITCOIN_CASH more lenient here because mining could be
+    // more erratic and this node is likely to connect to non-BCC nodes.
+#ifdef BITCOIN_CASH
+    SINGLE_PEER_REQUEST_MODE_AGE = (7* 24 * 60 * 60),
+#else
+    SINGLE_PEER_REQUEST_MODE_AGE = (24 * 60 * 60),
+#endif
 };
 
 class CBlock;
@@ -73,6 +83,9 @@ static const unsigned int DEFAULT_MIN_LIMITFREERELAY = 1;
 
 // The number of days in the past we check scripts during initial block download
 extern CTweak<uint64_t> checkScriptDays;
+
+// Allow getblocktemplate to succeed even if this node chain tip blocks are old or this node is not connected
+extern CTweak<bool> unsafeGetBlockTemplate;
 
 // print out a configuration warning during initialization
 // bool InitWarning(const std::string &str);

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -136,6 +136,9 @@ extern int isChainExcessive(const CBlockIndex *blk, unsigned int checkDepth = ex
 // Check whether any block N back in this chain is an excessive block
 extern int chainContainsExcessive(const CBlockIndex *blk, unsigned int goBack = 0);
 
+// Given an invalid block, find all chains containing this block and mark all children invalid
+void MarkAllContainingChainsInvalid(CBlockIndex* invalidBlock);
+
 //// Internal CPU miner
 
 static const bool DEFAULT_GENERATE = false;

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -137,7 +137,7 @@ extern int isChainExcessive(const CBlockIndex *blk, unsigned int checkDepth = ex
 extern int chainContainsExcessive(const CBlockIndex *blk, unsigned int goBack = 0);
 
 // Given an invalid block, find all chains containing this block and mark all children invalid
-void MarkAllContainingChainsInvalid(CBlockIndex* invalidBlock);
+void MarkAllContainingChainsInvalid(CBlockIndex *invalidBlock);
 
 //// Internal CPU miner
 

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -9,10 +9,10 @@
 #include "buip055fork.h"
 #include "chain.h"
 #include "checkqueue.h"
+#include "clientversion.h"
 #include "coins.h"
 #include "consensus/params.h"
 #include "consensus/validation.h"
-#include "clientversion.h"
 #include "leakybucket.h"
 #include "net.h"
 #include "script/script_error.h"
@@ -39,11 +39,11 @@ enum
     DEFAULT_CHECKPOINT_DAYS =
         30, // Default for the number of days in the past we check scripts during initial block download
 
-    // if the blockchain is this far (in seconds) behind the current time, only request headers from a single
-    // peer.  This makes IBD more efficient.  We make BITCOIN_CASH more lenient here because mining could be
-    // more erratic and this node is likely to connect to non-BCC nodes.
+// if the blockchain is this far (in seconds) behind the current time, only request headers from a single
+// peer.  This makes IBD more efficient.  We make BITCOIN_CASH more lenient here because mining could be
+// more erratic and this node is likely to connect to non-BCC nodes.
 #ifdef BITCOIN_CASH
-    SINGLE_PEER_REQUEST_MODE_AGE = (7* 24 * 60 * 60),
+    SINGLE_PEER_REQUEST_MODE_AGE = (7 * 24 * 60 * 60),
 #else
     SINGLE_PEER_REQUEST_MODE_AGE = (24 * 60 * 60),
 #endif
@@ -57,7 +57,7 @@ class CNode;
 class CNodeRef;
 class CChainParams;
 
-
+extern std::set<CBlockIndex *> setDirtyBlockIndex;
 extern uint32_t blockVersion; // Overrides the mined block version if non-zero
 extern uint64_t maxGeneratedBlock;
 extern uint64_t excessiveBlockSize;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -538,7 +538,7 @@ boost::filesystem::path GetConfigFile()
 
 void ReadConfigFile(map<string, string>& mapSettingsRet,
                     map<string, vector<string> >& mapMultiSettingsRet,
-                    CTweakMap *pTweaks)
+                    const AllowedArgs::AllowedArgs& allowedArgs)
 {
     boost::filesystem::ifstream streamConfig(GetConfigFile());
     if (!streamConfig.good())
@@ -546,7 +546,6 @@ void ReadConfigFile(map<string, string>& mapSettingsRet,
 
     set<string> setOptions;
     setOptions.insert("*");
-    AllowedArgs::ConfigFile allowedArgs(pTweaks);
 
     for (boost::program_options::detail::config_file_iterator it(streamConfig, setOptions), end; it != end; ++it)
     {

--- a/src/util.h
+++ b/src/util.h
@@ -158,7 +158,7 @@ void CreatePidFile(const boost::filesystem::path &path, pid_t pid);
 #endif
 void ReadConfigFile(std::map<std::string, std::string>& mapSettingsRet,
                     std::map<std::string, std::vector<std::string> >& mapMultiSettingsRet,
-                    CTweakMap *pTweaks);
+                    const AllowedArgs::AllowedArgs& allowedArgs);
 #ifdef WIN32
 boost::filesystem::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
 #endif


### PR DESCRIPTION
Fix unknown argument error in bitcoin-cli, 
change testnet op_return testnet sunset to new time, 
fix getheaders sync problem.
add a hidden configurator that defeats the getblocktemplate RPC's safety checks.  These checks disallow you from mining blocks if you chain tip is too old or if you are not connected.  However, these checks can make it impossible to resume mining a test network if sufficient time has passed since you last mined it.