### PR TITLE
Reduce the size of the travis log

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,8 @@ script:
     - echo "BITCOIN_CONFIG_ALL=$BITCOIN_CONFIG_ALL"
     - echo "BITCOIN_CONFIG=$BITCOIN_CONFIG"
     - echo "GOAL=$GOAL"
-    - ../configure $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
+    - echo "../configure $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG"
+    - ../configure $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG > configure.out || ( cat configure.out && cat config.log && false)
     - if [ "$RUN_FORMATTING_CHECK" = "true" ]; then make $MAKEJOBS check-formatting VERBOSE=1; fi
     - make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false )
     - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
     - OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
     - BITCOIN_CONFIG_ALL="--without-comparison-tool --disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib"
     - depends/$HOST/native/bin/ccache --max-size=$CCACHE_SIZE
-    - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh > autogen.out"' || ./autogen.sh > autogen.out || ( cat autogen.out && false)
+    - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh 2>&1 > autogen.out"' || ./autogen.sh 2>&1 > autogen.out || ( cat autogen.out && false)
     - mkdir build && cd build
     - echo "BITCOIN_CONFIG_ALL=$BITCOIN_CONFIG_ALL"
     - echo "BITCOIN_CONFIG=$BITCOIN_CONFIG"

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,15 +63,14 @@ script:
     - OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
     - BITCOIN_CONFIG_ALL="--without-comparison-tool --disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib"
     - depends/$HOST/native/bin/ccache --max-size=$CCACHE_SIZE
-    - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh"' || ./autogen.sh
+    - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh > autogen.out"' || ./autogen.sh > autogen.out || ( cat autogen.out && false)
     - mkdir build && cd build
     - echo "BITCOIN_CONFIG_ALL=$BITCOIN_CONFIG_ALL"
     - echo "BITCOIN_CONFIG=$BITCOIN_CONFIG"
     - echo "GOAL=$GOAL"
-    - echo "../configure $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG"
     - ../configure $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG > configure.out || ( cat configure.out && cat config.log && false)
     - if [ "$RUN_FORMATTING_CHECK" = "true" ]; then make $MAKEJOBS check-formatting VERBOSE=1; fi
-    - make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false )
+    - stdbuf -i0 -o0 -e0 make $MAKEJOBS $GOAL 2>&1 | ../contrib/devtools/buildsilence.py || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false )
     - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
     - if [ "$RUN_TESTS" = "true" ] && { [ "$HOST" = "i686-w64-mingw32" ] || [ "$HOST" = "x86_64-w64-mingw32" ]; }; then travis_wait make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$RUN_TESTS" = "true" ] && ! { [ "$HOST" = "i686-w64-mingw32" ] || [ "$HOST" = "x86_64-w64-mingw32" ]; }; then make $MAKEJOBS check VERBOSE=1; fi

--- a/contrib/devtools/buildsilence.py
+++ b/contrib/devtools/buildsilence.py
@@ -4,15 +4,18 @@
 import sys
 count = 0
 
+dotMatches = [ "AR", "CXX", "make", "libtool"]
+
 while True:
     line = sys.stdin.readline()
     if line == "": break
     txt = line.strip()
-    if len(txt) >=2 and txt[0:2] == "AR":
-        sys.stdout.write(".")
-        sys.stdout.flush()
-        count += 1
-    elif len(txt) >= 3 and txt[0:3] == "CXX":
+    matched = False
+    for m in dotMatches:
+        if txt.startswith(m):
+            matched=True
+            break
+    if matched:
         sys.stdout.write(".")
         sys.stdout.flush()
         count += 1

--- a/contrib/devtools/buildsilence.py
+++ b/contrib/devtools/buildsilence.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+# output . rather than the build output, unless something interesting is printed
+# this script cleans up the travis build output
+import sys
+count = 0
+
+while True:
+    line = sys.stdin.readline()
+    if line == "": break
+    txt = line.strip()
+    if len(txt) >=2 and txt[0:2] == "AR":
+        sys.stdout.write(".")
+        sys.stdout.flush()
+        count += 1
+    elif len(txt) >= 3 and txt[0:3] == "CXX":
+        sys.stdout.write(".")
+        sys.stdout.flush()
+        count += 1
+    else:
+        if count:
+            sys.stdout.write("\n")
+        sys.stdout.write(line)
+        count = 0
+    if count > 80:
+        sys.stdout.write("\n")
+        count = 0
+


### PR DESCRIPTION
by not printing much information about stuff that is very stable like the build process.