### PR TITLE
Fix ThinBlockCapable and add new thinblock tests

### DIFF
--- a/qa/rpc-tests/thinblocks.py
+++ b/qa/rpc-tests/thinblocks.py
@@ -16,29 +16,72 @@ class ThinBlockTest(BitcoinTestFramework):
 
     def setup_chain(self):
         print ("Initializing test directory " + self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 2)
+        initialize_chain_clean(self.options.tmpdir, 3)
 
     def setup_network(self, split=False):
-        node_opts = [
+        node_opts1 = [
             "-rpcservertimeout=0",
             "-debug=thin",
             "-use-thinblocks=1",
             "-excessiveblocksize=6000000",
             "-blockprioritysize=6000000",
-            "-blockmaxsize=6000000"]
+            "-blockmaxsize=6000000",
+            "-peerbloomfilters=1"]
+
+        # These options have peerbloomfiters turned off.  Xthin's should still work with this option turned off.
+        node_opts2 = [
+            "-rpcservertimeout=0",
+            "-debug=thin",
+            "-use-thinblocks=1",
+            "-excessiveblocksize=6000000",
+            "-blockprioritysize=6000000",
+            "-blockmaxsize=6000000",
+            "-peerbloomfilters=0"]
 
         self.nodes = [
-            start_node(0, self.options.tmpdir, node_opts),
-            start_node(1, self.options.tmpdir, node_opts)
+            start_node(0, self.options.tmpdir, node_opts1),
+            start_node(1, self.options.tmpdir, node_opts1),
+            start_node(2, self.options.tmpdir, node_opts2)
         ]
         interconnect_nodes(self.nodes)
         self.is_network_split = False
         self.sync_all()
 
     def run_test(self):
-        self.nodes[0].generate(30)
+        # Generate blocks so we can send a few transactions.  We need some transactions in a block
+        # before an xthin can be send and created, otherwise we'll just end up sending a regular
+        # block.
+        self.nodes[0].generate(100)
+        self.sync_all()
+        self.nodes[0].generate(5)
         self.sync_all()
 
+        # Generate and propagate blocks from a node that has bloomfiltering turned on.
+        # This should work.
+        send_to = {}
+        self.nodes[0].keypoolrefill(20)
+        for i in range(20):
+            send_to[self.nodes[1].getnewaddress()] = Decimal("0.01")
+        self.nodes[0].sendmany("", send_to)
+        self.sync_all()
+
+        self.nodes[1].generate(1)
+        self.sync_all()
+
+        # Generate and propagate blocks from a node that does not have bloomfiltering turned on.
+        # This should work.
+        send_to = {}
+        self.nodes[0].keypoolrefill(20)
+        for i in range(20):
+            send_to[self.nodes[1].getnewaddress()] = Decimal("0.01")
+        self.nodes[0].sendmany("", send_to)
+        self.sync_all()
+
+        self.nodes[2].generate(1)
+        self.sync_all()
+
+
+        # Check thinblock stats
         gni = self.nodes[0].getnetworkinfo()
         assert "thinblockstats" in gni
 

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -588,7 +588,7 @@ static void addNodeRelayOptions(AllowedArgs &allowedArgs)
         .addArg("use-thinblocks", optionalBool, _("Enable thin blocks to speed up the relay of blocks (default: 1)"))
         .addArg("xthinbloomfiltersize=<n>", requiredInt,
             strprintf(_("The maximum xthin bloom filter size that our node will accept in Bytes (default: %u)"),
-                    MAX_BLOOM_FILTER_SIZE));
+                    SMALLEST_MAX_BLOOM_FILTER_SIZE));
 }
 
 static void addBlockCreationOptions(AllowedArgs &allowedArgs)

--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -23,7 +23,7 @@
 
 using namespace std;
 
