### PR TITLE
Don't format tinyformat.h

### DIFF
--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -119,7 +119,6 @@ thinblock.h
 threadsafety.h
 timedata.cpp
 timedata.h
-tinyformat.h
 torcontrol.cpp
 torcontrol.h
 tweak.cpp

--- a/src/tinyformat.h
+++ b/src/tinyformat.h
@@ -101,9 +101,7 @@
 #ifndef TINYFORMAT_H_INCLUDED
 #define TINYFORMAT_H_INCLUDED
 
-namespace tinyformat
-{
-}
+namespace tinyformat {}
 //------------------------------------------------------------------------------
 // Config section.  Customize to your liking!
 
@@ -126,120 +124,99 @@ namespace tfm = tinyformat;
 #include <stdexcept>
 
 #ifndef TINYFORMAT_ERROR
-#define TINYFORMAT_ERROR(reason) assert(0 && reason)
+#   define TINYFORMAT_ERROR(reason) assert(0 && reason)
 #endif
 
 #if !defined(TINYFORMAT_USE_VARIADIC_TEMPLATES) && !defined(TINYFORMAT_NO_VARIADIC_TEMPLATES)
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
-#define TINYFORMAT_USE_VARIADIC_TEMPLATES
-#endif
+#   ifdef __GXX_EXPERIMENTAL_CXX0X__
+#       define TINYFORMAT_USE_VARIADIC_TEMPLATES
+#   endif
 #endif
 
 #ifdef __GNUC__
-#define TINYFORMAT_NOINLINE __attribute__((noinline))
+#   define TINYFORMAT_NOINLINE __attribute__((noinline))
 #elif defined(_MSC_VER)
-#define TINYFORMAT_NOINLINE __declspec(noinline)
+#   define TINYFORMAT_NOINLINE __declspec(noinline)
 #else
-#define TINYFORMAT_NOINLINE
+#   define TINYFORMAT_NOINLINE
 #endif
 
 #if defined(__GLIBCXX__) && __GLIBCXX__ < 20080201
 //  std::showpos is broken on old libstdc++ as provided with OSX.  See
 //  http://gcc.gnu.org/ml/libstdc++/2007-11/msg00075.html
-#define TINYFORMAT_OLD_LIBSTDCPLUSPLUS_WORKAROUND
+#   define TINYFORMAT_OLD_LIBSTDCPLUSPLUS_WORKAROUND
 #endif
 
