### PR TITLE
Improve uncaching of coins

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -315,6 +315,12 @@ void CCoinsViewCache::Uncache(const COutPoint &hash)
     }
 }
 
+void CCoinsViewCache::UncacheTx(const CTransaction &tx)
+{
+    for (const CTxIn &txin : tx.vin)
+        Uncache(txin.prevout);
+}
+
 unsigned int CCoinsViewCache::GetCacheSize() const
 {
     LOCK(cs_utxo);

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -308,6 +308,8 @@ void CCoinsViewCache::Uncache(const COutPoint &hash)
 {
     LOCK(cs_utxo);
     CCoinsMap::iterator it = cacheCoins.find(hash);
+
+    // only uncache coins that are not dirty.
     if (it != cacheCoins.end() && it->second.flags == 0)
     {
         cachedCoinsUsage -= it->second.coin.DynamicMemoryUsage();

--- a/src/coins.h
+++ b/src/coins.h
@@ -277,6 +277,12 @@ public:
      */
     void Uncache(const COutPoint &outpoint);
 
+    /**
+     * Removes all the UTXO outpoints for a given transaction, if they are
+     * not modified.
+     */
+    void UncacheTx(const CTransaction &tx);
+
     //! Calculate the size of the cache (in number of transaction outputs)
     unsigned int GetCacheSize() const;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -751,7 +751,6 @@ void EraseOrphanTx(uint256 hash) EXCLUSIVE_LOCKS_REQUIRED(cs_orphancache)
 void EraseOrphansByTime() EXCLUSIVE_LOCKS_REQUIRED(cs_orphancache)
 {
     AssertLockHeld(cs_orphancache);
-
     // Because we have to iterate through the entire orphan cache which can be large we don't want to check this
     // every time a tx enters the mempool but just once every 5 minutes is good enough.
     if (GetTime() < nLastOrphanCheck + 5 * 60)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -767,8 +767,7 @@ void EraseOrphansByTime() EXCLUSIVE_LOCKS_REQUIRED(cs_orphancache)
             uint256 txHash = mi->second.tx.GetHash();
 
             // Uncache any coins that may exist for orphans that will be erased
-            for (const CTxIn &txin : mi->second.tx.vin)
-                pcoinsTip->Uncache(txin.prevout);
+            pcoinsTip->UncacheTx(mi->second.tx);
 
             LogPrint(
                 "mempool", "Erased old orphan tx %s of age %d seconds\n", txHash.ToString(), GetTime() - nEntryTime);
@@ -797,8 +796,7 @@ unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans, uint64_t nMaxBytes) EXC
             it = mapOrphanTransactions.begin();
 
         // Uncache any coins that may exist for orphans that will be erased
-        for (const CTxIn &txin : it->second.tx.vin)
-            pcoinsTip->Uncache(txin.prevout);
+        pcoinsTip->UncacheTx(it->second.tx);
 
         EraseOrphanTx(it->first);
         ++nEvicted;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1182,8 +1182,6 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
     unsigned int nSize = 0;
     uint64_t start = GetTimeMicros();
     AssertLockHeld(cs_main);
-    if (pfMissingInputs)
-        *pfMissingInputs = false;
 
     if (!CheckTransaction(tx, state))
         return false;
@@ -1259,20 +1257,18 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
             // do all inputs exist?
             if (pfMissingInputs)
             {
+                *pfMissingInputs = false;
                 BOOST_FOREACH (const CTxIn txin, tx.vin)
                 {
                     // At this point we begin to collect coins that are potential candidates for uncaching because as
                     // soon as we make the call below to view.HaveCoin() any missing coins will be pulled into cache.
                     // Therefore, any coin in this transaction that is not already in cache will be tracked here such
-                    // that
-                    // if this transaction fails to enter the memory pool, we will then uncache those coins that were
-                    // not
-                    // already present, unless the transaction is an orphan.
+                    // that if this transaction fails to enter the memory pool, we will then uncache those coins that
+                    // were not already present, unless the transaction is an orphan.
                     //
                     // We still want to keep orphantx coins in the event the orphantx is finally accepted into the
-                    // mempool
-                    // or shows up in a block that is mined.  Therefore if pfMissingInputs returns true then any coins
-                    // in vCoinsToUncache will NOT be uncached.
+                    // mempool or shows up in a block that is mined.  Therefore if pfMissingInputs returns true then
+                    // any coins in vCoinsToUncache will NOT be uncached.
                     if (!pcoinsTip->HaveCoinInCache(txin.prevout))
                     {
                         vCoinsToUncache.push_back(txin.prevout);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1279,10 +1279,10 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
                     // fMissingInputs and not state.IsInvalid() is used to detect this condition, don't set
                     // state.Invalid()
                     *pfMissingInputs = true;
-
-                    return false;
                 }
             }
+            if (*pfMissingInputs == true)
+                return false;
 
             // Bring the best block into scope
             view.GetBestBlock();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1532,8 +1532,8 @@ bool AcceptToMemoryPool(CTxMemPool &pool,
     if (!res && !*pfMissingInputs)
     {
         // Uncache any coins for txns that failed to enter the mempool but we're NOT orphan txns
-        for (const CTxIn &txin : tx.vin)
-            pcoinsTip->Uncache(txin.prevout);
+        for (const COutPoint &remove : vCoinsToUncache)
+            pcoinsTip->Uncache(remove);
     }
 
     return res;
@@ -3067,7 +3067,8 @@ bool static DisconnectTip(CValidationState &state, const Consensus::Params &cons
         // ignore validation errors in resurrected transactions
         std::list<CTransaction> removed;
         CValidationState stateDummy;
-        if (tx.IsCoinBase() || !AcceptToMemoryPool(mempool, stateDummy, tx, false, NULL, true))
+        bool fMissingInputsDummy = false;
+        if (tx.IsCoinBase() || !AcceptToMemoryPool(mempool, stateDummy, tx, false, &fMissingInputsDummy, true))
         {
             mempool.remove(tx, removed, true);
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1259,31 +1259,34 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
             // do all inputs exist?
             if (pfMissingInputs)
             {
-            BOOST_FOREACH (const CTxIn txin, tx.vin)
-            {
-                // At this point we begin to collect coins that are potential candidates for uncaching because as
-                // soon as we make the call below to view.HaveCoin() any missing coins will be pulled into cache.
-                // Therefore, any coin in this transaction that is not already in cache will be tracked here such that
-                // if this transaction fails to enter the memory pool, we will then uncache those coins that were not
-                // already present, unless the transaction is an orphan.
-                //
-                // We still want to keep orphantx coins in the event the orphantx is finally accepted into the mempool
-                // or shows up in a block that is mined.  Therefore if pfMissingInputs returns true then any coins
-                // in vCoinsToUncache will NOT be uncached.
-                if (!pcoinsTip->HaveCoinInCache(txin.prevout))
+                BOOST_FOREACH (const CTxIn txin, tx.vin)
                 {
-                    vCoinsToUncache.push_back(txin.prevout);
-                }
+                    // At this point we begin to collect coins that are potential candidates for uncaching because as
+                    // soon as we make the call below to view.HaveCoin() any missing coins will be pulled into cache.
+                    // Therefore, any coin in this transaction that is not already in cache will be tracked here such
+                    // that
+                    // if this transaction fails to enter the memory pool, we will then uncache those coins that were
+                    // not
+                    // already present, unless the transaction is an orphan.
+                    //
+                    // We still want to keep orphantx coins in the event the orphantx is finally accepted into the
+                    // mempool
+                    // or shows up in a block that is mined.  Therefore if pfMissingInputs returns true then any coins
+                    // in vCoinsToUncache will NOT be uncached.
+                    if (!pcoinsTip->HaveCoinInCache(txin.prevout))
+                    {
+                        vCoinsToUncache.push_back(txin.prevout);
+                    }
 
-                if (!view.HaveCoin(txin.prevout))
-                {
-                    // fMissingInputs and not state.IsInvalid() is used to detect this condition, don't set
-                    // state.Invalid()
-                    *pfMissingInputs = true;
+                    if (!view.HaveCoin(txin.prevout))
+                    {
+                        // fMissingInputs and not state.IsInvalid() is used to detect this condition, don't set
+                        // state.Invalid()
+                        *pfMissingInputs = true;
+                    }
                 }
-            }
-            if (*pfMissingInputs == true)
-                return false;
+                if (*pfMissingInputs == true)
+                    return false;
             }
 
             // Bring the best block into scope

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1459,7 +1459,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
         if (!CheckInputs(tx, state, view, true, STANDARD_SCRIPT_VERIFY_FLAGS | forkVerifyFlags, true, &resourceTracker,
                 NULL, &sighashType))
         {
-            LogPrint("mempool", "txn CheckInputs failed");
+            LogPrint("mempool", "CheckInputs failed for tx: %s\n", tx.GetHash().ToString().c_str());
             return false;
         }
         entry.UpdateRuntimeSigOps(resourceTracker.GetSigOps(), resourceTracker.GetSighashBytes());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1266,10 +1266,9 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
                 // if this transaction fails to enter the memory pool, we will then uncache those coins that were not
                 // already present, unless the transaction is an orphan.
                 //
-                // We still want to keep orphantx coins in the event the orphantx is finally
-                // accepted into the mempool or shows up in a block that is mined; this way the coins in the orphan
-                // do not have to be pulled back into the coins cache from disk. Furthermore, coins for orphans are
-                // only removed if/when the orphan expires either by time or otherwise expelled from the orphan pool.
+                // We still want to keep orphantx coins in the event the orphantx is finally accepted into the mempool
+                // or shows up in a block that is mined.  Therefore if pfMissingInputs returns true then any coins
+                // in vCoinsToUncache will NOT be uncached.
                 if (!pcoinsTip->HaveCoinInCache(txin.prevout))
                 {
                     vCoinsToUncache.push_back(txin.prevout);
@@ -1277,11 +1276,10 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
 
                 if (!view.HaveCoin(txin.prevout))
                 {
-                    if (pfMissingInputs)
-                    {
-                        *pfMissingInputs = true;
-                    }
-                    // fMissingInputs and !state.IsInvalid() is used to detect this condition, don't set state.Invalid()
+                    // fMissingInputs and not state.IsInvalid() is used to detect this condition, don't set
+                    // state.Invalid()
+                    *pfMissingInputs = true;
+
                     return false;
                 }
             }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1529,10 +1529,11 @@ bool AcceptToMemoryPool(CTxMemPool &pool,
     std::vector<COutPoint> vCoinsToUncache;
     bool res = AcceptToMemoryPoolWorker(
         pool, state, tx, fLimitFree, pfMissingInputs, fOverrideMempoolLimit, fRejectAbsurdFee, vCoinsToUncache);
-    if (!res)
+    if (!res && !*pfMissingInputs)
     {
-        for (const COutPoint &remove : vCoinsToUncache)
-            pcoinsTip->Uncache(remove);
+        // Uncache any coins for txns that failed to enter the mempool but we're NOT orphan txns
+        for (const CTxIn &txin : tx.vin)
+            pcoinsTip->Uncache(txin.prevout);
     }
 
     return res;

--- a/src/main.h
+++ b/src/main.h
@@ -190,6 +190,9 @@ extern int64_t nMaxTipAge;
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern CBlockIndex *pindexBestHeader;
 
+/** Used to determine whether it is time to check the orphan pool for any txns that can be evicted. */
+extern int64_t nLastOrphanCheck;
+
 /** Minimum disk space required - used in CheckDiskSpace() */
 static const uint64_t nMinDiskSpace = 52428800;
 

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -422,6 +422,7 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
     {
         LOCK(cs_orphancache);
         int64_t nStartTime = GetTime();
+        nLastOrphanCheck = nStartTime;
         SetMockTime(nStartTime); // Overrides future calls to GetTime()
         for (int i = 0; i < 50; i++)
         {
@@ -470,6 +471,8 @@ BOOST_AUTO_TEST_CASE(DoS_mapOrphans)
         SetMockTime(nStartTime + 60 * 60 * DEFAULT_ORPHANPOOL_EXPIRY + 300);
         EraseOrphansByTime();
         BOOST_CHECK(mapOrphanTransactions.size() == 0);
+
+        SetMockTime(0);
     }
 }
 

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -17,6 +17,11 @@
 
 #include <boost/test/unit_test.hpp>
 
+extern bool AddOrphanTx(const CTransaction &tx, NodeId peer);
+extern void EraseOrphansByTime();
+extern unsigned int LimitOrphanTxSize(unsigned int nMaxOrphans, uint64_t nMaxBytes);
+extern void LimitMempoolSize(CTxMemPool &pool, size_t limit, unsigned long age);
+
 BOOST_AUTO_TEST_SUITE(txvalidationcache_tests) // BU harmonize suite name with filename
 
 static bool ToMemPool(CMutableTransaction &tx)
@@ -24,7 +29,8 @@ static bool ToMemPool(CMutableTransaction &tx)
     LOCK(cs_main);
 
     CValidationState state;
-    return AcceptToMemoryPool(mempool, state, tx, false, NULL, true, false);
+    bool fMissingInputs = false;
+    return AcceptToMemoryPool(mempool, state, tx, false, &fMissingInputs, true, false);
 }
 
 BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
@@ -87,6 +93,214 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
     // spends[1] should have been removed from the mempool when the
     // block with spends[0] is accepted:
     BOOST_CHECK_EQUAL(mempool.size(), 0);
+    mempool.clear();
+}
+
+BOOST_FIXTURE_TEST_CASE(uncache_coins, TestChain100Setup)
+{
+    int64_t nStartTime = GetTime();
+    nLastOrphanCheck = nStartTime;
+    SetMockTime(nStartTime); // Overrides future calls to GetTime()
+
+    mempool.clear();
+    pcoinsTip->Flush();
+
+    // Make sure coins are uncached when txns are not accepted into the memory pool
+    // and also verify they are uncached when orphans or txns are evicted from either the
+    // orphan cache or the transaction memory pool.
+    CScript scriptPubKey = CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+
+    unsigned int sighashType = SIGHASH_ALL;
+    if (chainActive.Tip()->IsforkActiveOnNextBlock(miningForkTime.value))
+        sighashType |= SIGHASH_FORKID;
+
+    std::vector<CMutableTransaction> spends;
+
+    // Add valid txns to the memory pool.  The coins should be present in the coins cache.
+    spends.resize(1);
+    spends[0].vin.resize(1);
+    spends[0].vin[0].prevout.hash = coinbaseTxns[0].GetHash();
+    spends[0].vin[0].prevout.n = 0;
+    spends[0].vout.resize(1);
+    spends[0].vout[0].nValue = 11 * CENT;
+    spends[0].vout[0].scriptPubKey = scriptPubKey;
+
+    // Sign:
+    std::vector<unsigned char> vchSig1;
+    uint256 hash1 = SignatureHash(scriptPubKey, spends[0], 0, sighashType, coinbaseTxns[0].vout[0].nValue, 0);
+    BOOST_CHECK(coinbaseKey.Sign(hash1, vchSig1));
+    vchSig1.push_back((unsigned char)sighashType);
+    spends[0].vin[0].scriptSig << vchSig1;
+
+    BOOST_CHECK(ToMemPool(spends[0]));
+    BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[0].vin[0].prevout));
+
+    // Try to add the same tx to the memory pool. The coins should still be present.
+    BOOST_CHECK(!ToMemPool(spends[0]));
+    BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[0].vin[0].prevout));
+
+    // Try to add an invalid txn to the memory pool.  The coins for the previous txn should
+    // still be present and but the coins from the rejected txn should not be present.
+    spends.resize(2);
+    spends[1].vin.resize(1);
+    spends[1].vin[0].prevout.hash = coinbaseTxns[1].GetHash();
+    spends[1].vin[0].prevout.n = 0;
+    spends[1].vout.resize(1);
+    spends[1].vout[0].nValue = 11 * CENT;
+    spends[1].vout[0].scriptPubKey = scriptPubKey;
+
+    // Sign:
+    std::vector<unsigned char> vchSig2;
+    uint256 hash2 = SignatureHash(scriptPubKey, spends[1], 0, sighashType, coinbaseTxns[1].vout[0].nValue, 0);
+    BOOST_CHECK(coinbaseKey.Sign(hash2, vchSig2));
+    vchSig2.push_back((unsigned char)sighashType);
+    spends[1].vin[0].scriptSig << vchSig2;
+
+    BOOST_CHECK(!ToMemPool(spends[1]));
+    BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[0].vin[0].prevout)); // not uncached because from a previous txn
+    BOOST_CHECK(!pcoinsTip->HaveCoinInCache(spends[1].vin[0].prevout));
+
+    // Add an orphan to the orphan cache.  The valid inputs should be present in the coins cache.
+    spends.resize(3);
+    spends[2].vin.resize(3);
+    spends[2].vin[0].prevout.hash = GetRandHash();
+    spends[2].vin[0].prevout.n = 0;
+    spends[2].vin[1].prevout.hash = GetRandHash();
+    spends[2].vin[1].prevout.n = 0;
+    spends[2].vin[2].prevout.hash = coinbaseTxns[2].GetHash();
+    spends[2].vin[2].prevout.n = 0;
+    spends[2].vout.resize(1);
+    spends[2].vout[0].nValue = 799999999;
+    spends[2].vout[0].scriptPubKey = scriptPubKey;
+
+    // Sign:
+    std::vector<unsigned char> vchSig3;
+    uint256 hash3 = SignatureHash(scriptPubKey, spends[2], 0, sighashType, coinbaseTxns[2].vout[0].nValue, 0);
+    BOOST_CHECK(coinbaseKey.Sign(hash3, vchSig3));
+    vchSig3.push_back((unsigned char)sighashType);
+    spends[2].vin[0].scriptSig << vchSig2;
+
+    BOOST_CHECK(!ToMemPool(spends[2]));
+    {
+        LOCK(cs_orphancache);
+        BOOST_CHECK(AddOrphanTx(spends[2], 1));
+    }
+    BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[0].vin[0].prevout)); // valid coin from previous txn
+    BOOST_CHECK(!pcoinsTip->HaveCoinInCache(spends[2].vin[0].prevout));
+    BOOST_CHECK(!pcoinsTip->HaveCoinInCache(spends[2].vin[1].prevout));
+    BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[2].vin[2].prevout)); // the only valid coin from the orphantx
+
+    // Remove valid orphans by time.  The coins should be removed from the coins cache
+    {
+        LOCK(cs_orphancache);
+        SetMockTime(nStartTime + 3600 * DEFAULT_ORPHANPOOL_EXPIRY + 300);
+        EraseOrphansByTime();
+    }
+
+    BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[0].vin[0].prevout)); // valid coin from previous txn
+    BOOST_CHECK(!pcoinsTip->HaveCoinInCache(spends[2].vin[2].prevout)); // the valid coin from orphantx is uncached
+
+    // Remove valid orphans by size.  The coins should be removed from the coins cache
+    BOOST_CHECK(!ToMemPool(spends[2]));
+    {
+        LOCK(cs_orphancache);
+        BOOST_CHECK(AddOrphanTx(spends[2], 1));
+    }
+    BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[0].vin[0].prevout)); // valid coin from previous txn
+    BOOST_CHECK(!pcoinsTip->HaveCoinInCache(spends[2].vin[0].prevout));
+    BOOST_CHECK(!pcoinsTip->HaveCoinInCache(spends[2].vin[1].prevout));
+    BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[2].vin[2].prevout)); // the only valid coin from the orphantx
+
+    {
+        LOCK(cs_orphancache);
+        LimitOrphanTxSize(0, 0);
+    }
+
+    BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[0].vin[0].prevout)); // valid coin from previous txn
+    BOOST_CHECK(!pcoinsTip->HaveCoinInCache(spends[2].vin[2].prevout)); // the valid coin from orphantx is uncached
+
+    // Evict the valid previous tx, by time.  The coins should be removed from the coins cache
+    SetMockTime(nStartTime + 1 + 72 * 60 * 60); // move to 1 second beyond time to evict
+    BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[0].vin[0].prevout)); // valid coin from previous txn
+    LimitMempoolSize(mempool, 100 * 1000 * 1000, 72 * 60 * 60);
+    BOOST_CHECK(!pcoinsTip->HaveCoinInCache(spends[0].vin[0].prevout)); // valid coin from previous txn
+
+    // Add a tx to the memory pool.  The valid inputs should be present in the coins cache.
+    spends.resize(4);
+    spends[3].vin.resize(1);
+    spends[3].vin[0].prevout.hash = coinbaseTxns[0].GetHash();
+    spends[3].vin[0].prevout.n = 0;
+    spends[3].vout.resize(1);
+    spends[3].vout[0].nValue = 11 * CENT;
+    spends[3].vout[0].scriptPubKey = scriptPubKey;
+
+    // Sign:
+    std::vector<unsigned char> vchSig4;
+    uint256 hash4 = SignatureHash(scriptPubKey, spends[3], 0, sighashType, coinbaseTxns[3].vout[0].nValue, 0);
+    BOOST_CHECK(coinbaseKey.Sign(hash4, vchSig4));
+    vchSig4.push_back((unsigned char)sighashType);
+    spends[3].vin[0].scriptSig << vchSig4;
+
+    BOOST_CHECK(ToMemPool(spends[3]));
+    BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[3].vin[0].prevout));
+
+    // Evict a valid tx by size of memory pool.  The coins should be removed from the coins cache
+    SetMockTime(nStartTime + 1); // change start time so we are well within the limits
+    BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[3].vin[0].prevout)); // valid coin from previous txn
+    LimitMempoolSize(mempool, 0, 72 * 60 * 60); // limit mempool size to zero
+    BOOST_CHECK(!pcoinsTip->HaveCoinInCache(spends[3].vin[0].prevout)); // valid coin from previous txn
+
+    /**  Simulate the following scenario:
+     *     Add an orphan to the orphan pool
+     *     then add the parent to the mempool which causes the orphan to also be pulled into the mempool.
+     *     then delete the orphan using EraseOrphanTx(hash).
+     *   Result: All coins should still be present in cache.
+     */
+
+    // Add an orphan to the orphan cache.  The valid inputs should be present in the coins cache.
+    spends.resize(5);
+    spends[4].vin.resize(3);
+    spends[4].vin[0].prevout.hash = GetRandHash();
+    spends[4].vin[0].prevout.n = 0;
+    spends[4].vin[1].prevout.hash = GetRandHash();
+    spends[4].vin[1].prevout.n = 0;
+    spends[4].vin[2].prevout.hash = coinbaseTxns[5].GetHash();
+    spends[4].vin[2].prevout.n = 0;
+    spends[4].vout.resize(1);
+    spends[4].vout[0].nValue = 799999999;
+    spends[4].vout[0].scriptPubKey = scriptPubKey;
+
+    // Sign:
+    std::vector<unsigned char> vchSig5;
+    uint256 hash5 = SignatureHash(scriptPubKey, spends[2], 0, sighashType, coinbaseTxns[5].vout[0].nValue, 0);
+    BOOST_CHECK(coinbaseKey.Sign(hash5, vchSig5));
+    vchSig5.push_back((unsigned char)sighashType);
+    spends[4].vin[0].scriptSig << vchSig5;
+
+    BOOST_CHECK(!ToMemPool(spends[4]));
+    {
+        LOCK(cs_orphancache);
+        BOOST_CHECK(AddOrphanTx(spends[4], 1));
+    }
+    BOOST_CHECK(!pcoinsTip->HaveCoinInCache(spends[4].vin[0].prevout));
+    BOOST_CHECK(!pcoinsTip->HaveCoinInCache(spends[4].vin[1].prevout));
+    BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[4].vin[2].prevout)); // the only valid coin from the orphantx
+
+    // All we need to do to simluate the above scenario is now erase the orphan tx from the orphan cache as it
+    // would be if the orphan was moved into the mempool.
+    // Result: All the coins should still be remaining in the coins cache.
+    {
+        LOCK(cs_orphancache);
+        EraseOrphanTx(spends[4].GetHash());
+    }
+    BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[4].vin[2].prevout));
+
+
+    // cleanup
+    mempool.clear();
+    mapOrphanTransactions.clear();
+    pcoinsTip->Flush();
+    SetMockTime(0);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -580,11 +580,11 @@ public:
       *  pvNoSpendsRemaining, if set, will be populated with the list of outpoints
       *  which are not in mempool which no longer have any spends in this mempool.
       */
