### PR TITLE
Make null pointer check in ContextualCheckBlock explicit

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4106,8 +4106,12 @@ bool ContextualCheckBlock(const CBlock &block, CValidationState &state, CBlockIn
         nLockTimeFlags |= LOCKTIME_MEDIAN_TIME_PAST;
     }
 
-    int64_t nLockTimeCutoff =
-        (nLockTimeFlags & LOCKTIME_MEDIAN_TIME_PAST) ? pindexPrev->GetMedianTimePast() : block.GetBlockTime();
+    int64_t nLockTimeCutoff;
+    if (pindexPrev == NULL)
+        nLockTimeCutoff = block.GetBlockTime();
+    else
+        nLockTimeCutoff =
+            (nLockTimeFlags & LOCKTIME_MEDIAN_TIME_PAST) ? pindexPrev->GetMedianTimePast() : block.GetBlockTime();
 
     // Check that all transactions are finalized
     BOOST_FOREACH (const CTransaction &tx, block.vtx)


### PR DESCRIPTION
Make explicit what was implicit in #549. 

Review needed: Touches consensus code.