### PR TITLE
Only GetSpendHeight() when we are checking a coinbase spend

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1859,7 +1859,7 @@ int GetSpendHeight(const CCoinsViewCache &inputs)
 
 namespace Consensus
 {
-bool CheckTxInputs(const CTransaction &tx, CValidationState &state, const CCoinsViewCache &inputs, int nSpendHeight)
+bool CheckTxInputs(const CTransaction &tx, CValidationState &state, const CCoinsViewCache &inputs)
 {
     // This doesn't trigger the DoS code on purpose; if it did, it would make it easier
     // for an attacker to attempt to split the network.
@@ -1877,6 +1877,7 @@ bool CheckTxInputs(const CTransaction &tx, CValidationState &state, const CCoins
         // If prev is coinbase, check that it's matured
         if (coin.IsCoinBase())
         {
+            int nSpendHeight = GetSpendHeight(inputs);
             if (nSpendHeight - coin.nHeight < COINBASE_MATURITY)
                 return state.Invalid(false, REJECT_INVALID, "bad-txns-premature-spend-of-coinbase",
                     strprintf("tried to spend coinbase at depth %d", nSpendHeight - coin.nHeight));
@@ -1915,7 +1916,7 @@ bool CheckInputs(const CTransaction &tx,
 {
     if (!tx.IsCoinBase())
     {
-        if (!Consensus::CheckTxInputs(tx, state, inputs, GetSpendHeight(inputs)))
+        if (!Consensus::CheckTxInputs(tx, state, inputs))
             return false;
         if (pvChecks)
             pvChecks->reserve(tx.vin.size());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1868,6 +1868,7 @@ bool CheckTxInputs(const CTransaction &tx, CValidationState &state, const CCoins
 
     CAmount nValueIn = 0;
     CAmount nFees = 0;
+    int nSpendHeight = -1;
     for (unsigned int i = 0; i < tx.vin.size(); i++)
     {
         const COutPoint &prevout = tx.vin[i].prevout;
@@ -1877,7 +1878,8 @@ bool CheckTxInputs(const CTransaction &tx, CValidationState &state, const CCoins
         // If prev is coinbase, check that it's matured
         if (coin.IsCoinBase())
         {
-            int nSpendHeight = GetSpendHeight(inputs);
+            if (nSpendHeight == -1)
+                nSpendHeight = GetSpendHeight(inputs);
             if (nSpendHeight - coin.nHeight < COINBASE_MATURITY)
                 return state.Invalid(false, REJECT_INVALID, "bad-txns-premature-spend-of-coinbase",
                     strprintf("tried to spend coinbase at depth %d", nSpendHeight - coin.nHeight));


### PR DESCRIPTION
This is an expensive operation and also requires a cs_main lock.
There is no need to perform this lookup for every coin; we only
need to do this for a coinbase spend.  For the vast majority
of inputs that are checked, this prevents us from having
to take an unnecessary cs_main lock during PV.