-    void TrimToSize(size_t sizelimit, std::vector<COutPoint> *pvNoSpendsRemaining = NULL);
+    void TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpendsRemaining = nullptr);
 
     /** Expire all transaction (and their dependencies) in the mempool older than time. Return the number of removed
      * transactions. */
-    int Expire(int64_t time);
+    int Expire(int64_t time, std::vector<COutPoint> &vCoinsToUncache);
 
     /** BU: Every transaction that is accepted into the mempool will call this method to update the current value*/
     void UpdateTransactionsPerSecond();

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -580,7 +580,7 @@ public:
       *  pvNoSpendsRemaining, if set, will be populated with the list of outpoints
       *  which are not in mempool which no longer have any spends in this mempool.
       */
-    void TrimToSize(size_t sizelimit, std::vector<COutPoint>* pvNoSpendsRemaining = nullptr);
+    void TrimToSize(size_t sizelimit, std::vector<COutPoint> *pvNoSpendsRemaining = nullptr);
 
     /** Expire all transaction (and their dependencies) in the mempool older than time. Return the number of removed
      * transactions. */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3411,5 +3411,6 @@ int CMerkleTx::GetBlocksToMaturity() const
 bool CMerkleTx::AcceptToMemoryPool(bool fLimitFree, bool fRejectAbsurdFee)
 {
     CValidationState state;
-    return ::AcceptToMemoryPool(mempool, state, *this, fLimitFree, NULL, false, fRejectAbsurdFee);
+    bool fMissingInputs = false;
+    return ::AcceptToMemoryPool(mempool, state, *this, fLimitFree, &fMissingInputs, false, fRejectAbsurdFee);
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3411,6 +3411,5 @@ int CMerkleTx::GetBlocksToMaturity() const
 bool CMerkleTx::AcceptToMemoryPool(bool fLimitFree, bool fRejectAbsurdFee)
 {
     CValidationState state;
-    bool fMissingInputs = false;
-    return ::AcceptToMemoryPool(mempool, state, *this, fLimitFree, &fMissingInputs, false, fRejectAbsurdFee);
+    return ::AcceptToMemoryPool(mempool, state, *this, fLimitFree, nullptr, false, fRejectAbsurdFee);
 }


### PR DESCRIPTION
There are several improvements to make now that we are able to trim the coins cache regularly.  In this PR we only uncache coins if they were not accepted to the mempool, trimmed from the orphans cache, or trimmed later by the mempool.  This way we can keep the coins cache as full as possible with relevant coins and prevent any obscure attacks whereby out coins cache could get randomly trimmed of useful coins.

NOTE: when an orphan is moved from the orphan cache and finally accepted to the mempool we do NOT uncache the coins as would be the case if the orphan was simply expired by time , size or number of entries.