### PR TITLE
Prevent a race in Xpedited block processing (@awemany #857)

### DIFF
--- a/src/connmgr.h
+++ b/src/connmgr.h
@@ -12,8 +12,6 @@
 
 class CConnMgr
 {
-    // This critical section protects the vectors
-    CCriticalSection cs_expedited;
     // We send expedited blocks to these nodes
     std::vector<CNode *> vSendExpeditedBlocks;
     // We send expedited txs to these nodes
@@ -28,6 +26,11 @@ class CConnMgr
     std::atomic<NodeId> next;
 
 public:
+    /* This critical section protects the vectors regarding xpedited
+     * operation, as well as the data structures internal to the
+     * expedited.cpp module */
+    CCriticalSection cs_expedited;
+
     CConnMgr();
 
     /**

--- a/src/expedited.cpp
+++ b/src/expedited.cpp
@@ -79,8 +79,10 @@ bool HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom)
     return true;
 }
 
-bool IsRecentlyExpeditedAndStore(const uint256 &hash)
+static inline bool IsRecentlyExpeditedAndStore(const uint256 &hash)
 {
+    AssertLockHeld(connmgr->cs_expedited);
+
     for (int i = 0; i < NUM_XPEDITED_STORE; i++)
         if (xpeditedBlkSent[i] == hash)
             return true;
@@ -138,6 +140,7 @@ void SendExpeditedBlock(CXThinBlock &thinBlock, unsigned char hops, const CNode 
 
 void SendExpeditedBlock(const CBlock &block, const CNode *skip)
 {
+    LOCK(connmgr->cs_expedited);
     if (!IsRecentlyExpeditedAndStore(block.GetHash()))
     {
         CXThinBlock thinBlock(block);

--- a/src/expedited.cpp
+++ b/src/expedited.cpp
@@ -115,7 +115,7 @@ bool HandleExpeditedBlock(CDataStream &vRecv, CNode *pfrom)
     }
 }
 
-void SendExpeditedBlock(CXThinBlock &thinBlock, unsigned char hops, const CNode *skip)
+void ActuallySendExpreditedBlock(CXThinBlock &thinBlock, unsigned char hops, const CNode *skip)
 {
     VNodeRefs vNodeRefs(connmgr->ExpeditedBlockNodes());
 
@@ -138,13 +138,22 @@ void SendExpeditedBlock(CXThinBlock &thinBlock, unsigned char hops, const CNode 
     }
 }
 
+void SendExpeditedBlock(CXThinBlock &thinBlock, unsigned char hops, const CNode *skip)
+{
+    LOCK(connmgr->cs_expedited);
+    if (!IsRecentlyExpeditedAndStore(thinBlock.header.GetHash()))
+    {
+        ActuallySendExpreditedBlock(thinBlock, hops, skip);
+    }
+}
+
 void SendExpeditedBlock(const CBlock &block, const CNode *skip)
 {
     LOCK(connmgr->cs_expedited);
     if (!IsRecentlyExpeditedAndStore(block.GetHash()))
     {
         CXThinBlock thinBlock(block);
-        SendExpeditedBlock(thinBlock, 0, skip);
+        ActuallySendExpreditedBlock(thinBlock, 0, skip);
     }
     // else, nothing to do
 }

--- a/src/expedited.h
+++ b/src/expedited.h
@@ -28,7 +28,6 @@ extern bool CheckAndRequestExpeditedBlocks(CNode *pfrom);
 extern void SendExpeditedBlock(CXThinBlock &thinBlock, unsigned char hops, const CNode *skip = NULL);
 extern void SendExpeditedBlock(const CBlock &block, const CNode *skip = NULL);
 extern bool HandleExpeditedRequest(CDataStream &vRecv, CNode *pfrom);
-extern bool IsRecentlyExpeditedAndStore(const uint256 &hash);
 
 // process incoming unsolicited block
 extern bool HandleExpeditedBlock(CDataStream &vRecv, CNode *pfrom);

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -647,8 +647,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
     }
 
     // Send expedited block without checking merkle root.
-    if (!IsRecentlyExpeditedAndStore(inv.hash))
-        SendExpeditedBlock(thinBlock, nHops, pfrom);
+    SendExpeditedBlock(thinBlock, nHops, pfrom);
 
     return thinBlock.process(pfrom, nSizeThinBlock, strCommand);
 }


### PR DESCRIPTION
There was a potential race in IsRecentlyExpeditedAndStore(..).
This locks the module-level data structures of expedited.cpp.
It also removes a redundant check in thinblock.cpp regarding
xpedited propagation.