### PR TITLE
[WIP] Subchains / Weakblocks

### DIFF
--- a/doc/weakblocks/test-todo.md
+++ b/doc/weakblocks/test-todo.md
@@ -59,4 +59,10 @@ the newly written weakblocks code.
 
 Other TODO
 ==========
-Make Weakblocks object. Allow to set names for weakblocks for easier testing.
+Allow to set names for weakblocks for easier testing.
+
+Send multiple weakblocks blocks in chronological order.
+
+Allow receival of weakblocks out of order and still build correct chains, maybe?
+
+Check enable/disable logic thoroughly

--- a/doc/weakblocks/test-todo.md
+++ b/doc/weakblocks/test-todo.md
@@ -1,0 +1,62 @@
+TODO tests to be written for weak blocks
+----------------------------------------
+
+This is a list of test ideas to hammer the weakblocks implementation
+to help make sure it is as stable as possible.
+
+Unit testing
+============
+ - basic functionality of API in weakblock.h
+
+ - test storing and retrieving weak blocks, delta block detection
+
+ - test weak block height calculation
+
+ - test that the purgeOldWeakblocks(..) purges completely (all data
+   structures empty) when told to do so
+
+
+Regression network tests
+========================
+- Test that nodes that are configured to have no weakblocks support behave
+  as expected. This includes:
+     - nodes that submit weakblocks even though the service flag isn't set
+       should be banned.
+     - submitblock does not accept weakblock solutions.
+     - mining code does not generate any weak blocks.
+
+- Weak block enabling:
+  - test that weak blocks can be submitted to another node that supports
+    the weakblocks service flag without banning
+
+  - test that weak blocks can be mined
+
+  - test that weak blocks can be submitted through RPC
+
+  - test for longest weak block chain of work. Create multiple chains
+  of weak blocks and test that the longest and oldest chain is taken
+  for further consideration and mining on top
+
+  - test that changing the consideration POW ratio does work as expected
+
+  - test that submitting below the min POW ratio causes a node ban, even
+    with service flag enabled (flooding prevention)
+
+  - test that weak blocks are transmitted efficiently as deltablocks between
+    nodes.
+
+Fuzzing
+=======
+- Write a fuzzer that exercises the exposed API of weakblock.h and
+ensures that there's no crashes and no memleaks after destruction
+of the remaining weakblocks before program exit.
+
+Coverage
+========
+Ensure full coverage of all code changed (especially main.cpp) as well as
+the newly written weakblocks code.
+
+
+Other TODO
+==========
+Make Weakblocks object. Allow to set names for weakblocks for easier testing.

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -257,7 +257,8 @@ testScriptsExt = [ RpcTest(t) for t in [
     'maxblocksinflight',
     'p2p-acceptblock',
     'mempool_packages',
-    'maxuploadtarget'
+    'maxuploadtarget',
+    'addrindex'
 ] ]
 
 #Enable ZMQ tests

--- a/qa/rpc-tests/addrindex.py
+++ b/qa/rpc-tests/addrindex.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2018 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+import test_framework.loginit
+import time
+import sys
+if sys.version_info[0] < 3:
+    raise "Use Python 3"
+import logging
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class AddrIndexTest (BitcoinTestFramework):
+    def setup_chain(self,bitcoinConfDict=None, wallets=None):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 4, bitcoinConfDict, wallets)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(2, self.options.tmpdir)
+        connect_nodes_bi(self.nodes,0,1)
+        self.is_network_split=False
+        self.sync_all()
+
+    def run_test (self):
+        # generate enough blocks so that nodes[0] has a balance
+        self.sync_blocks()
+        self.nodes[0].generate(101)
+        self.sync_blocks()
+
+        assert_equal(self.nodes[0].getbalance(), 50)
+
+        n0, n1 = self.nodes
+
+        addr = n1.getnewaddress()
+
+        # address not yet used -> not in index
+        assert n0.searchrawtransactions(addr) == []
+        assert n1.searchrawtransactions(addr) == []
+
+        txid = n0.sendtoaddress(addr, 0.1)
+        # not yet mined -> not in index
+        assert n0.searchrawtransactions(addr) == []
+        assert n1.searchrawtransactions(addr) == []
+
+        # mine it
+        self.nodes[0].generate(1)
+        self.sync_blocks()
+
+        sresult0 = n0.searchrawtransactions(addr)
+        sresult1 = n1.searchrawtransactions(addr)
+
+        assert len(sresult0) == 1
+        assert sresult0[0]["txid"] == txid
+        assert len(sresult1) == 1
+        assert sresult1[0]["txid"] == txid
+
+        for i in range(10):
+            n0.sendtoaddress(addr, 0.01)
+
+        self.nodes[0].generate(1)
+        self.sync_blocks()
+
+        sresult0 = n0.searchrawtransactions(addr)
+        sresult1 = n1.searchrawtransactions(addr)
+
+        assert len(sresult0) == 11
+        assert sresult0[0]["txid"] == txid
+
+        assert len(sresult1) == 11
+        assert sresult1[0]["txid"] == txid
+
+        sresult0 = n0.searchrawtransactions(addr, False)
+        assert "txid" not in sresult0[0]
+
+        sresult0 = n0.searchrawtransactions(addr, True, 5) # skip=5
+        assert len(sresult0) == 6
+
+        sresult0 = n0.searchrawtransactions(addr, True, -3) # skip=-3
+        assert len(sresult0) == 3
+
+        sresult0 = n0.searchrawtransactions(addr, True, 5, 4) # skip=5, count=4
+        assert len(sresult0) == 4
+
+
+
+
+if __name__ == '__main__':
+    t = AddrIndexTest()
+    flags = []
+    bitcoinConf = { "addrindex": 1 }
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -278,7 +278,8 @@ def initialize_datadir(dirname, n, bitcoinConfDict=None, wallet=None, bins=None)
     rpc_u, rpc_p = rpc_auth_pair(n)
     defaults = {"server":1, "discover":0, "regtest":1,"rpcuser":"rt","rpcpassword":"rt",
                 "port":p2p_port(n),"rpcport":str(rpc_port(n)),"listenonion":0,"maxlimitertxfee":0,"usecashaddr":1,
-                "rpcuser":rpc_u, "rpcpassword":rpc_p, "bindallorfail" : 1}
+                "rpcuser":rpc_u, "rpcpassword":rpc_p, "bindallorfail" : 1,
+                "debug" : "mempool,weakblocks,rpc,blk,req,bloom,thin,net"}
 
     # switch off default IPv6 listening port (for travis)
     if UtilOptions.no_ipv6_rpc_listen:

--- a/qa/rpc-tests/weakblocks.py
+++ b/qa/rpc-tests/weakblocks.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2018 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+import test_framework.loginit
+# This is a template to make creating new QA tests easy.
+# You can also use this template to quickly start and connect a few regtest nodes.
+
+import time
+import sys
+if sys.version_info[0] < 3:
+    raise "Use Python 3"
+import logging
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class WeakblocksTest(BitcoinTestFramework):
+
+    def setup_chain(self,bitcoinConfDict=None, wallets=None):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 4, bitcoinConfDict, wallets)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(4, self.options.tmpdir)
+        connect_nodes_bi(self.nodes,0,1)
+        connect_nodes_bi(self.nodes,1,2)
+        connect_nodes_bi(self.nodes,2,0)
+        connect_nodes_bi(self.nodes,2,3)
+
+        # If not, the framework assumes this partition: (0,1) and (2,3)
+        # For more complex partitions, you can't use the self.sync* member functions
+        self.is_network_split=False
+        self.sync_all()
+
+    def run_test (self):
+        logging.info("Running weak blocks test")
+        n0, n1, n2, n3 = self.nodes
+
+        # generate enough blocks so that nodes[0] has a balance
+        self.sync_blocks()
+        n0.generate(101)
+        self.sync_blocks()
+
+        assert_equal(n0.getbalance(), 50)
+
+        ### SINGLE NODE WEAK BLOCK SANITY CHECKS
+        # check there's no weak blocks around for the freshly started nodes
+        wbstats = n0.weakstats()
+        wct = n0.weakchaintips()
+        assert_equal(wct, [])
+        assert_equal(wbstats,
+                     {"weakblocksknown" : 0,
+                      "weakchaintips" : 0,
+                      "weakchainheight" : -1 })
+
+        # generate some weak-only blocks and make sure that they are properly showing
+        # up in the various weak blocks calls.
+        old_blockcount = n0.getblockcount()
+
+        n0.generate(1, 1000000, "weak-only")
+        new_blockcount = n0.getblockcount()
+        assert_equal(old_blockcount, new_blockcount) # no new strong block might appear
+
+        wbstats = n0.weakstats()
+        wct = n0.weakchaintips()
+        assert_equal(len(wct), 1)
+        assert_equal(wct[0][1], 0) # weak chain height equals zero (one weak block)
+        assert_equal(wbstats["weakblocksknown"], 1)
+        assert_equal(wbstats["weakchaintips"], 1)
+        assert_equal(wbstats["weakchainheight"], 0)
+        assert_equal(wbstats["weakchaintipnumtx"], 1) # only CB
+
+        # and some more weak blocks
+        n0.generate(10, 1000000, "weak-only")
+        wbstats = n0.weakstats()
+        wct = n0.weakchaintips()
+        assert_equal(len(wct), 1)
+        assert_equal(wct[0][1], 10)
+        assert_equal(wbstats["weakblocksknown"], 11)
+        assert_equal(wbstats["weakchaintips"], 1)
+        assert_equal(wbstats["weakchainheight"], 10)
+        assert_equal(wbstats["weakchaintipnumtx"], 1) # again, only CB
+
+        # now, generate one strong block and make sure that all weak blocks are
+        # set to 'expired' state
+        n0.generate(1, 1000000, "strong-only")
+        wbstats = n0.weakstats()
+        wct = n0.weakchaintips()
+        assert_equal(len(wct), 1) # only one weak chain
+        assert_equal(wct[0][1], -1) # that is in expired state (height == -1)
+
+        # at this stage,
+        # the weak blocks are still known after receival of a strong block
+        # so that they can still be referred to for block transmission etc...
+        assert_equal(wbstats["weakblocksknown"], 11)
+        assert_equal(wbstats["weakchaintips"], 1)
+        assert_equal(wbstats["weakchainheight"], -1)
+        assert_equal(len(wbstats.keys()), 3)
+
+        # but with another strong block coming in, all weak blocks should be cleared:
+        n0.generate(1, 1000000, "strong-only")
+        wbstats = n0.weakstats()
+        wct = n0.weakchaintips()
+        assert_equal(len(wct), 0) # only one weak chain
+        assert_equal(wbstats,
+                     {"weakblocksknown": 0, "weakchaintips": 0, "weakchainheight": -1})
+
+        ### WEAK BLOCK TRANSMISSION CHECKS
+        # FIXME
+if __name__ == '__main__':
+    WeakblocksTest().main ()

--- a/qa/rpc-tests/weakblocks.py
+++ b/qa/rpc-tests/weakblocks.py
@@ -26,7 +26,7 @@ class WeakblocksTest(BitcoinTestFramework):
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)
         connect_nodes_bi(self.nodes,2,0)
-        connect_nodes_bi(self.nodes,2,3)
+        connect_nodes_bi(self.nodes,3,0)
 
         # If not, the framework assumes this partition: (0,1) and (2,3)
         # For more complex partitions, you can't use the self.sync* member functions
@@ -107,6 +107,27 @@ class WeakblocksTest(BitcoinTestFramework):
                      {"weakblocksknown": 0, "weakchaintips": 0, "weakchainheight": -1})
 
         ### WEAK BLOCK TRANSMISSION CHECKS
-        # FIXME
+        # a first, very simple 'does a weakblock propagate' test:
+        n0.generate(1, 1000000, "weak-only")
+        #self.sync_all()
+
+        wbstats_n0 = n0.weakstats()
+        wct_n0 = n0.weakchaintips()
+        #print (wbstats_n0, wct_n0)
+        assert len(wct_n0) == 1
+        assert_equal(wbstats_n0["weakblocksknown"], 1)
+        assert_equal(wbstats_n0["weakchaintips"], 1)
+        assert_equal(wbstats_n0["weakchainheight"], 0)
+
+        time.sleep(2.0) # FIXME, create proper weak blocks syncer!
+        for i, n in enumerate(self.nodes):
+            wbstats = n.weakstats()
+            wct = n.weakchaintips()
+            #print (i, n, wbstats, wct)
+            assert wbstats_n0 == wbstats
+            assert wct_n0 == wct
+
+        # now, let's add some transaction
+
 if __name__ == '__main__':
     WeakblocksTest().main ()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -200,6 +200,7 @@ BITCOIN_CORE_H = \
   wallet/rpcwallet.h \
   wallet/wallet.h \
   wallet/walletdb.h \
+  weakblock.h \
   zmq/zmqabstractnotifier.h \
   zmq/zmqconfig.h\
   zmq/zmqnotificationinterface.h \
@@ -272,6 +273,7 @@ libbitcoin_server_a_SOURCES = \
   requestManager.cpp \
   validationinterface.cpp \
   versionbits.cpp \
+  weakblock.cpp \
   $(BITCOIN_CORE_H)
 
 if ENABLE_ZMQ

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -256,6 +256,7 @@ libbitcoin_server_a_SOURCES = \
   rpc/net.cpp \
   rpc/rawtransaction.cpp \
   rpc/server.cpp \
+  rpc/weakblock.cpp \  
   respend/respendlogger.cpp \
   respend/respendrelayer.cpp \
   respend/respenddetector.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -256,7 +256,7 @@ libbitcoin_server_a_SOURCES = \
   rpc/net.cpp \
   rpc/rawtransaction.cpp \
   rpc/server.cpp \
-  rpc/weakblock.cpp \  
+  rpc/weakblock.cpp \
   respend/respendlogger.cpp \
   respend/respendrelayer.cpp \
   respend/respenddetector.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -120,7 +120,8 @@ BITCOIN_TESTS =\
   test/genversionbits_tests.cpp \
   test/uint256_tests.cpp \
   test/univalue_tests.cpp \
-  test/util_tests.cpp
+  test/util_tests.cpp \
+  test/weakblock_tests.cpp
 
 if ENABLE_WALLET
 BITCOIN_TESTS += \

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -282,7 +282,10 @@ static void addGeneralOptions(AllowedArgs &allowedArgs, HelpMessageMode mode)
         .addArg("reindex", optionalBool, _("Rebuild block chain index from current blk000??.dat files on startup"))
         .addArg("txindex", optionalBool,
             strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"),
-                    DEFAULT_TXINDEX));
+                    DEFAULT_TXINDEX))
+        .addArg("addrindex", optionalBool,
+            strprintf(_("Maintain a full address index, used by the searchrawtransactions rpc call (default: %u)"),
+                    DEFAULT_ADDRINDEX));
 }
 
 static void addConnectionOptions(AllowedArgs &allowedArgs)

--- a/src/blockstorage/sequential_files.cpp
+++ b/src/blockstorage/sequential_files.cpp
@@ -132,7 +132,7 @@ bool ReadBlockFromDiskSequential(CBlock &block, const CDiskBlockPos &pos, const 
     }
 
     // Check the header
-    if (!CheckProofOfWork(block.GetHash(), block.nBits, consensusParams))
+    if (!CheckProofOfWork(block.GetHash(), block.nBits, consensusParams, 1))
     {
         return error("ReadBlockFromDisk: Errors in block header at %s", pos.ToString());
     }

--- a/src/expedited.cpp
+++ b/src/expedited.cpp
@@ -126,19 +126,21 @@ void ActuallySendExpreditedBlock(CXThinBlock &thinBlock, unsigned char hops, con
 
         if (n != nullptr)
         {
-            LOCK(cs_weakblocks);
-            weakstore.set_nodeKnows(n->GetId(), thinBlock.header.GetHash());
-        }
+            {
+                LOCK(cs_weakblocks);
+                weakstore.set_nodeKnows(n->GetId(), thinBlock.header.GetHash());
+            }
 
-        if (n->fDisconnect)
-        {
-            connmgr->RemovedNode(n);
-        }
-        else if (n != skip) // Don't send back to the sending node to avoid looping
-        {
-            LOG(THIN, "Sending expedited block %s to %s\n", thinBlock.header.GetHash().ToString(), n->GetLogName());
-            n->PushMessage(NetMsgType::XPEDITEDBLK, (unsigned char)EXPEDITED_MSG_XTHIN, hops, thinBlock);
-            n->blocksSent += 1;
+            if (n->fDisconnect)
+            {
+                connmgr->RemovedNode(n);
+            }
+            else if (n != skip) // Don't send back to the sending node to avoid looping
+            {
+                LOG(THIN, "Sending expedited block %s to %s\n", thinBlock.header.GetHash().ToString(), n->GetLogName());
+                n->PushMessage(NetMsgType::XPEDITEDBLK, (unsigned char)EXPEDITED_MSG_XTHIN, hops, thinBlock);
+                n->blocksSent += 1;
+            }
         }
     }
 }

