### PR TITLE
Update thinblock timeout to be responsive to blkReqRetryInterval

### DIFF
--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -46,8 +46,11 @@ unsigned int ACCEPTABLE_PING_USEC = 25 * 1000;
 
 // When should I request an object from someone else (in microseconds)
 unsigned int MIN_TX_REQUEST_RETRY_INTERVAL = DEFAULT_MIN_TX_REQUEST_RETRY_INTERVAL;
+unsigned int txReqRetryInterval = MIN_TX_REQUEST_RETRY_INTERVAL;
 // When should I request a block from someone else (in microseconds)
 unsigned int MIN_BLK_REQUEST_RETRY_INTERVAL = DEFAULT_MIN_BLK_REQUEST_RETRY_INTERVAL;
+unsigned int blkReqRetryInterval = MIN_BLK_REQUEST_RETRY_INTERVAL;
+
 
 // defined in main.cpp.  should be moved into a utilities file but want to make rebasing easier
 extern bool CanDirectFetch(const Consensus::Params &consensusParams);

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -29,14 +29,13 @@ successful receipt, "requester.Rejected(...)" to indicate a bad object (request 
 #include "net.h"
 #include "stat.h"
 // When should I request a tx from someone else (in microseconds). cmdline/bitcoin.conf: -txretryinterval
+extern unsigned int txReqRetryInterval;
 extern unsigned int MIN_TX_REQUEST_RETRY_INTERVAL;
 static const unsigned int DEFAULT_MIN_TX_REQUEST_RETRY_INTERVAL = 5 * 1000 * 1000;
 // When should I request a block from someone else (in microseconds). cmdline/bitcoin.conf: -blkretryinterval
+extern unsigned int blkReqRetryInterval;
 extern unsigned int MIN_BLK_REQUEST_RETRY_INTERVAL;
 static const unsigned int DEFAULT_MIN_BLK_REQUEST_RETRY_INTERVAL = 5 * 1000 * 1000;
-
-// How long in seconds we wait for a xthin request to be fullfilled before disconnecting the node.
-static const unsigned int THINBLOCK_DOWNLOAD_TIMEOUT = 30;
 
 class CNode;
 

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -10,6 +10,7 @@
 #include "primitives/block.h"
 #include "protocol.h"
 #include "random.h"
+#include "requestManager.h"
 #include "serialize.h"
 #include "streams.h"
 #include "streams.h"
@@ -1019,6 +1020,55 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         vNodes.pop_back();
         dummyNode9.mapThinBlocksInFlight.erase(TestBlock1().GetHash());
 
+
+        /*
+         * Test the disconnection of a peers with thinblocks in flight that has gone over the timeout limit
+         */
+        {
+            int64_t nStartTime = GetTime();
+            uint256 hash1 = uint256S("3fba505b48865fccda4e248cecc39d5dfbc6b8ef7b4adc9cd27242c1193c7141");
+            uint256 hash2 = uint256S("3fba505b48865fccda4e248cecc39d5dfbc6b8ef7b4adc9cd27242c1193c7142");
+
+            CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
+            dummyNode1.fDisconnect = false;
+            dummyNode1.fSuccessfullyConnected = true;
+
+            CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
+            dummyNode2.fDisconnect = false;
+            dummyNode2.fSuccessfullyConnected = true;
+
+            SetMockTime(nStartTime);
+            AddThinBlockInFlight(&dummyNode1, hash1);
+            SetMockTime(nStartTime + 1);
+            AddThinBlockInFlight(&dummyNode1, hash2);
+            SetMockTime(nStartTime + 1);
+            AddThinBlockInFlight(&dummyNode2, hash1);
+
+            // Move clock forward to the boundary of the timeout interval
+            // No nodes should be disconnected.
+            SetMockTime(nStartTime + (6 * blkReqRetryInterval / 1000000));
+            SendMessages(&dummyNode1);
+            SendMessages(&dummyNode2);
+            BOOST_CHECK(!dummyNode1.fDisconnect);
+            BOOST_CHECK(!dummyNode2.fDisconnect);
+
+
+            // Move clock forward to 1 second past the boundary of the timeout interval
+            // DummyNode1 should be disconnected
+            // DummyNode2 should still be connected because it was added one second later.
+            SetMockTime(nStartTime + (6 * blkReqRetryInterval / 1000000) + 1);
+            SendMessages(&dummyNode1);
+            SendMessages(&dummyNode2);
+            BOOST_CHECK(dummyNode1.fDisconnect);
+            BOOST_CHECK(!dummyNode2.fDisconnect);
+
+            // Move clock forward to 1 second past the boundary of the timeout interval
+            // DummyNode2 should now be disconnected
+            SetMockTime(nStartTime + (6 * blkReqRetryInterval / 1000000) + 2);
+            SendMessages(&dummyNode2);
+            BOOST_CHECK(dummyNode2.fDisconnect);
+        }
+
         excessiveBlockSize = old_excessiveBlockSize; // reset
 
         // cleanup received queues
@@ -1027,9 +1077,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         vRecv3.clear();
         vRecv4.clear();
         vRecv5.clear();
-        printf("test complete, cleaning up nodes\n");
     }
-    printf("node cleanup completed\n");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Rather than hardcoding a timeout, use the blkReqRetryInterval which
is a config option as well as a tweak and which can dynamically change
depending on whether rate limiting is in effect.