### PR TITLE
Don't allow network connections while re-scanning wallet

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -24,6 +24,7 @@
 #include "ui_interface.h"
 #include "unlimited.h"
 #include "utilstrencodings.h"
+#include "wallet/wallet.h"
 
 #ifdef WIN32
 #include <string.h>
@@ -883,6 +884,10 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection)
 
 static void AcceptConnection(const ListenSocket &hListenSocket)
 {
+    // If a wallet rescan has started then do not accept any more connections until the rescan has completed.
+    if (fRescan)
+        return;
+
     struct sockaddr_storage sockaddr;
     socklen_t len = sizeof(sockaddr);
     SOCKET hSocket = accept(hListenSocket.socket, (struct sockaddr *)&sockaddr, &len);

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -19,6 +19,7 @@
 #include "wallet/rpcwallet.h"
 
 #include <algorithm>
+#include <atomic>
 #include <map>
 #include <set>
 #include <stdexcept>
@@ -38,6 +39,8 @@ extern CFeeRate payTxFee;
 extern unsigned int nTxConfirmTarget;
 extern bool bSpendZeroConfChange;
 extern bool fSendFreeTransactions;
+
+extern std::atomic<bool> fRescan;
 
 static const unsigned int DEFAULT_KEYPOOL_SIZE = 100;
 //! -paytxfee default


### PR DESCRIPTION
Fixes issue #718.  The problem we have during a wallet rescan
is that inbound connections were being allowed but then not
getting serviced causing some nodes to rapidly disconnect and
reconnect which then causes a ban due to our DOS prevention.  By not
allowing inbound connections during rescan we avoid this issue.
Furtherore we also disconnect any connections before the scan begins
to prevent connections from becoming stale.

@Justaphf would you be able to test this one out?