-namespace tinyformat
-{
+namespace tinyformat {
+
 //------------------------------------------------------------------------------
-namespace detail
-{
+namespace detail {
+
 // Test whether type T1 is convertible to type T2
 template <typename T1, typename T2>
 struct is_convertible
 {
-private:
-    // two types of different size
-    struct fail
-    {
-        char dummy[2];
-    };
-    struct succeed
-    {
-        char dummy;
-    };
-    // Try to convert a T1 to a T2 by plugging into tryConvert
-    static fail tryConvert(...);
-    static succeed tryConvert(const T2 &);
-    static const T1 &makeT1();
-
-public:
-#ifdef _MSC_VER
-// Disable spurious loss of precision warnings in tryConvert(makeT1())
-#pragma warning(push)
-#pragma warning(disable : 4244)
-#pragma warning(disable : 4267)
-#endif
-    // Standard trick: the (...) version of tryConvert will be chosen from
-    // the overload set only if the version taking a T2 doesn't match.
-    // Then we compare the sizes of the return types to check which
-    // function matched.  Very neat, in a disgusting kind of way :)
-    static const bool value = sizeof(tryConvert(makeT1())) == sizeof(succeed);
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
+    private:
+        // two types of different size
+        struct fail { char dummy[2]; };
+        struct succeed { char dummy; };
+        // Try to convert a T1 to a T2 by plugging into tryConvert
+        static fail tryConvert(...);
+        static succeed tryConvert(const T2&);
+        static const T1& makeT1();
+    public:
+#       ifdef _MSC_VER
+        // Disable spurious loss of precision warnings in tryConvert(makeT1())
+#       pragma warning(push)
+#       pragma warning(disable:4244)
+#       pragma warning(disable:4267)
+#       endif
+        // Standard trick: the (...) version of tryConvert will be chosen from
+        // the overload set only if the version taking a T2 doesn't match.
+        // Then we compare the sizes of the return types to check which
+        // function matched.  Very neat, in a disgusting kind of way :)
+        static const bool value =
+            sizeof(tryConvert(makeT1())) == sizeof(succeed);
+#       ifdef _MSC_VER
+#       pragma warning(pop)
+#       endif
 };
 
 
 // Detect when a type is not a wchar_t string
-template <typename T>
-struct is_wchar
-{
-    typedef int tinyformat_wchar_is_not_supported;
-};
-template <>
-struct is_wchar<wchar_t *>
-{
-};
-template <>
-struct is_wchar<const wchar_t *>
-{
-};
-template <int n>
-struct is_wchar<const wchar_t[n]>
-{
-};
-template <int n>
-struct is_wchar<wchar_t[n]>
-{
-};
+template<typename T> struct is_wchar { typedef int tinyformat_wchar_is_not_supported; };
+template<> struct is_wchar<wchar_t*> {};
+template<> struct is_wchar<const wchar_t*> {};
+template<int n> struct is_wchar<const wchar_t[n]> {};
+template<int n> struct is_wchar<wchar_t[n]> {};
 
 
 // Format the value by casting to type fmtT.  This default implementation
 // should never be called.
-template <typename T, typename fmtT, bool convertible = is_convertible<T, fmtT>::value>
+template<typename T, typename fmtT, bool convertible = is_convertible<T, fmtT>::value>
 struct formatValueAsType
 {
-    static void invoke(std::ostream & /*out*/, const T & /*value*/) { assert(0); }
+    static void invoke(std::ostream& /*out*/, const T& /*value*/) { assert(0); }
 };
 // Specialized version for types that can actually be converted to fmtT, as
 // indicated by the "convertible" template parameter.
-template <typename T, typename fmtT>
-struct formatValueAsType<T, fmtT, true>
+template<typename T, typename fmtT>
+struct formatValueAsType<T,fmtT,true>
 {
-    static void invoke(std::ostream &out, const T &value) { out << static_cast<fmtT>(value); }
+    static void invoke(std::ostream& out, const T& value)
+        { out << static_cast<fmtT>(value); }
 };
 
 #ifdef TINYFORMAT_OLD_LIBSTDCPLUSPLUS_WORKAROUND
-template <typename T, bool convertible = is_convertible<T, int>::value>
+template<typename T, bool convertible = is_convertible<T, int>::value>
 struct formatZeroIntegerWorkaround
 {
-    static bool invoke(std::ostream & /**/, const T & /**/) { return false; }
+    static bool invoke(std::ostream& /**/, const T& /**/) { return false; }
 };
-template <typename T>
-struct formatZeroIntegerWorkaround<T, true>
+template<typename T>
+struct formatZeroIntegerWorkaround<T,true>
 {
-    static bool invoke(std::ostream &out, const T &value)
+    static bool invoke(std::ostream& out, const T& value)
     {
         if (static_cast<int>(value) == 0 && out.flags() & std::ios::showpos)
         {
@@ -253,10 +230,10 @@ struct formatZeroIntegerWorkaround<T, true>
 
 // Convert an arbitrary type to integer.  The version with convertible=false
 // throws an error.
-template <typename T, bool convertible = is_convertible<T, int>::value>
+template<typename T, bool convertible = is_convertible<T,int>::value>
 struct convertToInt
 {
-    static int invoke(const T & /*value*/)
+    static int invoke(const T& /*value*/)
     {
         TINYFORMAT_ERROR("tinyformat: Cannot convert from argument type to "
                          "integer for use as variable width or precision");
@@ -264,10 +241,10 @@ struct convertToInt
     }
 };
 // Specialization for convertToInt when conversion is possible
-template <typename T>
-struct convertToInt<T, true>
+template<typename T>
+struct convertToInt<T,true>
 {
-    static int invoke(const T &value) { return static_cast<int>(value); }
+    static int invoke(const T& value) { return static_cast<int>(value); }
 };
 
 } // namespace detail
@@ -287,29 +264,29 @@ struct convertToInt<T, true>
 // By default, formatValue() uses the usual stream insertion operator
 // operator<< to format the type T, with special cases for the %c and %p
 // conversions.
-template <typename T>
-inline void formatValue(std::ostream &out, const char * /*fmtBegin*/, const char *fmtEnd, const T &value)
+template<typename T>
+inline void formatValue(std::ostream& out, const char* /*fmtBegin*/,
+                        const char* fmtEnd, const T& value)
 {
 #ifndef TINYFORMAT_ALLOW_WCHAR_STRINGS
     // Since we don't support printing of wchar_t using "%ls", make it fail at
     // compile time in preference to printing as a void* at runtime.
     typedef typename detail::is_wchar<T>::tinyformat_wchar_is_not_supported DummyType;
-    (void)DummyType(); // avoid unused type warning with gcc-4.8
+    (void) DummyType(); // avoid unused type warning with gcc-4.8
 #endif
     // The mess here is to support the %c and %p conversions: if these
     // conversions are active we try to convert the type to a char or const
     // void* respectively and format that instead of the value itself.  For the
     // %p conversion it's important to avoid dereferencing the pointer, which
     // could otherwise lead to a crash when printing a dangling (const char*).
-    const bool canConvertToChar = detail::is_convertible<T, char>::value;
-    const bool canConvertToVoidPtr = detail::is_convertible<T, const void *>::value;
-    if (canConvertToChar && *(fmtEnd - 1) == 'c')
+    const bool canConvertToChar = detail::is_convertible<T,char>::value;
+    const bool canConvertToVoidPtr = detail::is_convertible<T, const void*>::value;
+    if(canConvertToChar && *(fmtEnd-1) == 'c')
         detail::formatValueAsType<T, char>::invoke(out, value);
-    else if (canConvertToVoidPtr && *(fmtEnd - 1) == 'p')
-        detail::formatValueAsType<T, const void *>::invoke(out, value);
+    else if(canConvertToVoidPtr && *(fmtEnd-1) == 'p')
+        detail::formatValueAsType<T, const void*>::invoke(out, value);
 #ifdef TINYFORMAT_OLD_LIBSTDCPLUSPLUS_WORKAROUND
-    else if (detail::formatZeroIntegerWorkaround<T>::invoke(out, value)) /**/
-        ;
+    else if(detail::formatZeroIntegerWorkaround<T>::invoke(out, value)) /**/;
 #endif
     else
         out << value;
@@ -317,24 +294,18 @@ inline void formatValue(std::ostream &out, const char * /*fmtBegin*/, const char
 
 
 // Overloaded version for char types to support printing as an integer
-#define TINYFORMAT_DEFINE_FORMATVALUE_CHAR(charType)                                                          \
-    inline void formatValue(std::ostream &out, const char * /*fmtBegin*/, const char *fmtEnd, charType value) \
-    {                                                                                                         \
-        switch (*(fmtEnd - 1))                                                                                \
-        {                                                                                                     \
-        case 'u':                                                                                             \
-        case 'd':                                                                                             \
-        case 'i':                                                                                             \
-        case 'o':                                                                                             \
-        case 'X':                                                                                             \
-        case 'x':                                                                                             \
-            out << static_cast<int>(value);                                                                   \
-            break;                                                                                            \
-        default:                                                                                              \
-            out << value;                                                                                     \
-            break;                                                                                            \
-        }                                                                                                     \
-    }
+#define TINYFORMAT_DEFINE_FORMATVALUE_CHAR(charType)                  \
+inline void formatValue(std::ostream& out, const char* /*fmtBegin*/,  \
+                        const char* fmtEnd, charType value)           \
+{                                                                     \
+    switch(*(fmtEnd-1))                                               \
+    {                                                                 \
+        case 'u': case 'd': case 'i': case 'o': case 'X': case 'x':   \
+            out << static_cast<int>(value); break;                    \
+        default:                                                      \
+            out << value;                   break;                    \
+    }                                                                 \
+}
 // per 3.9.1: char, signed char and unsigned char are all distinct types
 TINYFORMAT_DEFINE_FORMATVALUE_CHAR(char)
 TINYFORMAT_DEFINE_FORMATVALUE_CHAR(signed char)
@@ -347,10 +318,10 @@ TINYFORMAT_DEFINE_FORMATVALUE_CHAR(unsigned char)
 // stolen from the boost preprocessor metaprogramming library and cut down to
 // be just general enough for what we need.
 
-#define TINYFORMAT_ARGTYPES(n) TINYFORMAT_ARGTYPES_##n
-#define TINYFORMAT_VARARGS(n) TINYFORMAT_VARARGS_##n
-#define TINYFORMAT_PASSARGS(n) TINYFORMAT_PASSARGS_##n
-#define TINYFORMAT_PASSARGS_TAIL(n) TINYFORMAT_PASSARGS_TAIL_##n
+#define TINYFORMAT_ARGTYPES(n) TINYFORMAT_ARGTYPES_ ## n
+#define TINYFORMAT_VARARGS(n) TINYFORMAT_VARARGS_ ## n
+#define TINYFORMAT_PASSARGS(n) TINYFORMAT_PASSARGS_ ## n
+#define TINYFORMAT_PASSARGS_TAIL(n) TINYFORMAT_PASSARGS_TAIL_ ## n
 
 // To keep it as transparent as possible, the macros below have been generated
 // using python via the excellent cog.py code generation script.  This avoids
@@ -397,61 +368,30 @@ cog.outl('#define TINYFORMAT_FOREACH_ARGNUM(m) \\\n    ' +
 #define TINYFORMAT_ARGTYPES_7 class T1, class T2, class T3, class T4, class T5, class T6, class T7
 #define TINYFORMAT_ARGTYPES_8 class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8
 #define TINYFORMAT_ARGTYPES_9 class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9
-#define TINYFORMAT_ARGTYPES_10 \
-    class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10
-#define TINYFORMAT_ARGTYPES_11 \
-    class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11
-#define TINYFORMAT_ARGTYPES_12                                                                                      \
-    class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, \
-        class T12
-#define TINYFORMAT_ARGTYPES_13                                                                                      \
-    class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, \
-        class T12, class T13
-#define TINYFORMAT_ARGTYPES_14                                                                                      \
-    class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, \
-        class T12, class T13, class T14
-#define TINYFORMAT_ARGTYPES_15                                                                                      \
-    class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, \
-        class T12, class T13, class T14, class T15
-#define TINYFORMAT_ARGTYPES_16                                                                                      \
-    class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, \
-        class T12, class T13, class T14, class T15, class T16
+#define TINYFORMAT_ARGTYPES_10 class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10
+#define TINYFORMAT_ARGTYPES_11 class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11
+#define TINYFORMAT_ARGTYPES_12 class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12
+#define TINYFORMAT_ARGTYPES_13 class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13
+#define TINYFORMAT_ARGTYPES_14 class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14
+#define TINYFORMAT_ARGTYPES_15 class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15
+#define TINYFORMAT_ARGTYPES_16 class T1, class T2, class T3, class T4, class T5, class T6, class T7, class T8, class T9, class T10, class T11, class T12, class T13, class T14, class T15, class T16
 
-#define TINYFORMAT_VARARGS_1 const T1 &v1
-#define TINYFORMAT_VARARGS_2 const T1 &v1, const T2 &v2
-#define TINYFORMAT_VARARGS_3 const T1 &v1, const T2 &v2, const T3 &v3
-#define TINYFORMAT_VARARGS_4 const T1 &v1, const T2 &v2, const T3 &v3, const T4 &v4
-#define TINYFORMAT_VARARGS_5 const T1 &v1, const T2 &v2, const T3 &v3, const T4 &v4, const T5 &v5
-#define TINYFORMAT_VARARGS_6 const T1 &v1, const T2 &v2, const T3 &v3, const T4 &v4, const T5 &v5, const T6 &v6
-#define TINYFORMAT_VARARGS_7 \
-    const T1 &v1, const T2 &v2, const T3 &v3, const T4 &v4, const T5 &v5, const T6 &v6, const T7 &v7
-#define TINYFORMAT_VARARGS_8 \
-    const T1 &v1, const T2 &v2, const T3 &v3, const T4 &v4, const T5 &v5, const T6 &v6, const T7 &v7, const T8 &v8
-#define TINYFORMAT_VARARGS_9                                                                                        \
-    const T1 &v1, const T2 &v2, const T3 &v3, const T4 &v4, const T5 &v5, const T6 &v6, const T7 &v7, const T8 &v8, \
-        const T9 &v9
-#define TINYFORMAT_VARARGS_10                                                                                       \
-    const T1 &v1, const T2 &v2, const T3 &v3, const T4 &v4, const T5 &v5, const T6 &v6, const T7 &v7, const T8 &v8, \
-        const T9 &v9, const T10 &v10
-#define TINYFORMAT_VARARGS_11                                                                                       \
-    const T1 &v1, const T2 &v2, const T3 &v3, const T4 &v4, const T5 &v5, const T6 &v6, const T7 &v7, const T8 &v8, \
-        const T9 &v9, const T10 &v10, const T11 &v11
-#define TINYFORMAT_VARARGS_12                                                                                       \
-    const T1 &v1, const T2 &v2, const T3 &v3, const T4 &v4, const T5 &v5, const T6 &v6, const T7 &v7, const T8 &v8, \
-        const T9 &v9, const T10 &v10, const T11 &v11, const T12 &v12
-#define TINYFORMAT_VARARGS_13                                                                                       \
-    const T1 &v1, const T2 &v2, const T3 &v3, const T4 &v4, const T5 &v5, const T6 &v6, const T7 &v7, const T8 &v8, \
-        const T9 &v9, const T10 &v10, const T11 &v11, const T12 &v12, const T13 &v13
-#define TINYFORMAT_VARARGS_14                                                                                       \
-    const T1 &v1, const T2 &v2, const T3 &v3, const T4 &v4, const T5 &v5, const T6 &v6, const T7 &v7, const T8 &v8, \
-        const T9 &v9, const T10 &v10, const T11 &v11, const T12 &v12, const T13 &v13, const T14 &v14
-#define TINYFORMAT_VARARGS_15                                                                                       \
-    const T1 &v1, const T2 &v2, const T3 &v3, const T4 &v4, const T5 &v5, const T6 &v6, const T7 &v7, const T8 &v8, \
-        const T9 &v9, const T10 &v10, const T11 &v11, const T12 &v12, const T13 &v13, const T14 &v14, const T15 &v15
-#define TINYFORMAT_VARARGS_16                                                                                         \
-    const T1 &v1, const T2 &v2, const T3 &v3, const T4 &v4, const T5 &v5, const T6 &v6, const T7 &v7, const T8 &v8,   \
-        const T9 &v9, const T10 &v10, const T11 &v11, const T12 &v12, const T13 &v13, const T14 &v14, const T15 &v15, \
-        const T16 &v16
+#define TINYFORMAT_VARARGS_1 const T1& v1
+#define TINYFORMAT_VARARGS_2 const T1& v1, const T2& v2
+#define TINYFORMAT_VARARGS_3 const T1& v1, const T2& v2, const T3& v3
+#define TINYFORMAT_VARARGS_4 const T1& v1, const T2& v2, const T3& v3, const T4& v4
+#define TINYFORMAT_VARARGS_5 const T1& v1, const T2& v2, const T3& v3, const T4& v4, const T5& v5
+#define TINYFORMAT_VARARGS_6 const T1& v1, const T2& v2, const T3& v3, const T4& v4, const T5& v5, const T6& v6
+#define TINYFORMAT_VARARGS_7 const T1& v1, const T2& v2, const T3& v3, const T4& v4, const T5& v5, const T6& v6, const T7& v7
+#define TINYFORMAT_VARARGS_8 const T1& v1, const T2& v2, const T3& v3, const T4& v4, const T5& v5, const T6& v6, const T7& v7, const T8& v8
+#define TINYFORMAT_VARARGS_9 const T1& v1, const T2& v2, const T3& v3, const T4& v4, const T5& v5, const T6& v6, const T7& v7, const T8& v8, const T9& v9
+#define TINYFORMAT_VARARGS_10 const T1& v1, const T2& v2, const T3& v3, const T4& v4, const T5& v5, const T6& v6, const T7& v7, const T8& v8, const T9& v9, const T10& v10
+#define TINYFORMAT_VARARGS_11 const T1& v1, const T2& v2, const T3& v3, const T4& v4, const T5& v5, const T6& v6, const T7& v7, const T8& v8, const T9& v9, const T10& v10, const T11& v11
+#define TINYFORMAT_VARARGS_12 const T1& v1, const T2& v2, const T3& v3, const T4& v4, const T5& v5, const T6& v6, const T7& v7, const T8& v8, const T9& v9, const T10& v10, const T11& v11, const T12& v12
+#define TINYFORMAT_VARARGS_13 const T1& v1, const T2& v2, const T3& v3, const T4& v4, const T5& v5, const T6& v6, const T7& v7, const T8& v8, const T9& v9, const T10& v10, const T11& v11, const T12& v12, const T13& v13
+#define TINYFORMAT_VARARGS_14 const T1& v1, const T2& v2, const T3& v3, const T4& v4, const T5& v5, const T6& v6, const T7& v7, const T8& v8, const T9& v9, const T10& v10, const T11& v11, const T12& v12, const T13& v13, const T14& v14
+#define TINYFORMAT_VARARGS_15 const T1& v1, const T2& v2, const T3& v3, const T4& v4, const T5& v5, const T6& v6, const T7& v7, const T8& v8, const T9& v9, const T10& v10, const T11& v11, const T12& v12, const T13& v13, const T14& v14, const T15& v15
+#define TINYFORMAT_VARARGS_16 const T1& v1, const T2& v2, const T3& v3, const T4& v4, const T5& v5, const T6& v6, const T7& v7, const T8& v8, const T9& v9, const T10& v10, const T11& v11, const T12& v12, const T13& v13, const T14& v14, const T15& v15, const T16& v16
 
 #define TINYFORMAT_PASSARGS_1 v1
 #define TINYFORMAT_PASSARGS_2 v1, v2
@@ -492,169 +432,179 @@ cog.outl('#define TINYFORMAT_FOREACH_ARGNUM(m) \\\n    ' +
 //[[[end]]]
 
 
-namespace detail
-{
+
+namespace detail {
+
 // Class holding current position in format string and an output stream into
 // which arguments are formatted.
 class FormatIterator
 {
-public:
-    // Flags for features not representable with standard stream state
-    enum ExtraFormatFlags
-    {
-        Flag_None = 0,
-        Flag_TruncateToPrecision = 1 << 0, // truncate length to stream precision()
-        Flag_SpacePadPositive = 1 << 1, // pad positive values with spaces
-        Flag_VariableWidth = 1 << 2, // variable field width in arg list
-        Flag_VariablePrecision = 1 << 3 // variable field precision in arg list
-    };
-
-    // out is the output stream, fmt is the full format string
-    FormatIterator(std::ostream &out, const char *fmt)
-        : m_out(out), m_fmt(fmt), m_extraFlags(Flag_None), m_wantWidth(false), m_wantPrecision(false),
-          m_variableWidth(0), m_variablePrecision(0), m_origWidth(out.width()), m_origPrecision(out.precision()),
-          m_origFlags(out.flags()), m_origFill(out.fill())
-    {
-    }
-
-    // Print remaining part of format string.
-    void finish()
-    {
-        // It would be nice if we could do this from the destructor, but we
-        // can't if TINFORMAT_ERROR is used to throw an exception!
-        m_fmt = printFormatStringLiteral(m_out, m_fmt);
-        if (*m_fmt != '\0')
-            TINYFORMAT_ERROR("tinyformat: Too many conversion specifiers in format string");
-    }
-
-    ~FormatIterator()
-    {
-        // Restore stream state
-        m_out.width(m_origWidth);
-        m_out.precision(m_origPrecision);
-        m_out.flags(m_origFlags);
-        m_out.fill(m_origFill);
-    }
-
-    template <typename T>
-    void accept(const T &value);
-
-private:
-    // Parse and return an integer from the string c, as atoi()
-    // On return, c is set to one past the end of the integer.
-    static int parseIntAndAdvance(const char *&c)
-    {
-        int i = 0;
-        for (; *c >= '0' && *c <= '9'; ++c)
-            i = 10 * i + (*c - '0');
-        return i;
-    }
-
-    // Format at most truncLen characters of a C string to the given
-    // stream.  Return true if formatting proceeded (generic version always
-    // returns false)
-    template <typename T>
-    static bool formatCStringTruncate(std::ostream & /*out*/, const T & /*value*/, std::streamsize /*truncLen*/)
-    {
-        return false;
-    }
-#define TINYFORMAT_DEFINE_FORMAT_C_STRING_TRUNCATE(type)                                        \
-    static bool formatCStringTruncate(std::ostream &out, type *value, std::streamsize truncLen) \
-    {                                                                                           \
-        std::streamsize len = 0;                                                                \
-        while (len < truncLen && value[len] != 0)                                               \
-            ++len;                                                                              \
-        out.write(value, len);                                                                  \
-        return true;                                                                            \
-    }
-    // Overload for const char* and char*.  Could overload for signed &
-    // unsigned char too, but these are technically unneeded for printf
-    // compatibility.
-    TINYFORMAT_DEFINE_FORMAT_C_STRING_TRUNCATE(const char)
-    TINYFORMAT_DEFINE_FORMAT_C_STRING_TRUNCATE(char)
-#undef TINYFORMAT_DEFINE_FORMAT_C_STRING_TRUNCATE
-
-    // Print literal part of format string and return next format spec
-    // position.
-    //
-    // Skips over any occurrences of '%%', printing a literal '%' to the
-    // output.  The position of the first % character of the next
-    // nontrivial format spec is returned, or the end of string.
-    static const char *printFormatStringLiteral(std::ostream &out, const char *fmt)
-    {
-        const char *c = fmt;
-        for (; true; ++c)
+    public:
+        // Flags for features not representable with standard stream state
+        enum ExtraFormatFlags
         {
-            switch (*c)
+            Flag_None                = 0,
+            Flag_TruncateToPrecision = 1<<0, // truncate length to stream precision()
+            Flag_SpacePadPositive    = 1<<1, // pad positive values with spaces
+            Flag_VariableWidth       = 1<<2, // variable field width in arg list
+            Flag_VariablePrecision   = 1<<3  // variable field precision in arg list
+        };
+
+        // out is the output stream, fmt is the full format string
+        FormatIterator(std::ostream& out, const char* fmt)
+            : m_out(out),
+            m_fmt(fmt),
+            m_extraFlags(Flag_None),
+            m_wantWidth(false),
+            m_wantPrecision(false),
+            m_variableWidth(0),
+            m_variablePrecision(0),
+            m_origWidth(out.width()),
+            m_origPrecision(out.precision()),
+            m_origFlags(out.flags()),
+            m_origFill(out.fill())
+        { }
+
+        // Print remaining part of format string.
+        void finish()
+        {
+            // It would be nice if we could do this from the destructor, but we
+            // can't if TINFORMAT_ERROR is used to throw an exception!
+            m_fmt = printFormatStringLiteral(m_out, m_fmt);
+            if(*m_fmt != '\0')
+                TINYFORMAT_ERROR("tinyformat: Too many conversion specifiers in format string");
+        }
+
+        ~FormatIterator()
+        {
+            // Restore stream state
+            m_out.width(m_origWidth);
+            m_out.precision(m_origPrecision);
+            m_out.flags(m_origFlags);
+            m_out.fill(m_origFill);
+        }
+
+        template<typename T>
+        void accept(const T& value);
+
+    private:
+        // Parse and return an integer from the string c, as atoi()
+        // On return, c is set to one past the end of the integer.
+        static int parseIntAndAdvance(const char*& c)
+        {
+            int i = 0;
+            for(;*c >= '0' && *c <= '9'; ++c)
+                i = 10*i + (*c - '0');
+            return i;
+        }
+
+        // Format at most truncLen characters of a C string to the given
+        // stream.  Return true if formatting proceeded (generic version always
+        // returns false)
+        template<typename T>
+        static bool formatCStringTruncate(std::ostream& /*out*/, const T& /*value*/,
+                                        std::streamsize /*truncLen*/)
+        {
+            return false;
+        }
+#       define TINYFORMAT_DEFINE_FORMAT_C_STRING_TRUNCATE(type)            \
+        static bool formatCStringTruncate(std::ostream& out, type* value,  \
+                                        std::streamsize truncLen)          \
+        {                                                                  \
+            std::streamsize len = 0;                                       \
+            while(len < truncLen && value[len] != 0)                       \
+                ++len;                                                     \
+            out.write(value, len);                                         \
+            return true;                                                   \
+        }
+        // Overload for const char* and char*.  Could overload for signed &
+        // unsigned char too, but these are technically unneeded for printf
+        // compatibility.
+        TINYFORMAT_DEFINE_FORMAT_C_STRING_TRUNCATE(const char)
+        TINYFORMAT_DEFINE_FORMAT_C_STRING_TRUNCATE(char)
+#       undef TINYFORMAT_DEFINE_FORMAT_C_STRING_TRUNCATE
+
+        // Print literal part of format string and return next format spec
+        // position.
+        //
+        // Skips over any occurrences of '%%', printing a literal '%' to the
+        // output.  The position of the first % character of the next
+        // nontrivial format spec is returned, or the end of string.
+        static const char* printFormatStringLiteral(std::ostream& out,
+                                                    const char* fmt)
+        {
+            const char* c = fmt;
+            for(; true; ++c)
             {
-            case '\0':
-                out.write(fmt, static_cast<std::streamsize>(c - fmt));
-                return c;
-            case '%':
-                out.write(fmt, static_cast<std::streamsize>(c - fmt));
-                if (*(c + 1) != '%')
-                    return c;
-                // for "%%", tack trailing % onto next literal section.
-                fmt = ++c;
-                break;
+                switch(*c)
+                {
+                    case '\0':
+                        out.write(fmt, static_cast<std::streamsize>(c - fmt));
+                        return c;
+                    case '%':
+                        out.write(fmt, static_cast<std::streamsize>(c - fmt));
+                        if(*(c+1) != '%')
+                            return c;
+                        // for "%%", tack trailing % onto next literal section.
+                        fmt = ++c;
+                        break;
+                }
             }
         }
-    }
 
-    static const char *streamStateFromFormat(std::ostream &out,
-        unsigned int &extraFlags,
-        const char *fmtStart,
-        int variableWidth,
-        int variablePrecision);
+        static const char* streamStateFromFormat(std::ostream& out,
+                                                 unsigned int& extraFlags,
+                                                 const char* fmtStart,
+                                                 int variableWidth,
+                                                 int variablePrecision);
 
-    // Private copy & assign: Kill gcc warnings with -Weffc++
-    FormatIterator(const FormatIterator &);
-    FormatIterator &operator=(const FormatIterator &);
+        // Private copy & assign: Kill gcc warnings with -Weffc++
+        FormatIterator(const FormatIterator&);
+        FormatIterator& operator=(const FormatIterator&);
 
-    // Stream, current format string & state
-    std::ostream &m_out;
-    const char *m_fmt;
-    unsigned int m_extraFlags;
-    // State machine info for handling of variable width & precision
-    bool m_wantWidth;
-    bool m_wantPrecision;
-    int m_variableWidth;
-    int m_variablePrecision;
-    // Saved stream state
-    std::streamsize m_origWidth;
-    std::streamsize m_origPrecision;
-    std::ios::fmtflags m_origFlags;
-    char m_origFill;
+        // Stream, current format string & state
+        std::ostream& m_out;
+        const char* m_fmt;
+        unsigned int m_extraFlags;
+        // State machine info for handling of variable width & precision
+        bool m_wantWidth;
+        bool m_wantPrecision;
+        int m_variableWidth;
+        int m_variablePrecision;
+        // Saved stream state
+        std::streamsize m_origWidth;
+        std::streamsize m_origPrecision;
+        std::ios::fmtflags m_origFlags;
+        char m_origFill;
 };
 
 
 // Accept a value for formatting into the internal stream.
-template <typename T>
-TINYFORMAT_NOINLINE // < greatly reduces bloat in optimized builds
-    void
-    FormatIterator::accept(const T &value)
+template<typename T>
+TINYFORMAT_NOINLINE  // < greatly reduces bloat in optimized builds
+void FormatIterator::accept(const T& value)
 {
     // Parse the format string
-    const char *fmtEnd = 0;
-    if (m_extraFlags == Flag_None && !m_wantWidth && !m_wantPrecision)
+    const char* fmtEnd = 0;
+    if(m_extraFlags == Flag_None && !m_wantWidth && !m_wantPrecision)
     {
         m_fmt = printFormatStringLiteral(m_out, m_fmt);
         fmtEnd = streamStateFromFormat(m_out, m_extraFlags, m_fmt, 0, 0);
-        m_wantWidth = (m_extraFlags & Flag_VariableWidth) != 0;
+        m_wantWidth     = (m_extraFlags & Flag_VariableWidth) != 0;
         m_wantPrecision = (m_extraFlags & Flag_VariablePrecision) != 0;
     }
     // Consume value as variable width and precision specifier if necessary
-    if (m_extraFlags & (Flag_VariableWidth | Flag_VariablePrecision))
+    if(m_extraFlags & (Flag_VariableWidth | Flag_VariablePrecision))
     {
-        if (m_wantWidth || m_wantPrecision)
+        if(m_wantWidth || m_wantPrecision)
         {
             int v = convertToInt<T>::invoke(value);
-            if (m_wantWidth)
+            if(m_wantWidth)
             {
                 m_variableWidth = v;
                 m_wantWidth = false;
             }
-            else if (m_wantPrecision)
+            else if(m_wantPrecision)
             {
                 m_variablePrecision = v;
                 m_wantPrecision = false;
@@ -663,11 +613,12 @@ TINYFORMAT_NOINLINE // < greatly reduces bloat in optimized builds
         }
         // If we get here, we've set both the variable precision and width as
         // required and we need to rerun the stream state setup to insert these.
-        fmtEnd = streamStateFromFormat(m_out, m_extraFlags, m_fmt, m_variableWidth, m_variablePrecision);
+        fmtEnd = streamStateFromFormat(m_out, m_extraFlags, m_fmt,
+                                       m_variableWidth, m_variablePrecision);
     }
 
     // Format the value into the stream.
-    if (!(m_extraFlags & (Flag_SpacePadPositive | Flag_TruncateToPrecision)))
+    if(!(m_extraFlags & (Flag_SpacePadPositive | Flag_TruncateToPrecision)))
         formatValue(m_out, m_fmt, fmtEnd, value);
     else
     {
@@ -677,24 +628,26 @@ TINYFORMAT_NOINLINE // < greatly reduces bloat in optimized builds
         // temporary string stream and munging the resulting string.
         std::ostringstream tmpStream;
         tmpStream.copyfmt(m_out);
-        if (m_extraFlags & Flag_SpacePadPositive)
+        if(m_extraFlags & Flag_SpacePadPositive)
             tmpStream.setf(std::ios::showpos);
         // formatCStringTruncate is required for truncating conversions like
         // "%.4s" where at most 4 characters of the c-string should be read.
         // If we didn't include this special case, we might read off the end.
-        if (!((m_extraFlags & Flag_TruncateToPrecision) && formatCStringTruncate(tmpStream, value, m_out.precision())))
+        if(!( (m_extraFlags & Flag_TruncateToPrecision) &&
+             formatCStringTruncate(tmpStream, value, m_out.precision()) ))
         {
             // Not a truncated c-string; just format normally.
             formatValue(tmpStream, m_fmt, fmtEnd, value);
         }
         std::string result = tmpStream.str(); // allocates... yuck.
-        if (m_extraFlags & Flag_SpacePadPositive)
+        if(m_extraFlags & Flag_SpacePadPositive)
         {
-            for (size_t i = 0, iend = result.size(); i < iend; ++i)
-                if (result[i] == '+')
+            for(size_t i = 0, iend = result.size(); i < iend; ++i)
+                if(result[i] == '+')
                     result[i] = ' ';
         }
-        if ((m_extraFlags & Flag_TruncateToPrecision) && (int)result.size() > (int)m_out.precision())
+        if((m_extraFlags & Flag_TruncateToPrecision) &&
+           (int)result.size() > (int)m_out.precision())
             m_out.write(result.c_str(), m_out.precision());
         else
             m_out << result;
@@ -712,13 +665,13 @@ TINYFORMAT_NOINLINE // < greatly reduces bloat in optimized builds
 // Formatting options which can't be natively represented using the ostream
 // state are returned in the extraFlags parameter which is a bitwise
 // combination of values from the ExtraFormatFlags enum.
-inline const char *FormatIterator::streamStateFromFormat(std::ostream &out,
-    unsigned int &extraFlags,
-    const char *fmtStart,
-    int variableWidth,
-    int variablePrecision)
+inline const char* FormatIterator::streamStateFromFormat(std::ostream& out,
+                                                         unsigned int& extraFlags,
+                                                         const char* fmtStart,
+                                                         int variableWidth,
+                                                         int variablePrecision)
 {
-    if (*fmtStart != '%')
+    if(*fmtStart != '%')
     {
         TINYFORMAT_ERROR("tinyformat: Not enough conversion specifiers in format string");
         return fmtStart;
@@ -728,56 +681,57 @@ inline const char *FormatIterator::streamStateFromFormat(std::ostream &out,
     out.precision(6);
     out.fill(' ');
     // Reset most flags; ignore irrelevant unitbuf & skipws.
-    out.unsetf(std::ios::adjustfield | std::ios::basefield | std::ios::floatfield | std::ios::showbase |
-               std::ios::boolalpha | std::ios::showpoint | std::ios::showpos | std::ios::uppercase);
+    out.unsetf(std::ios::adjustfield | std::ios::basefield |
+               std::ios::floatfield | std::ios::showbase | std::ios::boolalpha |
+               std::ios::showpoint | std::ios::showpos | std::ios::uppercase);
     extraFlags = Flag_None;
     bool precisionSet = false;
     bool widthSet = false;
-    const char *c = fmtStart + 1;
+    const char* c = fmtStart + 1;
     // 1) Parse flags
-    for (;; ++c)
+    for(;; ++c)
     {
-        switch (*c)
+        switch(*c)
         {
-        case '#':
-            out.setf(std::ios::showpoint | std::ios::showbase);
-            continue;
-        case '0':
-            // overridden by left alignment ('-' flag)
-            if (!(out.flags() & std::ios::left))
-            {
-                // Use internal padding so that numeric values are
-                // formatted correctly, eg -00010 rather than 000-10
-                out.fill('0');
-                out.setf(std::ios::internal, std::ios::adjustfield);
-            }
-            continue;
-        case '-':
-            out.fill(' ');
-            out.setf(std::ios::left, std::ios::adjustfield);
-            continue;
-        case ' ':
-            // overridden by show positive sign, '+' flag.
-            if (!(out.flags() & std::ios::showpos))
-                extraFlags |= Flag_SpacePadPositive;
-            continue;
-        case '+':
-            out.setf(std::ios::showpos);
-            extraFlags &= ~Flag_SpacePadPositive;
-            continue;
+            case '#':
+                out.setf(std::ios::showpoint | std::ios::showbase);
+                continue;
+            case '0':
+                // overridden by left alignment ('-' flag)
+                if(!(out.flags() & std::ios::left))
+                {
+                    // Use internal padding so that numeric values are
+                    // formatted correctly, eg -00010 rather than 000-10
+                    out.fill('0');
+                    out.setf(std::ios::internal, std::ios::adjustfield);
+                }
+                continue;
+            case '-':
+                out.fill(' ');
+                out.setf(std::ios::left, std::ios::adjustfield);
+                continue;
+            case ' ':
+                // overridden by show positive sign, '+' flag.
+                if(!(out.flags() & std::ios::showpos))
+                    extraFlags |= Flag_SpacePadPositive;
+                continue;
+            case '+':
+                out.setf(std::ios::showpos);
+                extraFlags &= ~Flag_SpacePadPositive;
+                continue;
         }
         break;
     }
     // 2) Parse width
-    if (*c >= '0' && *c <= '9')
+    if(*c >= '0' && *c <= '9')
     {
         widthSet = true;
         out.width(parseIntAndAdvance(c));
     }
-    if (*c == '*')
+    if(*c == '*')
     {
         widthSet = true;
-        if (variableWidth < 0)
+        if(variableWidth < 0)
         {
             // negative widths correspond to '-' flag set
             out.fill(' ');
@@ -789,11 +743,11 @@ inline const char *FormatIterator::streamStateFromFormat(std::ostream &out,
         ++c;
     }
     // 3) Parse precision
-    if (*c == '.')
+    if(*c == '.')
     {
         ++c;
         int precision = 0;
-        if (*c == '*')
+        if(*c == '*')
         {
             ++c;
             extraFlags |= Flag_VariablePrecision;
@@ -801,82 +755,79 @@ inline const char *FormatIterator::streamStateFromFormat(std::ostream &out,
         }
         else
         {
-            if (*c >= '0' && *c <= '9')
+            if(*c >= '0' && *c <= '9')
                 precision = parseIntAndAdvance(c);
-            else if (*c == '-') // negative precisions ignored, treated as zero.
+            else if(*c == '-') // negative precisions ignored, treated as zero.
                 parseIntAndAdvance(++c);
         }
         out.precision(precision);
         precisionSet = true;
     }
     // 4) Ignore any C99 length modifier
-    while (*c == 'l' || *c == 'h' || *c == 'L' || *c == 'j' || *c == 'z' || *c == 't')
+    while(*c == 'l' || *c == 'h' || *c == 'L' ||
+          *c == 'j' || *c == 'z' || *c == 't')
         ++c;
     // 5) We're up to the conversion specifier character.
     // Set stream flags based on conversion specifier (thanks to the
     // boost::format class for forging the way here).
     bool intConversion = false;
-    switch (*c)
+    switch(*c)
     {
-    case 'u':
-    case 'd':
-    case 'i':
-        out.setf(std::ios::dec, std::ios::basefield);
-        intConversion = true;
-        break;
-    case 'o':
-        out.setf(std::ios::oct, std::ios::basefield);
-        intConversion = true;
-        break;
-    case 'X':
-        out.setf(std::ios::uppercase);
-    case 'x':
-    case 'p':
-        out.setf(std::ios::hex, std::ios::basefield);
-        intConversion = true;
-        break;
-    case 'E':
-        out.setf(std::ios::uppercase);
-    case 'e':
-        out.setf(std::ios::scientific, std::ios::floatfield);
-        out.setf(std::ios::dec, std::ios::basefield);
-        break;
-    case 'F':
-        out.setf(std::ios::uppercase);
-    case 'f':
-        out.setf(std::ios::fixed, std::ios::floatfield);
-        break;
-    case 'G':
-        out.setf(std::ios::uppercase);
-    case 'g':
-        out.setf(std::ios::dec, std::ios::basefield);
-        // As in boost::format, let stream decide float format.
-        out.flags(out.flags() & ~std::ios::floatfield);
-        break;
-    case 'a':
-    case 'A':
-        TINYFORMAT_ERROR("tinyformat: the %a and %A conversion specs "
-                         "are not supported");
-        break;
-    case 'c':
-        // Handled as special case inside formatValue()
-        break;
-    case 's':
-        if (precisionSet)
-            extraFlags |= Flag_TruncateToPrecision;
-        // Make %s print booleans as "true" and "false"
-        out.setf(std::ios::boolalpha);
-        break;
-    case 'n':
-        // Not supported - will cause problems!
-        TINYFORMAT_ERROR("tinyformat: %n conversion spec not supported");
-        break;
-    case '\0':
-        TINYFORMAT_ERROR("tinyformat: Conversion spec incorrectly "
-                         "terminated by end of string");
-        return c;
+        case 'u': case 'd': case 'i':
+            out.setf(std::ios::dec, std::ios::basefield);
+            intConversion = true;
+            break;
+        case 'o':
+            out.setf(std::ios::oct, std::ios::basefield);
+            intConversion = true;
+            break;
+        case 'X':
+            out.setf(std::ios::uppercase);
+        case 'x': case 'p':
+            out.setf(std::ios::hex, std::ios::basefield);
+            intConversion = true;
+            break;
+        case 'E':
+            out.setf(std::ios::uppercase);
+        case 'e':
+            out.setf(std::ios::scientific, std::ios::floatfield);
+            out.setf(std::ios::dec, std::ios::basefield);
+            break;
+        case 'F':
+            out.setf(std::ios::uppercase);
+        case 'f':
+            out.setf(std::ios::fixed, std::ios::floatfield);
+            break;
+        case 'G':
+            out.setf(std::ios::uppercase);
+        case 'g':
+            out.setf(std::ios::dec, std::ios::basefield);
+            // As in boost::format, let stream decide float format.
+            out.flags(out.flags() & ~std::ios::floatfield);
+            break;
+        case 'a': case 'A':
+            TINYFORMAT_ERROR("tinyformat: the %a and %A conversion specs "
+                             "are not supported");
+            break;
+        case 'c':
+            // Handled as special case inside formatValue()
+            break;
+        case 's':
+            if(precisionSet)
+                extraFlags |= Flag_TruncateToPrecision;
+            // Make %s print booleans as "true" and "false"
+            out.setf(std::ios::boolalpha);
+            break;
+        case 'n':
+            // Not supported - will cause problems!
+            TINYFORMAT_ERROR("tinyformat: %n conversion spec not supported");
+            break;
+        case '\0':
+            TINYFORMAT_ERROR("tinyformat: Conversion spec incorrectly "
+                             "terminated by end of string");
+            return c;
     }
-    if (intConversion && precisionSet && !widthSet)
+    if(intConversion && precisionSet && !widthSet)
     {
         // "precision" for integers gives the minimum number of digits (to be
         // padded with zeros on the left).  This isn't really supported by the
@@ -886,8 +837,9 @@ inline const char *FormatIterator::streamStateFromFormat(std::ostream &out,
         out.setf(std::ios::internal, std::ios::adjustfield);
         out.fill('0');
     }
-    return c + 1;
+    return c+1;
 }
+
 
 
 //------------------------------------------------------------------------------
@@ -898,16 +850,16 @@ inline const char *FormatIterator::streamStateFromFormat(std::ostream &out,
 //   printf(myStr);   // Parses % as a format specifier
 #ifdef TINYFORMAT_USE_VARIADIC_TEMPLATES
 
-template <typename T1>
-void format(FormatIterator &fmtIter, const T1 &value1)
+template<typename T1>
+void format(FormatIterator& fmtIter, const T1& value1)
 {
     fmtIter.accept(value1);
     fmtIter.finish();
 }
 
 // General version for C++11
-template <typename T1, typename... Args>
-void format(FormatIterator &fmtIter, const T1 &value1, const Args &... args)
+template<typename T1, typename... Args>
+void format(FormatIterator& fmtIter, const T1& value1, const Args&... args)
 {
     fmtIter.accept(value1);
     format(fmtIter, args...);
@@ -915,15 +867,19 @@ void format(FormatIterator &fmtIter, const T1 &value1, const Args &... args)
 
 #else
 
-inline void format(FormatIterator &fmtIter) { fmtIter.finish(); }
+inline void format(FormatIterator& fmtIter)
+{
+    fmtIter.finish();
+}
+
 // General version for C++98
-#define TINYFORMAT_MAKE_FORMAT_DETAIL(n)                                \
-    template <TINYFORMAT_ARGTYPES(n)>                                   \
-    void format(detail::FormatIterator &fmtIter, TINYFORMAT_VARARGS(n)) \
-    {                                                                   \
-        fmtIter.accept(v1);                                             \
-        format(fmtIter TINYFORMAT_PASSARGS_TAIL(n));                    \
-    }
+#define TINYFORMAT_MAKE_FORMAT_DETAIL(n)                                  \
+template<TINYFORMAT_ARGTYPES(n)>                                          \
+void format(detail::FormatIterator& fmtIter, TINYFORMAT_VARARGS(n))       \
+{                                                                         \
+    fmtIter.accept(v1);                                                   \
+    format(fmtIter TINYFORMAT_PASSARGS_TAIL(n));                          \
+}
 
 TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_FORMAT_DETAIL)
 #undef TINYFORMAT_MAKE_FORMAT_DETAIL
@@ -939,31 +895,31 @@ TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_FORMAT_DETAIL)
 #ifdef TINYFORMAT_USE_VARIADIC_TEMPLATES
 
 // C++11 - the simple case
-template <typename T1, typename... Args>
-void format(std::ostream &out, const char *fmt, const T1 &v1, const Args &... args)
+template<typename T1, typename... Args>
+void format(std::ostream& out, const char* fmt, const T1& v1, const Args&... args)
 {
     detail::FormatIterator fmtIter(out, fmt);
     format(fmtIter, v1, args...);
 }
 
-template <typename T1, typename... Args>
-std::string format(const char *fmt, const T1 &v1, const Args &... args)
+template<typename T1, typename... Args>
+std::string format(const char* fmt, const T1& v1, const Args&... args)
 {
     std::ostringstream oss;
     format(oss, fmt, v1, args...);
     return oss.str();
 }
 
-template <typename T1, typename... Args>
-std::string format(const std::string &fmt, const T1 &v1, const Args &... args)
+template<typename T1, typename... Args>
+std::string format(const std::string &fmt, const T1& v1, const Args&... args)
 {
     std::ostringstream oss;
     format(oss, fmt.c_str(), v1, args...);
     return oss.str();
 }
 
-template <typename T1, typename... Args>
-void printf(const char *fmt, const T1 &v1, const Args &... args)
+template<typename T1, typename... Args>
+void printf(const char* fmt, const T1& v1, const Args&... args)
 {
     format(std::cout, fmt, v1, args...);
 }
@@ -971,36 +927,36 @@ void printf(const char *fmt, const T1 &v1, const Args &... args)
 #else
 
 // C++98 - define the interface functions using the wrapping macros
-#define TINYFORMAT_MAKE_FORMAT_FUNCS(n)                                    \
-                                                                           \
-    template <TINYFORMAT_ARGTYPES(n)>                                      \
-    void format(std::ostream &out, const char *fmt, TINYFORMAT_VARARGS(n)) \
-    {                                                                      \
-        tinyformat::detail::FormatIterator fmtIter(out, fmt);              \
-        tinyformat::detail::format(fmtIter, TINYFORMAT_PASSARGS(n));       \
-    }                                                                      \
-                                                                           \
-    template <TINYFORMAT_ARGTYPES(n)>                                      \
-    std::string format(const char *fmt, TINYFORMAT_VARARGS(n))             \
-    {                                                                      \
-        std::ostringstream oss;                                            \
-        tinyformat::format(oss, fmt, TINYFORMAT_PASSARGS(n));              \
-        return oss.str();                                                  \
-    }                                                                      \
-                                                                           \
-    template <TINYFORMAT_ARGTYPES(n)>                                      \
-    std::string format(const std::string &fmt, TINYFORMAT_VARARGS(n))      \
-    {                                                                      \
-        std::ostringstream oss;                                            \
-        tinyformat::format(oss, fmt.c_str(), TINYFORMAT_PASSARGS(n));      \
-        return oss.str();                                                  \
-    }                                                                      \
-                                                                           \
-    template <TINYFORMAT_ARGTYPES(n)>                                      \
-    void printf(const char *fmt, TINYFORMAT_VARARGS(n))                    \
-    {                                                                      \
-        tinyformat::format(std::cout, fmt, TINYFORMAT_PASSARGS(n));        \
-    }
+#define TINYFORMAT_MAKE_FORMAT_FUNCS(n)                                   \
+                                                                          \
+template<TINYFORMAT_ARGTYPES(n)>                                          \
+void format(std::ostream& out, const char* fmt, TINYFORMAT_VARARGS(n))    \
+{                                                                         \
+    tinyformat::detail::FormatIterator fmtIter(out, fmt);                 \
+    tinyformat::detail::format(fmtIter, TINYFORMAT_PASSARGS(n));          \
+}                                                                         \
+                                                                          \
+template<TINYFORMAT_ARGTYPES(n)>                                          \
+std::string format(const char* fmt, TINYFORMAT_VARARGS(n))                \
+{                                                                         \
+    std::ostringstream oss;                                               \
+    tinyformat::format(oss, fmt, TINYFORMAT_PASSARGS(n));                 \
+    return oss.str();                                                     \
+}                                                                         \
+                                                                          \
+template<TINYFORMAT_ARGTYPES(n)>                                          \
+std::string format(const std::string &fmt, TINYFORMAT_VARARGS(n))         \
+{                                                                         \
+    std::ostringstream oss;                                               \
+    tinyformat::format(oss, fmt.c_str(), TINYFORMAT_PASSARGS(n));         \
+    return oss.str();                                                     \
+}                                                                         \
+                                                                          \
+template<TINYFORMAT_ARGTYPES(n)>                                          \
+void printf(const char* fmt, TINYFORMAT_VARARGS(n))                       \
+{                                                                         \
+    tinyformat::format(std::cout, fmt, TINYFORMAT_PASSARGS(n));           \
+}
 
 TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_FORMAT_FUNCS)
 #undef TINYFORMAT_MAKE_FORMAT_FUNCS
@@ -1011,36 +967,43 @@ TINYFORMAT_FOREACH_ARGNUM(TINYFORMAT_MAKE_FORMAT_FUNCS)
 // Define deprecated wrapping macro for backward compatibility in tinyformat
 // 1.x.  Will be removed in version 2!
 #define TINYFORMAT_WRAP_FORMAT_EXTRA_ARGS
-#define TINYFORMAT_WRAP_FORMAT_N(n, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix)    \
-    template <TINYFORMAT_ARGTYPES(n)>                                                                            \
-    returnType funcName(TINYFORMAT_WRAP_FORMAT_EXTRA_ARGS const char *fmt, TINYFORMAT_VARARGS(n)) funcDeclSuffix \
-    {                                                                                                            \
-        bodyPrefix tinyformat::format(streamName, fmt, TINYFORMAT_PASSARGS(n));                                  \
-        bodySuffix                                                                                               \
-    }
+#define TINYFORMAT_WRAP_FORMAT_N(n, returnType, funcName, funcDeclSuffix,  \
+                                 bodyPrefix, streamName, bodySuffix)       \
+template<TINYFORMAT_ARGTYPES(n)>                                           \
+returnType funcName(TINYFORMAT_WRAP_FORMAT_EXTRA_ARGS const char* fmt,     \
+                    TINYFORMAT_VARARGS(n)) funcDeclSuffix                  \
+{                                                                          \
+    bodyPrefix                                                             \
+    tinyformat::format(streamName, fmt, TINYFORMAT_PASSARGS(n));           \
+    bodySuffix                                                             \
+}                                                                          \
 
-#define TINYFORMAT_WRAP_FORMAT(returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix)   \
-    inline returnType funcName(TINYFORMAT_WRAP_FORMAT_EXTRA_ARGS const char *fmt) funcDeclSuffix           \
-    {                                                                                                      \
-        bodyPrefix tinyformat::detail::FormatIterator(streamName, fmt).finish();                           \
-        bodySuffix                                                                                         \
-    }                                                                                                      \
-    TINYFORMAT_WRAP_FORMAT_N(1, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix)  \
-    TINYFORMAT_WRAP_FORMAT_N(2, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix)  \
-    TINYFORMAT_WRAP_FORMAT_N(3, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix)  \
-    TINYFORMAT_WRAP_FORMAT_N(4, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix)  \
-    TINYFORMAT_WRAP_FORMAT_N(5, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix)  \
-    TINYFORMAT_WRAP_FORMAT_N(6, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix)  \
-    TINYFORMAT_WRAP_FORMAT_N(7, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix)  \
-    TINYFORMAT_WRAP_FORMAT_N(8, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix)  \
-    TINYFORMAT_WRAP_FORMAT_N(9, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix)  \
-    TINYFORMAT_WRAP_FORMAT_N(10, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
-    TINYFORMAT_WRAP_FORMAT_N(11, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
-    TINYFORMAT_WRAP_FORMAT_N(12, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
-    TINYFORMAT_WRAP_FORMAT_N(13, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
-    TINYFORMAT_WRAP_FORMAT_N(14, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
-    TINYFORMAT_WRAP_FORMAT_N(15, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
-    TINYFORMAT_WRAP_FORMAT_N(16, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix)
+#define TINYFORMAT_WRAP_FORMAT(returnType, funcName, funcDeclSuffix,       \
+                               bodyPrefix, streamName, bodySuffix)         \
+inline                                                                     \
+returnType funcName(TINYFORMAT_WRAP_FORMAT_EXTRA_ARGS const char* fmt      \
+                    ) funcDeclSuffix                                       \
+{                                                                          \
+    bodyPrefix                                                             \
+    tinyformat::detail::FormatIterator(streamName, fmt).finish();          \
+    bodySuffix                                                             \
+}                                                                          \
+TINYFORMAT_WRAP_FORMAT_N(1 , returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
+TINYFORMAT_WRAP_FORMAT_N(2 , returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
+TINYFORMAT_WRAP_FORMAT_N(3 , returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
+TINYFORMAT_WRAP_FORMAT_N(4 , returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
+TINYFORMAT_WRAP_FORMAT_N(5 , returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
+TINYFORMAT_WRAP_FORMAT_N(6 , returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
+TINYFORMAT_WRAP_FORMAT_N(7 , returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
+TINYFORMAT_WRAP_FORMAT_N(8 , returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
+TINYFORMAT_WRAP_FORMAT_N(9 , returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
+TINYFORMAT_WRAP_FORMAT_N(10, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
+TINYFORMAT_WRAP_FORMAT_N(11, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
+TINYFORMAT_WRAP_FORMAT_N(12, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
+TINYFORMAT_WRAP_FORMAT_N(13, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
+TINYFORMAT_WRAP_FORMAT_N(14, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
+TINYFORMAT_WRAP_FORMAT_N(15, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
+TINYFORMAT_WRAP_FORMAT_N(16, returnType, funcName, funcDeclSuffix, bodyPrefix, streamName, bodySuffix) \
 
 
 } // namespace tinyformat


### PR DESCRIPTION
Do not enforce BU formatting rules for `src/tinyformat.h`.
This is basically a git subtree even if maintained "manually".
The upstream project is https://github.com/c42f/tinyformat and
not mangling with the formatting of the file will make sync
changes from upstream a lot easier.