### PR TITLE
Set the default block size on the BitcoinCash chain to 2MB

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -107,7 +107,7 @@ vector<std::string> vUseDNSSeeds;
 vector<std::string> vAddedNodes;
 set<CNetAddr> setservAddNodeAddresses;
 
-uint64_t maxGeneratedBlock = DEFAULT_MAX_GENERATED_BLOCK_SIZE;
+uint64_t maxGeneratedBlock = DEFAULT_BLOCK_MAX_SIZE;
 uint64_t excessiveBlockSize = DEFAULT_EXCESSIVE_BLOCK_SIZE;
 unsigned int excessiveAcceptDepth = DEFAULT_EXCESSIVE_ACCEPT_DEPTH;
 unsigned int maxMessageSizeMultiplier = DEFAULT_MAX_MESSAGE_SIZE_MULTIPLIER;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -23,12 +23,8 @@ static const unsigned int DEFAULT_BLOCK_MAX_SIZE = BLOCKSTREAM_CORE_MAX_BLOCK_SI
 #endif
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 
-/** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
-#ifdef BITCOIN_CASH
+/** Default for -blockprioritysize, a 5% maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = DEFAULT_BLOCK_MAX_SIZE / 20;
-#else
-static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
-#endif
 
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -6,6 +6,7 @@
 #ifndef BITCOIN_POLICY_POLICY_H
 #define BITCOIN_POLICY_POLICY_H
 
+#include "clientversion.h"
 #include "consensus/consensus.h"
 #include "script/interpreter.h"
 #include "script/standard.h"
@@ -15,10 +16,20 @@
 class CCoinsViewCache;
 
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
+#ifdef BITCOIN_CASH
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 2000000;
+#else
 static const unsigned int DEFAULT_BLOCK_MAX_SIZE = BLOCKSTREAM_CORE_MAX_BLOCK_SIZE; // BU: crank the default up to the minimum  max defined in all clients.
+#endif
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
+
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
+#ifdef BITCOIN_CASH
+static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = DEFAULT_BLOCK_MAX_SIZE / 20;
+#else
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 50000;
+#endif
+
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -63,7 +63,7 @@ UniValue validatechainhistory(const UniValue &params, bool fHelp);
 bool MiningAndExcessiveBlockValidatorRule(const uint64_t newExcessiveBlockSize, const uint64_t newMiningBlockSize)
 {
     // The mined block size must be less then or equal too the excessive block size.
-    LogPrintf("newMiningBlockSizei: %d - newExcessiveBlockSize: %d", newMiningBlockSize, newExcessiveBlockSize);
+    LogPrintf("newMiningBlockSize: %d - newExcessiveBlockSize: %d\n", newMiningBlockSize, newExcessiveBlockSize);
     return (newMiningBlockSize <= newExcessiveBlockSize);
 }
 

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -27,7 +27,6 @@
 enum
 {
     TYPICAL_BLOCK_SIZE = 200000, // used for initial buffer size
-    DEFAULT_MAX_GENERATED_BLOCK_SIZE = 1000000, // default for the maximum size of mined blocks
     DEFAULT_EXCESSIVE_ACCEPT_DEPTH = 12, // Default is 12 to make it very expensive for a minority hash power to get
     // lucky, and potentially drive a block that the rest of the network sees as
     // "excessive" onto the blockchain.


### PR DESCRIPTION
Also, set the block priority area to 5% of the default blocksize