### PR TITLE
Fix unit tests compilation warnings

### DIFF
--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
         BOOST_CHECK(ExtractDestination(s, addr));
         BOOST_CHECK(addr == keyaddr[0]);
 #ifdef ENABLE_WALLET
-        CBlockIndex *nullBestBlock;
+        CBlockIndex *nullBestBlock = nullptr;
         BOOST_CHECK(IsMine(keystore, s, nullBestBlock));
         BOOST_CHECK(!IsMine(emptykeystore, s, nullBestBlock));
 #endif
@@ -232,7 +232,7 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
         BOOST_CHECK(ExtractDestination(s, addr));
         BOOST_CHECK(addr == keyaddr[0]);
 #ifdef ENABLE_WALLET
-        CBlockIndex *nullBestBlock;
+        CBlockIndex *nullBestBlock = nullptr;
         BOOST_CHECK(IsMine(keystore, s, nullBestBlock));
         BOOST_CHECK(!IsMine(emptykeystore, s, nullBestBlock));
 #endif
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
         CTxDestination addr;
         BOOST_CHECK(!ExtractDestination(s, addr));
 #ifdef ENABLE_WALLET
-        CBlockIndex *nullBestBlock;
+        CBlockIndex *nullBestBlock = nullptr;
         BOOST_CHECK(IsMine(keystore, s, nullBestBlock));
         BOOST_CHECK(!IsMine(emptykeystore, s, nullBestBlock));
         BOOST_CHECK(!IsMine(partialkeystore, s, nullBestBlock));
@@ -267,7 +267,7 @@ BOOST_AUTO_TEST_CASE(multisig_Solver1)
         BOOST_CHECK(addrs[1] == keyaddr[1]);
         BOOST_CHECK(nRequired == 1);
 #ifdef ENABLE_WALLET
-        CBlockIndex *nullBestBlock;
+        CBlockIndex *nullBestBlock = nullptr;
         BOOST_CHECK(IsMine(keystore, s, nullBestBlock));
         BOOST_CHECK(!IsMine(emptykeystore, s, nullBestBlock));
         BOOST_CHECK(!IsMine(partialkeystore, s, nullBestBlock));
@@ -392,7 +392,6 @@ BOOST_AUTO_TEST_CASE(opreturn_send)
     vector<valtype> solutions;
     txnouttype whichType;
     vector<CTxDestination> addresses;
-    txnouttype type = TX_LABELPUBLIC;
 
     string inMsg = "hello world", outMsg = "";
     CScript s = GetScriptLabelPublic(inMsg);

--- a/src/test/thinblock_data_tests.cpp
+++ b/src/test/thinblock_data_tests.cpp
@@ -37,7 +37,7 @@ BOOST_AUTO_TEST_CASE(test_thinblockdata_stats1)
 {
     vector<int64_t> times1(1000); // minutes
 
-    for (int i = 0; i < times1.size(); i++)
+    for (uint32_t i = 0; i < times1.size(); i++)
     {
         times1[i] = 1000 * 60 * i;
     }


### PR DESCRIPTION
- Fix compilation warning in `thinblock_data_tests.cpp`
- Fix a bunch of compilation warnings for `multisig_tests.cpp`
