### PR TITLE
[dev branch] Bug Fix for Coin Freeze when making payment request

### DIFF
--- a/src/qt/receivecoinsdialog.cpp
+++ b/src/qt/receivecoinsdialog.cpp
@@ -207,9 +207,6 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
     }
     else
     {
-        /* Generate new receiving address and add to the address table */
-        address = model->getAddressTableModel()->addRow(AddressTableModel::Receive, label, "", CScriptNum(0));
-
         // only use coin freeze if the freeze value is valid and the check box is still set
         if ((nFreezeLockTime > 0) && (ui->freezeCheck) && (ui->freezeCheck->isChecked()))
         {
@@ -217,6 +214,11 @@ void ReceiveCoinsDialog::on_receiveButton_clicked()
              * The address variable needs to show the freeze P2SH public key  */
             address = model->getAddressTableModel()->addRow(AddressTableModel::Receive, label, "", nFreezeLockTime);
             sFreezeLockTime = model->getAddressTableModel()->labelForFreeze(address);
+        }
+        else
+        {
+            /* Generate new receiving address and add to the address table */
+            address = model->getAddressTableModel()->addRow(AddressTableModel::Receive, label, "", CScriptNum(0));
         }
     }
     SendCoinsRecipient info(address, label, ui->reqAmount->value(), ui->reqMessage->text(), sFreezeLockTime, "");


### PR DESCRIPTION
Previously when making a new payment request, that would
generate a new P2SH freeze address, there would be another
P2KH address added to the address book which would also
have the same label applied.  This second address is not
needed and is confusing to the user who was only trying
to create only one freeze address.  The fix here is to only
create the P2SH freeze address as was intended.