### PR TITLE
Fix spurious failures in parallel.py

### DIFF
--- a/qa/rpc-tests/parallel.py
+++ b/qa/rpc-tests/parallel.py
@@ -99,168 +99,59 @@ class ParallelTest (BitcoinTestFramework):
             return
 
         print ("Mining blocks with PV off...")
-
         # Mine some blocks on node2 which we will need at the end to generate a few transactions from that node
         # in order to create the small block with just a few transactions in it.
-        self.nodes[2].generate(1)
+        self.nodes[2].generate(2)
         self.sync_all()
 
         # Mine the rest on node0 where we will generate the bigger block.
         self.nodes[0].generate(100)
         self.sync_all()
 
-        self.nodes[0].generate(100)
-        self.sync_all()
-
-        # Create many utxo's
-        print ("Generating txns...")
-        send_to = {}
-        self.nodes[0].keypoolrefill(100)
-        self.nodes[0].keypoolrefill(100)
-        for i in range(200):
-            send_to[self.nodes[0].getnewaddress()] = Decimal("0.01")
-        self.nodes[0].sendmany("", send_to)
-        self.nodes[0].keypoolrefill(100)
-        self.nodes[0].keypoolrefill(100)
-        for i in range(200):
-            send_to[self.nodes[0].getnewaddress()] = Decimal("0.01")
-        self.nodes[0].sendmany("", send_to)
-        self.nodes[0].keypoolrefill(100)
-        self.nodes[0].keypoolrefill(100)
-        for i in range(200):
-            send_to[self.nodes[0].getnewaddress()] = Decimal("0.01")
-        self.nodes[0].sendmany("", send_to)
-        self.nodes[0].keypoolrefill(100)
-        self.nodes[0].keypoolrefill(100)
-        for i in range(200):
-            send_to[self.nodes[0].getnewaddress()] = Decimal("0.01")
-        self.nodes[0].sendmany("", send_to)
-        self.nodes[0].keypoolrefill(100)
-        self.nodes[0].keypoolrefill(100)
-        for i in range(200):
-            send_to[self.nodes[0].getnewaddress()] = Decimal("0.01")
-        self.nodes[0].sendmany("", send_to)
-        self.nodes[0].keypoolrefill(100)
-        self.nodes[0].keypoolrefill(100)
-        for i in range(200):
-            send_to[self.nodes[0].getnewaddress()] = Decimal("0.01")
-        self.nodes[0].sendmany("", send_to)
-        self.nodes[0].keypoolrefill(100)
-        self.nodes[0].keypoolrefill(100)
-        for i in range(200):
-            send_to[self.nodes[0].getnewaddress()] = Decimal("0.01")
-        self.nodes[0].sendmany("", send_to)
-        self.nodes[0].keypoolrefill(100)
-        self.nodes[0].keypoolrefill(100)
-        for i in range(200):
-            send_to[self.nodes[0].getnewaddress()] = Decimal("0.01")
-        self.nodes[0].sendmany("", send_to)
-        self.nodes[0].keypoolrefill(100)
-        self.nodes[0].keypoolrefill(100)
-        for i in range(200):
-            send_to[self.nodes[0].getnewaddress()] = Decimal("0.01")
-        self.nodes[0].sendmany("", send_to)
-
-        # Mine a block so that the utxos are now spendable
-        print ("mine a block")
-        self.nodes[0].generate(1)
-
-        connect_nodes(self.nodes[0],1)
-        connect_nodes(self.nodes[0],2)
-        connect_nodes(self.nodes[0],3)
-        self.is_network_split=False
-        self.sync_all()
-
-        # Send more transactions
-        print ("Generating more txns...")
-        output_total = Decimal(0)
-        j = 0
-        self.utxo = self.nodes[0].listunspent()
-        utxo = self.utxo.pop()
-        txns_to_send = []
-        num_txns = 700
-        while j <= num_txns:
-            inputs = []
-            outputs = {}
-            utxo = self.utxo.pop()
-            if utxo["amount"] > Decimal("0.0100000") or utxo["amount"] < Decimal("0.0100000"):
-                continue
-            if utxo["spendable"] is True:
-                j = j + 1
-                inputs.append({ "txid" : utxo["txid"], "vout" : utxo["vout"]})
-                outputs[self.nodes[0].getnewaddress()] = utxo["amount"] - Decimal("0.000010000")
-                raw_tx = self.nodes[0].createrawtransaction(inputs, outputs)
-                txns_to_send.append(self.nodes[0].signrawtransaction(raw_tx))
-
-                # send the transaction
-        for i in range(num_txns):
-            self.nodes[0].sendrawtransaction(txns_to_send[i]["hex"], True)
-        while self.nodes[0].getmempoolinfo()['size'] < num_txns:
-            time.sleep(1)
-
         self.nodes[0].generate(1)
         self.sync_all()
 
