### PR TITLE
Update bcc seeders list

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -118,17 +118,11 @@ public:
 
 #ifdef BITCOIN_CASH
         // List of Bitcoin Cash compatible seeders
-        vSeeds.push_back(
-CDNSSeedData("bitcoinunlimited.info", "btccash-seeder.bitcoinunlimited.info", true));
-        vSeeds.push_back(
-CDNSSeedData("bitcoinabc.org", "seed.bitcoinabc.org", true));
-
+        vSeeds.push_back(CDNSSeedData("bitcoinunlimited.info", "btccash-seeder.bitcoinunlimited.info", true));
+        vSeeds.push_back(CDNSSeedData("bitcoinabc.org", "seed.bitcoinabc.org", true));
         vSeeds.push_back(CDNSSeedData("bitcoinforks.org", "seed-abc.bitcoinforks.org", true));
-        vSeeds.push_back(CDNSSeedData("bitprim.org", "seed.bitprim.org", true));
- // Bitprim
-
-        vSeeds.push_back(
-CDNSSeedData("deadalnix.me", "seed.deadalnix.me", true)); // Amaury SÉCHET
+        vSeeds.push_back(CDNSSeedData("bitprim.org", "seed.bitprim.org", true)); // Bitprim
+        vSeeds.push_back(CDNSSeedData("deadalnix.me", "seed.deadalnix.me", true)); // Amaury SÉCHET
 
 #else
         // List of BitcoinUnlimited seeders

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -124,8 +124,6 @@ CDNSSeedData("bitcoinunlimited.info", "btccash-seeder.bitcoinunlimited.info", tr
 CDNSSeedData("bitcoinabc.org", "seed.bitcoinabc.org", true));
 
         vSeeds.push_back(CDNSSeedData("bitcoinforks.org", "seed-abc.bitcoinforks.org", true));
-        vSeeds.push_back(CDNSSeedData("bitcoinunlimited.info",
- "seed.bitcoinunlimited.info", true));
         vSeeds.push_back(CDNSSeedData("bitprim.org", "seed.bitprim.org", true));
  // Bitprim
 


### PR DESCRIPTION
Remove seed.bu.info from the BCC seeder ￼

Since seed.bu.info provides only IPs of non compliant BCC nodes, it is useless if not harmful to keep it in the list of the seeders used in the Bitcoin Cash implementation.

While at it use the BU format convention to indent the list of the BCC seeder