### PR TITLE
[dev branch] Add init message for Reaccepting Wallet Transactions

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1386,9 +1386,9 @@ bool AppInit2(boost::thread_group &threadGroup, CScheduler &scheduler)
     // ********************************************************* Step 12: finished
 
     SetRPCWarmupFinished();
-    uiInterface.InitMessage(_("Done loading"));
 
 #ifdef ENABLE_WALLET
+    uiInterface.InitMessage(_("Reaccepting Wallet Transactions"));
     if (pwalletMain)
     {
         // Add wallet transactions that aren't already in a block to mapTransactions
@@ -1399,5 +1399,6 @@ bool AppInit2(boost::thread_group &threadGroup, CScheduler &scheduler)
     }
 #endif
 
+    uiInterface.InitMessage(_("Done loading"));
     return !fRequestShutdown;
 }


### PR DESCRIPTION
During startup the very last step is to reaccept wallet transactions.
Previously the client was indicating that loading was complete before
this last step. Here we send a ui message and also print to the logfile
to indicate that wallet transactions are still being reacceted and then
only when finally complete we indicate that loading is finished.

What prompted this PR is that someone had reported recently that the startup screen was stuck at the "Done loading" phase.  When they restarted the problem went way, however it would have been good to know if wallet txns were still being reaccepted or not.