### PR TITLE
Trim coin cache by coin height

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -309,7 +309,7 @@ void CCoinsViewCache::Trim(size_t nTrimSize) const
     // This has been proven to improve sync performance significantly for nodes that can not hold the entire dbcache
     // in memory.
     bool fDone = false;
-    int nSmallestDelta = 50; // number of blocks to adjust trim height by
+    uint64_t nSmallestDelta = 50; // number of blocks to adjust trim height by
     CCoinsMap::iterator iter = cacheCoins.begin();
     while (!fDone && DynamicMemoryUsage() > nTrimSize)
     {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -310,13 +310,14 @@ void CCoinsViewCache::Trim(size_t nTrimSize) const
     // in memory.
     bool fDone = false;
     int nSmallestDelta = 100;
+    CCoinsMap::iterator iter = cacheCoins.begin();
     while (!fDone && DynamicMemoryUsage() > nTrimSize)
     {
         LogPrint("coindb", "cacheCoinsUsage at start: %d total dynamic usage: %d trim to size: %d nBestCoinHeight: %d "
                            "trim height:%d\n",
             cachedCoinsUsage, DynamicMemoryUsage(), nTrimSize, nBestCoinHeight, nTrimHeight);
 
-        CCoinsMap::iterator iter = cacheCoins.begin();
+        iter = cacheCoins.begin();
         while (DynamicMemoryUsage() > nTrimSize)
         {
             if (iter == cacheCoins.end())
@@ -359,7 +360,6 @@ void CCoinsViewCache::Trim(size_t nTrimSize) const
     // If trimming by coin height failed to find any or enough coins to trim then trim the cache further by ignoring
     // coin height.
     // While this is not ideal we still have to trim to keep the cache from growing unbounded.
-    CCoinsMap::iterator iter = cacheCoins.begin();
     iter = cacheCoins.begin();
     while (DynamicMemoryUsage() > nTrimSize)
     {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -303,7 +303,7 @@ void CCoinsViewCache::Trim(size_t nTrimSize) const
     uint64_t nTrimmed = 0;
     uint64_t nTrimmedByHeight = 0;
     static uint64_t nTrimHeightDelta = nBestCoinHeight * 0.80; // This is where we attempt to do our first trim
-    int64_t nTrimHeight = nBestCoinHeight - nTrimHeightDelta;
+    uint64_t nTrimHeight = nBestCoinHeight - nTrimHeightDelta;
 
     // Begin first Trim loop. This loop will trim coins from cache by the coin height, removing the oldest coins first.
     // This has been proven to improve sync performance significantly for nodes that can not hold the entire dbcache
@@ -342,13 +342,16 @@ void CCoinsViewCache::Trim(size_t nTrimSize) const
         if (fDone && DynamicMemoryUsage() > nTrimSize && nTrimHeightDelta > nSmallestDelta)
         {
             if (nTrimHeightDelta <= nSmallestDelta * 100)
-                nTrimHeightDelta -= (nSmallestDelta * 2);
+                nTrimHeightDelta =
+                    (nTrimHeightDelta > (nSmallestDelta * 2) ? nTrimHeightDelta - (nSmallestDelta * 2) : 0);
             else if (nTrimHeightDelta <= nSmallestDelta * 400)
-                nTrimHeightDelta -= (nSmallestDelta * 10);
+                nTrimHeightDelta =
+                    (nTrimHeightDelta > (nSmallestDelta * 10) ? nTrimHeightDelta - (nSmallestDelta * 10) : 0);
             else
-                nTrimHeightDelta -= (nSmallestDelta * 200);
+                nTrimHeightDelta =
+                    (nTrimHeightDelta > (nSmallestDelta * 200) ? nTrimHeightDelta - (nSmallestDelta * 200) : 0);
 
-            nTrimHeight = nBestCoinHeight - nTrimHeightDelta;
+            nTrimHeight = (nBestCoinHeight > nTrimHeightDelta ? nBestCoinHeight - nTrimHeightDelta : 0);
 
             // We're not done yet. We've adjusted the nTrimHeight so we have to go back and trim again.
             fDone = false;

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -15,14 +15,26 @@
 bool CCoinsView::GetCoin(const COutPoint &outpoint, Coin &coin) const { return false; }
 bool CCoinsView::HaveCoin(const COutPoint &outpoint) const { return false; }
 uint256 CCoinsView::GetBestBlock() const { return uint256(); }
-bool CCoinsView::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, const uint64_t nBestCoinHeight, size_t &nChildCachedCoinsUsage) { return false; }
+bool CCoinsView::BatchWrite(CCoinsMap &mapCoins,
+    const uint256 &hashBlock,
+    const uint64_t nBestCoinHeight,
+    size_t &nChildCachedCoinsUsage)
+{
+    return false;
+}
 CCoinsViewCursor *CCoinsView::Cursor() const { return nullptr; }
 CCoinsViewBacked::CCoinsViewBacked(CCoinsView *viewIn) : base(viewIn) {}
 bool CCoinsViewBacked::GetCoin(const COutPoint &outpoint, Coin &coin) const { return base->GetCoin(outpoint, coin); }
 bool CCoinsViewBacked::HaveCoin(const COutPoint &outpoint) const { return base->HaveCoin(outpoint); }
 uint256 CCoinsViewBacked::GetBestBlock() const { return base->GetBestBlock(); }
 void CCoinsViewBacked::SetBackend(CCoinsView &viewIn) { base = &viewIn; }
-bool CCoinsViewBacked::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, const uint64_t nBestCoinHeight, size_t &nChildCachedCoinsUsage) { return base->BatchWrite(mapCoins, hashBlock,  nBestCoinHeight, nChildCachedCoinsUsage); }
+bool CCoinsViewBacked::BatchWrite(CCoinsMap &mapCoins,
+    const uint256 &hashBlock,
+    const uint64_t nBestCoinHeight,
+    size_t &nChildCachedCoinsUsage)
+{
+    return base->BatchWrite(mapCoins, hashBlock, nBestCoinHeight, nChildCachedCoinsUsage);
+}
 CCoinsViewCursor *CCoinsViewBacked::Cursor() const { return base->Cursor(); }
 size_t CCoinsViewBacked::EstimateSize() const { return base->EstimateSize(); }
 SaltedOutpointHasher::SaltedOutpointHasher()
@@ -30,9 +42,12 @@ SaltedOutpointHasher::SaltedOutpointHasher()
 {
 }
 
-CCoinsViewCache::CCoinsViewCache(CCoinsView *baseIn) : CCoinsViewBacked(baseIn), nBestCoinHeight(0), cachedCoinsUsage(0) {}
+CCoinsViewCache::CCoinsViewCache(CCoinsView *baseIn) : CCoinsViewBacked(baseIn), nBestCoinHeight(0), cachedCoinsUsage(0)
+{
+}
 
-size_t CCoinsViewCache::DynamicMemoryUsage() const {
+size_t CCoinsViewCache::DynamicMemoryUsage() const
+{
     LOCK(cs_utxo);
     return memusage::DynamicUsage(cacheCoins) + cachedCoinsUsage;
 }
@@ -199,12 +214,14 @@ void CCoinsViewCache::SetBestBlock(const uint256 &hashBlockIn)
     hashBlock = hashBlockIn;
 }
 
-bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlockIn, const uint64_t nBestCoinHeightIn, size_t &nChildCachedCoinsUsage)
+bool CCoinsViewCache::BatchWrite(CCoinsMap &mapCoins,
+    const uint256 &hashBlockIn,
+    const uint64_t nBestCoinHeightIn,
+    size_t &nChildCachedCoinsUsage)
 {
     LOCK(cs_utxo);
     for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();)
     {
-        
         if (it->second.flags & CCoinsCacheEntry::DIRTY)
         { // Ignore non-dirty entries (optimization).
             // Update usage of the child cache before we do any swapping and deleting
@@ -295,8 +312,9 @@ void CCoinsViewCache::Trim(size_t nTrimSize) const
     int nSmallestDelta = 100;
     while (!fDone && DynamicMemoryUsage() > nTrimSize)
     {
-        LogPrint("coindb", "cacheCoinsUsage at start: %d total dynamic usage: %d trim to size: %d nBestCoinHeight: %d trim height:%d\n", 
-                  cachedCoinsUsage, DynamicMemoryUsage(), nTrimSize, nBestCoinHeight, nTrimHeight);
+        LogPrint("coindb", "cacheCoinsUsage at start: %d total dynamic usage: %d trim to size: %d nBestCoinHeight: %d "
+                           "trim height:%d\n",
+            cachedCoinsUsage, DynamicMemoryUsage(), nTrimSize, nBestCoinHeight, nTrimHeight);
 
         CCoinsMap::iterator iter = cacheCoins.begin();
         while (DynamicMemoryUsage() > nTrimSize)
@@ -330,13 +348,16 @@ void CCoinsViewCache::Trim(size_t nTrimSize) const
                 nTrimHeightDelta -= (nSmallestDelta * 100);
 
             nTrimHeight = nBestCoinHeight - nTrimHeightDelta;
-            fDone = false; // we're not done yet we have adjusted the nTrimHeight downward so we have to go back and trim again.
+            // we're not done yet we have adjusted the nTrimHeight downward so we have to go back and trim again.
+            fDone = false;
 
-            LogPrint("coindb", "Re-adjusting trim height to %d using a trim height delta of %d\n", nTrimHeight, nTrimHeightDelta);
+            LogPrint("coindb", "Re-adjusting trim height to %d using a trim height delta of %d\n", nTrimHeight,
+                nTrimHeightDelta);
         }
     }
 
-    // If trimming by coin height failed to find any or enough coins to trim then trim the cache further by ignoring coin height.
+    // If trimming by coin height failed to find any or enough coins to trim then trim the cache further by ignoring
+    // coin height.
     // While this is not ideal we still have to trim to keep the cache from growing unbounded.
     CCoinsMap::iterator iter = cacheCoins.begin();
     iter = cacheCoins.begin();
@@ -370,7 +391,8 @@ void CCoinsViewCache::Trim(size_t nTrimSize) const
     {
         nTrimHeightDelta += (nSmallestDelta >> 1);
         nTrimHeight = nBestCoinHeight - nTrimHeightDelta;
-        LogPrint("coindb", "Re-adjusting trim height to %d using a trim height delta of %d\n", nTrimHeight, nTrimHeightDelta);
+        LogPrint("coindb", "Re-adjusting trim height to %d using a trim height delta of %d\n", nTrimHeight,
+            nTrimHeightDelta);
     }
 }
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -175,7 +175,7 @@ public:
 
     //! Do a bulk modification (multiple Coin changes + BestBlock change).
     //! The passed mapCoins can be modified.
-    virtual bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, size_t &nChildCachedCoinsUsage);
+    virtual bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, const uint64_t bestCoinHeight, size_t &nChildCachedCoinsUsage);
 
     //! Get a cursor to iterate over the whole state
     virtual CCoinsViewCursor *Cursor() const;
