### PR TITLE
[WIP] Request manager spin loop and rerequest inefficiencies

### DIFF
--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -206,8 +206,9 @@ class TestManager(object):
                 for node in self.test_nodes
             )
         # --> error if not requested
-        if not wait_until(blocks_requested, attempts=20*num_blocks):
+        if not wait_until(blocks_requested, attempts=100*num_blocks):
             # print [ c.cb.block_request_map for c in self.connections ]
+            pdb.set_trace()
             raise AssertionError("Not all nodes requested block")
 
         # Send getheaders message

--- a/src/buip055fork.cpp
+++ b/src/buip055fork.cpp
@@ -52,7 +52,7 @@ bool IsTxBUIP055Only(const CTransaction& tx)
 {
     if (tx.sighashType & SIGHASH_FORKID)
     {
-        LogPrintf("txn is BUIP055-specific\n");
+        // LogPrintf("txn is BUIP055-specific\n");
         return true;
     }
     return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7708,8 +7708,8 @@ bool SendMessages(CNode *pto)
                 if (!AlreadyHave(inv))
                 {
                     requester.AskFor(inv, pto);
-                    LogPrint("req", "AskFor block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
-                        pindex->nHeight, pto->id);
+                    //LogPrint("req", "AskFor block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
+                    //    pindex->nHeight, pto->id);
                 }
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7708,7 +7708,7 @@ bool SendMessages(CNode *pto)
                 if (!AlreadyHave(inv))
                 {
                     requester.AskFor(inv, pto);
-                    //LogPrint("req", "AskFor block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
+                    // LogPrint("req", "AskFor block %s (%d) peer=%d\n", pindex->GetBlockHash().ToString(),
                     //    pindex->nHeight, pto->id);
                 }
             }

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -73,11 +73,9 @@ public:
     bool rateLimited;
     int64_t lastRequestTime; // In microseconds, 0 means no request
     unsigned int outstandingReqs;
-    // unsigned int receivingFrom;
-    // char    requestCount[MAX_AVAIL_FROM];
-    // CNode* availableFrom[MAX_AVAIL_FROM];
     ObjectSourceList availableFrom;
     unsigned int priority;
+    bool hasThinSource;
 
     CUnknownObj()
     {
@@ -85,6 +83,7 @@ public:
         outstandingReqs = 0;
         lastRequestTime = 0;
         priority = 0;
+        hasThinSource = false;
     }
 
     bool AddSource(CNode *from); // returns true if the source did not already exist


### PR DESCRIPTION
The request manager had several recently introduced inefficiencies caused by moving the thin vs full block decision making into the request manager.  First, a communications cycle: a caller would request a block; the block request would request the block header first; receiving the block header would cause the block to be requested.  This cycle was fixed by not requesting the header if we already have it.  Second, if a call to RequestBlock resulted in no request, the system would push the same node back into the request manager as a data source, causing another no request -- repeatedly.  This spin loop resulted in a lot of logs.  This loop was fixed by leaving the no-request node in the request manager so subsequent AddSource requests for that same node just get ignored.  Next the request manager was changed to enable the normal request timeout if we decide to not request on that node, however, one optimization is special-cased: the first thin block capable node that is added as a source kicks the timeout to right now