### PR TITLE
importprivatekeys and importaddresses RPC calls

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -58,6 +58,7 @@ boost::thread_specific_ptr<LockStack> lockstack;
 std::atomic<bool> fIsInitialBlockDownload{false};
 std::atomic<bool> fRescan{false}; // this flag is set to true when a wallet rescan has been invoked.
 
+CStatusString statusStrings;
 // main.cpp CriticalSections:
 CCriticalSection cs_LastBlockFile;
 CCriticalSection cs_nBlockSequenceId;

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -64,6 +64,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
             "  \"paytxfee\": x.xxxx,         (numeric) the transaction fee set in " + CURRENCY_UNIT + "/kB\n"
             "  \"relayfee\": x.xxxx,         (numeric) minimum relay fee for non-free transactions in " + CURRENCY_UNIT + "/kB\n"
             "  \"fork\": \"...\"             (string) \"Bitcoin Cash\" or \"Bitcoin\".  Will display as Bitcoin pre-fork.\n"
+            "  \"status\":\"...\"            (string) long running operations are indicated here (rescan).\n" 
             "  \"errors\": \"...\"           (string) any error messages\n"
             "}\n"
             "\nExamples:\n"
@@ -105,6 +106,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("paytxfee",      ValueFromAmount(payTxFee.GetFeePerK())));
 #endif
     obj.push_back(Pair("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK())));
+    obj.push_back(Pair("status",        statusStrings.GetPrintable()));
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));
     CBlockIndex *cashFork = chainActive.Tip();
     if (cashFork) cashFork = cashFork->GetAncestor(BITCOIN_CASH_FORK_HEIGHT);

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1938,3 +1938,31 @@ void MarkAllContainingChainsInvalid(CBlockIndex *invalidBlock)
     if (dirty)
         FlushStateToDisk();
 }
+
+std::string CStatusString::GetPrintable() const
+{
+    LOCK(cs);
+    if (strSet.empty())
+        return "ready";
+    std::string ret;
+    for (auto it : strSet)
+    {
+        if (!ret.empty())
+            ret.append(" ");
+        std::string &s = it;
+        ret.append(s);
+    }
+    return ret;
+}
+
+void CStatusString::Set(const std::string &yourStatus)
+{
+    LOCK(cs);
+    strSet.insert(yourStatus);
+}
+
+void CStatusString::Clear(const std::string &yourStatus)
+{
+    LOCK(cs);
+    strSet.erase(yourStatus);
+}

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -60,6 +60,22 @@ class CNode;
 class CNodeRef;
 class CChainParams;
 
+/** Add or remove a string to indicate ongoing status */
+class CStatusString
+{
+    mutable CCriticalSection cs;
+    std::set<std::string> strSet;
+
+public:
+    void Set(const std::string &yourStatus);
+    void Clear(const std::string &yourStatus);
+
+    std::string GetPrintable() const;
+};
+
+extern CStatusString statusStrings;
+
+
 extern uint256 bitcoinCashForkBlockHash;
 
 extern std::set<CBlockIndex *> setDirtyBlockIndex;

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -199,7 +199,6 @@ extern CLeakyBucket sendShaper;
 // Test to determine if traffic shaping is enabled
 extern bool IsTrafficShapingEnabled();
 
-
 // Check whether we are doing an initial block download (synchronizing from disk or network)
 extern bool IsInitialBlockDownload();
 extern void IsInitialBlockDownloadInit();

--- a/src/util.h
+++ b/src/util.h
@@ -23,6 +23,7 @@
 
 #include <exception>
 #include <map>
