### PR TITLE
dbcache (phase2) enhancements

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -273,7 +273,8 @@ void CCoinsViewCache::Trim(size_t nTrimSize) const
             iter++;
     }
 
-    LogPrint("coindb", "Trimmed %ld from the CoinsViewCache, current size after trim: %ld and usage %ld bytes\n", nTrimmed, cacheCoins.size(), cachedCoinsUsage);
+    if (nTrimmed > 0)
+        LogPrint("coindb", "Trimmed %ld from the CoinsViewCache, current size after trim: %ld and usage %ld bytes\n", nTrimmed, cacheCoins.size(), cachedCoinsUsage);
 }
 
 void CCoinsViewCache::Uncache(const uint256& hash)

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -68,6 +68,11 @@ public:
 
         batch.Delete(slKey);
     }
+
+    void Clear()
+    {
+        batch.Clear();
+    }
 };
 
 class CDBIterator

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6010,8 +6010,11 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
     }
 
 
-    else if (strCommand == NetMsgType::INV && !fImporting && !fReindex)
+    else if (strCommand == NetMsgType::INV)
     {
+        if (fImporting || fReindex)
+            return true;
+
         std::vector<CInv> vInv;
         vRecv >> vInv;
 
@@ -6097,8 +6100,11 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
     }
 
 
-    else if (strCommand == NetMsgType::GETDATA && !fImporting && !fReindex)
+    else if (strCommand == NetMsgType::GETDATA)
     {
+        if (fImporting || fReindex)
+            return true;
+
         std::vector<CInv> vInv;
         vRecv >> vInv;
         // BU check size == 0 to be intolerant of an empty and useless request
@@ -6133,8 +6139,11 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
     }
 
 
-    else if (strCommand == NetMsgType::GETBLOCKS && !fImporting && !fReindex)
+    else if (strCommand == NetMsgType::GETBLOCKS)
     {
+        if (fImporting || fReindex)
+            return true;
+
         CBlockLocator locator;
         uint256 hashStop;
         vRecv >> locator >> hashStop;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -22,11 +22,13 @@ struct CDiskTxPos;
 class uint256;
 
 //! -dbcache default (MiB)
-static const int64_t nDefaultDbCache = 300; // BU Xtreme Thinblocks bump to support a larger ophan cache
+static const int64_t nDefaultDbCache = 500;
 //! max. -dbcache in (MiB)
-static const int64_t nMaxDbCache = sizeof(void*) > 4 ? 16384 : 1024;
+static const int64_t nMaxDbCache = sizeof(void*) > 4 ? 16384 : 2048;
 //! min. -dbcache in (MiB)
 static const int64_t nMinDbCache = 4;
+//! max increase in cache size since the last time we did a full flush
+static const int64_t nMaxCacheIncreaseSinceLastFlush = 512 * 1000 * 1000;
 
 /** CCoinsView backed by the coin database (chainstate/) */
 class CCoinsViewDB : public CCoinsView


### PR DESCRIPTION
 Only flush and delete pruned entries

    When reindexing or syncing the blockchain we want to keep
    any useful coins that may be dirty but have not been pruned yet.
    In this way sync and reindexing will be faster since we will
    not have to retrieve those coins again from leveldb.  Then rather 
    than flushing the entire in memory cache when it's full we trim it
    instead, just as we currently do when the chain is nearly synd.