### PR TITLE
[BUCash] - Update BUCash to allow BU/BUCash side-by-side w/o interfering with each other's Qt Settings

### DIFF
--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -694,7 +694,7 @@ int main(int argc, char *argv[])
     // BU changed the QAPP_ORG_NAME and since this is used for reading the app settings
     // from the registry (Windows) or a configuration file (Linux/OSX)
     // we need to check to see if we need to migrate old settings to the new location
-    TryMigrateQtAppSettings("Bitcoin", QAPP_ORG_NAME);
+    TryMigrateQtAppSettings(QAPP_ORG_NAME_LEGACY, QAPP_ORG_NAME);
 
     /// 4. Application identification
     // must be set before OptionsModel is initialized or translations are loaded,

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -701,9 +701,20 @@ int main(int argc, char *argv[])
     // from the registry (Windows) or a configuration file (Linux/OSX)
     // we need to check to see if we need to migrate old settings to the new location
 #ifdef BITCOIN_CASH
-    // TODO: Add migration code which first tries to move from BU to BUcash settings,
-    //       or if there weren't pre-existing BU settings, try to migrate from a legacy settings
+    bool fMigrated = false;
+    // For BUCash, first try to migrate from BTC BU settings
+    fMigrated = TryMigrateQtAppSettings(QAPP_ORG_NAME, QAPP_APP_NAME_DEFAULT, QAPP_ORG_NAME, QAPP_APP_NAME_BUCASH);
+    // Then try to migrate from non-BU client settings (if we didn't just migrate from BU settings)
+    fMigrated = fMigrated ||
+        TryMigrateQtAppSettings(QAPP_ORG_NAME_LEGACY, QAPP_APP_NAME_DEFAULT, QAPP_ORG_NAME, QAPP_APP_NAME_BUCASH);
+
+    // If we just migrated and this is a BUcash node, have the user reconfirm the data directory.
+    // This is necessary in case the user wants to run side-by-side BTC chain and BCC chain nodes
+    // in which case each instance requires a different data directory.
+    if (fMigrated)
+        SoftSetBoolArg("-choosedatadir", true);
 #else
