### PR TITLE
support running qa tests using an out-of-source build

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -37,7 +37,14 @@ import subprocess
 import tempfile
 import re
 
-sys.path.append("qa/pull-tester/")
+# to support out-of-source builds, we need to add both the source directory to the path, and the out-of-source directory
+# because tests_config is a generated file
+sourcePath = os.path.dirname(os.path.realpath(__file__))
+outOfSourceBuildPath = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(sourcePath)
+if sourcePath != outOfSourceBuildPath:
+    sys.path.append(outOfSourceBuildPath)
+
 from tests_config import *
 from test_classes import RpcTest, Disabled, Skip
 


### PR DESCRIPTION
to support out-of-source builds, we need to also add the generated out-of-source directory (where rpc-tests.py gets symlinked to) because tests_config is a generated python file so only exists in the out-of-source location