### PR TITLE
Update mouse-over dialogue tooltip for consistency

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -199,7 +199,7 @@
        <item>
         <widget class="QCheckBox" name="allowIncoming">
          <property name="toolTip">
-          <string>Accept connections from outside</string>
+          <string>Accept connections from outside.</string>
          </property>
          <property name="text">
           <string>Allow incoming connections</string>


### PR DESCRIPTION
This change updates the mouse-over dialogue tooltip to add a (dot) at the end.

From: Accept connections from outside
To: Accept connections from outside.