### PR TITLE
Remove unnecessary call to nThinblockBytes.load()

### DIFF
--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -1315,9 +1315,9 @@ void CThinBlockData::ClearThinBlockData(CNode *pnode, uint256 hash)
 uint64_t CThinBlockData::AddThinBlockBytes(uint64_t bytes, CNode *pfrom)
 {
     pfrom->nLocalThinBlockBytes += bytes;
-    nThinBlockBytes.fetch_add(bytes);
+    uint64_t ret = nThinBlockBytes.fetch_add(bytes) + bytes;
 
-    return nThinBlockBytes.load();
+    return ret;
 }
 
 void CThinBlockData::DeleteThinBlockBytes(uint64_t bytes, CNode *pfrom)


### PR DESCRIPTION
slight enhancement pointed out by @gandrewstone 