--- a/src/expedited.cpp
+++ b/src/expedited.cpp
@@ -126,6 +126,7 @@ void ActuallySendExpreditedBlock(CXThinBlock &thinBlock, unsigned char hops, con
 
         if (n != nullptr)
         {
+            if (weakblocksEnabled())
             {
                 LOCK(cs_weakblocks);
                 weakstore.set_nodeKnows(n->GetId(), thinBlock.header.GetHash());

--- a/src/expedited.cpp
+++ b/src/expedited.cpp
@@ -9,6 +9,7 @@
 #include "dosman.h"
 #include "expedited.h"
 #include "main.h" // Misbehaving, cs_main
+#include "weakblock.h"
 
 
 #define NUM_XPEDITED_STORE 10
@@ -123,6 +124,12 @@ void ActuallySendExpreditedBlock(CXThinBlock &thinBlock, unsigned char hops, con
     {
         CNode *n = nodeRef.get();
 
+        if (n != nullptr)
+        {
+            LOCK(cs_weakblocks);
+            weakstore.set_nodeKnows(n->GetId(), thinBlock.header.GetHash());
+        }
+
         if (n->fDisconnect)
         {
             connmgr->RemovedNode(n);
@@ -130,7 +137,6 @@ void ActuallySendExpreditedBlock(CXThinBlock &thinBlock, unsigned char hops, con
         else if (n != skip) // Don't send back to the sending node to avoid looping
         {
             LOG(THIN, "Sending expedited block %s to %s\n", thinBlock.header.GetHash().ToString(), n->GetLogName());
-
             n->PushMessage(NetMsgType::XPEDITEDBLK, (unsigned char)EXPEDITED_MSG_XTHIN, hops, thinBlock);
             n->blocksSent += 1;
         }

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -39,6 +39,7 @@
 #include "utilstrencodings.h"
 #include "validationinterface.h"
 #include "version.h"
+#include "weakblock.h"
 
 #include <atomic>
 #include <boost/lexical_cast.hpp>
@@ -345,6 +346,14 @@ CTweak<double> dMinLimiterTxFee("minlimitertxfee",
               "zero fee and subject to -limitfreerelay (default: %.4f)",
                                     DEFAULT_MINLIMITERTXFEE),
     DEFAULT_MINLIMITERTXFEE);
+
+CTweak<bool> wbEnable("weakblocks.enable", "Enable weakblocks support", DEFAULT_WEAKBLOCKS_ENABLE);
+
+CTweak<uint32_t> wbConsiderPOWratio("weakblocks.considerPOW",
+    "The factor to be applied to the current strong blocks target value which will be the maximum target value where a "
+    "weak block will be stored and forwarded",
+    DEFAULT_WEAKBLOCKS_CONSIDER_POW_RATIO);
+
 
 CRequestManager requester; // after the maps nodes and tweaks
 

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -347,8 +347,11 @@ CTweak<double> dMinLimiterTxFee("minlimitertxfee",
                                     DEFAULT_MINLIMITERTXFEE),
     DEFAULT_MINLIMITERTXFEE);
 
+
+// FIXME: This is not meant to be changed on-the-fly due to the complexities of handling changes!
 CTweak<bool> wbEnable("weakblocks.enable", "Enable weakblocks support", DEFAULT_WEAKBLOCKS_ENABLE);
 
+// FIXME: This is not meant to be changed on-the-fly due to the complexities of handling changes!
 CTweak<uint32_t> wbConsiderPOWratio("weakblocks.considerPOW",
     "The factor to be applied to the current strong blocks target value which will be the maximum target value where a "
     "weak block will be stored and forwarded",

--- a/src/graphene.cpp
+++ b/src/graphene.cpp
@@ -347,7 +347,9 @@ bool CGrapheneBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string
 
         CValidationState state;
         CBlockIndex *pIndex = nullptr;
-        if (!AcceptBlockHeader(grapheneBlock.header, state, Params(), &pIndex))
+        bool isWeak = false;
+
+        if (!AcceptBlockHeader(grapheneBlock.header, state, Params(), &pIndex, &isWeak))
         {
             int nDoS;
             if (state.IsInvalid(nDoS))

--- a/src/graphene.cpp
+++ b/src/graphene.cpp
@@ -363,6 +363,8 @@ bool CGrapheneBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string
             return false;
         }
 
+        // FIXME: deal with weak blocks through graphene!
+
         // pIndex should always be set by AcceptBlockHeader
         if (!pIndex)
         {

--- a/src/graphene.cpp
+++ b/src/graphene.cpp
@@ -292,7 +292,7 @@ bool CRequestGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
 bool CGrapheneBlock::CheckBlockHeader(const CBlockHeader &block, CValidationState &state)
 {
     // Check proof of work matches claimed amount
-    if (!CheckProofOfWork(header.GetHash(), header.nBits, Params().GetConsensus()))
+    if (!CheckProofOfWork(header.GetHash(), header.nBits, Params().GetConsensus(), 1))
         return state.DoS(50, error("CheckBlockHeader(): proof of work failed"), REJECT_INVALID, "high-hash");
 
     // Check timestamp

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -678,6 +678,8 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
     {
         if (GetBoolArg("-txindex", DEFAULT_TXINDEX))
             return InitError(_("Prune mode is incompatible with -txindex."));
+        if (GetBoolArg("-addrindex", DEFAULT_ADDRINDEX))
+            return InitError(_("Prune mode is incompatible with -addrindex."));
 #ifdef ENABLE_WALLET
         if (GetBoolArg("-rescan", false))
         {
@@ -1104,6 +1106,12 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
                 if (fTxIndex != GetBoolArg("-txindex", DEFAULT_TXINDEX))
                 {
                     strLoadError = _("You need to rebuild the database using -reindex to change -txindex");
+                    break;
+                }
+                // Check for changed -txindex state
+                if (fAddrIndex != GetBoolArg("-addrindex", DEFAULT_ADDRINDEX))
+                {
+                    strLoadError = _("You need to rebuild the database using -reindex to change -addrindex");
                     break;
                 }
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -47,6 +47,8 @@
 #include "utilmoneystr.h"
 #include "utilstrencodings.h"
 #include "validationinterface.h"
+#include "weakblock.h"
+
 #ifdef ENABLE_WALLET
 #include "wallet/db.h"
 #include "wallet/wallet.h"
@@ -827,6 +829,11 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
 
     // UAHF - BitcoinCash service bit
     nLocalServices |= NODE_BITCOIN_CASH;
+
+    // support for receiving and sending weak blocks with less than
+    // full POW
+    if (weakblocksEnabled())
+        nLocalServices |= NODE_WEAKBLOCKS;
 
     nMaxTipAge = GetArg("-maxtipage", DEFAULT_MAX_TIP_AGE);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3690,6 +3690,16 @@ static bool AcceptBlock(const CBlock &block,
                 0, "bad-prevblk");
         CBlockIndex *pindexPrev = mi->second;
 
+        const uint256 *phashPrev_expected = nullptr;
+        if (chainActive.Tip() != nullptr)
+            phashPrev_expected = chainActive.Tip()->phashBlock;
+
+        if (phashPrev_expected == nullptr || block.hashPrevBlock != *phashPrev_expected)
+        {
+            LOG(WB, "Weak block is not on top of most current strong block. Not accepting.\n");
+            return false;
+        }
+
         if ((!CheckBlock(block, state)) || !ContextualCheckBlock(block, state, pindexPrev))
         {
             // FIXME: cache weak block validation results?

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,6 +59,7 @@
 #include <boost/math/distributions/poisson.hpp>
 #include <boost/scope_exit.hpp>
 #include <boost/thread.hpp>
+#include <boost/variant/polymorphic_get.hpp>
 #include <sstream>
 
 #if defined(NDEBUG)
@@ -988,24 +989,15 @@ bool ReadTransaction(CTransaction &tx, const CDiskTxPos &pos, uint256 &hashBlock
 
 bool FindTransactionsByDestination(const CTxDestination &dest, std::set<CExtDiskTxPos> &setpos)
 {
-    uint160 addrid;
-    const CKeyID *pkeyid = boost::get<CKeyID>(&dest);
-    if (pkeyid)
-        addrid = static_cast<uint160>(*pkeyid);
-    if (addrid.IsNull())
-    {
-        const CScriptID *pscriptid = boost::get<CScriptID>(&dest);
-        if (pscriptid)
-            addrid = static_cast<uint160>(*pscriptid);
-    }
-    if (addrid.IsNull())
+    const uint160 *const addrid = boost::polymorphic_get<const uint160>(&dest);
+    if (addrid == nullptr || addrid->IsNull())
         return false;
 
     LOCK(cs_main);
     if (!fAddrIndex)
         return false;
     std::vector<CExtDiskTxPos> vPos;
-    if (!pblocktree->ReadAddrIndex(addrid, vPos))
+    if (!pblocktree->ReadAddrIndex(*addrid, vPos))
         return false;
     setpos.insert(vPos.begin(), vPos.end());
     return true;
@@ -1873,10 +1865,6 @@ bool ConnectBlock(const CBlock &block,
     int nInputs = 0;
     unsigned int nSigOps = 0;
 
-    // CDiskTxPos pos(pindex->GetBlockPos(), GetSizeOfCompactSize(block.vtx.size()));
-    // std::vector<std::pair<uint256, CDiskTxPos> > vPos;
-    // vPos.reserve(block.vtx.size());
-
     CExtDiskTxPos pos(CDiskTxPos(pindex->GetBlockPos(), GetSizeOfCompactSize(block.vtx.size())), pindex->nHeight);
     std::vector<std::pair<uint256, CDiskTxPos> > vPosTxid;
     std::vector<std::pair<uint160, CExtDiskTxPos> > vPosAddrid;
@@ -2053,7 +2041,6 @@ bool ConnectBlock(const CBlock &block,
                 blockundo.vtxundo.push_back(CTxUndo());
             }
             UpdateCoins(tx, state, view, i == 0 ? undoDummy : blockundo.vtxundo.back(), pindex->nHeight);
-            // vPos.push_back(std::make_pair(tx.GetHash(), pos));
             pos.nTxOffset += ::GetSerializeSize(tx, SER_DISK, CLIENT_VERSION);
 
             if (PV->QuitReceived(this_id, fParallel))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6275,14 +6275,13 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                     }
                 }
             }
-            else
-            {
-                dosMan.Misbehaving(pfrom, 100);
-                return error("Peer %srequested nonexistent block %s", pfrom->GetLogName(), inv.hash.ToString());
-            }
-
             if (!handled)
             {
+                if (mi == mapBlockIndex.end())
+                {
+                    dosMan.Misbehaving(pfrom, 100);
+                    return error("Peer %srequested nonexistent block %s", pfrom->GetLogName(), inv.hash.ToString());
+                }
                 CBlock block;
                 const Consensus::Params &consensusParams = Params().GetConsensus();
                 if (!ReadBlockFromDisk(block, (*mi).second, consensusParams))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3340,7 +3340,7 @@ bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, unsigne
 bool CheckBlockHeader(const CBlockHeader &block, CValidationState &state, bool fCheckPOW)
 {
     // Check proof of work matches claimed amount
-    if (fCheckPOW && !CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus()))
+    if (fCheckPOW && !CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus(), 1))
         return state.DoS(50, error("CheckBlockHeader(): proof of work failed"), REJECT_INVALID, "high-hash");
 
     // Check timestamp

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3612,7 +3612,7 @@ bool AcceptBlockHeader(const CBlockHeader &block,
         if (pWeak != nullptr && *pWeak)
         {
             LOG(WB, "Block is weak.\n");
-            return true; // do not add weak block to index, just keep in the structures of weakblock.cpp
+            return true; // do not add weak block to index, just keep in the structures of weakblock.cpp (if enabled)
         }
         else
         {
@@ -3662,9 +3662,8 @@ static bool AcceptBlock(const CBlock &block,
             if (!weakblocksEnabled())
             {
                 return state.DoS(10,
-                    error("%s: Received weakblocks though weakblocks are disabled. Ignoring.\n", __func__), 0,
+                    error("%s: Received weakblock though weakblocks are disabled. Ignoring.\n", __func__), 0,
                     "wb-disabled");
-                // FIXME: ban?
                 return true;
             }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5917,8 +5917,11 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                     hashLastBlock = header.hashPrevBlock;
             }
 
-            // Add this header to the map if it doesn't connect to a previous header
-            if (header.hashPrevBlock != hashLastBlock)
+            // Add this header to the map if it doesn't connect to a previous header and is not
+            // connecting to the current head (e.g. a weak block)
+            // FIXME: check logic!
+            if (header.hashPrevBlock != hashLastBlock &&
+                (chainActive.Tip() == nullptr || header.hashPrevBlock != chainActive.Tip()->GetBlockHash()))
             {
                 // If we still haven't finished downloading the initial headers during node sync and we get
                 // an out of order header then we must disconnect the node so that we can finish downloading

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6022,8 +6022,24 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                 break;
             }
             else
-                PV->UpdateMostWorkOurFork(header);
-
+            {
+                // if a weak header, request weak block
+                if (isWeak)
+                {
+                    // pindex must be nonnull because we populated vToFetch a few lines above
+                    CInv inv(MSG_BLOCK, header.GetHash());
+                    if (weakstore.byHash(header.GetHash()) == nullptr)
+                    {
+                        requester.AskFor(inv, pfrom);
+                        LOG(REQ, "AskFor weak block via headers direct fetch %s peer=%d\n", header.GetHash().ToString(),
+                            pfrom->id);
+                    }
+                }
+                else
+                {
+                    PV->UpdateMostWorkOurFork(header);
+                }
+            }
             i++;
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3457,14 +3457,7 @@ bool ContextualCheckBlockHeader(const CBlockHeader &block,
     const int nHeight = pindexPrev == nullptr ? 0 : pindexPrev->nHeight + 1;
 
     if (pWeak != nullptr)
-    {
-        LOCK(cs_weakblocks);
-        const bool hasWeakPOW = CheckProofOfWork(
-            block.GetHash(), MinWeakblockProofOfWork(block.nBits), Params().GetConsensus(), weakblocksMinPOWRatio());
-        const bool hasStrongPOW = CheckProofOfWork(block.GetHash(), block.nBits, Params().GetConsensus(), 1);
-
-        *pWeak = hasWeakPOW && !hasStrongPOW;
-    }
+        *pWeak = hasWeakButNotStrongPOW(&block);
 
     // Check proof of work
     uint32_t expectedNbits = GetNextWorkRequired(pindexPrev, &block, consensusParams);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 
 #include "addrman.h"
 #include "arith_uint256.h"
+#include "base58.h"
 #include "blockstorage/blockstorage.h"
 #include "blockstorage/sequential_files.h"
 #include "chainparams.h"
@@ -76,6 +77,7 @@ std::atomic<int64_t> nTimeBestReceived{0};
 bool fImporting = false;
 bool fReindex = false;
 bool fTxIndex = false;
+bool fAddrIndex = false;
 bool fHavePruned = false;
 bool fPruneMode = false;
 bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
@@ -966,6 +968,49 @@ bool AcceptToMemoryPool(CTxMemPool &pool,
     return res;
 }
 
+bool ReadTransaction(CTransaction &tx, const CDiskTxPos &pos, uint256 &hashBlock)
+{
+    CAutoFile file(OpenBlockFile(pos, true), SER_DISK, CLIENT_VERSION);
+    CBlockHeader header;
+    try
+    {
+        file >> header;
+        fseek(file.Get(), pos.nTxOffset, SEEK_CUR);
+        file >> tx;
+    }
+    catch (std::exception &e)
+    {
+        return error("%s() : deserialize or I/O error", __PRETTY_FUNCTION__);
+    }
+    hashBlock = header.GetHash();
+    return true;
+}
+
+bool FindTransactionsByDestination(const CTxDestination &dest, std::set<CExtDiskTxPos> &setpos)
+{
+    uint160 addrid;
+    const CKeyID *pkeyid = boost::get<CKeyID>(&dest);
+    if (pkeyid)
+        addrid = static_cast<uint160>(*pkeyid);
+    if (addrid.IsNull())
+    {
+        const CScriptID *pscriptid = boost::get<CScriptID>(&dest);
+        if (pscriptid)
+            addrid = static_cast<uint160>(*pscriptid);
+    }
+    if (addrid.IsNull())
+        return false;
+
+    LOCK(cs_main);
+    if (!fAddrIndex)
+        return false;
+    std::vector<CExtDiskTxPos> vPos;
+    if (!pblocktree->ReadAddrIndex(addrid, vPos))
+        return false;
+    setpos.insert(vPos.begin(), vPos.end());
+    return true;
+}
+
 /** Return transaction in tx, and if it was found inside a block, its hash is placed in hashBlock */
 bool GetTransaction(const uint256 &hash,
     CTransactionRef &txOut,
@@ -1661,6 +1706,41 @@ static int64_t nTimeIndex = 0;
 static int64_t nTimeCallbacks = 0;
 static int64_t nTimeTotal = 0;
 
+// Index either: a) every data push >=8 bytes,  b) if no such pushes, the entire script
+void static BuildAddrIndex(const CScript &script,
+    const CExtDiskTxPos &pos,
+    std::vector<std::pair<uint160, CExtDiskTxPos> > &out)
+{
+    CScript::const_iterator pc = script.begin();
+    CScript::const_iterator pend = script.end();
+    std::vector<unsigned char> data;
+    opcodetype opcode;
+    bool fHaveData = false;
+    while (pc < pend)
+    {
+        script.GetOp(pc, opcode, data);
+        if (0 <= opcode && opcode <= OP_PUSHDATA4 && data.size() >= 8)
+        { // data element
+            uint160 addrid;
+            if (data.size() <= 20)
+            {
+                memcpy(&addrid, &data[0], data.size());
+            }
+            else
+            {
+                addrid = Hash160(data);
+            }
+            out.push_back(std::make_pair(addrid, pos));
+            fHaveData = true;
+        }
+    }
+    if (!fHaveData)
+    {
+        uint160 addrid = Hash160(script);
+        out.push_back(std::make_pair(addrid, pos));
+    }
+}
+
 bool ConnectBlock(const CBlock &block,
     CValidationState &state,
     CBlockIndex *pindex,
@@ -1792,9 +1872,19 @@ bool ConnectBlock(const CBlock &block,
     CAmount nFees = 0;
     int nInputs = 0;
     unsigned int nSigOps = 0;
-    CDiskTxPos pos(pindex->GetBlockPos(), GetSizeOfCompactSize(block.vtx.size()));
-    std::vector<std::pair<uint256, CDiskTxPos> > vPos;
-    vPos.reserve(block.vtx.size());
+
+    // CDiskTxPos pos(pindex->GetBlockPos(), GetSizeOfCompactSize(block.vtx.size()));
+    // std::vector<std::pair<uint256, CDiskTxPos> > vPos;
+    // vPos.reserve(block.vtx.size());
+
+    CExtDiskTxPos pos(CDiskTxPos(pindex->GetBlockPos(), GetSizeOfCompactSize(block.vtx.size())), pindex->nHeight);
+    std::vector<std::pair<uint256, CDiskTxPos> > vPosTxid;
+    std::vector<std::pair<uint160, CExtDiskTxPos> > vPosAddrid;
+    if (fTxIndex)
+        vPosTxid.reserve(block.vtx.size());
+    if (fAddrIndex)
+        vPosAddrid.reserve(4 * block.vtx.size());
+
     blockundo.vtxundo.reserve(block.vtx.size() - 1);
     int nChecked = 0;
     int nOrphansChecked = 0;
@@ -1933,13 +2023,37 @@ bool ConnectBlock(const CBlock &block,
                 }
             }
 
+            if (fTxIndex)
+                vPosTxid.push_back(std::make_pair(tx.GetHash(), pos));
+            if (fAddrIndex)
+            {
+                if (!tx.IsCoinBase())
+                {
+                    for (const auto &txin : tx.vin)
+                    {
+                        Coin coin;
+                        if (!view.GetCoin(txin.prevout, coin))
+                        {
+                            LOGA("%s: error: no coins found for: %s\n\tfor block: %d, vtx.size=%d\n", __func__,
+                                txin.prevout.hash.ToString(), pindex->nHeight, block.vtx.size());
+                            return AbortNode(state, "Failed to write AddrIndex");
+                        }
+                        BuildAddrIndex(coin.out.scriptPubKey, pos, vPosAddrid);
+                    }
+                }
+                for (const CTxOut &txout : tx.vout)
+                {
+                    BuildAddrIndex(txout.scriptPubKey, pos, vPosAddrid);
+                }
+            }
+
             CTxUndo undoDummy;
             if (i > 0)
             {
                 blockundo.vtxundo.push_back(CTxUndo());
             }
             UpdateCoins(tx, state, view, i == 0 ? undoDummy : blockundo.vtxundo.back(), pindex->nHeight);
-            vPos.push_back(std::make_pair(tx.GetHash(), pos));
+            // vPos.push_back(std::make_pair(tx.GetHash(), pos));
             pos.nTxOffset += ::GetSerializeSize(tx, SER_DISK, CLIENT_VERSION);
 
             if (PV->QuitReceived(this_id, fParallel))
@@ -2029,8 +2143,12 @@ bool ConnectBlock(const CBlock &block,
     }
 
     if (fTxIndex)
-        if (!pblocktree->WriteTxIndex(vPos))
+        if (!pblocktree->WriteTxIndex(vPosTxid))
             return AbortNode(state, "Failed to write transaction index");
+
+    if (fAddrIndex)
+        if (!pblocktree->AddAddrIndex(vPosAddrid))
+            return AbortNode(state, "Failed to write address index");
 
     // add this block to the view's block chain (the main UTXO in memory cache)
     view.SetBestBlock(pindex->GetBlockHash());
@@ -3946,6 +4064,9 @@ bool static LoadBlockIndexDB()
     pblocktree->ReadFlag("txindex", fTxIndex);
     LOGA("%s: transaction index %s\n", __func__, fTxIndex ? "enabled" : "disabled");
 
+    pblocktree->ReadFlag("addrindex", fAddrIndex);
+    LOGA("%s: address index %s\n", __func__, fAddrIndex ? "enabled" : "disabled");
+
     // Load pointer to end of best chain
     uint256 bestblockhash;
     if (BLOCK_DB_MODE == SEQUENTIAL_BLOCK_FILES)
@@ -4160,6 +4281,8 @@ bool InitBlockIndex(const CChainParams &chainparams)
     // Use the provided setting for -txindex in the new database
     fTxIndex = GetBoolArg("-txindex", DEFAULT_TXINDEX);
     pblocktree->WriteFlag("txindex", fTxIndex);
+    fAddrIndex = GetBoolArg("-addrindex", DEFAULT_ADDRINDEX);
+    pblocktree->WriteFlag("addrindex", fAddrIndex);
     LOGA("Initializing databases...\n");
 
     // Only add the genesis block if not reindexing (in which case we reuse the one already on disk)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3696,7 +3696,7 @@ static bool AcceptBlock(const CBlock &block,
             return false;
         }
 
-        if (storeWeakblock(block))
+        if (weakstore.store(&block))
         {
             // FIXME: Send out here?
         }
@@ -3710,7 +3710,7 @@ static bool AcceptBlock(const CBlock &block,
     {
         // strong block came in - discard weak ones coming before the last strong block
         LOG(WB, "Strong block came in - discarding old weak blocks.\n");
-        purgeOldWeakblocks();
+        weakstore.expireOld();
     }
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -286,7 +286,8 @@ bool AlreadyHaveBlock(const CInv &inv);
 bool AcceptBlockHeader(const CBlockHeader &block,
     CValidationState &state,
     const CChainParams &chainparams,
-    CBlockIndex **ppindex = nullptr);
+    CBlockIndex **ppindex,
+    bool *pWeak);
 
 bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, unsigned int nAddSize);
 
@@ -495,7 +496,10 @@ bool CheckBlock(const CBlock &block,
     bool conservative = false);
 
 /** Context-dependent validity checks */
-bool ContextualCheckBlockHeader(const CBlockHeader &block, CValidationState &state, CBlockIndex *pindexPrev);
+bool ContextualCheckBlockHeader(const CBlockHeader &block,
+    CValidationState &state,
+    CBlockIndex *pindexPrev,
+    bool *pWeak);
 bool ContextualCheckBlock(const CBlock &block, CValidationState &state, CBlockIndex *pindexPrev);
 
 /** Check a block is completely valid from start to finish (only works on top of our current best block, with cs_main

--- a/src/main.h
+++ b/src/main.h
@@ -183,6 +183,7 @@ extern CConditionVariable cvBlockChange;
 extern bool fImporting;
 extern bool fReindex;
 extern bool fTxIndex;
+extern bool fAddrIndex;
 extern bool fIsBareMultisigStd;
 extern unsigned int nBytesPerSigOp;
 extern bool fCheckBlockIndex;
@@ -459,6 +460,9 @@ public:
     }
 };
 
+
+bool ReadTransaction(CTransaction &tx, const CDiskTxPos &pos, uint256 &hashBlock);
+bool FindTransactionsByDestination(const CTxDestination &dest, std::set<CExtDiskTxPos> &setpos);
 
 /** Functions for validating blocks and updating the block tree */
 

--- a/src/miner.h
+++ b/src/miner.h
@@ -49,7 +49,7 @@ private:
     uint64_t nBlockTx;
     unsigned int nBlockSigOps;
     CAmount nFees;
-    CTxMemPool::setEntries inBlock;
+    std::set<uint256> inBlock;
 
     // Chain context for the block
     int nHeight;
@@ -72,9 +72,12 @@ private:
     /** Clear the block's state and prepare for assembling a new block */
     void resetBlock(const CScript &scriptPubKeyIn);
     /** Add a tx to the block */
-    void AddToBlock(CBlockTemplate *, CTxMemPool::txiter iter);
+    void AddToBlock(CBlockTemplate *, const CTxMemPoolEntry *iter);
 
     // Methods for how to add transactions to a block.
+    /** Add transactions from latest weak block. Returns the hash
+     (or zero if no weak block has been found to base of off)*/
+    uint256 addFromLatestWeakBlock(CBlockTemplate *);
     /** Add transactions based on modified feerate */
     void addScoreTxs(CBlockTemplate *);
     /** Add transactions based on tx "priority" */
@@ -83,7 +86,7 @@ private:
     // helper function for addScoreTxs and addPriorityTxs
     bool IsIncrementallyGood(uint64_t nExtraSize, unsigned int nExtraSigOps);
     /** Test if tx will still "fit" in the block */
-    bool TestForBlock(CTxMemPool::txiter iter);
+    bool TestForBlock(const CTxMemPoolEntry *iter);
     /** Test if tx still has unconfirmed parents not yet in block */
     bool isStillDependent(CTxMemPool::txiter iter);
     /** Bytes to reserve for coinbase and block header */
@@ -91,7 +94,7 @@ private:
     /** Internal method to construct a new block template */
     std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript &scriptPubKeyIn, bool blockstreamCoreCompatible);
     /** Constructs a coinbase transaction */
-    CTransactionRef coinbaseTx(const CScript &scriptPubKeyIn, int nHeight, CAmount nValue);
+    CTransactionRef coinbaseTx(const CScript &scriptPubKeyIn, int nHeight, CAmount nValue, const uint256 &weakhash);
 };
 
 /** Modify the extranonce in a block */

--- a/src/net.h
+++ b/src/net.h
@@ -576,6 +576,7 @@ public:
         return false;
     }
 
+    bool WeakblocksCapable() { return nServices & NODE_WEAKBLOCKS; }
     void AddAddressKnown(const CAddress &_addr) { addrKnown.insert(_addr.GetKey()); }
     void PushAddress(const CAddress &_addr, FastRandomContext &insecure_rand)
     {

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -194,6 +194,14 @@ uint32_t ConsiderationWeakblockProofOfWork(uint32_t nBits)
     return considertarget.GetCompact();
 }
 
+bool hasWeakButNotStrongPOW(const CBlockHeader *block)
+{
+    LOCK(cs_weakblocks);
+    const bool hasWeakPOW = CheckProofOfWork(
+        block->GetHash(), MinWeakblockProofOfWork(block->nBits), Params().GetConsensus(), weakblocksMinPOWRatio());
+    const bool hasStrongPOW = CheckProofOfWork(block->GetHash(), block->nBits, Params().GetConsensus(), 1);
+    return hasWeakPOW && !hasStrongPOW;
+}
 
 arith_uint256 GetBlockProof(const CBlockIndex &block)
 {

--- a/src/pow.h
+++ b/src/pow.h
@@ -22,7 +22,15 @@ unsigned int CalculateNextWorkRequired(const CBlockIndex *pindexLast,
     const Consensus::Params &);
 
 /** Check whether a block hash satisfies the proof-of-work requirement specified by nBits */
-bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params &);
+bool CheckProofOfWork(uint256 hash, unsigned int nBits, const Consensus::Params &, const uint32_t weakFactor);
+
+// minimum to be considered "possibly valid" and not lead to banning
+uint32_t MinWeakblockProofOfWork(uint32_t nBits);
+
+// actual minimum for consideration and store/forward. This is set by
+// the -weakblocks-max-difficulty-factor command line argument
+uint32_t ConsiderationWeakblockProofOfWork(uint32_t nBits);
+
 arith_uint256 GetBlockProof(const CBlockIndex &block);
 
 /** Return the time it would take to redo the work difference between from and to, assuming the current hashrate

--- a/src/pow.h
+++ b/src/pow.h
@@ -31,6 +31,9 @@ uint32_t MinWeakblockProofOfWork(uint32_t nBits);
 // the -weakblocks-max-difficulty-factor command line argument
 uint32_t ConsiderationWeakblockProofOfWork(uint32_t nBits);
 
+// Returns true iff the given block has weak but not strong POW
+bool hasWeakButNotStrongPOW(const CBlockHeader *block);
+
 arith_uint256 GetBlockProof(const CBlockIndex &block);
 
 /** Return the time it would take to redo the work difference between from and to, assuming the current hashrate

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -335,6 +335,8 @@ enum
     // collisions and other cases where nodes may be advertising a service they
     // do not actually support. Other service bits should be allocated via the
     // BUIP process.
+
+    NODE_WEAKBLOCKS = (1 << 7)
 };
 
 /** A CService with information about it as peer */

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -124,6 +124,7 @@ void CRequestManager::cleanup(OdMap::iterator &itemIt)
             node->Release();
         }
     }
+    LOG(REQ, "Clearing item available from for obj: %s\n", item.obj.hash.GetHex());
     item.availableFrom.clear();
 
     if (item.obj.type == MSG_TX)
@@ -640,8 +641,13 @@ void CRequestManager::SendRequests()
                 // Go thru the availableFrom list, looking for the first node that isn't disconnected
                 while (!item.availableFrom.empty() && (next.node == nullptr))
                 {
+                    LOG(REQ, "At next available block item: node:%d item:%s\n", item.availableFrom.front().node->id,
+                        item.obj.hash.GetHex());
+
                     next = item.availableFrom.front(); // Grab the next location where we can find this object.
                     item.availableFrom.pop_front();
+
+
                     if (next.node != nullptr)
                     {
                         // Do not request from this node if it was disconnected

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -46,12 +46,13 @@ static const CRPCConvertParam vRPCConvertParams[] = {{"stop", 0}, {"setmocktime"
     {"addmultisigaddress", 1}, {"createmultisig", 0}, {"createmultisig", 1}, {"listunspent", 0}, {"listunspent", 1},
     {"listunspent", 2}, {"getblock", 1}, {"getblock", 2}, {"getblockheader", 1}, {"gettransaction", 1},
     {"getrawtransaction", 1}, {"createrawtransaction", 0}, {"createrawtransaction", 1}, {"createrawtransaction", 2},
-    {"signrawtransaction", 1}, {"signrawtransaction", 2}, {"sendrawtransaction", 1}, {"fundrawtransaction", 1},
-    {"gettxout", 1}, {"gettxout", 2}, {"gettxoutproof", 0}, {"lockunspent", 0}, {"lockunspent", 1},
-    {"importprivkey", 2}, {"importaddress", 2}, {"importaddress", 3}, {"importpubkey", 2}, {"verifychain", 0},
-    {"verifychain", 1}, {"keypoolrefill", 0}, {"getrawmempool", 0}, {"estimatefee", 0}, {"estimatepriority", 0},
-    {"estimatesmartfee", 0}, {"estimatesmartpriority", 0}, {"prioritisetransaction", 1}, {"prioritisetransaction", 2},
-    {"setban", 2}, {"setban", 3}, {"rollbackchain", 0}, {"rollbackchain", 1}};
+    {"searchrawtransactions", 2}, {"searchrawtransactions", 3}, {"searchrawtransactions", 4}, {"signrawtransaction", 1},
+    {"signrawtransaction", 2}, {"sendrawtransaction", 1}, {"fundrawtransaction", 1}, {"gettxout", 1}, {"gettxout", 2},
+    {"gettxoutproof", 0}, {"lockunspent", 0}, {"lockunspent", 1}, {"importprivkey", 2}, {"importaddress", 2},
+    {"importaddress", 3}, {"importpubkey", 2}, {"verifychain", 0}, {"verifychain", 1}, {"keypoolrefill", 0},
+    {"getrawmempool", 0}, {"estimatefee", 0}, {"estimatepriority", 0}, {"estimatesmartfee", 0},
+    {"estimatesmartpriority", 0}, {"prioritisetransaction", 1}, {"prioritisetransaction", 2}, {"setban", 2},
+    {"setban", 3}, {"rollbackchain", 0}, {"rollbackchain", 1}};
 
 class CRPCConvertTable
 {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -248,6 +248,10 @@ UniValue generate(const UniValue &params, bool fHelp)
             throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid genmode");
     }
 
+    if (genmode != genStrongOnly && !weakblocksEnabled())
+        throw JSONRPCError(
+            RPC_INVALID_PARAMETER, "Only strong-blocks-mining is available as weak blocks are disabled.");
+
     boost::shared_ptr<CReserveScript> coinbaseScript;
     GetMainSignals().ScriptForMining(coinbaseScript);
 

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -131,7 +131,7 @@ UniValue generateBlocks(boost::shared_ptr<CReserveScript> coinbaseScript,
             IncrementExtraNonce(pblock, nExtraNonce);
         }
         while (nMaxTries > 0 && pblock->nNonce < nInnerLoopCount &&
-               !CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus()))
+               !CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus(), 1))
         {
             ++pblock->nNonce;
             --nMaxTries;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -134,10 +134,6 @@ UniValue searchrawtransactions(const UniValue &params, bool fHelp)
     if (!fAddrIndex)
         throw JSONRPCError(RPC_MISC_ERROR, "Address index not enabled");
 
-    // CBitcoinAddress address(params[0].get_str());
-    // if (!address.IsValid())
-    //     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
-    // CTxDestination dest = address.Get();
     CTxDestination dest = DecodeDestination(params[0].get_str());
 
     std::set<CExtDiskTxPos> setpos;
@@ -148,7 +144,7 @@ UniValue searchrawtransactions(const UniValue &params, bool fHelp)
     int nCount = 100;
     bool fVerbose = true;
     if (params.size() > 1)
-        fVerbose = (params[1].get_int() != 0);
+        fVerbose = params[1].get_bool();
     if (params.size() > 2)
         nSkip = params[2].get_int();
     if (params.size() > 3)
@@ -174,7 +170,7 @@ UniValue searchrawtransactions(const UniValue &params, bool fHelp)
             throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Cannot read transaction from disk");
         CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
         ssTx << tx;
-        string strHex = HexStr(ssTx.begin(), ssTx.end());
+        string strHex = HexStr(ssTx);
         if (fVerbose)
         {
             UniValue object(UniValue::VOBJ);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -129,7 +129,15 @@ void TxToJSON(const CTransaction &tx, const uint256 hashBlock, UniValue &entry)
 UniValue searchrawtransactions(const UniValue &params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 4)
-        throw runtime_error("searchrawtransactions <address> [verbose=1] [skip=0] [count=100]\n");
+        throw runtime_error(
+            "searchrawtransactions <address> [verbose=true] [skip=0] [count=100]\n"
+            "\nSearch for transactions by address. Requires address index to be enabled (-addrindex option)\n"
+            "\nArguments:\n"
+            "1. address     (address, mandatory) The address to look for\n"
+            "2. verbose     (boolean, optional, default=true) If this is set, also return the decoded transaction\n"
+            "3. skip        (integer, optional, default=0) The number of entries to skip from the beginning. If "
+            "negative, skip that many before the end\n"
+            "4. count       (integer, optiona, default=100) The number of entries to return\n");
 
     if (!fAddrIndex)
         throw JSONRPCError(RPC_MISC_ERROR, "Address index not enabled");

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -126,6 +126,71 @@ void TxToJSON(const CTransaction &tx, const uint256 hashBlock, UniValue &entry)
     }
 }
 
+UniValue searchrawtransactions(const UniValue &params, bool fHelp)
+{
+    if (fHelp || params.size() < 1 || params.size() > 4)
+        throw runtime_error("searchrawtransactions <address> [verbose=1] [skip=0] [count=100]\n");
+
+    if (!fAddrIndex)
+        throw JSONRPCError(RPC_MISC_ERROR, "Address index not enabled");
+
+    // CBitcoinAddress address(params[0].get_str());
+    // if (!address.IsValid())
+    //     throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address");
+    // CTxDestination dest = address.Get();
+    CTxDestination dest = DecodeDestination(params[0].get_str());
+
+    std::set<CExtDiskTxPos> setpos;
+    if (!FindTransactionsByDestination(dest, setpos))
+        throw JSONRPCError(RPC_DATABASE_ERROR, "Cannot search for address");
+
+    int nSkip = 0;
+    int nCount = 100;
+    bool fVerbose = true;
+    if (params.size() > 1)
+        fVerbose = (params[1].get_int() != 0);
+    if (params.size() > 2)
+        nSkip = params[2].get_int();
+    if (params.size() > 3)
+        nCount = params[3].get_int();
+
+    if (nSkip < 0)
+        nSkip += setpos.size();
+    if (nSkip < 0)
+        nSkip = 0;
+    if (nCount < 0)
+        nCount = 0;
+
+    std::set<CExtDiskTxPos>::const_iterator it = setpos.begin();
+    while (it != setpos.end() && nSkip--)
+        it++;
+
+    UniValue result(UniValue::VARR);
+    while (it != setpos.end() && nCount--)
+    {
+        CTransaction tx;
+        uint256 hashBlock;
+        if (!ReadTransaction(tx, *it, hashBlock))
+            throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Cannot read transaction from disk");
+        CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
+        ssTx << tx;
+        string strHex = HexStr(ssTx.begin(), ssTx.end());
+        if (fVerbose)
+        {
+            UniValue object(UniValue::VOBJ);
+            TxToJSON(tx, hashBlock, object);
+            object.push_back(Pair("hex", strHex));
+            result.push_back(object);
+        }
+        else
+        {
+            result.push_back(strHex);
+        }
+        it++;
+    }
+    return result;
+}
+
 UniValue getrawtransaction(const UniValue &params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 2)
@@ -1026,6 +1091,7 @@ static const CRPCCommand commands[] = {
     //  category              name                      actor (function)         okSafeMode
     //  --------------------- ------------------------  -----------------------  ----------
     {"rawtransactions", "getrawtransaction", &getrawtransaction, true},
+    {"rawtransactions", "searchrawtransactions", &searchrawtransactions, true},
     {"rawtransactions", "createrawtransaction", &createrawtransaction, true},
     {"rawtransactions", "decoderawtransaction", &decoderawtransaction, true},
     {"rawtransactions", "decodescript", &decodescript, true},

--- a/src/rpc/register.h
+++ b/src/rpc/register.h
@@ -21,6 +21,8 @@ void RegisterMiningRPCCommands(CRPCTable &tableRPC);
 void RegisterRawTransactionRPCCommands(CRPCTable &tableRPC);
 /** Register Bitcoin Unlimited's RPC commands */
 void RegisterUnlimitedRPCCommands(CRPCTable &tableRPC);
+/** Register Weakblock RPC commands */
+void RegisterWeakBlockRPCCommands(CRPCTable &tableRPC);
 
 static inline void RegisterAllCoreRPCCommands(CRPCTable &tableRPC)
 {
@@ -30,6 +32,7 @@ static inline void RegisterAllCoreRPCCommands(CRPCTable &tableRPC)
     RegisterMiningRPCCommands(tableRPC);
     RegisterRawTransactionRPCCommands(tableRPC);
     RegisterUnlimitedRPCCommands(tableRPC);
+    RegisterWeakBlockRPCCommands(tableRPC);
 }
 
 #endif

--- a/src/rpc/weakblock.cpp
+++ b/src/rpc/weakblock.cpp
@@ -121,7 +121,7 @@ static const CRPCCommand commands[] =
 { //  category              name                      actor (function)         okSafeMode
   //  --------------------- ------------------------  -----------------------  ----------
     { "weakblocks",         "weakstats",              &weakstats,              true  },
-    { "weakblocks",         "weakchaintips",          &weakchaintips,          true },
+    { "weakblocks",         "weakchaintips",          &weakchaintips,          true  },
     { "weakblocks",         "weakconfirmations",      &weakconfirmations,      true  },
     { "weakblocks",         "weaknodeknowledge",      &weaknodeknowledge,      true  }
 };

--- a/src/rpc/weakblock.cpp
+++ b/src/rpc/weakblock.cpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2018 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "rpc/server.h"
+#include "utilstrencodings.h"
+#include "weakblock.h"
+#include <univalue.h>
+
+using namespace std;
+
+UniValue weakstats(const UniValue& params, bool fHelp) {
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "weakstats\n"
+            "\nReturns various high level weak block statistics.\n");
+
+    UniValue result(UniValue::VOBJ);
+
+    LOCK(cs_weakblocks);
+    result.push_back(Pair("weakblocksknown", (uint64_t)weakstore.size()));
+    result.push_back(Pair("weakchaintips", (uint64_t)weakstore.chainTips().size()));
+
+    CWeakblockRef tip = weakstore.Tip();
+    if (tip == nullptr) {
+        result.push_back(Pair("weakchainheight", -1));
+    } else {
+        result.push_back(Pair("weakchainheight", tip->GetWeakHeight()));
+        result.push_back(Pair("weakchaintiphash",  tip->GetHash().GetHex()));
+        result.push_back(Pair("weakchaintipnumtx", (uint64_t)tip->vtx.size()));
+    }
+    return result;
+}
+
+UniValue weakchaintips(const UniValue &params, bool fHelp) {
+    if (fHelp || params.size() != 0)
+        throw runtime_error(
+            "weakchaintips\n"
+            "\nGives back the current weak chain tips as pairs of (weak block hash, weak chain height), in chronological order\n");
+
+    const std::vector<CWeakblockRef>& tips = weakstore.chainTips();
+    UniValue result(UniValue::VARR);
+
+    for (auto wb : tips) {
+        UniValue entry(UniValue::VARR);
+        entry.push_back(wb->GetHash().GetHex());
+        entry.push_back(wb->GetWeakHeight());
+        result.push_back(entry);
+    }
+    return result;
+}
+
+UniValue weakconfirmations(const UniValue &params, bool fHelp) {
+    // FIXME: This is currently slow. Needs a proper index. */
+    if (fHelp || params.size() < 1)
+        throw runtime_error(
+            "weakconfirmations \"hexstring\"\n"
+            "\nReturns the depth the given transaction can be found in the current weak block chain tip.\n"
+            "\nArguments:\n"
+            "1. \"hexstring\"    (string, required) The hex string of the TXID\n"
+            "\nResult:\n"
+            "\"num\"             (int) The number of weak block confirmations\n");
+
+
+    std::string txid_hex = params[0].get_str();
+    uint256 hash = ParseHashV(params[0], "parameter 1");
+
+    CWeakblockRef pblock = weakstore.Tip();
+    int confs = 0;
+
+    while (pblock != nullptr) {
+        bool found =false;
+        for (auto tx : pblock->vtx) {
+            if (tx->GetHash() == hash) {
+                found = true;
+                break;
+            }
+        }
+        if (found) confs++;
+        else break;
+        pblock = weakstore.parent(pblock->GetHash());
+    }
+    return confs;
+}
+
+
+static const CRPCCommand commands[] =
+{ //  category              name                      actor (function)         okSafeMode
+  //  --------------------- ------------------------  -----------------------  ----------
+    { "weakblocks",         "weakstats",              &weakstats,   true  },
+    { "weakblocks",         "weakchaintips",          &weakchaintips, true },
+    { "weakblocks",         "weakconfirmations",      &weakconfirmations,      true  },
+};
+
+void RegisterWeakBlockRPCCommands(CRPCTable &table)
+{
+    for (auto cmd : commands)
+        table.appendCommand(cmd);
+}

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -505,8 +505,8 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         BuildSeededBloomFilter(filter, vOrphanHashes, TestBlock1().GetHash(), &dummyNode, true);
 
         block = TestBlock1();
-        CThinBlock thinblock(block, filter);
-        CXThinBlock xthinblock(block, &filter);
+        CThinBlock thinblock(block, filter, nullptr);
+        CXThinBlock xthinblock(block, &filter, nullptr);
 
         /** FILTERSIZEXTHIN tests */
 

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -873,7 +873,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // Process an xthinblock which causes a disconnect
             dummyNode6.fDisconnect = false;
-            xthin2.process(&dummyNode6, nSizeXthin, NetMsgType::XTHINBLOCK);
+            xthin2.process(&dummyNode6, nSizeXthin, NetMsgType::XTHINBLOCK, uint256());
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
             BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
             BOOST_CHECK_EQUAL(-1, dummyNode6.thinBlockWaitingForTxns);
@@ -894,7 +894,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // Process a regular thinblock
             dummyNode6.fDisconnect = false;
-            thin2.process(&dummyNode6, nSizeThinblock);
+            thin2.process(&dummyNode6, nSizeThinblock, uint256());
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
             BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
             BOOST_CHECK_EQUAL(-1, dummyNode6.thinBlockWaitingForTxns);
@@ -965,7 +965,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // Process an xthinblock which will be the largest over limit and will be the one that gets disconnected.
             dummyNode6.fDisconnect = false;
-            xthin3.process(&dummyNode6, nSizeXthin, NetMsgType::XTHINBLOCK);
+            xthin3.process(&dummyNode6, nSizeXthin, NetMsgType::XTHINBLOCK, uint256());
             BOOST_CHECK(!dummyNode7.fDisconnect); // node should *not* be disconnected
             BOOST_CHECK_EQUAL(nBytes1, dummyNode7.nLocalThinBlockBytes);
             BOOST_CHECK(!dummyNode8.fDisconnect); // node should *not* be disconnected
@@ -1040,7 +1040,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             // and cause itself to be disconnected.
             dummyNode6.fDisconnect = false;
             dummyNode7.fDisconnect = false;
-            xthin4.process(&dummyNode6, nSizeXthin, NetMsgType::XTHINBLOCK);
+            xthin4.process(&dummyNode6, nSizeXthin, NetMsgType::XTHINBLOCK, uint256());
             BOOST_CHECK(!dummyNode8.fDisconnect); // node should *not* be disconnected
             BOOST_CHECK_EQUAL(nBytes1, dummyNode8.nLocalThinBlockBytes);
             BOOST_CHECK(!dummyNode9.fDisconnect); // node should *not* be disconnected

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -226,14 +226,15 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 
     // Assert we went right up to the limit.  We reserved 4 bytes for height but only use 2 as height is 110.
     // We also reserved 5 bytes for tx count but only use 3 as we don't have > 65535 txs in a block
-    BOOST_CHECK_EQUAL(minRoom, 4);
+    // and add 45 for the empty room for the unused weak hash reference output
+    BOOST_CHECK_EQUAL(minRoom, 4 + 45);
 
     minRoom = 1000;
     std::string testMinerComment("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdefghijklmnopqrstuvw"
                                  "xyzABCDEFGHIJKLM__________");
     // Now generate lots of full size blocks and verify that none exceed the maxGeneratedBlock value
     // printf("test mining with different sized miner comments");
-    for (unsigned int i = 2000; i <= 40000; i += 89)
+    for (unsigned int i = 1936; i <= 40000; i += 89)
     {
         maxGeneratedBlock = i;
         if ((i % 100) > 0)
@@ -255,7 +256,8 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     // Assert we went right up to the limit.  We reserved 4 bytes for height but only use 2 as height is 110.
     // However those 2 bytes are instead used by the long miner comment.
     // We also reserved 5 bytes for tx count but only use 3 as we don't have > 65535 txs in a block
-    BOOST_CHECK_EQUAL(minRoom, 2);
+    // and add 45 for the empty room for the unused weak hash reference output
+    BOOST_CHECK_EQUAL(minRoom, 2 + 45);
 
     mempool.clear();
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -165,6 +165,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         mempool.addUnchecked(hash, entry.Fee(1000000).Time(GetTime()).SpendsCoinbase(spendsCoinbase).FromTx(tx));
         tx.vin[0].prevout.hash = hash;
     }
+    LOGA("Transaction size: %d\n", GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION));
 
     BOOST_CHECK_EXCEPTION(
         BlockAssembler(chainparams).CreateNewBlock(scriptPubKey), std::runtime_error, HasReason("bad-blk-sigops"));

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 
     // Assert we went right up to the limit.  We reserved 4 bytes for height but only use 2 as height is 110.
     // We also reserved 5 bytes for tx count but only use 3 as we don't have > 65535 txs in a block
-    BOOST_CHECK(minRoom == 4);
+    BOOST_CHECK_EQUAL(minRoom, 4);
 
     minRoom = 1000;
     std::string testMinerComment("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890abcdefghijklmnopqrstuvw"
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     // Assert we went right up to the limit.  We reserved 4 bytes for height but only use 2 as height is 110.
     // However those 2 bytes are instead used by the long miner comment.
     // We also reserved 5 bytes for tx count but only use 3 as we don't have > 65535 txs in a block
-    BOOST_CHECK(minRoom == 2);
+    BOOST_CHECK_EQUAL(minRoom, 2);
 
     mempool.clear();
 

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -14,6 +14,7 @@
 #include "streams.h"
 #include "test/test_bitcoin.h"
 #include "test/test_random.h"
+#include "test/testutil.h"
 #include "util.h"
 #include "utilstrencodings.h"
 #include "version.h"
@@ -87,42 +88,6 @@ uint256 static SignatureHashOld(CScript scriptCode, const CTransaction &txTo, un
     CHashWriter ss(SER_GETHASH, 0);
     ss << txTmp << nHashType;
     return ss.GetHash();
-}
-
-void static RandomScript(CScript &script)
-{
-    static const opcodetype oplist[] = {
-        OP_FALSE, OP_1, OP_2, OP_3, OP_CHECKSIG, OP_IF, OP_VERIF, OP_RETURN, OP_CODESEPARATOR};
-    script = CScript();
-    int ops = (insecure_rand() % 10);
-    for (int i = 0; i < ops; i++)
-        script << oplist[insecure_rand() % (sizeof(oplist) / sizeof(oplist[0]))];
-}
-
-void static RandomTransaction(CMutableTransaction &tx, bool fSingle)
-{
-    tx.nVersion = insecure_rand();
-    tx.vin.clear();
-    tx.vout.clear();
-    tx.nLockTime = (insecure_rand() % 2) ? insecure_rand() : 0;
-    int ins = (insecure_rand() % 4) + 1;
-    int outs = fSingle ? ins : (insecure_rand() % 4) + 1;
-    for (int in = 0; in < ins; in++)
-    {
-        tx.vin.push_back(CTxIn());
-        CTxIn &txin = tx.vin.back();
-        txin.prevout.hash = GetRandHash();
-        txin.prevout.n = insecure_rand() % 4;
-        RandomScript(txin.scriptSig);
-        txin.nSequence = (insecure_rand() % 2) ? insecure_rand() : (unsigned int)-1;
-    }
-    for (int out = 0; out < outs; out++)
-    {
-        tx.vout.push_back(CTxOut());
-        CTxOut &txout = tx.vout.back();
-        txout.nValue = insecure_rand() % 100000000;
-        RandomScript(txout.scriptPubKey);
-    }
 }
 
 BOOST_FIXTURE_TEST_SUITE(sighash_tests, BasicTestingSetup)

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -114,7 +114,7 @@ CBlock TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransa
     unsigned int extraNonce = 0;
     IncrementExtraNonce(&block, extraNonce);
 
-    while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus()))
+    while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus(), 1))
         ++block.nNonce;
 
     CValidationState state;

--- a/src/test/testutil.cpp
+++ b/src/test/testutil.cpp
@@ -3,6 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "testutil.h"
+#include "primitives/transaction.h"
+#include "test/test_random.h"
 
 #ifdef WIN32
 #include <shlobj.h>
@@ -11,3 +13,38 @@
 #include "fs.h"
 
 fs::path GetTempPath() { return fs::temp_directory_path(); }
+void RandomScript(CScript &script)
+{
+    static const opcodetype oplist[] = {
+        OP_FALSE, OP_1, OP_2, OP_3, OP_CHECKSIG, OP_IF, OP_VERIF, OP_RETURN, OP_CODESEPARATOR};
+    script = CScript();
+    int ops = (insecure_rand() % 10);
+    for (int i = 0; i < ops; i++)
+        script << oplist[insecure_rand() % (sizeof(oplist) / sizeof(oplist[0]))];
+}
+
+void RandomTransaction(CMutableTransaction &tx, bool fSingle)
+{
+    tx.nVersion = insecure_rand();
+    tx.vin.clear();
+    tx.vout.clear();
+    tx.nLockTime = (insecure_rand() % 2) ? insecure_rand() : 0;
+    int ins = (insecure_rand() % 4) + 1;
+    int outs = fSingle ? ins : (insecure_rand() % 4) + 1;
+    for (int in = 0; in < ins; in++)
+    {
+        tx.vin.push_back(CTxIn());
+        CTxIn &txin = tx.vin.back();
+        txin.prevout.hash = GetRandHash();
+        txin.prevout.n = insecure_rand() % 4;
+        RandomScript(txin.scriptSig);
+        txin.nSequence = (insecure_rand() % 2) ? insecure_rand() : (unsigned int)-1;
+    }
+    for (int out = 0; out < outs; out++)
+    {
+        tx.vout.push_back(CTxOut());
+        CTxOut &txout = tx.vout.back();
+        txout.nValue = insecure_rand() % 100000000;
+        RandomScript(txout.scriptPubKey);
+    }
+}

--- a/src/test/testutil.h
+++ b/src/test/testutil.h
@@ -12,4 +12,10 @@
 
 fs::path GetTempPath();
 
+class CMutableTransaction;
+class CScript;
+
+void RandomScript(CScript &script);
+void RandomTransaction(CMutableTransaction &tx, bool fSingle);
+
 #endif // BITCOIN_TEST_TESTUTIL_H

--- a/src/test/thinblock_tests.cpp
+++ b/src/test/thinblock_tests.cpp
@@ -126,24 +126,24 @@ BOOST_AUTO_TEST_CASE(thinblock_test)
 
     /* empty filter */
     CBlock block = TestBlock();
-    CThinBlock thinblock(block, filter);
-    CXThinBlock xthinblock(block, &filter);
+    CThinBlock thinblock(block, filter, nullptr);
+    CXThinBlock xthinblock(block, &filter, nullptr);
     BOOST_CHECK_EQUAL(9, thinblock.vMissingTx.size());
     BOOST_CHECK_EQUAL(9, xthinblock.vMissingTx.size());
 
     /* insert txid not in block */
     const uint256 random_hash = uint256S("3fba505b48865fccda4e248cecc39d5dfbc6b8ef7b4adc9cd27242c1193c7133");
     filter.insert(random_hash);
-    CThinBlock thinblock1(block, filter);
-    CXThinBlock xthinblock1(block, &filter);
+    CThinBlock thinblock1(block, filter, nullptr);
+    CXThinBlock xthinblock1(block, &filter, nullptr);
     BOOST_CHECK_EQUAL(9, thinblock1.vMissingTx.size());
     BOOST_CHECK_EQUAL(9, xthinblock1.vMissingTx.size());
 
     /* insert txid in block */
     const uint256 hash_in_block = block.vtx[1]->GetHash();
     filter.insert(hash_in_block);
-    CThinBlock thinblock2(block, filter);
-    CXThinBlock xthinblock2(block, &filter);
+    CThinBlock thinblock2(block, filter, nullptr);
+    CXThinBlock xthinblock2(block, &filter, nullptr);
     BOOST_CHECK_EQUAL(8, thinblock2.vMissingTx.size());
     BOOST_CHECK_EQUAL(8, xthinblock2.vMissingTx.size());
 
@@ -151,7 +151,7 @@ BOOST_AUTO_TEST_CASE(thinblock_test)
     BOOST_CHECK(!xthinblock2.collision);
     block.vtx.push_back(block.vtx[1]); // duplicate tx
     filter.clear();
-    CXThinBlock xthinblock3(block, &filter);
+    CXThinBlock xthinblock3(block, &filter, nullptr);
     BOOST_CHECK(xthinblock3.collision);
 
 
@@ -162,24 +162,24 @@ BOOST_AUTO_TEST_CASE(thinblock_test)
 
     /* empty filter */
     CBlock block1 = TestBlock();
-    CThinBlock thinblock4(block1, filter1);
-    CXThinBlock xthinblock4(block1, &filter1);
+    CThinBlock thinblock4(block1, filter1, nullptr);
+    CXThinBlock xthinblock4(block1, &filter1, nullptr);
     BOOST_CHECK(thinblock4.vMissingTx.size() >= 8 && thinblock4.vMissingTx.size() <= 9);
     BOOST_CHECK(xthinblock4.vMissingTx.size() >= 8 && xthinblock4.vMissingTx.size() <= 9);
 
     /* insert txid not in block */
     const uint256 random_hash1 = uint256S("3fba505b48865fccda4e248cecc39d5dfbc6b8ef7b4adc9cd27242c1193c7132");
     filter1.insert(random_hash1);
-    CThinBlock thinblock5(block1, filter1);
-    CXThinBlock xthinblock5(block1, &filter1);
+    CThinBlock thinblock5(block1, filter1, nullptr);
+    CXThinBlock xthinblock5(block1, &filter1, nullptr);
     BOOST_CHECK(thinblock5.vMissingTx.size() >= 8 && thinblock5.vMissingTx.size() <= 9);
     BOOST_CHECK(xthinblock5.vMissingTx.size() >= 8 && xthinblock5.vMissingTx.size() <= 9);
 
     /* insert txid in block */
     const uint256 hash_in_block1 = block.vtx[1]->GetHash();
     filter1.insert(hash_in_block1);
-    CThinBlock thinblock6(block1, filter1);
-    CXThinBlock xthinblock6(block1, &filter1);
+    CThinBlock thinblock6(block1, filter1, nullptr);
+    CXThinBlock xthinblock6(block1, &filter1, nullptr);
     BOOST_CHECK(thinblock6.vMissingTx.size() >= 7 && thinblock6.vMissingTx.size() <= 8);
     BOOST_CHECK(xthinblock6.vMissingTx.size() >= 7 && xthinblock6.vMissingTx.size() <= 8);
 
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE(thinblock_test)
     BOOST_CHECK(!xthinblock6.collision);
     block.vtx.push_back(block1.vtx[1]); // duplicate tx
     filter1.clear();
-    CXThinBlock xthinblock7(block, &filter1);
+    CXThinBlock xthinblock7(block, &filter1, nullptr);
     BOOST_CHECK(xthinblock7.collision);
 }
 

--- a/src/test/weakblock_tests.cpp
+++ b/src/test/weakblock_tests.cpp
@@ -131,8 +131,11 @@ static void scenario1() {
     CBlockRef b1 = weakextendBlock(&b0, 100);
 
     CWeakblockRef wb0, wb1, wb2;
+    BOOST_CHECK(weakstore.byHash(b0.GetHash()) == nullptr);
+    BOOST_CHECK(weakstore.byHash(b0.GetHash().GetCheapHash()) == nullptr);
     BOOST_CHECK(nullptr != (wb0 = weakstore.store(&b0)));
     BOOST_CHECK_EQUAL(weakstore.Tip()->GetHash(), b0.GetHash());
+    BOOST_CHECK(weakstore.byHash(b0.GetHash().GetCheapHash()) == wb0);
     BOOST_CHECK_EQUAL(weakstore.size(), 1);
     BOOST_CHECK(!weakstore.empty());
 

--- a/src/test/weakblock_tests.cpp
+++ b/src/test/weakblock_tests.cpp
@@ -17,6 +17,7 @@ struct WeakTestSetup : public TestingSetup {
     WeakTestSetup() : TestingSetup() {
         wbEnable.Set(DEFAULT_WEAKBLOCKS_ENABLE);
         wbConsiderPOWratio.Set(DEFAULT_WEAKBLOCKS_CONSIDER_POW_RATIO);
+        weakstore.expireOld(true);
     }
     ~WeakTestSetup() {
         weakstore.consistencyCheck();

--- a/src/test/weakblock_tests.cpp
+++ b/src/test/weakblock_tests.cpp
@@ -26,6 +26,8 @@ BOOST_FIXTURE_TEST_SUITE(weakblock_tests, WeakTestSetup)
 // check basic state when everything's fresh and empty
 BOOST_AUTO_TEST_CASE(default_tests)
 {
+    LOCK(cs_weakblocks);
+
     BOOST_CHECK_EQUAL(weakblocksEnabled(), DEFAULT_WEAKBLOCKS_ENABLE);
     BOOST_CHECK_EQUAL(weakblocksConsiderPOWRatio(), DEFAULT_WEAKBLOCKS_CONSIDER_POW_RATIO);
     BOOST_CHECK_EQUAL(weakblocksMinPOWRatio(), 600);
@@ -117,6 +119,7 @@ BOOST_AUTO_TEST_CASE(construct_empty)
 {
     CBlock b0;
     CWeakblock wb(&b0);
+    LOCK(cs_weakblocks);
     BOOST_CHECK_EQUAL(wb.GetWeakHeight(), 0);
     BOOST_CHECK_EQUAL(wb.GetWeakHeight(), 0); // using cached value
 }
@@ -128,7 +131,6 @@ static void scenario1() {
     CBlockRef b1 = weakextendBlock(&b0, 100);
 
     CWeakblockRef wb0, wb1, wb2;
-
     BOOST_CHECK(nullptr != (wb0 = weakstore.store(&b0)));
     BOOST_CHECK_EQUAL(weakstore.Tip()->GetHash(), b0.GetHash());
     BOOST_CHECK_EQUAL(weakstore.size(), 1);
@@ -215,6 +217,8 @@ static void scenario2() {
 BOOST_AUTO_TEST_CASE(weak_chain1)
 {
     CBlock b0;
+    LOCK(cs_weakblocks);
+
     // mark all for expiry
     weakstore.expireOld();
     // and check that all are at height -1

--- a/src/test/weakblock_tests.cpp
+++ b/src/test/weakblock_tests.cpp
@@ -1,0 +1,245 @@
+// Copyright (c) 2018 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "weakblock.h"
+#include "consensus/merkle.h"
+#include "test/test_bitcoin.h"
+#include "test/testutil.h"
+#include <boost/test/unit_test.hpp>
+#include <string>
+using namespace std;
+
+struct WeakTestSetup : public TestingSetup {
+    WeakTestSetup() : TestingSetup() {
+        wbEnable.Set(DEFAULT_WEAKBLOCKS_ENABLE);
+        wbConsiderPOWratio.Set(DEFAULT_WEAKBLOCKS_CONSIDER_POW_RATIO);
+    }
+    ~WeakTestSetup() {
+        weakstore.consistencyCheck();
+    }
+};
+static uint256 null;
+
+BOOST_FIXTURE_TEST_SUITE(weakblock_tests, WeakTestSetup)
+
+// check basic state when everything's fresh and empty
+BOOST_AUTO_TEST_CASE(default_tests)
+{
+    BOOST_CHECK_EQUAL(weakblocksEnabled(), DEFAULT_WEAKBLOCKS_ENABLE);
+    BOOST_CHECK_EQUAL(weakblocksConsiderPOWRatio(), DEFAULT_WEAKBLOCKS_CONSIDER_POW_RATIO);
+    BOOST_CHECK_EQUAL(weakblocksMinPOWRatio(), 600);
+    wbConsiderPOWratio.Set("123");
+    BOOST_CHECK_EQUAL(weakblocksConsiderPOWRatio(), 123);
+    wbEnable.Set("false");
+    BOOST_CHECK_EQUAL(weakblocksEnabled(), false);
+    wbEnable.Set("true");
+    BOOST_CHECK_EQUAL(weakblocksEnabled(), true);
+
+    BOOST_CHECK(weakstore.Tip() == nullptr);
+
+    BOOST_CHECK_EQUAL(weakstore.size(), 0);
+    BOOST_CHECK(weakstore.empty());
+    weakstore.consistencyCheck();
+    weakstore.expireOld();
+    weakstore.consistencyCheck();
+}
+
+// helper function to create coinbase txn with prev-weak-block-pointers
+static CTransactionRef weakblockCB(uint256 weakref,
+                            char size_byte = 0x22,
+                            char marker1 = 'W',
+                            char marker2 = 'B') {
+    CMutableTransaction cb;
+    cb.vin.resize(1);
+    cb.vin[0].prevout.SetNull();
+    cb.vout.resize(2);
+    cb.vout[0].scriptPubKey = CScript();
+    cb.vout[0].nValue = 100000000;
+    uint64_t pseudoHeight = 100000;
+
+    cb.vin[0].scriptSig = CScript() << pseudoHeight << OP_0;
+
+    cb.vout[1].nValue = 0;
+    cb.vout[1].scriptPubKey = CScript() << OP_RETURN;
+    cb.vout[1].scriptPubKey.push_back(size_byte); // size byte
+    cb.vout[1].scriptPubKey.push_back(marker1); // marker
+    cb.vout[1].scriptPubKey.push_back(marker2);
+    cb.vout[1].scriptPubKey.insert(cb.vout[1].scriptPubKey.end(),
+                                   weakref.begin(),
+                                   weakref.end());
+
+    return make_shared<CTransaction>(cb);
+}
+
+static CBlockRef weakextendBlock(const CBlock *underlying,
+                                 size_t ntx) {
+    CBlockRef res;
+    assert (ntx>0);
+
+    size_t otx =0;
+    if (underlying != nullptr) {
+        res = make_shared<CBlock>(*underlying);
+        otx = underlying->vtx.size();
+        assert(otx<=ntx);
+    }
+    else {
+        res = make_shared<CBlock>();
+    }
+    res->vtx.resize(ntx);
+    res->vtx[0] = weakblockCB(underlying->GetHash());
+
+    for (size_t i=otx > 0 ? otx : 1; i<ntx; i++) {
+        CMutableTransaction tx;
+        RandomTransaction(tx, false);
+        res->vtx[i] = make_shared<CTransaction>(tx);
+    }
+    res->hashMerkleRoot = BlockMerkleRoot(*res);
+    return res;
+}
+
+// test weakblocksExtractCommitment
+BOOST_AUTO_TEST_CASE(extract_commitment)
+{
+    BOOST_CHECK(null.IsNull());
+    BOOST_CHECK_EQUAL(weakblocksExtractCommitment(nullptr), null);
+
+    CBlock b0;
+    BOOST_CHECK_EQUAL(weakblocksExtractCommitment(&b0),  null);
+    BOOST_CHECK(b0.GetHash() != null);
+
+    CBlockRef b1 = weakextendBlock(&b0, 100);
+    BOOST_CHECK_EQUAL(weakblocksExtractCommitment(b1.get()), b0.GetHash());
+}
+
+// test empty weak block
+BOOST_AUTO_TEST_CASE(construct_empty)
+{
+    CBlock b0;
+    CWeakblock wb(&b0);
+    BOOST_CHECK_EQUAL(wb.GetWeakHeight(), 0);
+    BOOST_CHECK_EQUAL(wb.GetWeakHeight(), 0); // using cached value
+}
+
+
+static void scenario1() {
+
+    CBlock b0;
+    CBlockRef b1 = weakextendBlock(&b0, 100);
+
+    CWeakblockRef wb0, wb1, wb2;
+
+    BOOST_CHECK(nullptr != (wb0 = weakstore.store(&b0)));
+    BOOST_CHECK_EQUAL(weakstore.Tip()->GetHash(), b0.GetHash());
+    BOOST_CHECK_EQUAL(weakstore.size(), 1);
+    BOOST_CHECK(!weakstore.empty());
+
+    BOOST_CHECK(nullptr != (wb1 = weakstore.store(b1.get())));
+    BOOST_CHECK_EQUAL(weakstore.Tip()->GetHash(), b1->GetHash());
+    BOOST_CHECK_EQUAL(weakstore.size(), 2);
+
+    CBlockRef b2 = weakextendBlock(b1.get(), 200);
+    BOOST_CHECK(nullptr != (wb2 = weakstore.store(b2.get())));
+    BOOST_CHECK_EQUAL(weakstore.Tip()->GetHash(), b2->GetHash());
+    BOOST_CHECK_EQUAL(weakstore.size(), 3);
+
+    BOOST_CHECK_EQUAL(wb0, weakstore.byHash(b0.GetHash()));
+    BOOST_CHECK_EQUAL(wb1, weakstore.byHash(b1->GetHash()));
+    BOOST_CHECK_EQUAL(wb2, weakstore.byHash(b2->GetHash()));
+
+    BOOST_CHECK(wb1->extends(b0));
+    BOOST_CHECK(wb1->extends(wb0));
+    BOOST_CHECK(wb2->extends(b1));
+    BOOST_CHECK(wb2->extends(wb1));
+    BOOST_CHECK(wb2->extends(b0));
+
+    BOOST_CHECK_EQUAL(wb0->GetWeakHeight(), 0);
+    BOOST_CHECK_EQUAL(wb1->GetWeakHeight(), 1);
+    BOOST_CHECK_EQUAL(wb2->GetWeakHeight(), 2);
+
+    // now overtake with a second chain starting at wb1
+
+    CWeakblockRef wb1_1 = weakstore.store(weakextendBlock(b1.get(), 300).get());
+    BOOST_CHECK_EQUAL(weakstore.Tip()->GetHash(), b2->GetHash());
+    BOOST_CHECK_EQUAL(weakstore.chainTips().size(), 2);
+    BOOST_CHECK_EQUAL(weakstore.Tip()->GetWeakHeight(), 2);
+
+    CWeakblockRef wb1_2 = weakstore.store(weakextendBlock(wb1_1.get(), 300).get());
+    BOOST_CHECK_EQUAL(weakstore.Tip()->GetHash(), wb1_2->GetHash());
+    BOOST_CHECK_EQUAL(weakstore.chainTips().size(), 2);
+    BOOST_CHECK_EQUAL(weakstore.Tip()->GetWeakHeight(), 3);
+}
+
+static void scenario2() {
+
+    CBlock b0_2;
+
+    CMutableTransaction tx;
+    RandomTransaction(tx, false);
+    b0_2.vtx.push_back(make_shared<CTransaction>(tx));
+    b0_2.hashMerkleRoot = BlockMerkleRoot(b0_2);
+
+    CWeakblockRef wb0_2, wb1_2, wb2_2, wb3_2, wb4_2, wb5_2;
+
+    BOOST_CHECK(nullptr != (wb0_2 = weakstore.store(&b0_2)));
+    BOOST_CHECK(weakstore.Tip() != wb0_2);
+
+    BOOST_CHECK(weakstore.Tip()->GetWeakHeight() == 3);
+
+    wb1_2 = weakstore.store(weakextendBlock(wb0_2.get(), 1000).get());
+    BOOST_CHECK(wb1_2 != nullptr);
+    BOOST_CHECK(weakstore.Tip() != wb1_2);
+    BOOST_CHECK(weakstore.Tip()->GetWeakHeight() == 3);
+
+    wb2_2 = weakstore.store(weakextendBlock(wb1_2.get(), 2000).get());
+    BOOST_CHECK(weakstore.Tip() != wb2_2);
+    BOOST_CHECK(wb2_2 != nullptr);
+    BOOST_CHECK(weakstore.Tip()->GetWeakHeight() == 3);
+
+    wb3_2 = weakstore.store(weakextendBlock(wb2_2.get(), 3000).get());
+    BOOST_CHECK(wb3_2 != nullptr);
+    BOOST_CHECK(weakstore.Tip()->GetWeakHeight() == 3);
+
+    wb4_2 = weakstore.store(weakextendBlock(wb3_2.get(), 4000).get());
+    BOOST_CHECK(wb4_2 != nullptr);
+    BOOST_CHECK_EQUAL(weakstore.Tip(), wb4_2);
+    BOOST_CHECK(weakstore.Tip()->GetWeakHeight() == 4);
+
+    wb5_2 = weakstore.store(weakextendBlock(wb4_2.get(), 5000).get());
+    BOOST_CHECK(wb5_2 != nullptr);
+    BOOST_CHECK_EQUAL(weakstore.Tip(), wb5_2);
+    BOOST_CHECK(weakstore.Tip()->GetWeakHeight() == 5);
+    BOOST_CHECK_EQUAL(weakstore.Tip(), wb5_2);
+}
+
+BOOST_AUTO_TEST_CASE(weak_chain1)
+{
+    CBlock b0;
+    // mark all for expiry
+    weakstore.expireOld();
+    // and check that all are at height -1
+    for (auto wb : weakstore.chainTips())
+        BOOST_CHECK_EQUAL(wb->GetWeakHeight(), -1);
+
+    // and throw all stuff away this time
+    weakstore.expireOld();
+    BOOST_CHECK_EQUAL(weakstore.chainTips().size(), 0);
+    BOOST_CHECK(weakstore.empty());
+
+    // recreate scenario1 to overtake just once more with a wholly new chain
+    scenario1();
+
+    BOOST_CHECK_EQUAL(weakstore.chainTips().size(), 2);
+    scenario2();
+    BOOST_CHECK_EQUAL(weakstore.chainTips().size(), 3);
+
+    weakstore.expireOld();
+    BOOST_CHECK_EQUAL(weakstore.chainTips().size(), 3);
+    // 3 tips, but all marked with a chain height of -1 now
+    BOOST_CHECK(weakstore.Tip() == nullptr);
+
+    weakstore.expireOld();
+    BOOST_CHECK_EQUAL(weakstore.chainTips().size(), 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -576,7 +576,9 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
         CValidationState state;
         CBlockIndex *pIndex = nullptr;
 
-        if (!AcceptBlockHeader(thinBlock.header, state, Params(), &pIndex, nullptr))
+        bool isWeak = false;
+
+        if (!AcceptBlockHeader(thinBlock.header, state, Params(), &pIndex, &isWeak))
         {
             int nDoS;
             if (state.IsInvalid(nDoS))
@@ -588,6 +590,13 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
 
             thindata.ClearThinBlockData(pfrom, thinBlock.header.GetHash());
             return false;
+        }
+
+        // check for weak block
+        if (isWeak)
+        {
+            LOG(WB, "Received weak XThin block.");
+            return thinBlock.process(pfrom, nSizeThinBlock, strCommand);
         }
 
         // pIndex should always be set by AcceptBlockHeader

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -785,7 +785,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
                         "Received weak xthinblock but returning because we already have block data %s from peer %s hop"
                         " %d size %d bytes\n",
                         inv.hash.ToString(), pfrom->GetLogName(), nHops, nSizeThinBlock);
-                    requester.AlreadyReceived(inv);
+                    requester.AlreadyReceived(pfrom, inv);
                     thindata.ClearThinBlockData(pfrom, thinBlock.header.GetHash());
                     return true;
                 }
@@ -810,7 +810,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
             if (pIndex->nStatus & BLOCK_HAVE_DATA)
             {
                 // Tell the Request Manager we received this block
-                requester.AlreadyReceived(inv);
+                requester.AlreadyReceived(pfrom, inv);
 
                 thindata.ClearThinBlockData(pfrom, thinBlock.header.GetHash());
                 LOG(THIN, "Received xthinblock but returning because we already have block data %s from peer %s hop"

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -96,8 +96,9 @@ unsigned int addFromWeak(std::vector<T> &vTxHashes,
             {
                 LOG(WB, "Remote node does not know about underlying weak block. Not sending a delta block.\n");
             }
-            // assert that the target node knows about this block now
-            weakstore.set_nodeKnows(pto->GetId(), block.GetHash());
+            if (pto != nullptr)
+                // assert that the target node knows about this block now
+                weakstore.set_nodeKnows(pto->GetId(), block.GetHash());
         }
     }
     return skip_underlying;

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -656,7 +656,7 @@ bool CXRequestThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
 bool CXThinBlock::CheckBlockHeader(const CBlockHeader &block, CValidationState &state)
 {
     // Check proof of work matches claimed amount
-    if (!CheckProofOfWork(header.GetHash(), header.nBits, Params().GetConsensus(), 1))
+    if (!CheckProofOfWork(header.GetHash(), header.nBits, Params().GetConsensus(), weakblocksMinPOWRatio()))
         return state.DoS(50, error("CheckBlockHeader(): proof of work failed"), REJECT_INVALID, "high-hash");
 
     // Check timestamp

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -969,6 +969,8 @@ bool CXThinBlock::process(CNode *pfrom,
                     header.GetHash().GetHex());
             }
         }
+        if (_collision)
+            LOG(THIN, "XThin collision detected.\n");
         if (!_collision)
         {
             // Start gathering the full tx hashes. If some are not available then add them to setHashesToRequest.

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -983,8 +983,10 @@ bool CXThinBlock::process(CNode *pfrom,
                 {
                     pfrom->thinBlockHashes.push_back(nullhash); // placeholder
                     setHashesToRequest.insert(cheapHash);
+                    LOG(THIN, "Cheap hash to request: %ull\n", cheapHash);
                 }
             }
+            LOG(THIN, "Hash stats: request: %d, have: %d.\n", setHashesToRequest.size(), pfrom->thinBlockHashes.size());
 
             // We don't need this after here.
             mapPartialTxHash.clear();

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -358,7 +358,8 @@ CXThinBlock::CXThinBlock(const CBlock &block)
     vTxHashes.reserve(nTx);
     std::set<uint64_t> setPartialTxHash;
 
-    unsigned int skip_underlying = addFromWeak<uint64_t>(vTxHashes, block, &setPartialTxHash, &collision);
+    // no deltablocks for xpedited for now (FIXME)
+    unsigned int skip_underlying = 0; // addFromWeak<uint64_t>(vTxHashes, block, &setPartialTxHash, &collision);
 
     LOCK(orphanpool.cs);
     for (unsigned int i = skip_underlying; i < nTx; i++)

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -519,7 +519,7 @@ bool CXRequestThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
 bool CXThinBlock::CheckBlockHeader(const CBlockHeader &block, CValidationState &state)
 {
     // Check proof of work matches claimed amount
-    if (!CheckProofOfWork(header.GetHash(), header.nBits, Params().GetConsensus()))
+    if (!CheckProofOfWork(header.GetHash(), header.nBits, Params().GetConsensus(), 1))
         return state.DoS(50, error("CheckBlockHeader(): proof of work failed"), REJECT_INVALID, "high-hash");
 
     // Check timestamp

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -735,6 +735,10 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
             {
                 LOCK(cs_weakblocks);
                 LOG(WB, "Received weak XThin block.\n");
+
+                inv.hash = thinBlock.header.GetHash();
+                requester.UpdateBlockAvailability(pfrom->GetId(), inv.hash);
+
                 if (weakstore.byHash(thinBlock.header.GetHash()) != nullptr)
                 {
                     LOG(THIN,
@@ -745,6 +749,8 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
                     thindata.ClearThinBlockData(pfrom, thinBlock.header.GetHash());
                     return true;
                 }
+                // weak blocks handling should not need to deal with ones that are not extending
+                // the best chain
             }
         }
         else

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -96,7 +96,7 @@ unsigned int addFromWeak(std::vector<T> &vTxHashes,
             {
                 LOG(WB, "Remote node does not know about underlying weak block. Not sending a delta block.\n");
             }
-            if (pto != nullptr)
+            if (pto != nullptr && weakblocksEnabled())
                 // assert that the target node knows about this block now
                 weakstore.set_nodeKnows(pto->GetId(), block.GetHash());
         }
@@ -772,6 +772,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
         // check for weak block
         if (isWeak)
         {
+            if (weakblocksEnabled())
             {
                 LOCK(cs_weakblocks);
                 LOG(WB, "Received weak XThin block.\n");
@@ -791,6 +792,12 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
                 }
                 // weak blocks handling should not need to deal with ones that are not extending
                 // the best chain
+            }
+            else
+            {
+                LOGA("Received weak block %s from peer %s, but weak blocks are disabled.",
+                    thinBlock.header.GetHash().GetHex(), pfrom->GetLogName());
+                return false;
             }
         }
         else

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -83,7 +83,8 @@ bool CThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
         }
         CBlockIndex *pprev = mi->second;
         CValidationState state;
-        if (!ContextualCheckBlockHeader(thinBlock.header, state, pprev))
+
+        if (!ContextualCheckBlockHeader(thinBlock.header, state, pprev, nullptr))
         {
             // Thin block does not fit within our blockchain
             dosMan.Misbehaving(pfrom, 100);
@@ -574,7 +575,8 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
 
         CValidationState state;
         CBlockIndex *pIndex = nullptr;
-        if (!AcceptBlockHeader(thinBlock.header, state, Params(), &pIndex))
+
+        if (!AcceptBlockHeader(thinBlock.header, state, Params(), &pIndex, nullptr))
         {
             int nDoS;
             if (state.IsInvalid(nDoS))

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -375,6 +375,7 @@ CXThinBlock::CXThinBlock(const CBlock &block)
 
     // no deltablocks for xpedited for now (FIXME)
     unsigned int skip_underlying = 0; // addFromWeak<uint64_t>(vTxHashes, block, &setPartialTxHash, &collision);
+    LOG(WB, "Building xpedited block for %s, which does not support delta transmission.\n", header.GetHash().GetHex());
 
     LOCK(orphanpool.cs);
     for (unsigned int i = skip_underlying; i < nTx; i++)

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -27,7 +27,7 @@ public:
     std::vector<CTransaction> vMissingTx; // vector of transactions that did not match the bloom filter
 
 public:
-    CThinBlock(const CBlock &block, CBloomFilter &filter);
+    CThinBlock(const CBlock &block, CBloomFilter &filter, const CNode *pto);
     CThinBlock() {}
     /**
      * Handle an incoming thin block.  The block is fully validated, and if any transactions are missing, we fall
@@ -61,7 +61,8 @@ public:
     bool collision;
 
 public:
-    CXThinBlock(const CBlock &block, CBloomFilter *filter); // Use the filter to determine which txns the client has
+    // Use the filter to determine which txns the client has
+    CXThinBlock(const CBlock &block, CBloomFilter *filter, const CNode *pto);
     CXThinBlock(const CBlock &block); // Assume client has all of the transactions (except coinbase)
     CXThinBlock() {}
     /**

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -49,7 +49,7 @@ public:
     }
 
     CInv GetInv() { return CInv(MSG_BLOCK, header.GetHash()); }
-    bool process(CNode *pfrom, int nSizeThinBlock);
+    bool process(CNode *pfrom, int nSizeThinBlock, uint256 underlying_weakref);
 };
 
 class CXThinBlock
@@ -88,7 +88,7 @@ public:
         READWRITE(vMissingTx);
     }
     CInv GetInv() { return CInv(MSG_BLOCK, header.GetHash()); }
-    bool process(CNode *pfrom, int nSizeThinbBlock, std::string strCommand);
+    bool process(CNode *pfrom, int nSizeThinbBlock, std::string strCommand, uint256 underlying_weakref);
     bool CheckBlockHeader(const CBlockHeader &block, CValidationState &state);
 };
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -371,7 +371,7 @@ bool CBlockTreeDB::FindBlockIndex(uint256 blockhash, CDiskBlockIndex *pindex)
             {
                 if (pcursor->GetValue(*pindex))
                 {
-                    if (!CheckProofOfWork(blockhash, pindex->nBits, Params().GetConsensus()))
+                    if (!CheckProofOfWork(blockhash, pindex->nBits, Params().GetConsensus(), 1))
                     {
                         return error("LoadBlockIndex(): CheckProofOfWork failed: %s", pindex->ToString());
                     }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -302,17 +302,20 @@ bool CBlockTreeDB::WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos>
     return WriteBatch(batch);
 }
 
+uint64_t CBlockTreeDB::saltedAddrHash(const uint160 &addrid) const
+{
+    CHashWriter ss(SER_GETHASH, 0);
+    ss << salt;
+    ss << addrid;
+    return UintToArith256(ss.GetHash()).GetLow64();
+}
+
+
 bool CBlockTreeDB::ReadAddrIndex(uint160 addrid, std::vector<CExtDiskTxPos> &list)
 {
     boost::scoped_ptr<CDBIterator> pcursor(NewIterator());
 
-    uint64_t lookupid;
-    {
-        CHashWriter ss(SER_GETHASH, 0);
-        ss << salt;
-        ss << addrid;
-        lookupid = UintToArith256(ss.GetHash()).GetLow64();
-    }
+    uint64_t lookupid = saltedAddrHash(addrid);
 
     pcursor->Seek(make_pair(DB_ADDRINDEX, lookupid));
 
@@ -320,13 +323,9 @@ bool CBlockTreeDB::ReadAddrIndex(uint160 addrid, std::vector<CExtDiskTxPos> &lis
     {
         std::pair<std::pair<char, uint64_t>, CExtDiskTxPos> key;
         if (pcursor->GetKey(key) && key.first.first == DB_ADDRINDEX && key.first.second == lookupid)
-        {
             list.push_back(key.second);
-        }
         else
-        {
             break;
-        }
         pcursor->Next();
     }
     return true;
@@ -338,11 +337,7 @@ bool CBlockTreeDB::AddAddrIndex(const std::vector<std::pair<uint160, CExtDiskTxP
     CDBBatch batch(*this);
     for (std::vector<std::pair<uint160, CExtDiskTxPos> >::const_iterator it = list.begin(); it != list.end(); it++)
     {
-        CHashWriter ss(SER_GETHASH, 0);
-        ss << salt;
-        ss << it->first;
-        batch.Write(
-            make_pair(make_pair(DB_ADDRINDEX, UintToArith256(ss.GetHash()).GetLow64()), it->second), FLATDATA(foo));
+        batch.Write(make_pair(make_pair(DB_ADDRINDEX, saltedAddrHash(it->first)), it->second), FLATDATA(foo));
     }
     return WriteBatch(batch, true);
 }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -426,7 +426,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->nStatus = diskindex.nStatus;
                 pindexNew->nTx = diskindex.nTx;
 
-                if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, Params().GetConsensus()))
+                if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, Params().GetConsensus(), 1))
                     return error("LoadBlockIndex(): CheckProofOfWork failed: %s", pindexNew->ToString());
 
                 pcursor->Next();

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -209,6 +209,8 @@ private:
     CBlockTreeDB(const CBlockTreeDB &);
     void operator=(const CBlockTreeDB &);
 
+    uint64_t saltedAddrHash(const uint160 &addrid) const;
+
 public:
     bool WriteBatchSync(const std::vector<std::pair<int, const CBlockFileInfo *> > &fileInfo,
         int nLastFile,

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -19,8 +19,10 @@
 class CBlockFileInfo;
 class CBlockIndex;
 class uint256;
+struct CExtDiskTxPos;
 
 static const bool DEFAULT_TXINDEX = false;
+static const bool DEFAULT_ADDRINDEX = false;
 
 //! -dbcache default (MiB)
 static const int64_t nDefaultDbCache = 500;
@@ -96,6 +98,49 @@ struct CDiskTxPos : public CDiskBlockPos
         CDiskBlockPos::SetNull();
         nTxOffset = 0;
     }
+
+    friend bool operator<(const CDiskTxPos &a, const CDiskTxPos &b)
+    {
+        return (a.nFile < b.nFile ||
+                ((a.nFile == b.nFile) && (a.nPos < b.nPos || ((a.nPos == b.nPos) && (a.nTxOffset < b.nTxOffset)))));
+    }
+};
+
+struct CExtDiskTxPos : public CDiskTxPos
+{
+    unsigned int nHeight;
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action)
+    {
+        READWRITE(*(CDiskTxPos *)this);
+        READWRITE(VARINT(nHeight));
+    }
+
+    CExtDiskTxPos(const CDiskTxPos &pos, int nHeightIn) : CDiskTxPos(pos), nHeight(nHeightIn) {}
+    CExtDiskTxPos() { SetNull(); }
+    void SetNull()
+    {
+        CDiskTxPos::SetNull();
+        nHeight = 0;
+    }
+
+    friend bool operator==(const CExtDiskTxPos &a, const CExtDiskTxPos &b)
+    {
+        return (a.nHeight == b.nHeight && a.nFile == b.nFile && a.nPos == b.nPos && a.nTxOffset == b.nTxOffset);
+    }
+
+    friend bool operator!=(const CExtDiskTxPos &a, const CExtDiskTxPos &b) { return !(a == b); }
+    friend bool operator<(const CExtDiskTxPos &a, const CExtDiskTxPos &b)
+    {
+        if (a.nHeight < b.nHeight)
+            return true;
+        if (a.nHeight > b.nHeight)
+            return false;
+        return ((const CDiskTxPos)a < (const CDiskTxPos)b);
+    }
 };
 
 class CCoinsViewDBCursor;
@@ -160,6 +205,7 @@ public:
     CBlockTreeDB(size_t nCacheSize, std::string folder, bool fMemory = false, bool fWipe = false);
 
 private:
+    uint256 salt;
     CBlockTreeDB(const CBlockTreeDB &);
     void operator=(const CBlockTreeDB &);
 
@@ -173,6 +219,8 @@ public:
     bool ReadReindexing(bool &fReindex);
     bool ReadTxIndex(const uint256 &txid, CDiskTxPos &pos);
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &list);
+    bool ReadAddrIndex(uint160 addrid, std::vector<CExtDiskTxPos> &list);
+    bool AddAddrIndex(const std::vector<std::pair<uint160, CExtDiskTxPos> > &list);
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
     bool FindBlockIndex(uint256 blockhash, CDiskBlockIndex *index);

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1362,8 +1362,9 @@ bool TestConservativeBlockValidity(CValidationState &state,
     indexDummy.pprev = pindexPrev;
     indexDummy.nHeight = pindexPrev->nHeight + 1;
 
+    bool dummy = false;
     // NOTE: CheckBlockHeader is called by CheckBlock
-    if (!ContextualCheckBlockHeader(block, state, pindexPrev))
+    if (!ContextualCheckBlockHeader(block, state, pindexPrev, &dummy))
         return false;
     if (!CheckBlock(block, state, fCheckPOW, fCheckMerkleRoot, true))
         return false;

--- a/src/util.h
+++ b/src/util.h
@@ -158,8 +158,10 @@ enum
     ZMQ = 0x2000000,
     QT = 0x4000000,
     IBD = 0x8000000,
+
     GRAPHENE = 0x10000000,
-    RESPEND = 0x20000000
+    RESPEND = 0x20000000,
+    WB = 0x40000000 // weak blocks
 };
 
 // Add corresponding lower case string for the category:
@@ -171,7 +173,7 @@ enum
             {MEMPOOLREJ, "mempoolrej"}, {BLK, "blk"}, {EVICT, "evict"}, {PARALLEL, "parallel"}, {RAND, "rand"}, \
             {REQ, "req"}, {BLOOM, "bloom"}, {LCK, "lck"}, {PROXY, "proxy"}, {DBASE, "dbase"},                   \
             {SELECTCOINS, "selectcoins"}, {ESTIMATEFEE, "estimatefee"}, {QT, "qt"}, {IBD, "ibd"},               \
-            {GRAPHENE, "graphene"}, {RESPEND, "respend"},                                                       \
+            {GRAPHENE, "graphene"}, {RESPEND, "respend"}, {WB, "weakblocks"},                                   \
         {                                                                                                       \
             ZMQ, "zmq"                                                                                          \
         }                                                                                                       \

--- a/src/weakblock.cpp
+++ b/src/weakblock.cpp
@@ -178,7 +178,7 @@ CWeakblockRef CWeakStore::store(const CBlock* block) {
         }
     }
     chain_tips.push_back(wb);
-    LOG(WB, "Tracking weak block %s of %d transaction(s).\n", blockhash.GetHex(), wb->vtx.size());
+    LOG(WB, "Tracking weak block %s (short: %x) of %d transaction(s), parent: %s.\n", blockhash.GetHex(), blockhash.GetCheapHash(), wb->vtx.size(), wb->hashPrevBlock.GetHex());
     return wb;
 }
 

--- a/src/weakblock.cpp
+++ b/src/weakblock.cpp
@@ -17,79 +17,28 @@
 extern CTweak<uint32_t> wbConsiderPOWratio;
 extern CTweak<uint32_t> wbEnable;
 
-bool weakblocksEnabled() {
-    LOCK(cs_weakblocks);
-    return wbEnable.value;
-}
+static const uint32_t WB_MIN_POW_RATIO = 600;
+
+CCriticalSection cs_weakblocks;
+
+bool weakblocksEnabled()  { LOCK(cs_weakblocks); return wbEnable.value; }
 
 uint32_t weakblocksConsiderPOWRatio() {
     AssertLockHeld(cs_weakblocks);
-    if (Consensus::Params().fPowNoRetargeting) {
-        //LOG(WB, "Returning consideration POW for testnet.\n");
-        return 4;
-    }
-    //LOG(WB, "Returning configured consideration POW ratio %d.\n", wbConsiderPOWratio.value);
     return wbConsiderPOWratio.value;
 }
 
 uint32_t weakblocksMinPOWRatio() {
     AssertLockHeld(cs_weakblocks);
-    if (Consensus::Params().fPowNoRetargeting)
-        return 8;
-    return 600;
+    return WB_MIN_POW_RATIO;
 }
 
+uint256 weakblocksExtractCommitment(const CBlock* block) {
+    if (block == nullptr) return uint256();
 
-// Weak blocks data structures
+    if (block->vtx.size()<1) return uint256();
 
-// map from TXID back to weak blocks it is contained in
-std::multimap<uint256, const Weakblock*> txid2weakblock;
-
-// set of all weakly confirmed transactions
-// this one uses most of the memory
-std::map<uint256, CTransaction> weak_transactions;
-
-// counts the number of weak blocks found per TXID
-// is the number of weak block confirmations
-// FIXME: maybe use an appropriate smart pointer structure here?
-// Drawback would be to do all the ref counting where it doesn't really matters
-std::map<uint256, size_t> weak_txid_refcount;
-
-// map from block hash to weak block.
-std::map<uint256, const Weakblock*> hash2weakblock;
-
-// map from weak block memory location to hash
-std::unordered_map<const Weakblock*, uint256> weakblock2hash;
-
-// map from weakblock memory location to header info
-std::unordered_map<const Weakblock*, CBlockHeader> weakblock2header;
-
-// map of weak block hashes to their underlying weak block hashes
-// This is a map of hashes to possibly allow referencing to not-yet-received
-// weakblocks in the future.
-std::map<uint256, uint256> extends;
-
-// weak/delta block chain tips
-// Ordered chronologically - a later chain tip will be further down in the vector
-// Therefore the "best weak block" is the one with the largest weak height that
-// comes earliest in this vector.
-std::vector<const Weakblock*> weak_chain_tips;
-
-// Cache of blocks reassembled from weakblocks
-std::unordered_map<const Weakblock*, const CBlock*> reassembled;
-
-// weak chain tips to remove next round
-// The weak blocks that are listed here can still be referenced for efficient
-// delta transmission but will not be considered as active chain tips otherwise.
-std::unordered_set<const Weakblock*> to_remove;
-
-
-CCriticalSection cs_weakblocks;
-
-uint256 candidateWeakHash(const CBlock& block) {
-    if (block.vtx.size()<1) return uint256();
-
-    const CTransactionRef& coinbase = block.vtx[0];
+    const CTransactionRef& coinbase = block->vtx[0];
 
     for (const CTxOut out : coinbase->vout) {
         const CScript& cand = out.scriptPubKey;
@@ -99,7 +48,7 @@ uint256 candidateWeakHash(const CBlock& block) {
                 cand[2] == 'W' && cand[3] == 'B') {
                 uint256 hash;
                 std::copy(cand.begin()+4, cand.end(), hash.begin());
-                LOG(WB, "Found candidate weak block hash %s in block %s.\n", hash.GetHex(), block.GetHash().GetHex());
+                LOG(WB, "Found candidate weak block hash %s in block %s.\n", hash.GetHex(), block->GetHash().GetHex());
                 return hash;
             }
         }
@@ -107,369 +56,218 @@ uint256 candidateWeakHash(const CBlock& block) {
     return uint256();
 }
 
-bool extendsWeak(const CBlock &block, const Weakblock* underlying) {
+CWeakblock::CWeakblock(const CBlock* other) {
+    SetNull();
+    weak_height_cache = 0;
+    weak_height_cache_valid = false;
+    *((CBlock*)this) = *other;
+}
+
+static bool extends_check(const CBlock* block, const CBlock* underlying) {
     AssertLockHeld(cs_weakblocks);
-    if (underlying == NULL) return false;
-    if (underlying->size() > block.vtx.size()) return false;
-    for (size_t i=1; i < underlying->size(); i++)
-        if (*(*underlying)[i] != *block.vtx[i])
+    if (block == nullptr || underlying == nullptr) return false;
+
+    if (underlying->vtx.size() > block->vtx.size()) return false;
+
+    // start at index 1 to skip coinbase transaction
+    for (size_t i=1; i < underlying->vtx.size(); i++)
+        // FIXME: should this compare refs instead? Would that always work?
+        if (*underlying->vtx[i] != *block->vtx[i])
             return false;
     return true;
 }
 
-bool extendsWeak(const Weakblock *wb, const Weakblock* underlying) {
-    AssertLockHeld(cs_weakblocks);
-    if (underlying == NULL || wb == NULL) return false;
-    if (underlying->size() > wb->size()) return false;
-    for (size_t i=1; i < underlying->size(); i++)
-        if ((*underlying)[i] != (*wb)[i])
-            return false;
-    return true;
+bool CWeakblock::extends(const CBlock* underlying) {
+    return extends_check(this, underlying);
 }
 
+bool CWeakblock::extends(const CBlock& underlying) {
+    return extends_check(this, &underlying);
+}
 
-// Helper function to insert a transaction into the weak_transactions list
-// and do ref counting.
-static inline CTransaction* storeTransaction(const CTransaction &otx) {
+bool CWeakblock::extends(const ConstCBlockRef& underlying) {
+    return extends_check(this, underlying.get());
+}
+
+int CWeakblock::GetWeakHeight() const {
     AssertLockHeld(cs_weakblocks);
-    uint256 txid = otx.GetHash();
-    CTransaction *tx = NULL;
-    if (weak_transactions.count(txid) != 0) {
-        tx = &weak_transactions[txid];
-        weak_txid_refcount[txid]++;
-    } else {
-        assert (weak_txid_refcount.count(txid) == 0);
-        weak_transactions[otx.GetHash()] = otx;
-        tx = &weak_transactions[txid];
-        weak_txid_refcount[txid]=1;
+
+    if (weak_height_cache_valid) return weak_height_cache;
+
+    uint256 wbhash = GetHash();
+
+    if (weakstore.to_remove.count(wbhash)) {
+        //LOG(WB, "weakHeight(%s) == -1 (block marked for removal)\n", wbhash.GetHex());
+        weak_height_cache_valid = true;
+        return weak_height_cache = -1;
     }
-    return tx;
+
+    if (weakstore.extends_map.count(wbhash)) {
+        int prev_height = -1;
+
+        const uint256 underlying_hash = weakstore.extends_map.at(wbhash);
+
+        if (weakstore.hash2wb.count(underlying_hash)) {
+            CWeakblockRef underlying_wb = weakstore.hash2wb[underlying_hash];
+            if (underlying_wb != nullptr)
+                prev_height = underlying_wb->GetWeakHeight();
+            else {
+                // FIXME: what else to do? this should never happen
+                LOG(WB, "GetWeakHeight(): Nullpointer encountered in hash2wb!!\n");
+            }
+        } else {
+            // FIXME: what else to do? this should never happen
+            LOG(WB, "GetWeakHeight(): Underlying weakblock not found!!\n");
+        }
+        if (prev_height >=0) {
+            weak_height_cache_valid = true;
+            return weak_height_cache = 1 + prev_height;
+        }
+        else {
+            weak_height_cache_valid = true;
+            return weak_height_cache = -1;
+        }
+    } else {
+        weak_height_cache_valid = true;
+        return weak_height_cache = 0;
+    }
 }
 
-bool storeWeakblock(const CBlock &block) {
-    uint256 blockhash = block.GetHash();
-    Weakblock* wb=new Weakblock();
+CWeakblockRef CWeakStore::store(const CBlock* block) {
+    const uint256 blockhash = block->GetHash();
+    const uint256 underlyinghash = weakblocksExtractCommitment(block);
 
     LOCK(cs_weakblocks);
-    if (hash2weakblock.count(blockhash) > 0) {
+
+    if (hash2wb.count(blockhash) > 0) {
         LOG(WB, "Ignoring attempt to store weak block %s twice.\n", blockhash.GetHex());
         // stored it already
-        return false;
-    }
-    uint256 underlyinghash = candidateWeakHash(block);
-
-    const Weakblock* underlying = NULL;
-    if (hash2weakblock.count(underlyinghash) > 0)
-        underlying = hash2weakblock[underlyinghash];
-
-#if 0
-    if (!underlyinghash.IsNull() && underlying == NULL) {
-        // Note: It might be possible to store dangling underlying weakblocks in the extends map and fill then in later. But this makes it necessary to have some more complex validation checks here.
-        LOG(WB, "Weak block %s with unknown underlying block %s. Ignoring.\n", blockhash.GetHex(), underlyinghash.GetHex());
-        return false;
+        return nullptr;
     }
 
-    if (underlying != NULL && !extendsWeak(block, underlying)) {
-        LOG(WB, "WARNING, block %s does not extend weak block %s, even though it says so!\n", blockhash.GetHex(), underlyinghash.GetHex());
-        // Won't store invalid block
-        return false;
-    }
-#else
-    if (!underlyinghash.IsNull() && underlying == NULL) {
+    CWeakblockRef underlying = nullptr;
+    if (hash2wb.count(underlyinghash) > 0)
+        underlying = hash2wb[underlyinghash];
+
+    if (!underlyinghash.IsNull() && underlying == nullptr) {
         LOG(WB, "Weak block %s with unknown underlying block %s. Assuming start of new chain.\n", blockhash.GetHex(), underlyinghash.GetHex());
-    } else if (underlying != NULL && !extendsWeak(block, underlying)) {
+    } else if (underlying != nullptr && !extends_check(
+                   block, underlying.get())) {
         LOG(WB, "WARNING, block %s does not extend weak block %s, even though it says so! Assuming start of new chain.\n", blockhash.GetHex(), underlyinghash.GetHex());
-        underlying = NULL;
+        underlying = nullptr;
     }
 
-#endif
+    CWeakblockRef wb=std::make_shared<CWeakblock>(block);
 
-    for (const CTransactionRef& otx : block.vtx) {
-        CTransaction *tx = storeTransaction(*otx);
-        uint256 txhash = tx->GetHash();
-        txid2weakblock.insert(std::pair<uint256, const Weakblock*>(txhash, wb));
-        wb->push_back(tx);
-    }
+    // FIXME: assert ..
+    assert(wb->GetHash() == blockhash);
 
-    hash2weakblock[blockhash] = wb;
-    weakblock2hash[wb] = blockhash;
-    weakblock2header[wb] = block;
+    hash2wb[blockhash] = wb;
 
-    if (underlying != NULL) {
-        extends[blockhash]=underlyinghash;
-        LOG(WB, "Weakblock %s is referring to underlying weak block %s.\n", weakblock2hash[wb].GetHex(), underlyinghash.GetHex());
+    // extend the DAG
+    if (underlying != nullptr) {
+        extends_map[blockhash]=underlyinghash;
+        LOG(WB, "Weakblock %s is referring to underlying weak block %s.\n", wb->GetHash().GetHex(), underlyinghash.GetHex());
 
-        auto wct_iter = find(weak_chain_tips.begin(),
-                         weak_chain_tips.end(),
+        auto wct_iter = find(chain_tips.begin(),
+                         chain_tips.end(),
                          underlying);
-        if (wct_iter != weak_chain_tips.end()) {
-            LOG(WB, "Underlying weak block %s was chain tip before. Moving to new weakblock.\n", underlyinghash.GetHex());
-            weak_chain_tips.erase(wct_iter);
+        if (wct_iter != chain_tips.end()) {
+            LOG(WB, "Underlying weak block %s was weak chain tip before. Moving to new weakblock.\n", underlyinghash.GetHex());
+            chain_tips.erase(wct_iter);
         }
     }
-    weak_chain_tips.push_back(wb);
-    LOG(WB, "Tracking weak block %s of %d transactions.\n", blockhash.GetHex(), wb->size());
-    return true;
+    chain_tips.push_back(wb);
+    LOG(WB, "Tracking weak block %s of %d transaction(s).\n", blockhash.GetHex(), wb->vtx.size());
+    return wb;
 }
 
-/*! Reassemble a block from a weak block. Does NOT check the
-  reassembled array for a cached result first; that is the purpose of
-  the blockForWeak(..) accessor. */
-static inline const CBlock* reassembleFromWeak(const Weakblock* wb) {
-    AssertLockHeld(cs_weakblocks);
-    assert(wb != NULL);
-
-    CBlock* result = new CBlock(weakblock2header[wb]);
-    for (CTransaction* tx : *wb) {
-        result->vtx.push_back(std::shared_ptr<CTransaction>(tx));
-    }
-    assert (weakblock2hash[wb] == result->GetHash());
-    return result;
-}
-
-const CBlock* blockForWeak(const Weakblock* wb) {
-    AssertLockHeld(cs_weakblocks);
-    if (wb == NULL) return NULL;
-    if (reassembled.count(wb) == 0)
-        reassembled[wb] = reassembleFromWeak(wb);
-    return reassembled[wb];
-}
-
-const Weakblock* getWeakblock(const uint256& blockhash) {
-    AssertLockHeld(cs_weakblocks);
-    if (hash2weakblock.count(blockhash))
-        return hash2weakblock[blockhash];
-    else return NULL;
-}
-
-const uint256 HashForWeak(const Weakblock *wb) {
-    AssertLockHeld(cs_weakblocks);
-    if (wb == NULL) return uint256();
-    return weakblock2hash[wb];
-}
-
-int weakHeight(const uint256 wbhash) {
-    AssertLockHeld(cs_weakblocks);
-    if (wbhash.IsNull()) {
-        LOG(WB, "weakHeight(0) == -1\n");
-        return -1;
-    }
-    if (to_remove.count(hash2weakblock[wbhash])) {
-        //LOG(WB, "weakHeight(%s) == -1 (block marked for removal)\n", wbhash.GetHex());
-        return -1;
-    }
-
-    if (extends.count(wbhash)) {
-        int prev_height = weakHeight(extends[wbhash]);
-        if (prev_height >=0)
-            return 1+prev_height;
-        else
-            return -1;
-    } else return 0;
-}
-
-int weakHeight(const Weakblock* wb) {
-    if (wb == NULL) {
-        LOG(WB, "weakHeight(NULL) == -1\n");
-        return -1;
-    }
-    return weakHeight(weakblock2hash[wb]);
-}
-
-const Weakblock* getWeakLongestChainTip() {
+CWeakblockRef CWeakStore::Tip() {
     LOCK(cs_weakblocks);
-    int max_height=-1;
-    const Weakblock* longest = NULL;
 
-    for (const Weakblock* wb : weak_chain_tips) {
-        int height = weakHeight(wb);
-        if (height > max_height) {
+    int max_wheight=-1;
+    CWeakblockRef longest = nullptr;
+
+    for (CWeakblockRef wb : chain_tips) {
+        int wheight = wb->GetWeakHeight();
+        if (wheight > max_wheight) {
             longest = wb;
-            max_height = height;
+            max_wheight = wheight;
         }
     }
     return longest;
 }
 
-// opposite of storeTransaction: remove a transaction from weak_transactions and
-// do ref-counting.
-static inline void removeTransaction(const CTransaction *tx) {
-    AssertLockHeld(cs_weakblocks);
-    uint256  txhash=tx->GetHash();
-    assert (weak_txid_refcount[txhash] > 0);
-    assert (weak_transactions.count(txhash) > 0);
-    weak_txid_refcount[txhash]--;
-
-    if (weak_txid_refcount[txhash] == 0) {
-        weak_transactions.erase(txhash);
-        weak_txid_refcount.erase(txhash);
-        txid2weakblock.erase(txhash);
-    }
-}
-
-// Forget about a weak block. Cares about the immediate indices and the transaction list
-// but NOT the DAG in extends / weak_chain_tips.
-static inline void forgetWeakblock(Weakblock *wb) {
-    AssertLockHeld(cs_weakblocks);
-    LOG(WB, "Removing weakblock %s.\n", weakblock2hash[wb].GetHex());
-    // map from TXID back to weak blocks it is contained in
-    uint256 wbhash = weakblock2hash[wb];
-
-    for (CTransaction* tx : *wb) {
-        removeTransaction(tx);
-    }
-    hash2weakblock.erase(wbhash);
-    weakblock2hash.erase(wb);
-    weakblock2header.erase(wb);
-    if (reassembled.count(wb) > 0)
-        reassembled.erase(wb);
-    delete wb;
-}
-
-/* Remove a weak block chain tip and all blocks before that one that are not part of other known chains. */
-static inline void purgeChainTip(Weakblock *wb) {
-    AssertLockHeld(cs_weakblocks);
-    LOG(WB, "Purging weak block %s, which is currently a chain tip.\n", weakblock2hash[wb].GetHex());
-
-    Weakblock* wb_old;
-
-    do {
-        uint256 wbhash=weakblock2hash[wb];
-        forgetWeakblock(wb);
-        wb_old = NULL;
-
-        if (extends.count(wbhash)) {
-            uint256 underlyinghash=extends[wbhash];
-            extends.erase(wbhash);
-            if (hash2weakblock.count(underlyinghash)) {
-                wb_old = const_cast<Weakblock*>(wb);
-                wb = const_cast<Weakblock*>(hash2weakblock[underlyinghash]);
-
-                // stop if any other chain depends on wb now
-                // FIXME: this might be somewhat slow?
-                for (std::pair<const Weakblock*, uint256> p : weakblock2hash) {
-                    const uint256 otherhash = p.second;
-                    if (extends.count(otherhash)) {
-                        if (extends[otherhash] == underlyinghash) {
-                            LOG(WB, "Stopping removal at %s as it is used by other chain block %s.\n",
-                                     otherhash.GetHex(), underlyinghash.GetHex());
-                            return;
-                        }
-                    }
-                }
-            }
-        }
-    } while (wb_old != NULL);
-    LOG(WB, "Purge finished, reached bottom of chain.\n");
-}
-
-void purgeOldWeakblocks() {
+void CWeakStore::expireOld(const bool fThorough) {
     LOCK(cs_weakblocks);
-    LOG(WB, "Purging old chain tips. %d chain tips right now.\n", weak_chain_tips.size());
+    if (fThorough) {
+        hash2wb.clear();
+        extends_map.clear();
+        chain_tips.clear();
+        to_remove.clear();
+        return;
+    } else {
+        for (uint256 hash : to_remove) {
 
-    std::vector<const Weakblock*> new_weak_chain_tips;
-    for (const Weakblock* wb : weak_chain_tips) {
-        if (to_remove.count(wb)) {
-            purgeChainTip(const_cast<Weakblock*>(wb));
-            to_remove.erase(wb);
-        } else {
-            to_remove.insert(wb);
-            new_weak_chain_tips.push_back(wb);
+            auto hash2wb_iter = hash2wb.find(hash);
+            // FIXME: assert
+            assert (hash2wb_iter != hash2wb.end());
+            CWeakblockRef wb = hash2wb[hash];
+
+            hash2wb.erase(hash2wb_iter);
+
+            auto extends_iter = extends_map.find(hash);
+
+            if (extends_iter != extends_map.end())
+                extends_map.erase(extends_iter);
+
+            auto wct_iter = find(chain_tips.begin(),
+                                 chain_tips.end(),
+                wb);
+            if (wct_iter != chain_tips.end())
+                chain_tips.erase(wct_iter);
+        }
+        to_remove.clear();
+        for (auto hashwb_pair : hash2wb) {
+            to_remove.insert(hashwb_pair.first);
+            hashwb_pair.second->weak_height_cache_valid = false;
         }
     }
-    weak_chain_tips = new_weak_chain_tips;
 }
 
-std::vector<std::pair<uint256, int> > weakChainTips() {
-    LOCK(cs_weakblocks);
-    std::vector<std::pair<uint256, int> > result;
-    for (const Weakblock* wb : weak_chain_tips)
-        result.push_back(std::pair<uint256, int>(weakblock2hash[wb],
-                                                    weakHeight(wb)));
-    return result;
+CWeakblockRef CWeakStore::byHash(const uint256& hash) const {
+    if (hash2wb.count(hash))
+        return hash2wb.at(hash);
+    else return nullptr;
 }
 
-const Weakblock* underlyingWeak(const Weakblock *wb) {
-    AssertLockHeld(cs_weakblocks);
-    if (wb == NULL) return NULL;
-
-    if (extends.count(weakblock2hash[wb])) {
-        uint256 underlyinghash=extends[weakblock2hash[wb]];
-        if (hash2weakblock.count(underlyinghash))
-            return hash2weakblock[underlyinghash];
-        else return NULL;
-    }
-    else return NULL;
+CWeakblockRef CWeakStore::parent(const uint256& hash) const {
+    if (extends_map.count(hash))
+        return byHash(extends_map.at(hash));
+    else return nullptr;
 }
 
-int numKnownWeakblocks() { LOCK(cs_weakblocks); return weakblock2hash.size(); }
-int numKnownWeakblockTransactions() { LOCK(cs_weakblocks); return weak_transactions.size(); }
+size_t CWeakStore::size() const { LOCK(cs_weakblocks); return hash2wb.size(); }
+bool CWeakStore::empty() const { return size() == 0; }
 
-
-void weakblocksConsistencyCheck() {
+void CWeakStore::consistencyCheck() const {
     LOCK(cs_weakblocks);
     LOG(WB, "Doing internal consistency check.\n");
-    assert(hash2weakblock.count(uint256()) == 0);
-    assert(weakblock2header.count(NULL) == 0);
-    assert(weakblock2hash.count(NULL) == 0);
-    assert(hash2weakblock.size() == weakblock2hash.size());
-    assert(weakblock2header.size() == hash2weakblock.size());
-    assert(weak_chain_tips.size() <= hash2weakblock.size());
-    int longest_height=-1;
-    std::set<const Weakblock*> longest_tips;
+    assert(hash2wb.count(uint256()) == 0);
+    assert(extends_map.count(uint256()) == 0);
+    assert(extends_map.size() <= hash2wb.size());
+    assert(chain_tips.size() <= hash2wb.size());
+    for (auto ext_pair : extends_map)
+        assert(hash2wb.count(ext_pair.first) > 0);
 
-    for (std::pair<uint256, const Weakblock*> p : hash2weakblock) {
-        const uint256 blockhash = p.first;
-        const Weakblock* wb = p.second;
+    for (auto wb : chain_tips)
+        assert(hash2wb.count(wb->GetHash()) > 0);
 
-        LOG(WB, "Consistency check for weak block %s.\n", blockhash.GetHex());
-
-        assert(weakblock2hash[wb] == blockhash);
-
-        // collect chain of blocks this one builds upon
-        std::set<const Weakblock*> chain;
-        const Weakblock* node = wb;
-
-        while (underlyingWeak(node) != NULL) {
-            node = underlyingWeak(node);
-            chain.insert(node);
-            assert(extendsWeak(wb, node));
-        }
-        LOG(WB, "Chain size: %d, weak height: %d\n", chain.size(), weakHeight(wb));
-        assert ((int)chain.size() == weakHeight(wb));
-
-        if ((int)chain.size() >= longest_height) {
-            if ((int)chain.size() > longest_height) {
-                longest_tips.clear();
-            }
-            longest_tips.insert(wb);
-            longest_height = chain.size();
-        }
-    }
-
-    if (longest_height < 0) {
-        assert(getWeakLongestChainTip() == NULL);
-    } else {
-        assert(longest_tips.count(getWeakLongestChainTip()));
-    }
-
-    // make sure that all hashes in extends are actual, known weak blocks
-    // this requirement might be relaxed later on
-    for (std::pair<uint256, uint256> p : extends) {
-        assert (hash2weakblock.count(p.first) > 0);
-        assert (hash2weakblock.count(p.second) > 0);
-    }
+    // TODO: check that extends_map does not have any cycles
 }
 
-void weakblocksEmptyCheck() {
-    LOCK(cs_weakblocks);
-    assert (txid2weakblock.size() == 0);
-    assert (weak_transactions.size() == 0);
-    assert (weak_txid_refcount.size() == 0);
-    assert (hash2weakblock.size() == 0);
-    assert (weakblock2hash.size() == 0);
-    assert (weakblock2header.size() == 0);
-    assert (extends.size() == 0);
-    assert (weak_chain_tips.size() == 0);
-    assert (reassembled.size() == 0);
+const std::vector<CWeakblockRef>& CWeakStore::chainTips() const {
+    return chain_tips;
 }
+
+CWeakStore weakstore;

--- a/src/weakblock.cpp
+++ b/src/weakblock.cpp
@@ -61,7 +61,6 @@ CWeakblock::CWeakblock(const CBlock* other) {
 }
 
 static bool extends_check(const CBlock* block, const CBlock* underlying) {
-    AssertLockHeld(cs_weakblocks);
     if (block == nullptr || underlying == nullptr) return false;
 
     if (underlying->vtx.size() > block->vtx.size()) return false;
@@ -233,19 +232,21 @@ void CWeakStore::expireOld(const bool fThorough) {
 }
 
 CWeakblockRef CWeakStore::byHash(const uint256& hash) const {
+    AssertLockHeld(cs_weakblocks);
     if (hash2wb.count(hash))
         return hash2wb.at(hash);
     else return nullptr;
 }
 
 CWeakblockRef CWeakStore::parent(const uint256& hash) const {
+    AssertLockHeld(cs_weakblocks);
     if (extends_map.count(hash))
         return byHash(extends_map.at(hash));
     else return nullptr;
 }
 
-size_t CWeakStore::size() const { LOCK(cs_weakblocks); return hash2wb.size(); }
-bool CWeakStore::empty() const { return size() == 0; }
+size_t CWeakStore::size() const { AssertLockHeld(cs_weakblocks); return hash2wb.size(); }
+bool CWeakStore::empty() const { AssertLockHeld(cs_weakblocks); return size() == 0; }
 
 void CWeakStore::consistencyCheck() const {
     LOCK(cs_weakblocks);
@@ -264,6 +265,7 @@ void CWeakStore::consistencyCheck() const {
 }
 
 const std::vector<CWeakblockRef>& CWeakStore::chainTips() const {
+    AssertLockHeld(cs_weakblocks);
     return chain_tips;
 }
 

--- a/src/weakblock.cpp
+++ b/src/weakblock.cpp
@@ -106,11 +106,12 @@ int CWeakblock::GetWeakHeight() const {
                 prev_height = underlying_wb->GetWeakHeight();
             else {
                 // FIXME: what else to do? this should never happen
-                LOG(WB, "GetWeakHeight(): Nullpointer encountered in hash2wb!!\n");
+                LOG(WB, "GetWeakHeight(): INTERNAL ERROR. Null pointer encountered in hash2wb!!\n");
+                return -2;
             }
         } else {
-            // FIXME: what else to do? this should never happen
-            LOG(WB, "GetWeakHeight(): Underlying weakblock not found!!\n");
+            weak_height_cache_valid = true;
+            return weak_height_cache = 0;
         }
         if (prev_height >=0) {
             weak_height_cache_valid = true;
@@ -350,10 +351,16 @@ void CWeakStore::consistencyCheck(const bool check_cached_heights) const {
         for (auto p : hash2wb)
             p.second->weak_height_cache_valid = false;
 
-        for (auto p : hash2wb)
+        for (auto p : hash2wb) {
             assert(cached_chain_heights[p.second->GetHash()]
                    == p.second->GetWeakHeight());
+            assert(cached_chain_heights[p.second->GetHash()] >= -1);
+            assert(p.second->GetWeakHeight() >= -1);
+        }
     }
+    // FIXME: add check that when all chains have a height >=0, that the number of
+    // blocks divided by the number of chain tips is less or equal to the maximum chain height.
+
 }
 
 const std::vector<CWeakblockRef>& CWeakStore::chainTips() const {

--- a/src/weakblock.cpp
+++ b/src/weakblock.cpp
@@ -1,0 +1,475 @@
+#include <map>
+#include <unordered_map>
+#include <unordered_set>
+#include <memory>
+#include <queue>
+#include "sync.h"
+#include "weakblock.h"
+#include "tweak.h"
+#include "util.h"
+#include "chainparams.h"
+
+// FIXME: what about asserts here?
+
+//#define DEBUG_DETAIL 1
+
+// BU tweaks enable and config for weak blocks
+extern CTweak<uint32_t> wbConsiderPOWratio;
+extern CTweak<uint32_t> wbEnable;
+
+bool weakblocksEnabled() {
+    LOCK(cs_weakblocks);
+    return wbEnable.value;
+}
+
+uint32_t weakblocksConsiderPOWRatio() {
+    AssertLockHeld(cs_weakblocks);
+    if (Consensus::Params().fPowNoRetargeting) {
+        //LOG(WB, "Returning consideration POW for testnet.\n");
+        return 4;
+    }
+    //LOG(WB, "Returning configured consideration POW ratio %d.\n", wbConsiderPOWratio.value);
+    return wbConsiderPOWratio.value;
+}
+
+uint32_t weakblocksMinPOWRatio() {
+    AssertLockHeld(cs_weakblocks);
+    if (Consensus::Params().fPowNoRetargeting)
+        return 8;
+    return 600;
+}
+
+
+// Weak blocks data structures
+
+// map from TXID back to weak blocks it is contained in
+std::multimap<uint256, const Weakblock*> txid2weakblock;
+
+// set of all weakly confirmed transactions
+// this one uses most of the memory
+std::map<uint256, CTransaction> weak_transactions;
+
+// counts the number of weak blocks found per TXID
+// is the number of weak block confirmations
+// FIXME: maybe use an appropriate smart pointer structure here?
+// Drawback would be to do all the ref counting where it doesn't really matters
+std::map<uint256, size_t> weak_txid_refcount;
+
+// map from block hash to weak block.
+std::map<uint256, const Weakblock*> hash2weakblock;
+
+// map from weak block memory location to hash
+std::unordered_map<const Weakblock*, uint256> weakblock2hash;
+
+// map from weakblock memory location to header info
+std::unordered_map<const Weakblock*, CBlockHeader> weakblock2header;
+
+// map of weak block hashes to their underlying weak block hashes
+// This is a map of hashes to possibly allow referencing to not-yet-received
+// weakblocks in the future.
+std::map<uint256, uint256> extends;
+
+// weak/delta block chain tips
+// Ordered chronologically - a later chain tip will be further down in the vector
+// Therefore the "best weak block" is the one with the largest weak height that
+// comes earliest in this vector.
+std::vector<const Weakblock*> weak_chain_tips;
+
+// Cache of blocks reassembled from weakblocks
+std::unordered_map<const Weakblock*, const CBlock*> reassembled;
+
+// weak chain tips to remove next round
+// The weak blocks that are listed here can still be referenced for efficient
+// delta transmission but will not be considered as active chain tips otherwise.
+std::unordered_set<const Weakblock*> to_remove;
+
+
+CCriticalSection cs_weakblocks;
+
+uint256 candidateWeakHash(const CBlock& block) {
+    if (block.vtx.size()<1) return uint256();
+
+    const CTransactionRef& coinbase = block.vtx[0];
+
+    for (const CTxOut out : coinbase->vout) {
+        const CScript& cand = out.scriptPubKey;
+        // is it OP_RETURN, size byte (34), 'WB'+32 byte hash?
+        if (cand.size() == 36) {
+            if (cand[0] == OP_RETURN && cand[1] == 0x22 &&
+                cand[2] == 'W' && cand[3] == 'B') {
+                uint256 hash;
+                std::copy(cand.begin()+4, cand.end(), hash.begin());
+                LOG(WB, "Found candidate weak block hash %s in block %s.\n", hash.GetHex(), block.GetHash().GetHex());
+                return hash;
+            }
+        }
+    }
+    return uint256();
+}
+
+bool extendsWeak(const CBlock &block, const Weakblock* underlying) {
+    AssertLockHeld(cs_weakblocks);
+    if (underlying == NULL) return false;
+    if (underlying->size() > block.vtx.size()) return false;
+    for (size_t i=1; i < underlying->size(); i++)
+        if (*(*underlying)[i] != *block.vtx[i])
+            return false;
+    return true;
+}
+
+bool extendsWeak(const Weakblock *wb, const Weakblock* underlying) {
+    AssertLockHeld(cs_weakblocks);
+    if (underlying == NULL || wb == NULL) return false;
+    if (underlying->size() > wb->size()) return false;
+    for (size_t i=1; i < underlying->size(); i++)
+        if ((*underlying)[i] != (*wb)[i])
+            return false;
+    return true;
+}
+
+
+// Helper function to insert a transaction into the weak_transactions list
+// and do ref counting.
+static inline CTransaction* storeTransaction(const CTransaction &otx) {
+    AssertLockHeld(cs_weakblocks);
+    uint256 txid = otx.GetHash();
+    CTransaction *tx = NULL;
+    if (weak_transactions.count(txid) != 0) {
+        tx = &weak_transactions[txid];
+        weak_txid_refcount[txid]++;
+    } else {
+        assert (weak_txid_refcount.count(txid) == 0);
+        weak_transactions[otx.GetHash()] = otx;
+        tx = &weak_transactions[txid];
+        weak_txid_refcount[txid]=1;
+    }
+    return tx;
+}
+
+bool storeWeakblock(const CBlock &block) {
+    uint256 blockhash = block.GetHash();
+    Weakblock* wb=new Weakblock();
+
+    LOCK(cs_weakblocks);
+    if (hash2weakblock.count(blockhash) > 0) {
+        LOG(WB, "Ignoring attempt to store weak block %s twice.\n", blockhash.GetHex());
+        // stored it already
+        return false;
+    }
+    uint256 underlyinghash = candidateWeakHash(block);
+
+    const Weakblock* underlying = NULL;
+    if (hash2weakblock.count(underlyinghash) > 0)
+        underlying = hash2weakblock[underlyinghash];
+
+#if 0
+    if (!underlyinghash.IsNull() && underlying == NULL) {
+        // Note: It might be possible to store dangling underlying weakblocks in the extends map and fill then in later. But this makes it necessary to have some more complex validation checks here.
+        LOG(WB, "Weak block %s with unknown underlying block %s. Ignoring.\n", blockhash.GetHex(), underlyinghash.GetHex());
+        return false;
+    }
+
+    if (underlying != NULL && !extendsWeak(block, underlying)) {
+        LOG(WB, "WARNING, block %s does not extend weak block %s, even though it says so!\n", blockhash.GetHex(), underlyinghash.GetHex());
+        // Won't store invalid block
+        return false;
+    }
+#else
+    if (!underlyinghash.IsNull() && underlying == NULL) {
+        LOG(WB, "Weak block %s with unknown underlying block %s. Assuming start of new chain.\n", blockhash.GetHex(), underlyinghash.GetHex());
+    } else if (underlying != NULL && !extendsWeak(block, underlying)) {
+        LOG(WB, "WARNING, block %s does not extend weak block %s, even though it says so! Assuming start of new chain.\n", blockhash.GetHex(), underlyinghash.GetHex());
+        underlying = NULL;
+    }
+
+#endif
+
+    for (const CTransactionRef& otx : block.vtx) {
+        CTransaction *tx = storeTransaction(*otx);
+        uint256 txhash = tx->GetHash();
+        txid2weakblock.insert(std::pair<uint256, const Weakblock*>(txhash, wb));
+        wb->push_back(tx);
+    }
+
+    hash2weakblock[blockhash] = wb;
+    weakblock2hash[wb] = blockhash;
+    weakblock2header[wb] = block;
+
+    if (underlying != NULL) {
+        extends[blockhash]=underlyinghash;
+        LOG(WB, "Weakblock %s is referring to underlying weak block %s.\n", weakblock2hash[wb].GetHex(), underlyinghash.GetHex());
+
+        auto wct_iter = find(weak_chain_tips.begin(),
+                         weak_chain_tips.end(),
+                         underlying);
+        if (wct_iter != weak_chain_tips.end()) {
+            LOG(WB, "Underlying weak block %s was chain tip before. Moving to new weakblock.\n", underlyinghash.GetHex());
+            weak_chain_tips.erase(wct_iter);
+        }
+    }
+    weak_chain_tips.push_back(wb);
+    LOG(WB, "Tracking weak block %s of %d transactions.\n", blockhash.GetHex(), wb->size());
+    return true;
+}
+
+/*! Reassemble a block from a weak block. Does NOT check the
+  reassembled array for a cached result first; that is the purpose of
+  the blockForWeak(..) accessor. */
+static inline const CBlock* reassembleFromWeak(const Weakblock* wb) {
+    AssertLockHeld(cs_weakblocks);
+    assert(wb != NULL);
+
+    CBlock* result = new CBlock(weakblock2header[wb]);
+    for (CTransaction* tx : *wb) {
+        result->vtx.push_back(std::shared_ptr<CTransaction>(tx));
+    }
+    assert (weakblock2hash[wb] == result->GetHash());
+    return result;
+}
+
+const CBlock* blockForWeak(const Weakblock* wb) {
+    AssertLockHeld(cs_weakblocks);
+    if (wb == NULL) return NULL;
+    if (reassembled.count(wb) == 0)
+        reassembled[wb] = reassembleFromWeak(wb);
+    return reassembled[wb];
+}
+
+const Weakblock* getWeakblock(const uint256& blockhash) {
+    AssertLockHeld(cs_weakblocks);
+    if (hash2weakblock.count(blockhash))
+        return hash2weakblock[blockhash];
+    else return NULL;
+}
+
+const uint256 HashForWeak(const Weakblock *wb) {
+    AssertLockHeld(cs_weakblocks);
+    if (wb == NULL) return uint256();
+    return weakblock2hash[wb];
+}
+
+int weakHeight(const uint256 wbhash) {
+    AssertLockHeld(cs_weakblocks);
+    if (wbhash.IsNull()) {
+        LOG(WB, "weakHeight(0) == -1\n");
+        return -1;
+    }
+    if (to_remove.count(hash2weakblock[wbhash])) {
+        //LOG(WB, "weakHeight(%s) == -1 (block marked for removal)\n", wbhash.GetHex());
+        return -1;
+    }
+
+    if (extends.count(wbhash)) {
+        int prev_height = weakHeight(extends[wbhash]);
+        if (prev_height >=0)
+            return 1+prev_height;
+        else
+            return -1;
+    } else return 0;
+}
+
+int weakHeight(const Weakblock* wb) {
+    if (wb == NULL) {
+        LOG(WB, "weakHeight(NULL) == -1\n");
+        return -1;
+    }
+    return weakHeight(weakblock2hash[wb]);
+}
+
+const Weakblock* getWeakLongestChainTip() {
+    LOCK(cs_weakblocks);
+    int max_height=-1;
+    const Weakblock* longest = NULL;
+
+    for (const Weakblock* wb : weak_chain_tips) {
+        int height = weakHeight(wb);
+        if (height > max_height) {
+            longest = wb;
+            max_height = height;
+        }
+    }
+    return longest;
+}
+
+// opposite of storeTransaction: remove a transaction from weak_transactions and
+// do ref-counting.
+static inline void removeTransaction(const CTransaction *tx) {
+    AssertLockHeld(cs_weakblocks);
+    uint256  txhash=tx->GetHash();
+    assert (weak_txid_refcount[txhash] > 0);
+    assert (weak_transactions.count(txhash) > 0);
+    weak_txid_refcount[txhash]--;
+
+    if (weak_txid_refcount[txhash] == 0) {
+        weak_transactions.erase(txhash);
+        weak_txid_refcount.erase(txhash);
+        txid2weakblock.erase(txhash);
+    }
+}
+
+// Forget about a weak block. Cares about the immediate indices and the transaction list
+// but NOT the DAG in extends / weak_chain_tips.
+static inline void forgetWeakblock(Weakblock *wb) {
+    AssertLockHeld(cs_weakblocks);
+    LOG(WB, "Removing weakblock %s.\n", weakblock2hash[wb].GetHex());
+    // map from TXID back to weak blocks it is contained in
+    uint256 wbhash = weakblock2hash[wb];
+
+    for (CTransaction* tx : *wb) {
+        removeTransaction(tx);
+    }
+    hash2weakblock.erase(wbhash);
+    weakblock2hash.erase(wb);
+    weakblock2header.erase(wb);
+    if (reassembled.count(wb) > 0)
+        reassembled.erase(wb);
+    delete wb;
+}
+
+/* Remove a weak block chain tip and all blocks before that one that are not part of other known chains. */
+static inline void purgeChainTip(Weakblock *wb) {
+    AssertLockHeld(cs_weakblocks);
+    LOG(WB, "Purging weak block %s, which is currently a chain tip.\n", weakblock2hash[wb].GetHex());
+
+    Weakblock* wb_old;
+
+    do {
+        uint256 wbhash=weakblock2hash[wb];
+        forgetWeakblock(wb);
+        wb_old = NULL;
+
+        if (extends.count(wbhash)) {
+            uint256 underlyinghash=extends[wbhash];
+            extends.erase(wbhash);
+            if (hash2weakblock.count(underlyinghash)) {
+                wb_old = const_cast<Weakblock*>(wb);
+                wb = const_cast<Weakblock*>(hash2weakblock[underlyinghash]);
+
+                // stop if any other chain depends on wb now
+                // FIXME: this might be somewhat slow?
+                for (std::pair<const Weakblock*, uint256> p : weakblock2hash) {
+                    const uint256 otherhash = p.second;
+                    if (extends.count(otherhash)) {
+                        if (extends[otherhash] == underlyinghash) {
+                            LOG(WB, "Stopping removal at %s as it is used by other chain block %s.\n",
+                                     otherhash.GetHex(), underlyinghash.GetHex());
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    } while (wb_old != NULL);
+    LOG(WB, "Purge finished, reached bottom of chain.\n");
+}
+
+void purgeOldWeakblocks() {
+    LOCK(cs_weakblocks);
+    LOG(WB, "Purging old chain tips. %d chain tips right now.\n", weak_chain_tips.size());
+
+    std::vector<const Weakblock*> new_weak_chain_tips;
+    for (const Weakblock* wb : weak_chain_tips) {
+        if (to_remove.count(wb)) {
+            purgeChainTip(const_cast<Weakblock*>(wb));
+            to_remove.erase(wb);
+        } else {
+            to_remove.insert(wb);
+            new_weak_chain_tips.push_back(wb);
+        }
+    }
+    weak_chain_tips = new_weak_chain_tips;
+}
+
+std::vector<std::pair<uint256, int> > weakChainTips() {
+    LOCK(cs_weakblocks);
+    std::vector<std::pair<uint256, int> > result;
+    for (const Weakblock* wb : weak_chain_tips)
+        result.push_back(std::pair<uint256, int>(weakblock2hash[wb],
+                                                    weakHeight(wb)));
+    return result;
+}
+
+const Weakblock* underlyingWeak(const Weakblock *wb) {
+    AssertLockHeld(cs_weakblocks);
+    if (wb == NULL) return NULL;
+
+    if (extends.count(weakblock2hash[wb])) {
+        uint256 underlyinghash=extends[weakblock2hash[wb]];
+        if (hash2weakblock.count(underlyinghash))
+            return hash2weakblock[underlyinghash];
+        else return NULL;
+    }
+    else return NULL;
+}
+
+int numKnownWeakblocks() { LOCK(cs_weakblocks); return weakblock2hash.size(); }
+int numKnownWeakblockTransactions() { LOCK(cs_weakblocks); return weak_transactions.size(); }
+
+
+void weakblocksConsistencyCheck() {
+    LOCK(cs_weakblocks);
+    LOG(WB, "Doing internal consistency check.\n");
+    assert(hash2weakblock.count(uint256()) == 0);
+    assert(weakblock2header.count(NULL) == 0);
+    assert(weakblock2hash.count(NULL) == 0);
+    assert(hash2weakblock.size() == weakblock2hash.size());
+    assert(weakblock2header.size() == hash2weakblock.size());
+    assert(weak_chain_tips.size() <= hash2weakblock.size());
+    int longest_height=-1;
+    std::set<const Weakblock*> longest_tips;
+
+    for (std::pair<uint256, const Weakblock*> p : hash2weakblock) {
+        const uint256 blockhash = p.first;
+        const Weakblock* wb = p.second;
+
+        LOG(WB, "Consistency check for weak block %s.\n", blockhash.GetHex());
+
+        assert(weakblock2hash[wb] == blockhash);
+
+        // collect chain of blocks this one builds upon
+        std::set<const Weakblock*> chain;
+        const Weakblock* node = wb;
+
+        while (underlyingWeak(node) != NULL) {
+            node = underlyingWeak(node);
+            chain.insert(node);
+            assert(extendsWeak(wb, node));
+        }
+        LOG(WB, "Chain size: %d, weak height: %d\n", chain.size(), weakHeight(wb));
+        assert ((int)chain.size() == weakHeight(wb));
+
+        if ((int)chain.size() >= longest_height) {
+            if ((int)chain.size() > longest_height) {
+                longest_tips.clear();
+            }
+            longest_tips.insert(wb);
+            longest_height = chain.size();
+        }
+    }
+
+    if (longest_height < 0) {
+        assert(getWeakLongestChainTip() == NULL);
+    } else {
+        assert(longest_tips.count(getWeakLongestChainTip()));
+    }
+
+    // make sure that all hashes in extends are actual, known weak blocks
+    // this requirement might be relaxed later on
+    for (std::pair<uint256, uint256> p : extends) {
+        assert (hash2weakblock.count(p.first) > 0);
+        assert (hash2weakblock.count(p.second) > 0);
+    }
+}
+
+void weakblocksEmptyCheck() {
+    LOCK(cs_weakblocks);
+    assert (txid2weakblock.size() == 0);
+    assert (weak_transactions.size() == 0);
+    assert (weak_txid_refcount.size() == 0);
+    assert (hash2weakblock.size() == 0);
+    assert (weakblock2hash.size() == 0);
+    assert (weakblock2header.size() == 0);
+    assert (extends.size() == 0);
+    assert (weak_chain_tips.size() == 0);
+    assert (reassembled.size() == 0);
+}

--- a/src/weakblock.cpp
+++ b/src/weakblock.cpp
@@ -11,9 +11,6 @@
 
 // FIXME: what about asserts here?
 
-//#define DEBUG_DETAIL 1
-
-
 static const uint32_t WB_MIN_POW_RATIO = 600;
 
 CCriticalSection cs_weakblocks;

--- a/src/weakblock.cpp
+++ b/src/weakblock.cpp
@@ -340,7 +340,6 @@ void CWeakStore::consistencyCheck() const {
     for (auto wb : chain_tips)
         assert(hash2wb.count(wb->GetHash()) > 0);
 
-    // TODO: check that extends_map does not have any cycles
 }
 
 const std::vector<CWeakblockRef>& CWeakStore::chainTips() const {

--- a/src/weakblock.cpp
+++ b/src/weakblock.cpp
@@ -243,7 +243,7 @@ CWeakblockRef CWeakStore::store(const CBlock* block) {
     return wb;
 }
 
-CWeakblockRef CWeakStore::Tip() {
+CWeakblockRef CWeakStore::Tip() const {
     LOCK(cs_weakblocks);
 
     int max_wheight=-1;

--- a/src/weakblock.cpp
+++ b/src/weakblock.cpp
@@ -15,11 +15,11 @@ static const uint32_t WB_MIN_POW_RATIO = 600;
 
 CCriticalSection cs_weakblocks;
 
-bool weakblocksEnabled()  { LOCK(cs_weakblocks); return wbEnable.value; }
+bool weakblocksEnabled()  { LOCK(cs_weakblocks); return wbEnable.Value(); }
 
 uint32_t weakblocksConsiderPOWRatio() {
     AssertLockHeld(cs_weakblocks);
-    return wbConsiderPOWratio.value;
+    return wbConsiderPOWratio.Value();
 }
 
 uint32_t weakblocksMinPOWRatio() {

--- a/src/weakblock.cpp
+++ b/src/weakblock.cpp
@@ -13,9 +13,6 @@
 
 //#define DEBUG_DETAIL 1
 
-// BU tweaks enable and config for weak blocks
-extern CTweak<uint32_t> wbConsiderPOWratio;
-extern CTweak<uint32_t> wbEnable;
 
 static const uint32_t WB_MIN_POW_RATIO = 600;
 

--- a/src/weakblock.cpp
+++ b/src/weakblock.cpp
@@ -238,6 +238,15 @@ CWeakblockRef CWeakStore::byHash(const uint256& hash) const {
     else return nullptr;
 }
 
+CWeakblockRef CWeakStore::byHash(const uint64_t& hash) const {
+    // FIXME, O(n) ...
+    for (auto p : hash2wb) {
+        if (p.first.GetCheapHash() == hash)
+            return p.second;
+    }
+    return nullptr;
+}
+
 CWeakblockRef CWeakStore::parent(const uint256& hash) const {
     AssertLockHeld(cs_weakblocks);
     if (extends_map.count(hash))

--- a/src/weakblock.h
+++ b/src/weakblock.h
@@ -16,92 +16,101 @@
 const uint32_t DEFAULT_WEAKBLOCKS_CONSIDER_POW_RATIO=4;
 const bool DEFAULT_WEAKBLOCKS_ENABLE=true;
 
-bool weakblocksEnabled();
-uint32_t weakblocksConsiderPOWRatio();
-
-// absolute minimum POW target multiplicator - below this, also weak blocks are considered invalid and nodes sending those are penalized and banned
-uint32_t weakblocksMinPOWRatio();
-
 //! protects all of the above data structures
 extern CCriticalSection cs_weakblocks;
 
-// Internally, a weak block is just a bunch of pointers, to save
-// memory compared to storing all transactions as duplicates for
-// each weak block
-typedef std::vector<CTransaction*> Weakblock;
+/** Returns true iff weak blocks are enabled. */
+bool weakblocksEnabled();
 
-/* From a block's coinbase transaction, extract the potential candidate hash
-   that point to the underlying weak block, as a "OP_RETURN WB <uint256>" scriptPubKey pattern. */
-uint256 candidateWeakHash(const CBlock &block);
+    /** For weak blocks to be considered by this node, the weak block
+        must meet a target at least this times smaller than the current
+        strong block target.
+        This is a value that can be configured live.
+    */
+uint32_t weakblocksConsiderPOWRatio();
 
-// Check whether a weak block is underlying a strong block by looking at the transaction contents
-bool extendsWeak(const CBlock &block, const Weakblock* underlying);
+    /** For a weak block to be considered a weak block and not just garbage
+        (and reception thus a bannable offense) by this node, the WB
+        must meet a target that is at least this times smaller than
+        the current strong block target.
+    */
+uint32_t weakblocksMinPOWRatio();
 
-// Check whether a weak block is underlying another weak block by looking at the transaction contents
-bool extendsWeak(const Weakblock *wb, const Weakblock* underlying);
+/** Extract commitment hash for any block in the coinbase
+    transaction. Returns a hash value of zero if none is found. */
+uint256 weakblocksExtractCommitment(const CBlock* block);
 
-// store CBlock as a weak block return  iff the block was stored, false if it already exists
-bool storeWeakblock(const CBlock &block);
+class CWeakblock : public CBlock {
+    friend class CWeakStore;
+public:
+    CWeakblock(const CBlock* other);
 
-// return pointer to a CBlock if a given hash is a stored, or NULL
-// returned block needs to be handled with cs_weakblocks locked
-// responsibility of memory management is internal to weakblocks module
-// the returned block is valid until the next call to purgeOldWeakblocks
-const CBlock* blockForWeak(const Weakblock *wb);
+    /** Returns true iff other is underlying this weak block - meaning
+     * that the underlying one contains the same transactions in same
+     * order, except for CB. */
+    bool extends(const CBlock* underlying);
+    bool extends(const CBlock& underlying);
+    bool extends(const ConstCBlockRef& underlying);
+    /** Returns the weak block's weak height. It's height is the
+     number of weak blocks that come before this one. It is minus one if the
+     block is not known as a weak block or when it is marked for removal. */
+    int GetWeakHeight() const;
+private:
+    mutable uint32_t weak_height_cache;
+    mutable bool weak_height_cache_valid;
+};
 
-// return a weak block. Caller needs to care for cs_weakblocks
-const Weakblock* getWeakblock(const uint256& hash);
+typedef std::shared_ptr<CWeakblock> CWeakblockRef;
+typedef std::shared_ptr<const CWeakblock> ConstCWeakblockRef;
 
-// give hash of a weak block. Needs to be cs_weakblocks locked
-const uint256 HashForWeak(const Weakblock* wb);
+class CWeakStore {
+    friend class CWeakblock;
+public:
+    /** Register the given block as a weak block. Returns the weak block or nullptr when it failed, respectively. */
+    CWeakblockRef store(const CBlock* block);
 
-// convenience function around getWeakblock
-inline bool isKnownWeakblock(const uint256& hash) {
-    AssertLockHeld(cs_weakblocks);
-    return getWeakblock(hash) != NULL;
-}
+    /** Purge old weak blocks (but leave enough of them around to help
+     * with transmission of the current chain tip!)
+     * If the thorough flag is set to true,
+     * all weak blocks are expired. */
+    void expireOld(const bool fThorough=false);
 
-/*! Return the weak height of a weakblock
-  The height is the number of weak blocks that come before this one.
-Needs to be called with cs_weakblocks locked. */
-int weakHeight(const uint256 wbhash);
-int weakHeight(const Weakblock* wb);
+    /** Look up weak block by its hash. */
+    CWeakblockRef byHash(const uint256& hash) const;
 
-/*! Return block from longest and earliest weak chain
-  Can return NULL if there is no weak block chain available. */
-const Weakblock* getWeakLongestChainTip();
+    /** Look up underlying weak block. */
+    CWeakblockRef parent(const uint256& hash) const;
 
-// Remove old weak blocks
-// This removes those chain tip that have been marked for removal in the last round
-// and marks the current one for removal in the next round.
-void purgeOldWeakblocks();
+    /** Return weak blocks chain tip (or nullptr if there's none)
+        This is the longest and earliest received (in terms of order of store() calls)
+        weak block chain's tip. */
+    CWeakblockRef Tip();
 
-// return a map of weak block hashes to their weak block height, in chronological order of receival
-std::vector<std::pair<uint256, int> > weakChainTips();
+    //! Number of known weak blocks
+    size_t size() const;
 
-// return block underlying the given weak block (or NULL)
-// This needs to be handled with cs_weakblocks locked
-const Weakblock* underlyingWeak(const Weakblock *block);
+    // returns true if no weak blocks are stored and is equivalent to (::size() == 0)
+    bool empty() const;
 
-// currently known number of weak blocks
-int numKnownWeakblocks();
+    /** Runs an internal consistency check that will fail with assert when something
+        is broken. FIXME: Not to be used in production, update asserts to exception or DbgAssert. */
+    void consistencyCheck() const;
 
-// currently known number of transactions appearing in weak blocks
-int numKnownWeakblockTransactions();
+    const std::vector<CWeakblockRef>& chainTips() const;
+private:
+    //! Map block hash to weak block
+    std::map<uint256, CWeakblockRef> hash2wb;
 
-//! Internal consistency check
-/*! To be used only for testing / debugging.
-  For each weak block that is registered, this checks that:
-  - hash2weakblock and weakblock2hash are consistent
+    //! Store DAG edges, so that extends[a] = b means b is the next underlying block for a
+    std::map<uint256, uint256> extends_map;
 
-  It also checks that getWeakLongestChainTip() is indeed pointing to one of
-  the longest chains of weakblocks.
+    /*! Store all weak block chain tips, ordered chronologically; meaning that a later received chain tip is further down in this vector. Therefore the weak block chain tip is the one with the largest weak height that comes earliest in this vector. */
+    std::vector<CWeakblockRef> chain_tips;
 
-  Runtime is O(<number-of-weak-blocks>^2)
-*/
-void weakblocksConsistencyCheck();
+    /** Chain tips pre-marked for removal for the next expireOld(..) call */
+    std::set<uint256> to_remove;
+};
 
-//! Consistency check that all internal data structures are empty
-void weakblocksEmptyCheck();
+extern CWeakStore weakstore;
 
 #endif

--- a/src/weakblock.h
+++ b/src/weakblock.h
@@ -1,0 +1,107 @@
+// Copyright (c) 2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_WEAKBLOCK_H
+#define BITCOIN_WEAKBLOCK_H
+
+#include "uint256.h"
+#include "consensus/params.h"
+#include "pow.h"
+#include "primitives/block.h"
+#include "primitives/transaction.h"
+#include "sync.h"
+#include "uint256.h"
+
+const uint32_t DEFAULT_WEAKBLOCKS_CONSIDER_POW_RATIO=4;
+const bool DEFAULT_WEAKBLOCKS_ENABLE=true;
+
+bool weakblocksEnabled();
+uint32_t weakblocksConsiderPOWRatio();
+
+// absolute minimum POW target multiplicator - below this, also weak blocks are considered invalid and nodes sending those are penalized and banned
+uint32_t weakblocksMinPOWRatio();
+
+//! protects all of the above data structures
+extern CCriticalSection cs_weakblocks;
+
+// Internally, a weak block is just a bunch of pointers, to save
+// memory compared to storing all transactions as duplicates for
+// each weak block
+typedef std::vector<CTransaction*> Weakblock;
+
+/* From a block's coinbase transaction, extract the potential candidate hash
+   that point to the underlying weak block, as a "OP_RETURN WB <uint256>" scriptPubKey pattern. */
+uint256 candidateWeakHash(const CBlock &block);
+
+// Check whether a weak block is underlying a strong block by looking at the transaction contents
+bool extendsWeak(const CBlock &block, const Weakblock* underlying);
+
+// Check whether a weak block is underlying another weak block by looking at the transaction contents
+bool extendsWeak(const Weakblock *wb, const Weakblock* underlying);
+
+// store CBlock as a weak block return  iff the block was stored, false if it already exists
+bool storeWeakblock(const CBlock &block);
+
+// return pointer to a CBlock if a given hash is a stored, or NULL
+// returned block needs to be handled with cs_weakblocks locked
+// responsibility of memory management is internal to weakblocks module
+// the returned block is valid until the next call to purgeOldWeakblocks
+const CBlock* blockForWeak(const Weakblock *wb);
+
+// return a weak block. Caller needs to care for cs_weakblocks
+const Weakblock* getWeakblock(const uint256& hash);
+
+// give hash of a weak block. Needs to be cs_weakblocks locked
+const uint256 HashForWeak(const Weakblock* wb);
+
+// convenience function around getWeakblock
+inline bool isKnownWeakblock(const uint256& hash) {
+    AssertLockHeld(cs_weakblocks);
+    return getWeakblock(hash) != NULL;
+}
+
+/*! Return the weak height of a weakblock
+  The height is the number of weak blocks that come before this one.
+Needs to be called with cs_weakblocks locked. */
+int weakHeight(const uint256 wbhash);
+int weakHeight(const Weakblock* wb);
+
+/*! Return block from longest and earliest weak chain
+  Can return NULL if there is no weak block chain available. */
+const Weakblock* getWeakLongestChainTip();
+
+// Remove old weak blocks
+// This removes those chain tip that have been marked for removal in the last round
+// and marks the current one for removal in the next round.
+void purgeOldWeakblocks();
+
+// return a map of weak block hashes to their weak block height, in chronological order of receival
+std::vector<std::pair<uint256, int> > weakChainTips();
+
+// return block underlying the given weak block (or NULL)
+// This needs to be handled with cs_weakblocks locked
+const Weakblock* underlyingWeak(const Weakblock *block);
+
+// currently known number of weak blocks
+int numKnownWeakblocks();
+
+// currently known number of transactions appearing in weak blocks
+int numKnownWeakblockTransactions();
+
+//! Internal consistency check
+/*! To be used only for testing / debugging.
+  For each weak block that is registered, this checks that:
+  - hash2weakblock and weakblock2hash are consistent
+
+  It also checks that getWeakLongestChainTip() is indeed pointing to one of
+  the longest chains of weakblocks.
+
+  Runtime is O(<number-of-weak-blocks>^2)
+*/
+void weakblocksConsistencyCheck();
+
+//! Consistency check that all internal data structures are empty
+void weakblocksEmptyCheck();
+
+#endif

--- a/src/weakblock.h
+++ b/src/weakblock.h
@@ -10,6 +10,7 @@
 #include "primitives/block.h"
 #include "primitives/transaction.h"
 #include "main.h"
+#include "net.h"
 #include "sync.h"
 #include "uint256.h"
 #include <unordered_map>
@@ -108,6 +109,17 @@ public:
     void consistencyCheck(const bool check_cached_heights=true) const;
 
     const std::vector<CWeakblockRef>& chainTips() const;
+
+    // Node weakblocks knowledge tracking
+
+    // Asks whether the given node likely knows about the given underlying weak hash
+    bool nodeKnows(NodeId nid, const uint256& weakhash) const;
+
+    //! asserts that the given node knows the given weakhash
+    void set_nodeKnows(NodeId nid, const uint256& weakhash);
+
+    //! Returns all node knowlege
+    const std::unordered_map<uint256, std::unordered_set<NodeId>, BlockHasher>& nodeKnowledge() const;
 private:
     //! Map block hash to weak block
     std::unordered_map<uint256, CWeakblockRef, BlockHasher> hash2wb;
@@ -123,8 +135,12 @@ private:
 
     /** Chain tips pre-marked for removal for the next expireOld(..) call */
     std::unordered_set<uint256, BlockHasher> to_remove;
+
+    //! Which node knows about which weak block
+    std::unordered_map<uint256, std::unordered_set<NodeId>, BlockHasher> node_knowledge;
 };
 
 extern CWeakStore weakstore;
+
 
 #endif

--- a/src/weakblock.h
+++ b/src/weakblock.h
@@ -16,6 +16,11 @@
 const uint32_t DEFAULT_WEAKBLOCKS_CONSIDER_POW_RATIO=4;
 const bool DEFAULT_WEAKBLOCKS_ENABLE=true;
 
+// BU tweaks enable and config for weak blocks
+// instantiated in globals.cpp
+extern CTweak<uint32_t> wbConsiderPOWratio;
+extern CTweak<bool> wbEnable;
+
 //! protects all of the above data structures
 extern CCriticalSection cs_weakblocks;
 

--- a/src/weakblock.h
+++ b/src/weakblock.h
@@ -95,7 +95,7 @@ public:
     /** Return weak blocks chain tip (or nullptr if there's none)
         This is the longest and earliest received (in terms of order of store() calls)
         weak block chain's tip. */
-    CWeakblockRef Tip();
+    CWeakblockRef Tip() const;
 
     //! Number of known weak blocks
     size_t size() const;

--- a/src/weakblock.h
+++ b/src/weakblock.h
@@ -5,14 +5,15 @@
 #ifndef BITCOIN_WEAKBLOCK_H
 #define BITCOIN_WEAKBLOCK_H
 
-#include "uint256.h"
 #include "consensus/params.h"
 #include "pow.h"
 #include "primitives/block.h"
 #include "primitives/transaction.h"
+#include "main.h"
 #include "sync.h"
 #include "uint256.h"
 #include <unordered_map>
+#include <unordered_set>
 
 const uint32_t DEFAULT_WEAKBLOCKS_CONSIDER_POW_RATIO=4;
 const bool DEFAULT_WEAKBLOCKS_ENABLE=true;
@@ -109,19 +110,19 @@ public:
     const std::vector<CWeakblockRef>& chainTips() const;
 private:
     //! Map block hash to weak block
-    std::map<uint256, CWeakblockRef> hash2wb;
+    std::unordered_map<uint256, CWeakblockRef, BlockHasher> hash2wb;
     //! same as above, but for cheap hashes. In case of collision, a newly inserted weakblock
     // will override the older one.
     std::unordered_map<uint64_t, CWeakblockRef> cheaphash2wb;
 
     //! Store DAG edges, so that extends[a] = b means b is the next underlying block for a
-    std::map<uint256, uint256> extends_map;
+    std::unordered_map<uint256, uint256, BlockHasher> extends_map;
 
     /*! Store all weak block chain tips, ordered chronologically; meaning that a later received chain tip is further down in this vector. Therefore the weak block chain tip is the one with the largest weak height that comes earliest in this vector. */
     std::vector<CWeakblockRef> chain_tips;
 
     /** Chain tips pre-marked for removal for the next expireOld(..) call */
-    std::set<uint256> to_remove;
+    std::unordered_set<uint256, BlockHasher> to_remove;
 };
 
 extern CWeakStore weakstore;

--- a/src/weakblock.h
+++ b/src/weakblock.h
@@ -83,6 +83,11 @@ public:
     /** Look up weak block by its hash. */
     CWeakblockRef byHash(const uint256& hash) const;
 
+    /** Look up weak block by its cheap hash.
+        Might return wrong block in case of collision.
+        FIXME: currently slow. */
+    CWeakblockRef byHash(const uint64_t& hash) const;
+
     /** Look up underlying weak block. */
     CWeakblockRef parent(const uint256& hash) const;
 

--- a/src/weakblock.h
+++ b/src/weakblock.h
@@ -112,7 +112,7 @@ public:
 
     // Node weakblocks knowledge tracking
 
-    // Asks whether the given node likely knows about the given underlying weak hash
+    // Asks whether the given node likely knows about the given underlying block hash
     bool nodeKnows(NodeId nid, const uint256& weakhash) const;
 
     //! asserts that the given node knows the given weakhash

--- a/src/weakblock.h
+++ b/src/weakblock.h
@@ -12,6 +12,7 @@
 #include "primitives/transaction.h"
 #include "sync.h"
 #include "uint256.h"
+#include <unordered_map>
 
 const uint32_t DEFAULT_WEAKBLOCKS_CONSIDER_POW_RATIO=4;
 const bool DEFAULT_WEAKBLOCKS_ENABLE=true;
@@ -84,9 +85,8 @@ public:
     CWeakblockRef byHash(const uint256& hash) const;
 
     /** Look up weak block by its cheap hash.
-        Might return wrong block in case of collision.
-        FIXME: currently slow. */
-    CWeakblockRef byHash(const uint64_t& hash) const;
+        Might return wrong block in case of collision! */
+    CWeakblockRef byHash(const uint64_t& cheaphash) const;
 
     /** Look up underlying weak block. */
     CWeakblockRef parent(const uint256& hash) const;
@@ -110,6 +110,9 @@ public:
 private:
     //! Map block hash to weak block
     std::map<uint256, CWeakblockRef> hash2wb;
+    //! same as above, but for cheap hashes. In case of collision, a newly inserted weakblock
+    // will override the older one.
+    std::unordered_map<uint64_t, CWeakblockRef> cheaphash2wb;
 
     //! Store DAG edges, so that extends[a] = b means b is the next underlying block for a
     std::map<uint256, uint256> extends_map;

--- a/src/weakblock.h
+++ b/src/weakblock.h
@@ -105,7 +105,7 @@ public:
 
     /** Runs an internal consistency check that will fail with assert when something
         is broken. FIXME: Not to be used in production, update asserts to exception or DbgAssert. */
-    void consistencyCheck() const;
+    void consistencyCheck(const bool check_cached_heights=true) const;
 
     const std::vector<CWeakblockRef>& chainTips() const;
 private:


### PR DESCRIPTION
Hey folks,

here is my very pre-alpha preliminary proof of concept implementation of Peter Rizun's subchain proposal (https://www.bitcoinunlimited.info/resources/subchains.pdf). 

In short, weakblocks/subchains will eventually allow to reduce effective interblock times on the blockchain, **but without touching any of the core consensus parameters**. A "weak" or "fractional" confirmation is introduced, which is expected to provide proof-of-work security intermediate between a "full strong confirmation" and "zero confirmation transactions". **From a user's or merchant's point of view, this will be reducing the effective wait time for making transactions on the BCH blockchain to as low as the network permits** and thus help BCH merchant adoption.

This code here needs a lot of review and is in parts unfinished (the weak block confirmation time setting is something that ideally would be open to miner voting, code to gracefully degrade to non-weakblocks is still missing, etc.). I published it in the spirit of 'release early and release often'. I like to gather feedback on the general approach of keeping the validation logic intact as much and implementing this as minimal set of changes that would represent weakblocks internally as orphaned, specially marked branches of the main chain.

My general idea is as follows: A weak block is handled just like a normal block and the validation logic in 
bitcoind is adapted so that blocks matching a weak difficulty target (which is easier than a strong block, of course) will be accepted as well.

With one difference: Those blocks are marked with a BLOCK_WEAK status flag and a weak block can never be part of the active chain.

In effect, this will result in incoming blocks being stored in orphan branches and alternative chain tips.

I adapted the RPC of 'getchaintips' to indicate the weak blocks and furthermore adapted the 'generate' RPC to allow generation of weak blocks. For integrating weak blocks into merchant's POS and similar, two new RPCs are added as well: "weakstats" to get a general view of all current weak blocks and "weakconfirmations" to get, for a given TXID, the number of weak blocks that TXIDs is part of - which would be the "fractional confirmations" for that transaction.

Whenever a strong block arrives, the set of weak blocks is cleared.

Furthermore, I adapted @ptschip 's  thinblocks transmission scheme to implement deltathinblocks. These are like delta blocks as Peter described them in his paper, while additionally using the thinblock bloom filtering and TX->TXID reducition scheme. Given an existing weak block, a deltathinblock will refer to that one if the new block to transmitted is a superset (except the coinbase) of that older weak block.

More detailed documentation (proper docs are stilll a TODO as well) can be found in the respective commit messages.

I split the code into multiple very small commits. This is to aid/ease review and understanding of where I want to go with this. I am of course fine to squash it all together into a few large (or a single) commit for final release (which is still a long time out).

If the general approach is sound and enough iterations have been made, I'll also work on implementing it on top of the BitcoinABC implementation (@deadalnix ) with a corresponding "deltacompactblocks" implementation to the "deltathin" blocks proposed here.

TODO
-----
- simplify weakblocks gossip
- Upgrade BIP37 to deal with weakblocks (as per Chris Pacia on reddit).
- ~clean up special numbers / negative values / to use enums / strings~
- make sure internal tracking of weak blocks is the right amount & no mem leaks or lots of dead weak block orphan branches are stored forever
- Docs!!
- right now, deltathin construction is O(blocksize). Looking for commonalities in the merkle tree should make one able to cut this down to O(log2(blocksize)**2) or so.
- guard against all forms of replay attacks that would send old weak blocks to cause excessive resource consumption (DOS). Rejecting and banning by checking whether the hashPrevBlock is too far down the chain might make sense, as well as maybe keeping an index of any weakblock received ever.
- spec proper deltathin blocks instead of using the adhoc hack to set the first transaction hash to the weak block's one and the next one to the new coinbase
- create comprehensive tests
- make sure the tests pass

EDIT: Adding a TODO to keep track of items.