### PR TITLE
test_bitcoin logging and speedup

### DIFF
--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -108,7 +108,7 @@ public:
 
 BOOST_FIXTURE_TEST_SUITE(coins_tests, BasicTestingSetup)
 
-static const unsigned int NUM_SIMULATION_ITERATIONS = 40000;
+static const unsigned int NUM_SIMULATION_ITERATIONS = 10000;
 
 // This is a large randomized insert/remove simulation test on a variable-size
 // stack of caches on top of CCoinsViewTest.

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -30,27 +30,36 @@ class prevector_tester {
         const pretype& const_pre_vector = pre_vector;
         BOOST_CHECK_EQUAL(real_vector.size(), pre_vector.size());
         BOOST_CHECK_EQUAL(real_vector.empty(), pre_vector.empty());
-        for (Size s = 0; s < real_vector.size(); s++) {
-             BOOST_CHECK(real_vector[s] == pre_vector[s]);
-             BOOST_CHECK(&(pre_vector[s]) == &(pre_vector.begin()[s]));
-             BOOST_CHECK(&(pre_vector[s]) == &*(pre_vector.begin() + s));
-             BOOST_CHECK(&(pre_vector[s]) == &*((pre_vector.end() + s) - real_vector.size()));
+        for (Size s = 0; s < real_vector.size(); s++)
+        {
+            if (real_vector[s] != pre_vector[s])
+                BOOST_CHECK(real_vector[s] == pre_vector[s]);
+            if (&(pre_vector[s]) != &(pre_vector.begin()[s]))
+                BOOST_CHECK(&(pre_vector[s]) == &(pre_vector.begin()[s]));
+            if (&(pre_vector[s]) != &*(pre_vector.begin() + s))
+                BOOST_CHECK(&(pre_vector[s]) == &*(pre_vector.begin() + s));
+            if (&(pre_vector[s]) != &*((pre_vector.end() + s) - real_vector.size()))
+                BOOST_CHECK(&(pre_vector[s]) == &*((pre_vector.end() + s) - real_vector.size()));
         }
         // BOOST_CHECK(realtype(pre_vector) == real_vector);
         BOOST_CHECK(pretype(real_vector.begin(), real_vector.end()) == pre_vector);
         BOOST_CHECK(pretype(pre_vector.begin(), pre_vector.end()) == pre_vector);
         size_t pos = 0;
         BOOST_FOREACH(const T& v, pre_vector) {
+            if (v != real_vector[pos++])
              BOOST_CHECK(v == real_vector[pos++]);
         }
         BOOST_REVERSE_FOREACH(const T& v, pre_vector) {
+            if (v != real_vector[--pos])
              BOOST_CHECK(v == real_vector[--pos]);
         }
         BOOST_FOREACH(const T& v, const_pre_vector) {
-             BOOST_CHECK(v == real_vector[pos++]);
+            if (v != real_vector[pos++])
+                BOOST_CHECK(v == real_vector[pos++]);
         }
         BOOST_REVERSE_FOREACH(const T& v, const_pre_vector) {
-             BOOST_CHECK(v == real_vector[--pos]);
+            if (v != real_vector[--pos])
+                BOOST_CHECK(v == real_vector[--pos]);
         }
         CDataStream ss1(SER_DISK, 0);
         CDataStream ss2(SER_DISK, 0);
@@ -58,7 +67,8 @@ class prevector_tester {
         ss2 << pre_vector;
         BOOST_CHECK_EQUAL(ss1.size(), ss2.size());
         for (Size s = 0; s < ss1.size(); s++) {
-            BOOST_CHECK_EQUAL(ss1[s], ss2[s]);
+            if (ss1[s] != ss2[s])
+              BOOST_CHECK_EQUAL(ss1[s], ss2[s]);
         }
     }
 

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -28,8 +28,10 @@ BOOST_AUTO_TEST_CASE(skiplist_test)
 
     for (int i=0; i<SKIPLIST_LENGTH; i++) {
         if (i > 0) {
-            BOOST_CHECK(vIndex[i].pskip == &vIndex[vIndex[i].pskip->nHeight]);
-            BOOST_CHECK(vIndex[i].pskip->nHeight < i);
+            if (vIndex[i].pskip != &vIndex[vIndex[i].pskip->nHeight])  // Skips logging if successful
+                BOOST_CHECK(vIndex[i].pskip == &vIndex[vIndex[i].pskip->nHeight]);
+            if (vIndex[i].pskip->nHeight >= i)
+                BOOST_CHECK(vIndex[i].pskip->nHeight < i);
         } else {
             BOOST_CHECK(vIndex[i].pskip == NULL);
         }
@@ -56,8 +58,10 @@ BOOST_AUTO_TEST_CASE(getlocator_test)
         vBlocksMain[i].pprev = i ? &vBlocksMain[i - 1] : NULL;
         vBlocksMain[i].phashBlock = &vHashMain[i];
         vBlocksMain[i].BuildSkip();
-        BOOST_CHECK_EQUAL((int)UintToArith256(vBlocksMain[i].GetBlockHash()).GetLow64(), vBlocksMain[i].nHeight);
-        BOOST_CHECK(vBlocksMain[i].pprev == NULL || vBlocksMain[i].nHeight == vBlocksMain[i].pprev->nHeight + 1);
+        if ((int)UintToArith256(vBlocksMain[i].GetBlockHash()).GetLow64() != vBlocksMain[i].nHeight)
+            BOOST_CHECK_EQUAL((int)UintToArith256(vBlocksMain[i].GetBlockHash()).GetLow64(), vBlocksMain[i].nHeight);
+        if (!(vBlocksMain[i].pprev == NULL || vBlocksMain[i].nHeight == vBlocksMain[i].pprev->nHeight + 1))
+            BOOST_CHECK(vBlocksMain[i].pprev == NULL || vBlocksMain[i].nHeight == vBlocksMain[i].pprev->nHeight + 1);
     }
 
     // Build a branch that splits off at block 49999, 50000 blocks long.
@@ -69,8 +73,10 @@ BOOST_AUTO_TEST_CASE(getlocator_test)
         vBlocksSide[i].pprev = i ? &vBlocksSide[i - 1] : &vBlocksMain[49999];
         vBlocksSide[i].phashBlock = &vHashSide[i];
         vBlocksSide[i].BuildSkip();
-        BOOST_CHECK_EQUAL((int)UintToArith256(vBlocksSide[i].GetBlockHash()).GetLow64(), vBlocksSide[i].nHeight);
-        BOOST_CHECK(vBlocksSide[i].pprev == NULL || vBlocksSide[i].nHeight == vBlocksSide[i].pprev->nHeight + 1);
+        if ((int)UintToArith256(vBlocksSide[i].GetBlockHash()).GetLow64() != vBlocksSide[i].nHeight)
+            BOOST_CHECK_EQUAL((int)UintToArith256(vBlocksSide[i].GetBlockHash()).GetLow64(), vBlocksSide[i].nHeight);
+        if (!(vBlocksSide[i].pprev == NULL || vBlocksSide[i].nHeight == vBlocksSide[i].pprev->nHeight + 1))
+            BOOST_CHECK(vBlocksSide[i].pprev == NULL || vBlocksSide[i].nHeight == vBlocksSide[i].pprev->nHeight + 1);
     }
 
     // Build a CChain for the main branch.

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -24,7 +24,7 @@
 #include "rpc/server.h"
 #include "rpc/register.h"
 #include "test/testutil.h"
-
+#include <boost/program_options.hpp>
 #include <boost/test/unit_test.hpp>
 
 #include <memory>
@@ -154,3 +154,47 @@ bool ShutdownRequested()
 {
   return false;
 }
+
+using namespace boost::program_options;
+
+struct StartupShutdown
+{
+    StartupShutdown()
+    {
+        options_description optDef("Options");
+        optDef.add_options()
+            ("testhelp", "program options information")
+            ("log_level", "set boost logging (all, test_suite, message, warning, error, ...)")
+            ("log_bitcoin", value<std::string>()->required(), "bitcoin logging destination (console, none)");
+        variables_map opts;
+        store(parse_command_line(boost::unit_test::framework::master_test_suite().argc,
+                                 boost::unit_test::framework::master_test_suite().argv, optDef), opts);
+
+        if (opts.count("testhelp"))
+        {
+            std::cout << optDef << std::endl;
+            exit(0);
+        }
+
+        if (opts.count("log_bitcoin"))
+        {
+            std::string s = opts["log_bitcoin"].as<std::string>();
+            if (s == "console")
+            {
+                fPrintToConsole = true;
+                fPrintToDebugLog = false;
+            }
+            else if (s == "none")
+            {
+                fPrintToConsole = false;
+                fPrintToDebugLog = false;
+            }
+        }
+    }
+    ~StartupShutdown()
+    {
+    }
+};
+
+BOOST_GLOBAL_FIXTURE( StartupShutdown );
+


### PR DESCRIPTION
create a flag to enable bitcoin logging to console.  Eliminate correct BOOST_CHECK macros from some inner loops so a vast quantity of logging is not produced when running with boost --log_level=all