### PR TITLE
Use CASH net magic by default when establishing outgoing conns

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2785,8 +2785,12 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
     nPingUsecStart = 0;
     nPingUsecTime = 0;
     fPingQueued = false;
+#ifdef BITCOIN_CASH
     // set when etablishing connection
+    fUsesCashMagic = true;
+#else
     fUsesCashMagic = false;
+#endif
     nMinPingUsecTime = std::numeric_limits<int64_t>::max();
     thinBlockWaitingForTxns = -1; // BUIP010 Xtreme Thinblocks
     nXthinBloomfilterSize = 0;


### PR DESCRIPTION
title is self explanatory, to apply ***after*** the next release 