### PR TITLE
[WIP] Add opt-in transaction avoidance (for legacy chain) using well known P2SH address

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -119,6 +119,11 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason)
         return false;
     }
 
+    if (tx.ReplayProtected()) {
+        reason = "replay-protected";
+        return false;
+    }
+
     return true;
 }
 

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -144,9 +144,9 @@ std::string CTransaction::ToString() const
 
 bool CTransaction::ReplayProtected() const
 {
-    // hex("RP=!>1x") = 52503d213e3178
+	// scriptAddress: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs, scriptSig: 03165c4d, scriptPubKey: OP_HASH160 e77dfed888d33a87c2f48849f54dc55f4e63e7b4 OP_EQUAL
     static const CScript noReplay =
-        CScript() << OP_RETURN << ParseHex("52503d213e3178");
+        CScript() << OP_HASH160 << ParseHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4") << OP_EQUAL;
 
     for (const auto& txout : this->vout) {
         if (txout.scriptPubKey == noReplay) {

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -141,3 +141,17 @@ std::string CTransaction::ToString() const
         str += "    " + vout[i].ToString() + "\n";
     return str;
 }
+
+bool CTransaction::ReplayProtected() const
+{
+    // hex("RP=!>1x") = 52503d213e3178
+    static const CScript noReplay =
+        CScript() << OP_RETURN << ParseHex("52503d213e3178");
+
+    for (const auto& txout : this->vout) {
+        if (txout.scriptPubKey == noReplay) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -144,9 +144,9 @@ std::string CTransaction::ToString() const
 
 bool CTransaction::ReplayProtected() const
 {
-	// scriptAddress: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs, scriptSig: 03165c4d, scriptPubKey: OP_HASH160 e77dfed888d33a87c2f48849f54dc55f4e63e7b4 OP_EQUAL
+	// scriptAddress: 3Bit1xA4apyzgmFNT2k8Pvnd6zb6TnwcTi, scriptSig: 04148f33be, scriptPubKey: OP_HASH160 6e0b7d51f9f68ba28cc33a6844d41a1880c58a19 OP_EQUAL
     static const CScript noReplay =
-        CScript() << OP_HASH160 << ParseHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4") << OP_EQUAL;
+        CScript() << OP_HASH160 << ParseHex("6e0b7d51f9f68ba28cc33a6844d41a1880c58a19") << OP_EQUAL;
 
     for (const auto& txout : this->vout) {
         if (txout.scriptPubKey == noReplay) {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -284,6 +284,8 @@ public:
     }
 
     std::string ToString() const;
+
+    bool ReplayProtected() const;
 };
 
 /** A mutable version of CTransaction. */

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -430,14 +430,27 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
     BOOST_CHECK(!IsStandardTx(t, reason));
 
-    // Replay-protected TX is non-std
-    std::string orig("RP=!>1x");
-    std::string origHex = HexStr(orig);
-    BOOST_CHECK_EQUAL(origHex, "52503d213e3178");
-
+	// scriptAddress: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs, scriptSig: 03165c4d, scriptPubKey: OP_HASH160 e77dfed888d33a87c2f48849f54dc55f4e63e7b4 OP_EQUAL
     t.vout.resize(1);
-    t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("52503d213e3178");
+    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << ParseHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4") << OP_EQUAL;
     BOOST_CHECK(!IsStandardTx(t, reason));
+}
+
+BOOST_AUTO_TEST_CASE(test_ReplayProtected)
+{
+    CMutableTransaction t;
+
+	// scriptAddress: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs, scriptSig: 03165c4d, scriptPubKey: OP_HASH160 e77dfed888d33a87c2f48849f54dc55f4e63e7b4 OP_EQUAL
+    t.vout.resize(1);
+    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << ParseHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4") << OP_EQUAL;
+    CTransaction tx1(t);
+    BOOST_CHECK(tx1.ReplayProtected());	
+
+	// scriptAddress: 3EZT2iZWYCpy1uXX6XtjX429TnsZ3vKvVV, scriptSig: 777777, scriptPubKey: OP_HASH160 8d2b43ea8081126af5bc392612b1471a0c4fe503 OP_EQUAL
+    t.vout.resize(1);
+    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << ParseHex("8d2b43ea8081126af5bc392612b1471a0c4fe503") << OP_EQUAL;
+    CTransaction tx2(t);
+    BOOST_CHECK(!tx2.ReplayProtected());	
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -430,9 +430,9 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
     BOOST_CHECK(!IsStandardTx(t, reason));
 
-	// scriptAddress: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs, scriptSig: 03165c4d, scriptPubKey: OP_HASH160 e77dfed888d33a87c2f48849f54dc55f4e63e7b4 OP_EQUAL
+	// scriptAddress: 3Bit1xA4apyzgmFNT2k8Pvnd6zb6TnwcTi, scriptSig: 04148f33be, scriptPubKey: OP_HASH160 6e0b7d51f9f68ba28cc33a6844d41a1880c58a19 OP_EQUAL
     t.vout.resize(1);
-    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << ParseHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4") << OP_EQUAL;
+    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << ParseHex("6e0b7d51f9f68ba28cc33a6844d41a1880c58a19") << OP_EQUAL;
     BOOST_CHECK(!IsStandardTx(t, reason));
 }
 
@@ -440,9 +440,9 @@ BOOST_AUTO_TEST_CASE(test_ReplayProtected)
 {
     CMutableTransaction t;
 
-	// scriptAddress: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs, scriptSig: 03165c4d, scriptPubKey: OP_HASH160 e77dfed888d33a87c2f48849f54dc55f4e63e7b4 OP_EQUAL
+	// scriptAddress: 3Bit1xA4apyzgmFNT2k8Pvnd6zb6TnwcTi, scriptSig: 04148f33be, scriptPubKey: OP_HASH160 6e0b7d51f9f68ba28cc33a6844d41a1880c58a19 OP_EQUAL
     t.vout.resize(1);
-    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << ParseHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4") << OP_EQUAL;
+    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << ParseHex("6e0b7d51f9f68ba28cc33a6844d41a1880c58a19") << OP_EQUAL;
     CTransaction tx1(t);
     BOOST_CHECK(tx1.ReplayProtected());	
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -429,6 +429,15 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
     BOOST_CHECK(!IsStandardTx(t, reason));
+
+    // Replay-protected TX is non-std
+    std::string orig("RP=!>1x");
+    std::string origHex = HexStr(orig);
+    BOOST_CHECK_EQUAL(origHex, "52503d213e3178");
+
+    t.vout.resize(1);
+    t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("52503d213e3178");
+    BOOST_CHECK(!IsStandardTx(t, reason));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This is a port of https://github.com/btc1/bitcoin/pull/127 by @jcansdale, which is based on https://github.com/btc1/bitcoin/pull/117 by @gavinandresen and @jgarzik.

The idea of this PR is to allow opt-in replay protection on the legacy chain by simply sending some dust to a well known P2SH address (`3Bit1xA4apyzgmFNT2k8Pvnd6zb6TnwcTi`). The change is returned to the wallet and can then only be spend on the legacy chain. This lets the user spend the same inputs on the 2x+ chain without the worry of replays.

This is how it will work on BTC1/Setwit2x:

Transactions may contain a marker output (txout) constructed as:
`OP_HASH160 6e0b7d51f9f68ba28cc33a6844d41a1880c58a19 OP_EQUAL`
This is a P2SH output with the vanity address:
`3Bit1xA4apyzgmFNT2k8Pvnd6zb6TnwcTi`.

To avoid indefinitely expanding the UTXO set, these outputs can be
spent by anyone using the intentionally concise scriptSig `03165c4d`.

1) All transactions containing this marker are considered non-standard,
and not relayed or mined by default. They may appear in a block
("valid"), but the software will not do this by default. This is
normal behavior for any valid-but-nonstandard transaction.

2) After the BIP102 hard fork point (fSegwitSeasoned), transactions
containing this marker are considered invalid. Blocks must not contain
outputs to the `3Bit1xA4apyzgmFNT2k8Pvnd6zb6TnwcTi` address.

This will appear as a soft-fork for Bitcoin Unlimited. To prevent Bitcoin Unlimited miners from mining invalid blocks on the 2x chain, I've simply ported the code that makes these tx non-standard (as opposed to invalid). I don't know if there would be much to gain by porting the more complex code that would make these tx invalid at the planned hard-fork height.

OTOH, exchanges might try to argue that Unlimited doesn't have *strong* replay protection, even if it is being enforced by Segwit2x. 😉 

This is WIP, but has a good chance of being merged into Segwit2x. I wanted to keep Bitcoin Unlimited in the loop!