### PR TITLE
Fix thinstats

### DIFF
--- a/src/stat.h
+++ b/src/stat.h
@@ -187,7 +187,7 @@ protected:
 public:
     CStatHistory() : CStat<DataType, RecordType>(), op(STAT_OP_SUM | STAT_KEEP_COUNT), timer(stat_io_service)
     {
-        Clear();
+        Clear(false);
     }
     CStatHistory(const char *name, unsigned int operation = STAT_OP_SUM)
         : CStat<DataType, RecordType>(name), op(operation), timer(stat_io_service)
@@ -215,7 +215,7 @@ public:
         Clear();
     }
 
-    void Clear(void)
+    void Clear(bool fStart = true)
     {
         timerCount = 0;
         sampleCount = 0;
@@ -230,7 +230,9 @@ public:
             }
         total = RecordType();
         this->value = RecordType();
-        Start();
+
+        if (fStart)
+            Start();
     }
 
     virtual ~CStatHistory() {}


### PR DESCRIPTION
Some of the thinstats were getting zero'd out.  The cause appears
to be happening when the constructor calls Clear() and then
starts a timer.