### PR TITLE
[WIP] Enforce extra stack element after OP_CHECKMULTISIG{VERIFY} to be empty

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2504,6 +2504,7 @@ bool ConnectBlock(const CBlock &block,
     if (IsCashHFEnabled(chainparams, pindex->pprev))
     {
         flags |= SCRIPT_VERIFY_LOW_S;
+        flags |= SCRIPT_VERIFY_NULLDUMMY;
         flags |= SCRIPT_VERIFY_NULLFAIL;
     }
 #endif


### PR DESCRIPTION
See BIP 147 for more details:

https://github.com/bitcoin/bips/blob/master/bip-0147.mediawiki

the logic is the same but the change s deployed via HF rather
than SF. 

This PR is stacked on top of #813 and #814.

edit: **not to be included in the next release**