+        self.nodes[2].generate(100)
+        self.sync_all()
 
-        #stop and restart nodes
+
+        #stop nodes
         stop_nodes(self.nodes)
         wait_bitcoinds()
 
-        self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-par=1","-rpcservertimeout=0","-debug", "-debug=parallel", "-debug=parallel_2", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-par=1", "-rpcservertimeout=0","-debug", "-debug=parallel", "-debug=parallel_2", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-par=1", "-rpcservertimeout=0","-debug", "-debug=parallel", "-debug=parallel_2", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
-        self.nodes.append(start_node(3, self.options.tmpdir, ["-par=1", "-rpcservertimeout=0","-debug", "-debug=parallel", "-debug=parallel_2", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
+        #restart nodes with -pvtest off and do not yet connect the nodes
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug","-pvtest=0"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug","-pvtest=0"]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug","-pvtest=0"]))
+        self.nodes.append(start_node(3, self.options.tmpdir, ["-debug","-pvtest=0"]))
 
-
-        # create transactions with many inputs
-        print ("Generating even more txns...")
-        num_txns2 = 5
-        self.utxo = self.nodes[0].listunspent()
-        for i in range(num_txns2):
-            inputs = []
-            outputs = {}
-            output_total = Decimal(0)
-            j = 1
-            print ("utxo length " + str(len(self.utxo)))
-            txns_to_send = []
-            while j < 600:
-                utxo = self.utxo.pop()
-                if utxo["amount"] > Decimal("0.0100000") or utxo["amount"] < Decimal("0.0100000"):
-                    continue
-                j = j + 1
-                inputs.append({ "txid" : utxo["txid"], "vout" : utxo["vout"]})
-                output_total = output_total + utxo["amount"]
-            outputs[self.nodes[0].getnewaddress()] = output_total/2 - Decimal("0.001")
-            outputs[self.nodes[0].getnewaddress()] = output_total/2 - Decimal("0.001")
-            raw_tx = self.nodes[0].createrawtransaction(inputs, outputs)
-            txns_to_send.append(self.nodes[0].signrawtransaction(raw_tx))
-    
-            # send the transactions
-            self.nodes[0].sendrawtransaction(txns_to_send[0]["hex"], True)
-
-        # Send big tx's which will now have many inputs
-        num_range = 50
-        for i in range(num_range):
-            self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 1)
-
-        while self.nodes[0].getmempoolinfo()['size'] < (num_txns2 + num_range):
-            time.sleep(1)
+        # Send tx's which do not propagate
+        for i in range(50):
+            self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(), "0.01")
 
         # Send a few transactions from node2 that will get mined so that we will have at least
         # a few inputs to check when the two competing blocks enter parallel validation.
-        for i in range(10):
-            self.nodes[2].sendtoaddress(self.nodes[2].getnewaddress(), "0.01")
+        for i in range(5):
+            self.nodes[2].sendtoaddress(self.nodes[0].getnewaddress(), "0.01")
+ 
 
         # Have node0 and node2 mine the same block which will compete to advance the chaintip when
         # The nodes are connected back together.
         print ("Mine two competing blocks...")
         self.nodes[0].generate(1)
         self.nodes[2].generate(1)
+
+        #stop nodes and restart right away
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+
+        # Restart nodes with pvtest=1
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug","-pvtest=1"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug","-pvtest=1"]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug","-pvtest=1"]))
+
         print ("Connect nodes...")
-        connect_nodes(self.nodes[0],1)
-        #time.sleep(1.2) #add this time in if you have compiled with --enable-debug since you need some extra time for the block to propagate due to the slowness of the build.
-        connect_nodes(self.nodes[1],2)
+        interconnect_nodes(self.nodes)
         sync_blocks(self.nodes[0:3])
 
         # Wait here to make sure a re-org does not happen on node0 so we want to give it some time.  If the 
