### PR TITLE
Add two new checkpoints for Cash main chain

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -197,11 +197,23 @@ public:
                 225430, uint256S("0x00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932"))(
                 250000, uint256S("0x000000000000003887df1f29024b06fc2200b55f8af8f35453d7be294df2d214"))(
                 279000, uint256S("0x0000000000000001ae8c72a0b0c301f67e3afca10e819efa9041e458e9bd7e40"))(
+#ifdef BITCOIN_CASH
+                295000, uint256S("0x00000000000000004d9b4ef50f0f9d686fd69db2e03af35a100370c64632a983"))(
+                // August 1st 2017 CASH fork (UAHF)
+                478559, uint256S("0x000000000000000000651ef99cb9fcbe0dadde1d424bd9f15ff20136191a5eec"))(
+                // November 13th 2017 new DAA fork
+                504031, uint256S("0x0000000000000000011ebf65b60d0a3de80b8175be709d653b4c1a1beeb6ab9c")),
+            1483472411, // * UNIX timestamp of last checkpoint block
+            184495391, // * total number of transactions between genesis and last checkpoint
+            //   (the tx=... number in the SetBestChain debug.log lines)
+            280000.0 // * estimated number of transactions per day after checkpoint (~3.5 TPS)
+#else
                 295000, uint256S("0x00000000000000004d9b4ef50f0f9d686fd69db2e03af35a100370c64632a983")),
             1397080064, // * UNIX timestamp of last checkpoint block
             36544669, // * total number of transactions between genesis and last checkpoint
             //   (the tx=... number in the SetBestChain debug.log lines)
             60000.0 // * estimated number of transactions per day after checkpoint
+#endif
         };
     }
 };


### PR DESCRIPTION
August 1st 2017 CASH fork, height 478559
November 13th 2017 new DAA fork, height 504031