+#include <set>
 #include <stdint.h>
 #include <string>
 #include <vector>

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -161,11 +161,11 @@ UniValue importprivatekeys(const UniValue& params, bool fHelp)
 
     if (fHelp || params.size() < 1)
         throw runtime_error(
-            "importprivatekeys [rescan | no-rescan] \"bitcoinprivkey\"...\n"
+            "importprivatekeys [rescan | no-rescan] \"bitcoinprivatekey\"...\n"
             "\nAdds private keys (as returned by dumpprivkey) to your wallet.\n"
             "\nArguments:\n"
             "1. \"rescan | no-rescan\" (string, optional default rescan) If \"no-rescan\", skip wallet rescan\n"
-            "2. \"bitcoinprivkey\"   (string, at least 1 required) The private keys (see dumpprivkey)\n"
+            "2. \"bitcoinprivatekey\"   (string, at least 1 required) The private keys (see dumpprivkey)\n"
             "\nNote: This command will return before the rescan (may take hours) is complete.\n"
             "\nExamples:\n"
             "\nDump a private key\n"
@@ -173,9 +173,9 @@ UniValue importprivatekeys(const UniValue& params, bool fHelp)
             "\nImport the private key with rescan\n"
             + HelpExampleCli("importprivatekey", "\"mykey\"") +
             "\nImport using a label and without rescan\n"
-            + HelpExampleCli("importprivkey", "no-rescan \"mykey\"") +
+            + HelpExampleCli("importprivatekeys", "no-rescan \"mykey\"") +
             "\nAs a JSON-RPC call\n"
-            + HelpExampleRpc("importprivkey", "\"mykey\"")
+            + HelpExampleRpc("importprivatekeys", "\"mykey\"")
         );
 
     LOCK2(cs_main, pwalletMain->cs_wallet);

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2487,7 +2487,9 @@ UniValue fundrawtransaction(const UniValue& params, bool fHelp)
 
 extern UniValue dumpprivkey(const UniValue& params, bool fHelp); // in rpcdump.cpp
 extern UniValue importprivkey(const UniValue& params, bool fHelp);
+extern UniValue importprivatekeys(const UniValue& params, bool fHelp);
 extern UniValue importaddress(const UniValue& params, bool fHelp);
+extern UniValue importaddresses(const UniValue& params, bool fHelp);
 extern UniValue importpubkey(const UniValue& params, bool fHelp);
 extern UniValue dumpwallet(const UniValue& params, bool fHelp);
 extern UniValue importwallet(const UniValue& params, bool fHelp);
@@ -2517,8 +2519,10 @@ static const CRPCCommand commands[] =
     { "wallet",             "getunconfirmedbalance",    &getunconfirmedbalance,    false },
     { "wallet",             "getwalletinfo",            &getwalletinfo,            false },
     { "wallet",             "importprivkey",            &importprivkey,            true  },
+    { "wallet",             "importprivatekeys",        &importprivatekeys,        true  },
     { "wallet",             "importwallet",             &importwallet,             true  },
     { "wallet",             "importaddress",            &importaddress,            true  },
+    { "wallet",             "importaddresses",          &importaddresses,          true  },
     { "wallet",             "importprunedfunds",        &importprunedfunds,        true  },
     { "wallet",             "importpubkey",             &importpubkey,             true  },
     { "wallet",             "keypoolrefill",            &keypoolrefill,            true  },

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3420,3 +3420,16 @@ bool CMerkleTx::AcceptToMemoryPool(bool fLimitFree, bool fRejectAbsurdFee)
     CValidationState state;
     return ::AcceptToMemoryPool(mempool, state, *this, fLimitFree, nullptr, false, fRejectAbsurdFee);
 }
+
+
+void ThreadRescan()
+{
+    pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), true);
+    pwalletMain->ReacceptWalletTransactions();
+}
+
+void StartWalletRescanThread()
+{
+    boost::thread rescanThread(boost::bind(&TraceThread<void (*)()>, "rescan", &ThreadRescan));
+    rescanThread.detach();
+}

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3426,10 +3426,13 @@ void ThreadRescan()
 {
     pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), true);
     pwalletMain->ReacceptWalletTransactions();
+    pwalletMain->Flush();
+    statusStrings.Clear("rescanning");
 }
 
 void StartWalletRescanThread()
 {
+    statusStrings.Set("rescanning");
     boost::thread rescanThread(boost::bind(&TraceThread<void (*)()>, "rescan", &ThreadRescan));
     rescanThread.detach();
 }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -957,4 +957,8 @@ public:
     }
 };
 
+// Rescan the blockchain for wallet transactions in a separate thread
+// This will drop all connections and spend a LONG time to complete
+extern void StartWalletRescanThread();
+
 #endif // BITCOIN_WALLET_WALLET_H


### PR DESCRIPTION
Add multiple arg importprivatekeys and importaddresses RPC calls to help with extremely long rescan times.  Also defers the rescan to a separate thread.