### PR TITLE
[depends] miniupnpc 2.0.20170509

### DIFF
--- a/depends/packages/miniupnpc.mk
+++ b/depends/packages/miniupnpc.mk
@@ -1,8 +1,8 @@
 package=miniupnpc
-$(package)_version=1.9.20151026
+$(package)_version=2.0.20170509
 $(package)_download_path=http://miniupnp.free.fr/files
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
-$(package)_sha256_hash=f3cf9a5a31588a917d4d9237e5bc50f84d00c5aa48e27ed50d9b88dfa6a25d47
+$(package)_sha256_hash=d3c368627f5cdfb66d3ebd64ca39ba54d6ff14a61966dbecb8dd296b7039f16a
 
 define $(package)_set_vars
 $(package)_build_opts=CC="$($(package)_cc)"


### PR DESCRIPTION
Backport from core by fanquake (ffb0c4b035a7c1fd1e714d94f92370b05ecb795b).

Update miniupnpc to 2.0.20170509.
See recent CVE-2017-8798.