-void CBloomFilter::setup(unsigned int nElements, double nFPRate, unsigned int nTweakIn, unsigned char nFlagsIn, bool size_constrained, uint32_t nMaxFilterSize = MAX_BLOOM_FILTER_SIZE) {
+void CBloomFilter::setup(unsigned int nElements, double nFPRate, unsigned int nTweakIn, unsigned char nFlagsIn, bool size_constrained, uint32_t nMaxFilterSize = SMALLEST_MAX_BLOOM_FILTER_SIZE) {
     if (nElements == 0) {
         LogPrintf("Construction of empty CBloomFilter attempted.\n");
         nElements = 1;
@@ -135,7 +135,7 @@ void CBloomFilter::reset(unsigned int nNewTweak)
 
 bool CBloomFilter::IsWithinSizeConstraints() const
 {
-    return vData.size() <= MAX_BLOOM_FILTER_SIZE && nHashFuncs <= MAX_HASH_FUNCS;
+    return vData.size() <= SMALLEST_MAX_BLOOM_FILTER_SIZE && nHashFuncs <= MAX_HASH_FUNCS;
 }
 
 bool CBloomFilter::IsRelevantAndUpdate(const CTransaction& tx)

--- a/src/bloom.h
+++ b/src/bloom.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_BLOOM_H
 #define BITCOIN_BLOOM_H
 
+#include "consensus/consensus.h"
 #include "serialize.h"
 
 #include <vector>
@@ -15,7 +16,6 @@ class CTransaction;
 class uint256;
 
 //! 20,000 items with fp rate < 0.1% or 10,000 items and <0.0001%
-static const unsigned int MAX_BLOOM_FILTER_SIZE = 36000; // bytes
 static const unsigned int MAX_HASH_FUNCS = 50;
 
 /**
@@ -79,7 +79,7 @@ public:
      * It should generally always be a random value (and is largely only exposed for unit testing)
      * nFlags should be one of the BLOOM_UPDATE_* enums (not _MASK)
      */
-    CBloomFilter(unsigned int nElements, double nFPRate, unsigned int nTweak, unsigned char nFlagsIn, uint32_t nMaxFilterSize = MAX_BLOOM_FILTER_SIZE);
+    CBloomFilter(unsigned int nElements, double nFPRate, unsigned int nTweak, unsigned char nFlagsIn, uint32_t nMaxFilterSize = SMALLEST_MAX_BLOOM_FILTER_SIZE);
     CBloomFilter() : isFull(true), isEmpty(true), nHashFuncs(0), nTweak(0), nFlags(0) {}
 
     ADD_SERIALIZE_METHODS;
@@ -106,7 +106,7 @@ public:
     void clear();
     void reset(unsigned int nNewTweak);
 
-    //! True if the size is <= MAX_BLOOM_FILTER_SIZE and the number of hash functions is <= MAX_HASH_FUNCS
+    //! True if the size is <= SMALLEST_MAX_BLOOM_FILTER_SIZE and the number of hash functions is <= MAX_HASH_FUNCS
     //! (catch a filter which was just deserialized which was too big)
     bool IsWithinSizeConstraints() const;
 

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -18,6 +18,11 @@ static const unsigned int MAX_TX_SIGOPS = BLOCKSTREAM_CORE_MAX_BLOCK_SIZE/50;
 */
 static const unsigned int DEFAULT_LARGEST_TRANSACTION = 1000000;
 
+/** This is the default max bloom filter size allowed on the bitcoin network.  In Bitcoin Unlimited we have the ability
+ *  to communicate to our peer what max bloom filter size we will accept but still observe this value as a default.
+ */
+static const unsigned int SMALLEST_MAX_BLOOM_FILTER_SIZE = 36000; // bytes
+
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -777,9 +777,9 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     nMaxTipAge = GetArg("-maxtipage", DEFAULT_MAX_TIP_AGE);
 
     // xthin bloom filter limits
-    nXthinBloomFilterSize = (uint32_t)GetArg("-xthinbloomfiltersize", MAX_BLOOM_FILTER_SIZE);
-    if (nXthinBloomFilterSize < MAX_BLOOM_FILTER_SIZE)
-        return InitError(strprintf(_("-xthinbloomfiltersize must be at least %d Bytes"), MAX_BLOOM_FILTER_SIZE));
+    nXthinBloomFilterSize = (uint32_t)GetArg("-xthinbloomfiltersize", SMALLEST_MAX_BLOOM_FILTER_SIZE);
+    if (nXthinBloomFilterSize < SMALLEST_MAX_BLOOM_FILTER_SIZE)
+        return InitError(strprintf(_("-xthinbloomfiltersize must be at least %d Bytes"), SMALLEST_MAX_BLOOM_FILTER_SIZE));
 
     // ********************************************************* Step 4: application initialization: dir lock, daemonize, pidfile, debug log
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,7 +88,7 @@ bool fCheckBlockIndex = false;
 bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
 size_t nCoinCacheUsage = 5000 * 300;
 uint64_t nPruneTarget = 0;
-uint32_t nXthinBloomFilterSize = MAX_BLOOM_FILTER_SIZE;
+uint32_t nXthinBloomFilterSize = SMALLEST_MAX_BLOOM_FILTER_SIZE;
 
 CFeeRate minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
 
@@ -7055,7 +7055,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             vRecv >> pfrom->nXthinBloomfilterSize;
 
             // As a safeguard don't allow a smaller max bloom filter size than the default max size.
-            if (!pfrom->nXthinBloomfilterSize || (pfrom->nXthinBloomfilterSize < MAX_BLOOM_FILTER_SIZE))
+            if (!pfrom->nXthinBloomfilterSize || (pfrom->nXthinBloomfilterSize < SMALLEST_MAX_BLOOM_FILTER_SIZE))
             {
                 pfrom->PushMessage(
                     NetMsgType::REJECT, strCommand, REJECT_INVALID, std::string("filter size was too small"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7053,6 +7053,15 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         if (pfrom->ThinBlockCapable())
         {
             vRecv >> pfrom->nXthinBloomfilterSize;
+
+            // As a safeguard don't allow a smaller max bloom filter size than the default max size.
+            if (!pfrom->nXthinBloomfilterSize || (pfrom->nXthinBloomfilterSize < MAX_BLOOM_FILTER_SIZE))
+            {
+                pfrom->PushMessage(
+                    NetMsgType::REJECT, strCommand, REJECT_INVALID, std::string("filter size was too small"));
+                pfrom->fDisconnect = true;
+                return false;
+            }
         }
         else
         {

--- a/src/net.h
+++ b/src/net.h
@@ -521,7 +521,7 @@ public:
     // BUIP010:
     bool ThinBlockCapable()
     {
-        if ((nServices & NODE_XTHIN) && (nServices & NODE_BLOOM))
+        if (nServices & NODE_XTHIN)
             return true;
         return false;
     }

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -462,7 +462,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     dummyNodeA.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNodeA.fSuccessfullyConnected = true;
     ProcessMessage(&dummyNodeA, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetTime());
-    BOOST_CHECK(dummyNodeA.fDisconnect); // node should be disconnected
+    BOOST_CHECK(!dummyNodeA.fDisconnect); // node should not be disconnected
 
     dosMan.ClearBanned();
     vRecv1.clear();

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -450,8 +450,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     /** FILTERSIZEXTHIN tests */
 
     CDataStream ssSend(SER_NETWORK, INIT_PROTO_VERSION);
-    ssSend << CMessageHeader(Params().MessageStart(), "filtersizext", 0);
-    ssSend << 36000;
+    ssSend << (uint32_t)36000;
 
     dosMan.ClearBanned();
     vRecv1.clear();
@@ -486,6 +485,23 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     dummyNodeC.fSuccessfullyConnected = true;
     ProcessMessage(&dummyNodeC, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetTime());
     BOOST_CHECK(!dummyNodeC.fDisconnect); // node should not be disconnected
+
+
+    // Send a filter message indicating a size that is less than the default 36000.
+    // This should get a disconnect.
+    CDataStream ssSend2(SER_NETWORK, INIT_PROTO_VERSION);
+    ssSend2 << (uint32_t)35999;
+
+    dosMan.ClearBanned();
+    vRecv1.clear();
+    vRecv1 << ssSend2;
+
+    CNode dummyNodeD(INVALID_SOCKET, addr1, "", true);
+    dummyNodeD.nServices |= NODE_XTHIN;
+    dummyNodeD.nVersion = MIN_PEER_PROTO_VERSION;
+    dummyNodeD.fSuccessfullyConnected = true;
+    ProcessMessage(&dummyNodeD, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetTime());
+    BOOST_CHECK(dummyNodeD.fDisconnect); // node should be disconnected
 
     /** XTHINBLOCK message consistency checks */
 

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -1806,7 +1806,7 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
     if (nTimePassed > nHoursToGrow * 3600)
         nFPRate = nMaxFalsePositive;
 
-    uint32_t nMaxFilterSize = std::max(MAX_BLOOM_FILTER_SIZE, pfrom->nXthinBloomfilterSize);
+    uint32_t nMaxFilterSize = std::max(SMALLEST_MAX_BLOOM_FILTER_SIZE, pfrom->nXthinBloomfilterSize);
     filterMemPool = CBloomFilter(nElements, nFPRate, insecure_rand(), BLOOM_UPDATE_ALL, nMaxFilterSize);
     LogPrint("thin", "FPrate: %f Num elements in bloom filter:%d high priority txs:%d high fee txs:%d orphans:%d total "
                      "txs in mempool:%d\n",


### PR DESCRIPTION
ThinBlockCapable was erroneously changed to prevent the download
of thinblocks from a peer that did not have -peerbloomfilters turned
on.  This was incorrect as -peerbloomfilters only affects SPV wallets.

Also, a few more tests were added to ensure that xthins works, with
or without, -peerbloomfilters.