### PR TITLE
[BUcash] Change currency unit to BCC when compiled for BUCash

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -30,7 +30,11 @@
 #endif
 
 // These globals are needed here so bitcoin-cli can link
+#ifdef BITCOIN_CASH
+const std::string CURRENCY_UNIT = "BCC";
+#else
 const std::string CURRENCY_UNIT = "BTC";
+#endif
 const std::string DEFAULT_TOR_CONTROL = "127.0.0.1:9051";
 const char DEFAULT_RPCCONNECT[] = "127.0.0.1";
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -743,7 +743,15 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     // any users that migrate from Core to BU that this option is not used.
     if (mapArgs.count("-minrelaytxfee"))
     {
-        InitWarning(_("Config option -minrelaytxfee is no longer supported.  To set the limit below which a transaction is considered zero fee please use -minlimitertxfee.  To convert -minrelaytxfee, which is specified  in BTC/KB, to -minlimtertxfee, which is specified in Satoshi/Byte, simply multiply the original -minrelaytxfee by 100,000. For example, a -minrelaytxfee=0.00001000 will become -minlimitertxfee=1.000"));
+        InitWarning(_("Config option -minrelaytxfee is no longer supported.  To set the limit "
+                      "below which a transaction is considered zero fee please use -minlimitertxfee.  "
+#ifdef BITCOIN_CASH
+                      "To convert -minrelaytxfee, which is specified  in BCC/KB, to -minlimtertxfee, "
+#else
+                      "To convert -minrelaytxfee, which is specified  in BTC/KB, to -minlimtertxfee, "
+#endif
+                      "which is specified in Satoshi/Byte, simply multiply the original -minrelaytxfee "
+                      "by 100,000. For example, a -minrelaytxfee=0.00001000 will become -minlimitertxfee=1.000"));
     }
 
 

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "bitcoinunits.h"
+#include "clientversion.h" // for BITCOIN_CASH define (if on BUCash branch)
 
 #include "primitives/transaction.h"
 
@@ -41,9 +42,15 @@ QString BitcoinUnits::name(int unit)
 {
     switch(unit)
     {
+#ifdef BITCOIN_CASH
+    case BTC: return QString("BCC");
+    case mBTC: return QString("mBCC");
+    case uBTC: return QString::fromUtf8("μBCC");
+#else
     case BTC: return QString("BTC");
     case mBTC: return QString("mBTC");
     case uBTC: return QString::fromUtf8("μBTC");
+#endif
     default: return QString("???");
     }
 }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -846,7 +846,11 @@ UniValue estimatesmartfee(const UniValue& params, bool fHelp)
             "1. nblocks     (numeric)\n"
             "\nResult:\n"
             "{\n"
+#ifdef BITCOIN_CASH
+            "  \"feerate\" : x.x,     (numeric) estimate fee-per-kilobyte (in BCC)\n"
+#else
             "  \"feerate\" : x.x,     (numeric) estimate fee-per-kilobyte (in BTC)\n"
+#endif
             "  \"blocks\" : n         (numeric) block number where estimate was found\n"
             "}\n"
             "\n"


### PR DESCRIPTION
Fixes #758 to update all locations where text is visible to users in the UI/logs.  Does not change internal variable names, comments, enumerations.

NOTE: This does NOT update translations.