@@ -280,11 +171,23 @@ class ParallelTest (BitcoinTestFramework):
             assert_not_equal(self.nodes[0].getbestblockhash(), self.nodes[1].getbestblockhash())
             time.sleep(1)
 
+        #stop nodes
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+
+        # Restart nodes with pvtest off.
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug","-pvtest=0"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug","-pvtest=0"]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug","-pvtest=0"]))
+
+        print ("Connect nodes...")
+        interconnect_nodes(self.nodes)
 
         # mine a block on node3 and then connect to the others.  This tests when a third block arrives after
         # the tip has been advanced.
         # this block should propagate to the other nodes but not cause a re-org
         print ("Mine another block...")
+        self.nodes.append(start_node(3, self.options.tmpdir, ["-debug","-pvtest=0"]))
         self.nodes[3].generate(1)
         connect_nodes(self.nodes[1],3)
         sync_blocks(self.nodes)
@@ -321,12 +224,12 @@ class ParallelTest (BitcoinTestFramework):
         wait_bitcoinds()
 
 
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-par=1", "-rpcservertimeout=0", "-debug", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-par=1", "-rpcservertimeout=0","-debug", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-par=1", "-rpcservertimeout=0","-debug", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
-        self.nodes.append(start_node(3, self.options.tmpdir, ["-par=1", "-rpcservertimeout=0","-debug", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
-        self.nodes.append(start_node(4, self.options.tmpdir, ["-par=1", "-rpcservertimeout=0","-debug", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
-        self.nodes.append(start_node(5, self.options.tmpdir, ["-par=1", "-rpcservertimeout=0","-debug", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug","-pvtest=0"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug","-pvtest=0"]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug","-pvtest=0"]))
+        self.nodes.append(start_node(3, self.options.tmpdir, ["-debug","-pvtest=0"]))
+        self.nodes.append(start_node(4, self.options.tmpdir, ["-debug","-pvtest=0"]))
+        self.nodes.append(start_node(5, self.options.tmpdir, ["-debug","-pvtest=0"]))
         connect_nodes(self.nodes[1],0)
         connect_nodes(self.nodes[1],2)
         connect_nodes(self.nodes[1],3)
@@ -354,17 +257,17 @@ class ParallelTest (BitcoinTestFramework):
         wait_bitcoinds()
 
 
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-par=1", "-rpcservertimeout=0","-debug", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-par=1", "-rpcservertimeout=0","-debug", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-par=1", "-rpcservertimeout=0","-debug", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
-        self.nodes.append(start_node(3, self.options.tmpdir, ["-par=1", "-rpcservertimeout=0","-debug", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
-        self.nodes.append(start_node(4, self.options.tmpdir, ["-par=1", "-rpcservertimeout=0","-debug", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
-        self.nodes.append(start_node(5, self.options.tmpdir, ["-par=1", "-rpcservertimeout=0","-debug", "-use-thinblocks=0", "-excessiveblocksize=6000000", "-blockprioritysize=6000000", "-blockmaxsize=6000000"]))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug","-pvtest=0"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug","-pvtest=0"]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-debug","-pvtest=0"]))
+        self.nodes.append(start_node(3, self.options.tmpdir, ["-debug","-pvtest=0"]))
+        self.nodes.append(start_node(4, self.options.tmpdir, ["-debug","-pvtest=0"]))
+        self.nodes.append(start_node(5, self.options.tmpdir, ["-debug","-pvtest=0"]))
 
         print ("Send more transactions...")
         num_range = 50
         for i in range(num_range):
-            self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 0.1)
+            self.nodes[0].sendtoaddress(self.nodes[0].getnewaddress(), 0.01)
         num_range = 10
         for i in range(num_range):
             self.nodes[2].sendtoaddress(self.nodes[2].getnewaddress(), 0.01)


### PR DESCRIPTION
The test was occasionally failing due to a timing issue with
the largest block of a two block race arriving too quickly and
being validated before the small block would show up.  This was
resulting in an assertion being thrown indicating that the small
block did not win the race, when in fact, a race hadn't even
occurred.  Here we set -pvtest=1 to make sure that the validation
of the inputs is done with 1 second thinktimes in order to slow the
validations down and make sure that both blocks arrive before
any block can finish it's own validation.

a chance to have a parallel validation race.