### PR TITLE
Add Satoshi Nakamoto copyright back.

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,5 +1,6 @@
 The MIT License (MIT)
 
+Copyright (c) 2009 Satoshi Nakamoto
 Copyright (c) 2009-2016 The Bitcoin Core developers
 Copyright (c) 2015-2017 The Bitcoin Unlimited developers
 


### PR DESCRIPTION
In the very first posting of the code on SourceForge, there was this:
Copyright (c) 2009 Satoshi Nakamoto Under MIT License, that should be
included.

see

https://github.com/trottier/original-bitcoin/blob/master/src/license.txt

[skip ci]