### PR TITLE
[WIP] Correctly calculate the dynamic memory usage for a coin.

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -117,13 +117,18 @@ void CCoinsViewCache::SpendCoin(const COutPoint &outpoint, Coin* moveout) {
     LOCK(cs_utxo);
     CCoinsMap::iterator it = FetchCoin(outpoint);
     if (it == cacheCoins.end()) return;
-    cachedCoinsUsage -= it->second.coin.DynamicMemoryUsage();
     if (moveout) {
         *moveout = std::move(it->second.coin);
     }
-    if (it->second.flags & CCoinsCacheEntry::FRESH) {
+    if (it->second.flags & CCoinsCacheEntry::FRESH)
+    {
+        cachedCoinsUsage -= it->second.coin.DynamicMemoryUsage();
         cacheCoins.erase(it);
-    } else {
+    }
+    else
+    {
+        // The coin is about to be cleared so delete the size of the scriptPubKey
+        cachedCoinsUsage -= memusage::DynamicUsage(it->second.coin.out.scriptPubKey);
         it->second.flags |= CCoinsCacheEntry::DIRTY;
         it->second.coin.Clear();
     }

--- a/src/coins.h
+++ b/src/coins.h
@@ -96,7 +96,8 @@ public:
     }
 
     size_t DynamicMemoryUsage() const {
-        return memusage::DynamicUsage(out.scriptPubKey);
+        // return the sum of sizes for out.scriptPubKey, out.nValue, nHeight and fCoinbase.
+        return memusage::DynamicUsage(out.scriptPubKey) + sizeof(int64_t) + sizeof(uint32_t) + sizeof(unsigned int);
     }
 };
 


### PR DESCRIPTION
The coin size was being underestimated and was returning only
the size of the scriptPubKey but not the internal storage for
traking height, coinbase and also Amount.