### PR TITLE
Fix issue 776: Remove setPublicLabelFilter and PublicLabelRole

### DIFF
--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -37,7 +37,6 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     int type = index.data(TransactionTableModel::TypeRole).toInt();
     QDateTime datetime = index.data(TransactionTableModel::DateRole).toDateTime();
     bool involvesWatchAddress = index.data(TransactionTableModel::WatchonlyRole).toBool();
-    bool involvesPublicLabelAddress = index.data(TransactionTableModel::PublicLabelRole).toBool();
     QString address = index.data(TransactionTableModel::AddressRole).toString();
     QString label = index.data(TransactionTableModel::LabelRole).toString();
     qint64 amount = llabs(index.data(TransactionTableModel::AmountRole).toLongLong());
@@ -51,8 +50,6 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
         return false;
     if (!involvesWatchAddress && watchOnlyFilter == WatchOnlyFilter_Yes)
         return false;
-    //if (involvesPublicLabelAddress == false && publicLabelFilter == true)
-    //    return false;
     if(datetime < dateFrom || datetime > dateTo)
         return false;
     if (!address.contains(addrPrefix, Qt::CaseInsensitive) && !label.contains(addrPrefix, Qt::CaseInsensitive))

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -51,8 +51,8 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
         return false;
     if (!involvesWatchAddress && watchOnlyFilter == WatchOnlyFilter_Yes)
         return false;
-    if (involvesPublicLabelAddress != publicLabelFilter)
-        return false;
+    //if (involvesPublicLabelAddress == false && publicLabelFilter == true)
+    //    return false;
     if(datetime < dateFrom || datetime > dateTo)
         return false;
     if (!address.contains(addrPrefix, Qt::CaseInsensitive) && !label.contains(addrPrefix, Qt::CaseInsensitive))
@@ -91,12 +91,6 @@ void TransactionFilterProxy::setMinAmount(const CAmount& minimum)
 void TransactionFilterProxy::setWatchOnlyFilter(WatchOnlyFilter filter)
 {
     this->watchOnlyFilter = filter;
-    invalidateFilter();
-}
-
-void TransactionFilterProxy::setPublicLabelFilter(bool filter)
-{
-    this->publicLabelFilter = filter;
     invalidateFilter();
 }
 

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -43,7 +43,6 @@ public:
     void setTypeFilter(quint32 modes);
     void setMinAmount(const CAmount& minimum);
     void setWatchOnlyFilter(WatchOnlyFilter filter);
-    void setPublicLabelFilter(bool filter);
 
     /** Set maximum number of rows returned, -1 if unlimited. */
     void setLimit(int limit);

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -378,8 +378,6 @@ QString TransactionTableModel::formatTxType(const TransactionRecord *wtx) const
         return tr("Payment to yourself");
     case TransactionRecord::Generated:
         return tr("Mined");
-    case TransactionRecord::PublicLabel:
-        return tr("Public label");
     default:
         return QString();
     }
@@ -618,8 +616,6 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         return QDateTime::fromTime_t(static_cast<uint>(rec->time));
     case WatchonlyRole:
         return rec->involvesWatchAddress;
-    case PublicLabelRole:
-        return (rec->type == TransactionRecord::PublicLabel);
     case WatchonlyDecorationRole:
         return txWatchonlyDecoration(rec);
     case LongDescriptionRole:

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -50,8 +50,6 @@ public:
         DateRole,
         /** Watch-only boolean */
         WatchonlyRole,
-        /** Public label boolean */
-        PublicLabelRole,
         /** Watch-only icon */
         WatchonlyDecorationRole,
         /** Long description (HTML format) */

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -184,7 +184,6 @@ void TransactionView::setModel(WalletModel *model)
     if(model)
     {
         transactionProxyModel = new TransactionFilterProxy(this);
-        transactionProxyModel->setPublicLabelFilter(false);
         transactionProxyModel->setSourceModel(model->getTransactionTableModel());
         transactionProxyModel->setDynamicSortFilter(true);
         transactionProxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);


### PR DESCRIPTION
The setPublicLabelFilter function and PublicLabelRole are a part of a draft branch (gui_top_public_labels) and not required.

See issue: https://github.com/BitcoinUnlimited/BitcoinUnlimited/issues/776