### PR TITLE
Download all valid headers up to an invalid header

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6569,21 +6569,30 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         }
 
         // Check and accept each header in order from youngest block to oldest
-        CBlockIndex *pindexLast = NULL;
+        CBlockIndex *pindexLast = nullptr;
+        int i = 0;
         for (const CBlockHeader &header : headers)
         {
             CValidationState state;
             if (!AcceptBlockHeader(header, state, chainparams, &pindexLast))
             {
-                int nDoS;
-                if (state.IsInvalid(nDoS))
+                int nDos;
+                if (state.IsInvalid(nDos))
                 {
-                    if (nDoS > 0)
-                        dosMan.Misbehaving(pfrom, nDoS);
-                    return error("invalid header received");
+                    if (nDos > 0)
+                    {
+                        dosMan.Misbehaving(pfrom, nDos);
+                    }
                 }
+
+                headers.erase(headers.begin() + i, headers.end());
+                nCount = headers.size();
+                break;
             }
-            PV->UpdateMostWorkOurFork(header);
+            else
+                PV->UpdateMostWorkOurFork(header);
+
+            i++;
         }
 
         if (pindexLast)


### PR DESCRIPTION
If we download a group of headers and one or more valid headers
preceed an invalid one when download the valid headers. This allows
our peer to download all valid headers and blocks up to a fork
point.