@@ -199,7 +199,7 @@ public:
     bool HaveCoin(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
     void SetBackend(CCoinsView &viewIn);
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, size_t &nChildCachedCoinsUsage) override;
+    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, const uint64_t nBestCoinHeight, size_t &nChildCachedCoinsUsage) override;
     CCoinsViewCursor *Cursor() const override;
     size_t EstimateSize() const override;
 };
@@ -214,10 +214,12 @@ protected:
      * declared as "const".
      */
     mutable uint256 hashBlock;
+    mutable uint64_t nBestCoinHeight;
     mutable CCoinsMap cacheCoins;
 
     /* Cached dynamic memory usage for the inner Coin objects. */
     mutable size_t cachedCoinsUsage;
+
 
 public:
     CCoinsViewCache(CCoinsView *baseIn);
@@ -227,7 +229,7 @@ public:
     bool HaveCoin(const COutPoint &outpoint) const;
     uint256 GetBestBlock() const;
     void SetBestBlock(const uint256 &hashBlock);
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, size_t &nChildCachedCoinsUsage);
+    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, const uint64_t nBestCoinHeight, size_t &nChildCachedCoinsUsage);
 
     /**
      * Check if we have the given utxo already loaded in this cache.

--- a/src/coins.h
+++ b/src/coins.h
@@ -111,12 +111,7 @@ private:
 public:
     SaltedOutpointHasher();
 
-    /**
-     * This *must* return size_t. With Boost 1.46 on 32-bit systems the
-     * unordered_map will behave unpredictably if the custom hasher returns a
-     * uint64_t, resulting in failures when syncing the chain (#4634).
-     */
-    size_t operator()(const COutPoint &id) const { return SipHashUint256Extra(k0, k1, id.hash, id.n); }
+    uint64_t operator()(const COutPoint& id) const { return SipHashUint256Extra(k0, k1, id.hash, id.n); }
 };
 
 struct CCoinsCacheEntry