+    // Try to migrate from non-BU client settings
     TryMigrateQtAppSettings(QAPP_ORG_NAME_LEGACY, QAPP_APP_NAME_DEFAULT, QAPP_ORG_NAME, QAPP_APP_NAME_DEFAULT);
 #endif
 

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -632,8 +632,8 @@ bool TryMigrateQtAppSettings(const QString &oldOrg, const QString &oldApp, const
     // lastly we need to add the flag which indicates we have performed a migration
     sink.setValue(APP_SETTINGS_MIGRATED_FLAG, true);
 
-    LogPrintf("APP SETTINGS: Settings successfully migrated from '%s/%s' to '%s/%s'\n",
-        oldOrg.toStdString(), oldApp.toStdString(), newOrg.toStdString(), newApp.toStdString());
+    LogPrintf("APP SETTINGS: Settings successfully migrated from '%s/%s' to '%s/%s'\n", oldOrg.toStdString(),
+        oldApp.toStdString(), newOrg.toStdString(), newApp.toStdString());
 
     // NOTE: sink will go out of scope upon return so we don't need to manually call sync()
 
@@ -696,17 +696,17 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-    /// 3. Migrate application settings, if necessary
-    // BU changed the QAPP_ORG_NAME and since this is used for reading the app settings
-    // from the registry (Windows) or a configuration file (Linux/OSX)
-    // we need to check to see if we need to migrate old settings to the new location
+/// 3. Migrate application settings, if necessary
+// BU changed the QAPP_ORG_NAME and since this is used for reading the app settings
+// from the registry (Windows) or a configuration file (Linux/OSX)
+// we need to check to see if we need to migrate old settings to the new location
 #ifdef BITCOIN_CASH
     bool fMigrated = false;
     // For BUCash, first try to migrate from BTC BU settings
     fMigrated = TryMigrateQtAppSettings(QAPP_ORG_NAME, QAPP_APP_NAME_DEFAULT, QAPP_ORG_NAME, QAPP_APP_NAME_BUCASH);
     // Then try to migrate from non-BU client settings (if we didn't just migrate from BU settings)
-    fMigrated = fMigrated ||
-        TryMigrateQtAppSettings(QAPP_ORG_NAME_LEGACY, QAPP_APP_NAME_DEFAULT, QAPP_ORG_NAME, QAPP_APP_NAME_BUCASH);
+    fMigrated = fMigrated || TryMigrateQtAppSettings(
+                                 QAPP_ORG_NAME_LEGACY, QAPP_APP_NAME_DEFAULT, QAPP_ORG_NAME, QAPP_APP_NAME_BUCASH);
 
     // If we just migrated and this is a BUcash node, have the user reconfirm the data directory.
     // This is necessary in case the user wants to run side-by-side BTC chain and BCC chain nodes

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -556,7 +556,7 @@ bool BackupQtAppSettings(const QSettings &source, const QString &backupName)
         return true;
 
     // The backup settings location
-    QSettings backup(backupName, QAPP_APP_NAME_DEFAULT);
+    QSettings backup(backupName, source.applicationName());
 
     // verify that the backup location is writable
     if (!backup.isWritable())
@@ -586,23 +586,29 @@ bool BackupQtAppSettings(const QSettings &source, const QString &backupName)
 * Migration will only be performed if there are alternate settings and a prior
 * migration has not been performed.
 * @param[in] oldOrg    Org name to migrate settings from
+* @param[in] oldApp    App name to migrate settings from
 * @param[in] newOrg    Org name to migrate settings to
+* @param[in] newApp    App name to migrate settings to
 * @return true if migration was performed, otherwise false
 * @see CanMigrateQtAppSettings()
 * @see BackupQtAppSettings()
 */
-bool TryMigrateQtAppSettings(const QString &oldOrg, const QString &newOrg)
+bool TryMigrateQtAppSettings(const QString &oldOrg, const QString &oldApp, const QString &newOrg, const QString &newApp)
 {
     // parameter saftey checks
     if (oldOrg.trimmed().size() <= 0)
         return error("%s: Parameter oldOrg must contain a non-whitespace value.", __func__);
+    if (oldApp.trimmed().size() <= 0)
+        return error("%s: Parameter oldApp must contain a non-whitespace value.", __func__);
     if (newOrg.trimmed().size() <= 0)
         return error("%s: Parameter newOrg must contain a non-whitespace value.", __func__);
+    if (newApp.trimmed().size() <= 0)
+        return error("%s: Parameter newApp must contain a non-whitespace value.", __func__);
 
     // The desired settings location
-    QSettings sink(newOrg, QAPP_APP_NAME_DEFAULT);
+    QSettings sink(newOrg, newApp);
     // The previous settings location
-    QSettings source(oldOrg, QAPP_APP_NAME_DEFAULT);
+    QSettings source(oldOrg, oldApp);
 
     // Check to see if we actually can/need to migrate
     if (!CanMigrateQtAppSettings(sink, source))
@@ -626,8 +632,8 @@ bool TryMigrateQtAppSettings(const QString &oldOrg, const QString &newOrg)
     // lastly we need to add the flag which indicates we have performed a migration
     sink.setValue(APP_SETTINGS_MIGRATED_FLAG, true);
 
-    LogPrintf(
-        "APP SETTINGS: Settings successfully migrated from '%s' to '%s'\n", oldOrg.toStdString(), newOrg.toStdString());
+    LogPrintf("APP SETTINGS: Settings successfully migrated from '%s/%s' to '%s/%s'\n",
+        oldOrg.toStdString(), oldApp.toStdString(), newOrg.toStdString(), newApp.toStdString());
 
     // NOTE: sink will go out of scope upon return so we don't need to manually call sync()
 
@@ -694,7 +700,7 @@ int main(int argc, char *argv[])
     // BU changed the QAPP_ORG_NAME and since this is used for reading the app settings
     // from the registry (Windows) or a configuration file (Linux/OSX)
     // we need to check to see if we need to migrate old settings to the new location
-    TryMigrateQtAppSettings(QAPP_ORG_NAME_LEGACY, QAPP_ORG_NAME);
+    TryMigrateQtAppSettings(QAPP_ORG_NAME_LEGACY, QAPP_APP_NAME_DEFAULT, QAPP_ORG_NAME, QAPP_APP_NAME_DEFAULT);
 
     /// 4. Application identification
     // must be set before OptionsModel is initialized or translations are loaded,

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -700,14 +700,25 @@ int main(int argc, char *argv[])
     // BU changed the QAPP_ORG_NAME and since this is used for reading the app settings
     // from the registry (Windows) or a configuration file (Linux/OSX)
     // we need to check to see if we need to migrate old settings to the new location
+#ifdef BITCOIN_CASH
+    // TODO: Add migration code which first tries to move from BU to BUcash settings,
+    //       or if there weren't pre-existing BU settings, try to migrate from a legacy settings
+#else
     TryMigrateQtAppSettings(QAPP_ORG_NAME_LEGACY, QAPP_APP_NAME_DEFAULT, QAPP_ORG_NAME, QAPP_APP_NAME_DEFAULT);
+#endif
 
     /// 4. Application identification
     // must be set before OptionsModel is initialized or translations are loaded,
     // as it is used to locate QSettings
     QApplication::setOrganizationName(QAPP_ORG_NAME);
     QApplication::setOrganizationDomain(QAPP_ORG_DOMAIN);
+#ifdef BITCOIN_CASH
+    // Use a different app name for BUCash to enable side-by-side installations which won't
+    // interfere with each other
+    QApplication::setApplicationName(QAPP_APP_NAME_BUCASH);
+#else
     QApplication::setApplicationName(QAPP_APP_NAME_DEFAULT);
+#endif
     GUIUtil::SubstituteFonts(GetLangTerritory());
 
     /// 5. Initialization of translations, so that intro dialog is in user's language

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -62,6 +62,7 @@ static const int MAX_URI_LENGTH = 255;
 #define SPINNER_FRAMES 36
 
 #define QAPP_ORG_NAME "BitcoinUnlimited"
+#define QAPP_ORG_NAME_LEGACY "Bitcoin"
 #define QAPP_ORG_DOMAIN "bitcoinunlimited.info"
 #define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
 #define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"

--- a/src/qt/guiconstants.h
+++ b/src/qt/guiconstants.h
@@ -67,5 +67,6 @@ static const int MAX_URI_LENGTH = 255;
 #define QAPP_APP_NAME_DEFAULT "Bitcoin-Qt"
 #define QAPP_APP_NAME_TESTNET "Bitcoin-Qt-testnet"
 #define QAPP_APP_NAME_NOLNET "Bitcoin-Qt-nolimit" // BU
+#define QAPP_APP_NAME_BUCASH "Bitcoin-Qt-BUcash"
 
 #endif // BITCOIN_QT_GUICONSTANTS_H

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "clientversion.h" // for BITCOIN_CASH define (if on BUCash branch)
 #include "networkstyle.h"
 
 #include "guiconstants.h"
@@ -16,7 +17,12 @@ static const struct
     const int iconColorHueShift;
     const int iconColorSaturationReduction;
     const char *titleAddText;
-} network_styles[] = {{"main", QAPP_APP_NAME_DEFAULT, 0, 0, ""},
+} network_styles[] = {
+#ifdef BITCOIN_CASH
+    {"main", QAPP_APP_NAME_BUCASH, 0, 0, ""},
+#else
+    {"main", QAPP_APP_NAME_DEFAULT, 0, 0, ""},
+#endif
     {"test", QAPP_APP_NAME_TESTNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[testnet]")},
     {"nol", QAPP_APP_NAME_NOLNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[nolimit]")}, // BU
     {"regtest", QAPP_APP_NAME_TESTNET, 160, 30, "[regtest]"}};

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -3,8 +3,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "clientversion.h" // for BITCOIN_CASH define (if on BUCash branch)
 #include "networkstyle.h"
+#include "clientversion.h" // for BITCOIN_CASH define (if on BUCash branch)
 
 #include "guiconstants.h"
 


### PR DESCRIPTION
Looking for feedback on this implementation.

To allow side-by-side installs of BitcoinUnlimited and BUCash on the same machine, update the Qt App Name used by BUCash.  This will result in different registry location on Windows, or different settings file on Linux/Mac.

1. If BUCash, check to see if settings have already been migrated to the new app name.
2. If migration is needed, perform the full migration from old app name to new app name.
2.a. First check if there was already a BU install and clone these settings.
2.b. If no BU install, but another Satoshi based client installed, clone those settings instead.
3. If a migration occurred (BUCash client only), force the user to re-pick their data directory.  This is needed because side-by-side clients will need to maintain different data directories for BTC main chain vs BCC main chain.

Questions for feedback:
1. Should the migrated settings outright ignore the `strDataDir` setting from the source settings?  Prompting the user to reselect their data directory only works if the settings were just migrated in this session.  If they kill the app after the settings have been migrated, but having not yet selected a directory, they won't be prompted to reselect the next time they start bitcon-qt and the client will just use the migrated data directory (if not overridden via command-line/config file).
2. Are registry settings/configuration for Qt set as part of the Windows/Mac installers? I didn't see anything searching for specific string so I've only updated the bitcoin-qt client code.

TODO:
- Test on Linux/Mac (already tested on Windows)
- Possibly update text on the data directory picker dialog to add a warning for the BUCash client that if the user intends to run side-by-side clients for both the BTC and BCC chains, they need to have different data directories, and this is why the user is being prompted to pick the directory again.