### PR TITLE
Make fRescan a global var

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -56,6 +56,7 @@ boost::thread_specific_ptr<LockStack> lockstack;
 
 
 std::atomic<bool> fIsInitialBlockDownload{false};
+std::atomic<bool> fRescan{false}; // this flag is set to true when a wallet rescan has been invoked.
 
 // main.cpp CriticalSections:
 CCriticalSection cs_LastBlockFile;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -24,7 +24,6 @@
 #include "ui_interface.h"
 #include "unlimited.h"
 #include "utilstrencodings.h"
-#include "wallet/wallet.h"
 
 #ifdef WIN32
 #include <string.h>
@@ -67,6 +66,8 @@
 #define IPV6_PROTECTION_LEVEL 23
 #endif
 #endif
+
+extern std::atomic<bool> fRescan;
 
 using namespace std;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -43,8 +43,6 @@ unsigned int nTxConfirmTarget = DEFAULT_TX_CONFIRM_TARGET;
 bool bSpendZeroConfChange = DEFAULT_SPEND_ZEROCONF_CHANGE;
 bool fSendFreeTransactions = DEFAULT_SEND_FREE_TRANSACTIONS;
 
-std::atomic<bool> fRescan{false}; // this flag is set to true when a wallet rescan has been invoked.
-
 const char * DEFAULT_WALLET_DAT = "wallet.dat";
 
 /**


### PR DESCRIPTION
This is so that we can still compile when wallet is disabled.