--- a/src/coins.h
+++ b/src/coins.h
@@ -111,7 +111,7 @@ private:
 public:
     SaltedOutpointHasher();
 
-    uint64_t operator()(const COutPoint& id) const { return SipHashUint256Extra(k0, k1, id.hash, id.n); }
+    uint64_t operator()(const COutPoint &id) const { return SipHashUint256Extra(k0, k1, id.hash, id.n); }
 };
 
 struct CCoinsCacheEntry
@@ -170,7 +170,10 @@ public:
 
     //! Do a bulk modification (multiple Coin changes + BestBlock change).
     //! The passed mapCoins can be modified.
-    virtual bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, const uint64_t bestCoinHeight, size_t &nChildCachedCoinsUsage);
+    virtual bool BatchWrite(CCoinsMap &mapCoins,
+        const uint256 &hashBlock,
+        const uint64_t bestCoinHeight,
+        size_t &nChildCachedCoinsUsage);
 
     //! Get a cursor to iterate over the whole state
     virtual CCoinsViewCursor *Cursor() const;
@@ -194,7 +197,10 @@ public:
     bool HaveCoin(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
     void SetBackend(CCoinsView &viewIn);
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, const uint64_t nBestCoinHeight, size_t &nChildCachedCoinsUsage) override;
+    bool BatchWrite(CCoinsMap &mapCoins,
+        const uint256 &hashBlock,
+        const uint64_t nBestCoinHeight,
+        size_t &nChildCachedCoinsUsage) override;
     CCoinsViewCursor *Cursor() const override;
     size_t EstimateSize() const override;
 };
