### PR TITLE
Use the proper name of the clang-format program.

### DIFF
--- a/contrib/devtools/clang-format.py
+++ b/contrib/devtools/clang-format.py
@@ -78,7 +78,7 @@ def run_clang_check(clang_format_exe, files):
         print("\nNonexistent files: " + ",".join(nonexistent))
     if changed:
         print("\nImproper formatting found in: " + ",".join(list(changed)))
-        print("To properly format these files run: " + sys.argv[0] + " format clang-format " + " ".join(list(changed)))
+        print("To properly format these files run: " + sys.argv[0] + " format " + clang_format_exe + " " + " ".join(list(changed)))
         return 1
     else:
         print("All existing files are properly formatted")


### PR DESCRIPTION
Use the proper name of the clang-format program instead of just clang-format.  This is needed to ensure that people run clang-format version 3.8