### PR TITLE
Only request blocks via HEADERS and not by INV

### DIFF
--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -408,6 +408,8 @@ class SendHeadersTest(BitcoinTestFramework):
                 if j == 0:
                     # Announce via inv
                     test_node.send_block_inv(tip)
+                    test_node.wait_for_getheaders()
+                    test_node.send_header_for_blocks(blocks)
                     test_node.wait_for_getdata([tip], timeout=5)
                     # Test that duplicate inv's won't result in duplicate
                     # getdata requests, or duplicate headers announcements

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6066,7 +6066,12 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                 if ((!fAlreadyHave && !IsInitialBlockDownload()) ||
                     (!fAlreadyHave && Params().NetworkIDString() == "regtest"))
                 {
-                    requester.AskFor(inv, pfrom);
+                    // Since we now only rely on headers for block requests, if we get an INV from an older node or
+                    // if there was a very large re-org which resulted in a revert to block announcements via INV,
+                    // we will instead request the header rather than the block.  This is safer and prevents an
+                    // attacker from sending us fake INV's for blocks that do not exist or try to get us to request
+                    // and download fake blocks.
+                    pfrom->PushMessage(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexBestHeader), inv.hash);
                 }
                 else
                 {


### PR DESCRIPTION
We no longer request blocks by INV but instead issue a GETHEADERS
request if an older node sends us block announcements via INV.