@@ -224,7 +230,10 @@ public:
     bool HaveCoin(const COutPoint &outpoint) const;
     uint256 GetBestBlock() const;
     void SetBestBlock(const uint256 &hashBlock);
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, const uint64_t nBestCoinHeight, size_t &nChildCachedCoinsUsage);
+    bool BatchWrite(CCoinsMap &mapCoins,
+        const uint256 &hashBlock,
+        const uint64_t nBestCoinHeight,
+        size_t &nChildCachedCoinsUsage);
 
     /**
      * Check if we have the given utxo already loaded in this cache.

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -205,6 +205,13 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
             uncached_an_entry |= !stack[cacheid]->HaveCoinInCache(out);
         }
 
+        // One every 500 iterations, trim a random cache to zero
+        if (insecure_rand() % 500)
+        {
+            int cacheid = insecure_rand() % stack.size();
+            stack[cacheid]->Trim(0);
+        }
+
         // Once every 1000 iterations and at the end, verify the full cache.
         if (insecure_rand() % 1000 == 1 || i == NUM_SIMULATION_ITERATIONS - 1)
         {

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -63,7 +63,8 @@ public:
     }
 
     uint256 GetBestBlock() const { return hashBestBlock_; }
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, size_t &nChildCachedCoinsUsage)
+
+    bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock, const uint64_t nBestCoinHeight, size_t &nChildCachedCoinsUsage)
     {
         for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();)
         {
@@ -453,7 +454,8 @@ void WriteCoinsViewEntry(CCoinsView &view, CAmount value, char flags)
     uint256 hash;
     hash.SetNull();
     size_t cacheusage = 0;
-    view.BatchWrite(map, hash, cacheusage);
+    uint64_t bestCoinHeight = 0;
+    view.BatchWrite(map, hash, bestCoinHeight, cacheusage);
 }
 
 class SingleEntryCacheTest

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -63,8 +63,10 @@ public:
     }
 
     uint256 GetBestBlock() const { return hashBestBlock_; }
-
-    bool BatchWrite(CCoinsMap& mapCoins, const uint256& hashBlock, const uint64_t nBestCoinHeight, size_t &nChildCachedCoinsUsage)
+    bool BatchWrite(CCoinsMap &mapCoins,
+        const uint256 &hashBlock,
+        const uint64_t nBestCoinHeight,
+        size_t &nChildCachedCoinsUsage)
     {
         for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();)
         {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -70,7 +70,10 @@ uint256 CCoinsViewDB::GetBestBlock() const
     return hashBestChain;
 }
 
-bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, const uint64_t nBestCoinHeight, size_t &nChildCachedCoinsUsage)
+bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
+    const uint256 &hashBlock,
+    const uint64_t nBestCoinHeight,
+    size_t &nChildCachedCoinsUsage)
 {
     LOCK(cs_utxo);
     CDBBatch batch(db);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -70,7 +70,7 @@ uint256 CCoinsViewDB::GetBestBlock() const
     return hashBestChain;
 }
 
-bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, size_t &nChildCachedCoinsUsage)
+bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, const uint64_t nBestCoinHeight, size_t &nChildCachedCoinsUsage)
 {
     LOCK(cs_utxo);
     CDBBatch batch(db);
@@ -78,6 +78,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, siz
     size_t changed = 0;
     size_t nBatchSize = 0;
     size_t nBatchWrites = 0;
+
     for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();)
     {
         if (it->second.flags & CCoinsCacheEntry::DIRTY)

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -78,7 +78,10 @@ public:
     bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
     bool HaveCoin(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, const uint64_t nBestCoinHeight, size_t &nChildCachedCoinsUsage) override;
+    bool BatchWrite(CCoinsMap &mapCoins,
+        const uint256 &hashBlock,
+        const uint64_t nBestCoinHeight,
+        size_t &nChildCachedCoinsUsage) override;
     CCoinsViewCursor *Cursor() const override;
 
     //! Attempt to update from an older database format. Returns whether an error occurred.

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -72,14 +72,13 @@ class CCoinsViewDB : public CCoinsView
 protected:
     CDBWrapper db;
 
-
 public:
     CCoinsViewDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
 
     bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
     bool HaveCoin(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const override;
-    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, size_t &nChildCachedCoinsUsage) override;
+    bool BatchWrite(CCoinsMap &mapCoins, const uint256 &hashBlock, const uint64_t nBestCoinHeight, size_t &nChildCachedCoinsUsage) override;
     CCoinsViewCursor *Cursor() const override;
 
     //! Attempt to update from an older database format. Returns whether an error occurred.


### PR DESCRIPTION
According to @gandrewstone 's recent study, newer coins are more likely to be mined than older coins.  So, if the coins cache is full then we'll trim older coins first.