### PR TITLE
Remove BITCOIN_CASH ifdef completely

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -184,7 +184,7 @@ testScripts = [ RpcTest(t) for t in [
     'parallel',
     'wallet',
     'excessive',
-    Disabled('buip055', 'temporary disable due to remove of NODE_BITCOIN_CASH service bit'),
+    Disabled('buip055', 'temporary disable while waiting for a more comprehensive refactor'),
     'listtransactions',
     'receivedby',
     'mempool_resurrect_test',

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -184,7 +184,7 @@ testScripts = [ RpcTest(t) for t in [
     'parallel',
     'wallet',
     'excessive',
-    'buip055',
+    Disabled('buip055', 'temporary disable due to remove of NODE_BITCOIN_CASH service bit'),
     'listtransactions',
     'receivedby',
     'mempool_resurrect_test',

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -236,11 +236,6 @@ static void addGeneralOptions(AllowedArgs &allowedArgs, HelpMessageMode mode)
             strprintf(_("How thorough the block verification of -checkblocks is (0-4, default: %u)"),
                     DEFAULT_CHECKLEVEL));
 
-#ifdef BITCOIN_CASH
-    allowedArgs.addArg("newdaaactivationtime=<epoch>", requiredInt,
-        strprintf(_("Bitcoin Cash November 13th activation time (default: %u"), 1510600000));
-#endif
-
 #ifndef WIN32
     if (mode == HMM_BITCOIND)
         allowedArgs.addArg("daemon", optionalBool, _("Run in the background as a daemon and accept commands"));

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -144,27 +144,12 @@ public:
         assert(
             genesis.hashMerkleRoot == uint256S("0x4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"));
 
-#ifdef BITCOIN_CASH
         // List of Bitcoin Cash compatible seeders
         vSeeds.push_back(CDNSSeedData("bitcoinunlimited.info", "btccash-seeder.bitcoinunlimited.info", true));
         vSeeds.push_back(CDNSSeedData("bitcoinabc.org", "seed.bitcoinabc.org", true));
         vSeeds.push_back(CDNSSeedData("bitcoinforks.org", "seed-abc.bitcoinforks.org", true));
         vSeeds.push_back(CDNSSeedData("bitprim.org", "seed.bitprim.org", true)); // Bitprim
         vSeeds.push_back(CDNSSeedData("deadalnix.me", "seed.deadalnix.me", true)); // Amaury SÉCHET
-
-#else
-        // List of BitcoinUnlimited seeders
-        vSeeds.push_back(CDNSSeedData("bitcoinunlimited.info", "seed.bitcoinunlimited.info", true)); // BU seeder
-        vSeeds.push_back(CDNSSeedData("bitnodes.io", "seed.bitnodes.io")); // Bitnodes (Addy Yeow)
-        // Pieter Wuille, only supports x1, x5, x9, and xd
-        vSeeds.push_back(CDNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be", true));
-        vSeeds.push_back(CDNSSeedData("bluematt.me", "dnsseed.bluematt.me", true)); // Matt Corallo, only supports x9
-        vSeeds.push_back(CDNSSeedData("dashjr.org", "dnsseed.bitcoin.dashjr.org")); // Luke Dashjr
-        // Christian Decker, supports x1 - xf
-        vSeeds.push_back(CDNSSeedData("bitcoinstats.com", "seed.bitcoinstats.com", true));
-        // Jonas Schnelli, only supports x1, x5, x9, and xd
-        vSeeds.push_back(CDNSSeedData("bitcoin.jonasschnelli.ch", "seed.bitcoin.jonasschnelli.ch", true));
-#endif
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 0);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 5);
@@ -345,9 +330,8 @@ public:
 
         vFixedSeeds.clear();
         vSeeds.clear();
-// nodes with support for servicebits filtering should be at the top
+        // nodes with support for servicebits filtering should be at the top
 
-#ifdef BITCOIN_CASH
         // Bitcoin ABC seeder
         vSeeds.push_back(CDNSSeedData("bitcoinabc.org", "testnet-seed.bitcoinabc.org", true));
         // bitcoinforks seeders
@@ -360,13 +344,6 @@ public:
         vSeeds.push_back(CDNSSeedData("deadalnix.me", "testnet-seed.deadalnix.me", true));
         // criptolayer.net
         vSeeds.push_back(CDNSSeedData("criptolayer.net", "testnet-seeder.criptolayer.net", true));
-#else
-        vSeeds.push_back(
-            CDNSSeedData("testnetbitcoin.jonasschnelli.ch", "testnet-seed.bitcoin.jonasschnelli.ch", true));
-        vSeeds.push_back(CDNSSeedData("bitcoin.petertodd.org", "testnet-seed.bitcoin.petertodd.org"));
-        vSeeds.push_back(CDNSSeedData("bluematt.me", "testnet-seed.bluematt.me"));
-        vSeeds.push_back(CDNSSeedData("bitcoin.schildbach.de", "testnet-seed.bitcoin.schildbach.de"));
-#endif
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<uint8_t>(1, 111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<uint8_t>(1, 196);

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -16,11 +16,7 @@
  * for both bitcoind and bitcoin-core, to make it harder for attackers to
  * target servers or GUI users specifically.
  */
-#ifdef BITCOIN_CASH
 const std::string CLIENT_NAME("BUCash");
-#else
-const std::string CLIENT_NAME("BitcoinUnlimited");
-#endif
 
 // BU added
 /**

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -6,8 +6,6 @@
 #ifndef BITCOIN_CLIENTVERSION_H
 #define BITCOIN_CLIENTVERSION_H
 
-#define BITCOIN_CASH
-
 #if defined(HAVE_CONFIG_H)
 #include "config/bitcoin-config.h"
 #else

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -208,9 +208,6 @@ CTweakRef<int> maxConnectionsTweak("net.maxConnections", "Maximum number of conn
 CTweakRef<int> minXthinNodesTweak("net.minXthinNodes",
     "Minimum number of outbound xthin capable nodes to connect to",
     &nMinXthinNodes);
-CTweakRef<int> minBitcoinCashNodesTweak("net.minBitcoinCashNodes",
-    "Minimum number of outbound BitcoinCash capable nodes to connect to",
-    &nMinBitcoinCashNodes);
 // When should I request a tx from someone else (in microseconds). cmdline/bitcoin.conf: -txretryinterval
 CTweakRef<unsigned int> triTweak("net.txRetryInterval",
     "How long to wait in microseconds before requesting a transaction from another source",

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -820,12 +820,7 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
     // BUIP010 Xtreme Thinblocks: begin section Initialize XTHIN service
     if (GetBoolArg("-use-thinblocks", DEFAULT_USE_THINBLOCKS))
         nLocalServices |= NODE_XTHIN;
-// BUIP010 Xtreme Thinblocks: end section
-
-// UAHF - BitcoinCash
-#ifdef BITCOIN_CASH
-    nLocalServices |= NODE_BITCOIN_CASH;
-#endif
+    // BUIP010 Xtreme Thinblocks: end section
 
     nMaxTipAge = GetArg("-maxtipage", DEFAULT_MAX_TIP_AGE);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -818,6 +818,9 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
         nLocalServices |= NODE_XTHIN;
     // BUIP010 Xtreme Thinblocks: end section
 
+    // UAHF - BitcoinCash service bit
+    nLocalServices |= NODE_BITCOIN_CASH;
+
     nMaxTipAge = GetArg("-maxtipage", DEFAULT_MAX_TIP_AGE);
 
     // xthin bloom filter limits

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -786,11 +786,7 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
     {
         InitWarning(_("Config option -minrelaytxfee is no longer supported.  To set the limit "
                       "below which a transaction is considered zero fee please use -minlimitertxfee.  "
-#ifdef BITCOIN_CASH
                       "To convert -minrelaytxfee, which is specified  in BCH/KB, to -minlimtertxfee, "
-#else
-                      "To convert -minrelaytxfee, which is specified  in BTC/KB, to -minlimtertxfee, "
-#endif
                       "which is specified in Satoshi/Byte, simply multiply the original -minrelaytxfee "
                       "by 100,000. For example, a -minrelaytxfee=0.00001000 will become -minlimitertxfee=1.000"));
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2281,17 +2281,15 @@ bool ConnectBlock(const CBlock &block,
         nLockTimeFlags |= LOCKTIME_VERIFY_SEQUENCE;
     }
 
-// If the DAA HF is enabled, we start rejecting transaction that use a high
-// s in their signature. We also make sure that signature that are supposed
-// to fail (for instance in multisig or other forms of smart contracts) are
-// null.
-#ifdef BITCOIN_CASH
+    // If the DAA HF is enabled, we start rejecting transaction that use a high
+    // s in their signature. We also make sure that signature that are supposed
+    // to fail (for instance in multisig or other forms of smart contracts) are
+    // null.
     if (IsDAAEnabled(chainparams, pindex->pprev))
     {
         flags |= SCRIPT_VERIFY_LOW_S;
         flags |= SCRIPT_VERIFY_NULLFAIL;
     }
-#endif
 
     int64_t nTime2 = GetTimeMicros();
     nTimeForks += nTime2 - nTime1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5647,9 +5647,8 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         if (fLogIPs)
             remoteAddr = ", peeraddr=" + pfrom->addr.ToString();
 
-        LOG(NET, "receive version message: %s: version %d, blocks=%d, us=%s, peer=%d%s %s\n", pfrom->cleanSubVer,
-            pfrom->nVersion, pfrom->nStartingHeight, addrMe.ToString(), pfrom->id, remoteAddr,
-            pfrom->fUsesCashMagic ? "CashMagic" : "BTCMagic");
+        LOG(NET, "receive version message: %s: version %d, blocks=%d, us=%s, peer=%d%s\n", pfrom->cleanSubVer,
+            pfrom->nVersion, pfrom->nStartingHeight, addrMe.ToString(), pfrom->id, remoteAddr);
 
         int64_t nTimeOffset = nTime - GetTime();
         pfrom->nTimeOffset = nTimeOffset;
@@ -7004,15 +7003,6 @@ bool ProcessMessages(CNode *pfrom)
 
         // at this point, any failure means we can delete the current message
         it++;
-
-#ifdef BITCOIN_CASH
-        // This is a new peer. Before doing anything, we need to detect what magic the peer is using.
-        if (pfrom->nVersion == 0 &&
-            memcmp(msg.hdr.pchMessageStart, chainparams.CashMessageStart(), MESSAGE_START_SIZE) == 0)
-        {
-            pfrom->fUsesCashMagic = true;
-        }
-#endif
 
         // Scan for message start
         if (memcmp(msg.hdr.pchMessageStart, pfrom->GetMagic(chainparams), MESSAGE_START_SIZE) != 0)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -99,7 +99,6 @@ static std::vector<ListenSocket> vhListenSocket;
 extern CAddrMan addrman;
 int nMaxConnections = DEFAULT_MAX_PEER_CONNECTIONS;
 int nMinXthinNodes = MIN_XTHIN_NODES;
-int nMinBitcoinCashNodes = MIN_BITCOIN_CASH_NODES;
 
 bool fAddressesInitialized = false;
 std::string strSubVersion;
@@ -1760,8 +1759,6 @@ void ThreadOpenConnections()
 
                     if (pnode->ThinBlockCapable())
                         nThinBlockCapable++;
-                    else if (pnode->BitcoinCashCapable())
-                        nBitcoinCash++;
                     else
                         ptemp = pnode;
                 }
@@ -1769,7 +1766,6 @@ void ThreadOpenConnections()
             // Disconnect a node that is not XTHIN capable if all outbound slots are full and we
             // have not yet connected to enough XTHIN nodes.
             nMinXthinNodes = GetArg("-min-xthin-nodes", MIN_XTHIN_NODES);
-            nMinBitcoinCashNodes = GetArg("-min-bitcoin-cash-nodes", MIN_BITCOIN_CASH_NODES);
             if (nOutbound >= nMaxOutConnections && nThinBlockCapable <= min(nMinXthinNodes, nMaxOutConnections) &&
                 nDisconnects < MAX_DISCONNECTS && IsThinBlocksEnabled() && IsChainNearlySyncd())
             {
@@ -1780,20 +1776,6 @@ void ThreadOpenConnections()
                     nDisconnects++;
                 }
             }
-#ifdef BITCOIN_CASH
-            // Disconnect a node that is not BitcoinCash capable if all outbound slots are full and we
-            // have not yet connected to enough BitcoinCash nodes.
-            else if (nOutbound >= nMaxOutConnections && nBitcoinCash <= min(nMinBitcoinCashNodes, nMaxOutConnections) &&
-                     nDisconnects < MAX_DISCONNECTS && IsChainNearlySyncd())
-            {
-                if (ptemp != nullptr)
-                {
-                    ptemp->fDisconnect = true;
-                    fDisconnected = true;
-                    nDisconnects++;
-                }
-            }
-#endif
 
             // In the event that outbound nodes restart or drop off the network over time we need to
             // replenish the number of disconnects allowed once per day.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1744,7 +1744,6 @@ void ThreadOpenConnections()
         // we don't have enough connections to XTHIN capable nodes yet.
         int nOutbound = 0;
         int nThinBlockCapable = 0;
-        int nBitcoinCash = 0;
         set<vector<unsigned char> > setConnected;
         CNode *ptemp = nullptr;
         bool fDisconnected = false;
@@ -2803,12 +2802,6 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
     nPingUsecStart = 0;
     nPingUsecTime = 0;
     fPingQueued = false;
-#ifdef BITCOIN_CASH
-    // set when etablishing connection
-    fUsesCashMagic = true;
-#else
-    fUsesCashMagic = false;
-#endif
     nMinPingUsecTime = std::numeric_limits<int64_t>::max();
     thinBlockWaitingForTxns = -1; // BUIP010 Xtreme Thinblocks
     nXthinBloomfilterSize = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -458,8 +458,6 @@ public:
 
 
     CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNameIn = "", bool fInboundIn = false);
-    // Whether the node uses the bitcoin cash magic to communicate.
-    std::atomic<bool> fUsesCashMagic;
     ~CNode();
 
 private:
@@ -508,7 +506,7 @@ public:
 
     const CMessageHeader::MessageStartChars &GetMagic(const CChainParams &params) const
     {
-        return fUsesCashMagic ? params.CashMessageStart() : params.MessageStart();
+        return params.CashMessageStart();
     }
 
     CNode *AddRef()

--- a/src/net.h
+++ b/src/net.h
@@ -82,8 +82,6 @@ static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 12;
 /** BU: The minimum number of xthin nodes to connect */
 static const uint8_t MIN_XTHIN_NODES = 8;
-/** BU: The minimum number of BitcoinCash nodes to connect */
-static const uint8_t MIN_BITCOIN_CASH_NODES = 4;
 /** BU: The daily maximum disconnects while searching for xthin nodes to connect */
 static const unsigned int MAX_DISCONNECTS = 200;
 /** The default for -maxuploadtarget. 0 = Unlimited */
@@ -190,8 +188,6 @@ extern CAddrMan addrman;
 extern int nMaxConnections;
 /** The minimum number of xthin nodes to connect to */
 extern int nMinXthinNodes;
-/** The minimum number of BitcoinCash nodes to connect to */
-extern int nMinBitcoinCashNodes;
 extern std::vector<CNode *> vNodes;
 extern CCriticalSection cs_vNodes;
 extern std::map<CInv, CDataStream> mapRelay;
@@ -526,14 +522,6 @@ public:
     bool ThinBlockCapable()
     {
         if (nServices & NODE_XTHIN)
-            return true;
-        return false;
-    }
-
-    // UAHF:
-    bool BitcoinCashCapable()
-    {
-        if (nServices & NODE_BITCOIN_CASH)
             return true;
         return false;
     }

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -302,13 +302,6 @@ enum
     NODE_XTHIN = (1 << 4),
     // BUIP010 - Xtreme Thinblocks - end section
 
-    // UAHF
-    // NODE_BITCOIN_CASH means the node supports the UAHF hard fork.  This is intended to be just
-    // a temporary service bit until the fork actually happens.  After the for it can be
-    // removed.
-    // If this is turned off then the node will not follow the UAHF hardfork
-    NODE_BITCOIN_CASH = (1 << 5),
-
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the
     // bitcoin-development mailing list. Remember that service bits are just

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -302,6 +302,13 @@ enum
     NODE_XTHIN = (1 << 4),
     // BUIP010 - Xtreme Thinblocks - end section
 
+    // UAHF
+    // NODE_BITCOIN_CASH means the node supports the UAHF hard fork.  This is intended to be just
+    // a temporary service bit until the fork actually happens.  After the for it can be
+    // removed.
+    // If this is turned off then the node will not follow the UAHF hardfork
+    NODE_BITCOIN_CASH = (1 << 5),
+
     // Bits 24-31 are reserved for temporary experiments. Just pick a bit that
     // isn't getting used, or one not being used much, and notify the
     // bitcoin-development mailing list. Remember that service bits are just

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -704,11 +704,10 @@ int main(int argc, char *argv[])
         return EXIT_FAILURE;
     }
 
-/// 3. Migrate application settings, if necessary
-// BU changed the QAPP_ORG_NAME and since this is used for reading the app settings
-// from the registry (Windows) or a configuration file (Linux/OSX)
-// we need to check to see if we need to migrate old settings to the new location
-#ifdef BITCOIN_CASH
+    /// 3. Migrate application settings, if necessary
+    // BU changed the QAPP_ORG_NAME and since this is used for reading the app settings
+    // from the registry (Windows) or a configuration file (Linux/OSX)
+    // we need to check to see if we need to migrate old settings to the new location
     bool fMigrated = false;
     // For BUCash, first try to migrate from BTC BU settings
     fMigrated = TryMigrateQtAppSettings(QAPP_ORG_NAME, QAPP_APP_NAME_DEFAULT, QAPP_ORG_NAME, QAPP_APP_NAME_BUCASH);
@@ -721,23 +720,15 @@ int main(int argc, char *argv[])
     // in which case each instance requires a different data directory.
     if (fMigrated)
         SoftSetBoolArg("-choosedatadir", true);
-#else
-    // Try to migrate from non-BU client settings
-    TryMigrateQtAppSettings(QAPP_ORG_NAME_LEGACY, QAPP_APP_NAME_DEFAULT, QAPP_ORG_NAME, QAPP_APP_NAME_DEFAULT);
-#endif
 
     /// 4. Application identification
     // must be set before OptionsModel is initialized or translations are loaded,
     // as it is used to locate QSettings
     QApplication::setOrganizationName(QAPP_ORG_NAME);
     QApplication::setOrganizationDomain(QAPP_ORG_DOMAIN);
-#ifdef BITCOIN_CASH
     // Use a different app name for BUCash to enable side-by-side installations which won't
     // interfere with each other
     QApplication::setApplicationName(QAPP_APP_NAME_BUCASH);
-#else
-    QApplication::setApplicationName(QAPP_APP_NAME_DEFAULT);
-#endif
     GUIUtil::SubstituteFonts(GetLangTerritory());
 
     /// 5. Initialization of translations, so that intro dialog is in user's language

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -4,8 +4,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "bitcoinunits.h"
-#include "clientversion.h" // for BITCOIN_CASH define (if on BUCash branch)
-
 #include "primitives/transaction.h"
 
 #include <QStringList>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -991,11 +991,6 @@ QString formatServicesStr(quint64 mask)
             case NODE_XTHIN:
                 strList.append("XTHIN");
                 break;
-#ifdef BITCOIN_CASH
-            case NODE_BITCOIN_CASH:
-                strList.append("CASH");
-                break;
-#endif
             default:
                 strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
             }

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -1014,13 +1014,5 @@ QString formatTimeOffset(int64_t nTimeOffset)
     return QString(QObject::tr("%1 s")).arg(QString::number((int)nTimeOffset, 10));
 }
 
-QString uriPrefix()
-{
-#ifdef BITCOIN_CASH
-    return "bitcoincash";
-#else
-    return "bitcoin";
-#endif
-}
-
+QString uriPrefix() { return "bitcoincash"; }
 } // namespace GUIUtil

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -991,6 +991,9 @@ QString formatServicesStr(quint64 mask)
             case NODE_XTHIN:
                 strList.append("XTHIN");
                 break;
+            case NODE_BITCOIN_CASH:
+                strList.append("CASH");
+                break;
             default:
                 strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
             }

--- a/src/qt/networkstyle.cpp
+++ b/src/qt/networkstyle.cpp
@@ -4,8 +4,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "networkstyle.h"
-#include "clientversion.h" // for BITCOIN_CASH define (if on BUCash branch)
-
 #include "guiconstants.h"
 
 #include <QApplication>
@@ -17,12 +15,7 @@ static const struct
     const int iconColorHueShift;
     const int iconColorSaturationReduction;
     const char *titleAddText;
-} network_styles[] = {
-#ifdef BITCOIN_CASH
-    {"main", QAPP_APP_NAME_BUCASH, 0, 0, ""},
-#else
-    {"main", QAPP_APP_NAME_DEFAULT, 0, 0, ""},
-#endif
+} network_styles[] = {{"main", QAPP_APP_NAME_BUCASH, 0, 0, ""},
     {"test", QAPP_APP_NAME_TESTNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[testnet]")},
     {"nol", QAPP_APP_NAME_NOLNET, 70, 30, QT_TRANSLATE_NOOP("SplashScreen", "[nolimit]")}, // BU
     {"regtest", QAPP_APP_NAME_TESTNET, 160, 30, "[regtest]"}};

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -900,11 +900,7 @@ UniValue estimatesmartfee(const UniValue &params, bool fHelp)
                             "1. nblocks     (numeric)\n"
                             "\nResult:\n"
                             "{\n"
-#ifdef BITCOIN_CASH
                             "  \"feerate\" : x.x,     (numeric) estimate fee-per-kilobyte (in BCH)\n"
-#else
-                            "  \"feerate\" : x.x,     (numeric) estimate fee-per-kilobyte (in BTC)\n"
-#endif
                             "  \"blocks\" : n         (numeric) block number where estimate was found\n"
                             "}\n"
                             "\n"

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -116,8 +116,9 @@ UniValue getinfo(const UniValue &params, bool fHelp)
     obj.push_back(Pair("status", statusStrings.GetPrintable()));
     obj.push_back(Pair("errors", GetWarnings("statusbar")));
     CBlockIndex *cashFork = chainActive.Tip();
+    const Consensus::Params &consensusParams = Params().GetConsensus();
     if (cashFork)
-        cashFork = cashFork->GetAncestor(BITCOIN_CASH_FORK_HEIGHT);
+        cashFork = cashFork->GetAncestor(consensusParams.uahfHeight);
     std::string fork = "Bitcoin";
     if (cashFork && cashFork->phashBlock)
     {

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -115,19 +115,7 @@ UniValue getinfo(const UniValue &params, bool fHelp)
     obj.push_back(Pair("relayfee", ValueFromAmount(::minRelayTxFee.GetFeePerK())));
     obj.push_back(Pair("status", statusStrings.GetPrintable()));
     obj.push_back(Pair("errors", GetWarnings("statusbar")));
-    CBlockIndex *cashFork = chainActive.Tip();
-    const Consensus::Params &consensusParams = Params().GetConsensus();
-    if (cashFork)
-        cashFork = cashFork->GetAncestor(consensusParams.uahfHeight);
-    std::string fork = "Bitcoin";
-    if (cashFork && cashFork->phashBlock)
-    {
-        if (*cashFork->phashBlock == bitcoinCashForkBlockHash)
-        {
-            fork = "Bitcoin Cash";
-        }
-    }
-    obj.push_back(Pair("fork", fork));
+    obj.push_back(Pair("fork", "Bitcoin Cash"));
 
     return obj;
 }

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -155,7 +155,6 @@ protected:
         const uint256 &sighash) const;
 
 public:
-#ifdef BITCOIN_CASH
     TransactionSignatureChecker(const CTransaction *txToIn,
         unsigned int nInIn,
         const CAmount &amountIn,
@@ -163,15 +162,6 @@ public:
         : txTo(txToIn), nIn(nInIn), amount(amountIn), nBytesHashed(0), nSigops(0), nFlags(flags)
     {
     }
-#else
-    TransactionSignatureChecker(const CTransaction *txToIn,
-        unsigned int nInIn,
-        const CAmount &amountIn,
-        unsigned int flags = 0)
-        : txTo(txToIn), nIn(nInIn), amount(amountIn), nBytesHashed(0), nSigops(0), nFlags(flags)
-    {
-    }
-#endif
     bool CheckSig(const std::vector<unsigned char> &scriptSig,
         const std::vector<unsigned char> &vchPubKey,
         const CScript &scriptCode) const;
@@ -187,7 +177,6 @@ private:
     const CTransaction txTo;
 
 public:
-#ifdef BITCOIN_CASH
     MutableTransactionSignatureChecker(const CMutableTransaction *txToIn,
         unsigned int nInIn,
         const CAmount &amount,
@@ -195,15 +184,6 @@ public:
         : TransactionSignatureChecker(&txTo, nInIn, amount, flags), txTo(*txToIn)
     {
     }
-#else
-    MutableTransactionSignatureChecker(const CMutableTransaction *txToIn,
-        unsigned int nInIn,
-        const CAmount &amount,
-        unsigned int flags = 0)
-        : TransactionSignatureChecker(&txTo, nInIn, amount, flags), txTo(*txToIn)
-    {
-    }
-#endif
 };
 
 bool EvalScript(std::vector<std::vector<unsigned char> > &stack,

--- a/src/script/sign.h
+++ b/src/script/sign.h
@@ -66,7 +66,6 @@ public:
 bool ProduceSignature(const BaseSignatureCreator &creator, const CScript &scriptPubKey, CScript &scriptSig);
 
 /** Produce a script signature for a transaction. */
-#ifdef BITCOIN_CASH
 bool SignSignature(const CKeyStore &keystore,
     const CScript &fromPubKey,
     CMutableTransaction &txTo,
@@ -78,19 +77,6 @@ bool SignSignature(const CKeyStore &keystore,
     CMutableTransaction &txTo,
     unsigned int nIn,
     uint32_t nHashType = SIGHASH_ALL | SIGHASH_FORKID);
-#else
-bool SignSignature(const CKeyStore &keystore,
-    const CScript &fromPubKey,
-    CMutableTransaction &txTo,
-    unsigned int nIn,
-    const CAmount &amount,
-    uint32_t nHashType = SIGHASH_ALL);
-bool SignSignature(const CKeyStore &keystore,
-    const CTransaction &txFrom,
-    CMutableTransaction &txTo,
-    unsigned int nIn,
-    uint32_t nHashType = SIGHASH_ALL);
-#endif
 
 /** Combine two script signatures using a generic signature checker, intelligently, possibly with OP_0 placeholders. */
 CScript CombineSignatures(const CScript &scriptPubKey,

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -32,11 +32,7 @@ BOOST_FIXTURE_TEST_SUITE(multisig_tests, BasicTestingSetup)
 
 CScript sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction transaction, int whichIn)
 {
-#ifdef BITCOIN_CASH
     uint256 hash = SignatureHash(scriptPubKey, transaction, whichIn, SIGHASH_ALL | SIGHASH_FORKID, 0);
-#else
-    uint256 hash = SignatureHash(scriptPubKey, transaction, whichIn, SIGHASH_ALL, 0);
-#endif
 
     CScript result;
     result << OP_0; // CHECKMULTISIG bug workaround
@@ -44,11 +40,7 @@ CScript sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction tran
     {
         vector<unsigned char> vchSig;
         BOOST_CHECK(key.Sign(hash, vchSig));
-#ifdef BITCOIN_CASH
         vchSig.push_back((unsigned char)SIGHASH_ALL | SIGHASH_FORKID);
-#else
-        vchSig.push_back((unsigned char)SIGHASH_ALL);
-#endif
         result << vchSig;
     }
     return result;
@@ -56,11 +48,7 @@ CScript sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction tran
 
 BOOST_AUTO_TEST_CASE(multisig_verify)
 {
-#ifdef BITCOIN_CASH
     unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC | SCRIPT_ENABLE_SIGHASH_FORKID;
-#else
-    unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
-#endif
 
     ScriptError err;
     CKey key[4];

--- a/src/test/pow_tests.cpp
+++ b/src/test/pow_tests.cpp
@@ -84,11 +84,7 @@ BOOST_AUTO_TEST_CASE(GetBlockProofEquivalentTime_test)
         blocks[i].nHeight = i;
         blocks[i].nTime = 1269211443 + i * params.nPowTargetSpacing;
         blocks[i].nBits = 0x207fffff; /* target 0x7fffff000... */
-#ifndef BITCOIN_CASH
         blocks[i].nChainWork = i ? blocks[i - 1].nChainWork + GetBlockProof(blocks[i - 1]) : arith_uint256(0);
-#else
-        blocks[i].nChainWork = i ? blocks[i - 1].nChainWork + GetBlockProof(blocks[i]) : arith_uint256(0);
-#endif
     }
 
     for (int j = 0; j < 1000; j++)
@@ -109,9 +105,7 @@ static CBlockIndex GetBlockIndex(CBlockIndex *pindexPrev, int64_t nTimeInterval,
     block.nHeight = pindexPrev->nHeight + 1;
     block.nTime = pindexPrev->nTime + nTimeInterval;
     block.nBits = nBits;
-#ifdef BITCOIN_CASH
     block.nChainWork = pindexPrev->nChainWork + GetBlockProof(block);
-#endif
     return block;
 }
 
@@ -132,9 +126,7 @@ BOOST_AUTO_TEST_CASE(retargeting_test)
     blocks[0].nTime = 1269211443;
     blocks[0].nBits = initialBits;
 
-#ifdef BITCOIN_CASH
     blocks[0].nChainWork = GetBlockProof(blocks[0]);
-#endif
     // Pile up some blocks.
     for (size_t i = 1; i < 100; i++)
     {
@@ -183,7 +175,6 @@ BOOST_AUTO_TEST_CASE(retargeting_test)
     BOOST_CHECK_EQUAL(GetNextWorkRequired(&blocks[114], &blkHeaderDummy, params), powLimit.GetCompact());
 }
 
-#ifdef BITCOIN_CASH
 BOOST_AUTO_TEST_CASE(cash_difficulty_test)
 {
     SelectParams(CBaseChainParams::MAIN);
@@ -356,6 +347,5 @@ BOOST_AUTO_TEST_CASE(cash_difficulty_test)
         nBits = nextBits;
     }
 }
-#endif
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/script_P2SH_tests.cpp
+++ b/src/test/script_P2SH_tests.cpp
@@ -116,13 +116,8 @@ BOOST_AUTO_TEST_CASE(sign)
             txTo[i].vin[0].scriptSig = txTo[j].vin[0].scriptSig;
 
             const CTxOut &output = txFrom.vout[txTo[i].vin[0].prevout.n];
-#ifdef BITCOIN_CASH
             bool sigOK = CScriptCheck(nullptr, output.scriptPubKey, output.nValue, txTo[i], 0,
                 SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC | SCRIPT_ENABLE_SIGHASH_FORKID, false)();
-#else
-            bool sigOK = CScriptCheck(nullptr, output.scriptPubKey, output.nValue, txTo[i], 0,
-                SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC, false)();
-#endif
             if (i == j)
                 BOOST_CHECK_MESSAGE(sigOK, strprintf("VerifySignature %d %d", i, j));
             else

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -35,11 +35,7 @@ using namespace std;
 // Uncomment if you want to output updated JSON tests.
 // #define UPDATE_JSON_TESTS
 
-#ifdef BITCOIN_CASH
 static const unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC | SCRIPT_ENABLE_SIGHASH_FORKID;
-#else
-static const unsigned int flags = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC;
-#endif
 
 unsigned int ParseScriptFlags(string strFlags);
 string FormatScriptFlags(unsigned int flags);
@@ -998,11 +994,7 @@ BOOST_AUTO_TEST_CASE(script_PushData)
 
 CScript sign_multisig(const CScript &scriptPubKey, std::vector<CKey> keys, const CTransaction &transaction, CAmount amt)
 {
-#ifdef BITCOIN_CASH
     unsigned char sighashType = SIGHASH_ALL | SIGHASH_FORKID;
-#else
-    unsigned char sighashType = SIGHASH_ALL;
-#endif
 
     uint256 hash = SignatureHash(scriptPubKey, transaction, 0, sighashType, amt, 0);
 
@@ -1226,8 +1218,7 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     combined = CombineSignatures(scriptPubKey, MutableTransactionSignatureChecker(&txTo, 0, amount), empty, scriptSig);
     BOOST_CHECK(combined == scriptSig);
 
-// A couple of partially-signed versions:
-#ifdef BITCOIN_CASH
+    // A couple of partially-signed versions:
     vector<unsigned char> sig1;
     uint256 hash1 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_ALL | SIGHASH_FORKID, 0);
     BOOST_CHECK(keys[0].Sign(hash1, sig1));
@@ -1240,20 +1231,6 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     uint256 hash3 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_SINGLE | SIGHASH_FORKID, 0);
     BOOST_CHECK(keys[2].Sign(hash3, sig3));
     sig3.push_back(SIGHASH_SINGLE | SIGHASH_FORKID);
-#else
-    vector<unsigned char> sig1;
-    uint256 hash1 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_ALL, 0);
-    BOOST_CHECK(keys[0].Sign(hash1, sig1));
-    sig1.push_back(SIGHASH_ALL);
-    vector<unsigned char> sig2;
-    uint256 hash2 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_NONE, 0);
-    BOOST_CHECK(keys[1].Sign(hash2, sig2));
-    sig2.push_back(SIGHASH_NONE);
-    vector<unsigned char> sig3;
-    uint256 hash3 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_SINGLE, 0);
-    BOOST_CHECK(keys[2].Sign(hash3, sig3));
-    sig3.push_back(SIGHASH_SINGLE);
-#endif
 
     // Not fussy about order (or even existence) of placeholders or signatures:
     CScript partial1a = CScript() << OP_0 << sig1 << OP_0;

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -39,14 +39,11 @@ enum
         30, // Default for the number of days in the past we check scripts during initial block download
 
     MAX_HEADER_REQS_DURING_IBD = 3,
-// if the blockchain is this far (in seconds) behind the current time, only request headers from a single
-// peer.  This makes IBD more efficient.  We make BITCOIN_CASH more lenient here because mining could be
-// more erratic and this node is likely to connect to non-BCH nodes.
-#ifdef BITCOIN_CASH
+    // if the blockchain is this far (in seconds) behind the current time, only request headers from a single
+    // peer.  This makes IBD more efficient.
+    // TODO: since the new DAA cash mining is no more erratic than bitcoin legacy.
+    // Wouldn't been better to set it back to what it was? (i.e. 24 * 60 * 60)
     SINGLE_PEER_REQUEST_MODE_AGE = (7 * 24 * 60 * 60),
-#else
-    SINGLE_PEER_REQUEST_MODE_AGE = (24 * 60 * 60),
-#endif
 };
 
 class CBlock;

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -47,9 +47,6 @@ enum
 #else
     SINGLE_PEER_REQUEST_MODE_AGE = (24 * 60 * 60),
 #endif
-
-    BITCOIN_CASH_FORK_HEIGHT = 478559,
-
 };
 
 class CBlock;

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -60,12 +60,8 @@ static const bool DEFAULT_SEND_FREE_TRANSACTIONS = false;
 //! -txconfirmtarget default
 static const unsigned int DEFAULT_TX_CONFIRM_TARGET = 2;
 //! Largest (in bytes) free transaction we're willing to creat
-#ifdef BITCOIN_CASH
 //! We can allow a maximum sized free transaction in the Bitcoin Cash Network.
 static const unsigned int MAX_FREE_TRANSACTION_CREATE_SIZE = MAX_STANDARD_TX_SIZE;
-#else
-static const unsigned int MAX_FREE_TRANSACTION_CREATE_SIZE = 1000;
-#endif
 static const bool DEFAULT_WALLETBROADCAST = true;
 
 extern const char *DEFAULT_WALLET_DAT;


### PR DESCRIPTION
Since release 1.2.0.0 BUCash release enforce the use of the new cash net magic bit, e.g. incoming connections that used the legacy magic are reject now, this PR removes: 

- NODE_BITCOIN_CASH service bit and related code 
- `fUsesCashMagic` logic.

The former was used to implement preferential peering toward cash nodes in the period of time  when we share the same magic bit along with bitcoin legacy node. 
The latter was used to avoid banning cash nodes that instantiate incoming connections using the legacy net magic bit.

The PR is marked as WIP cause I need to refactor `buip055.py`, the test is temporarely disabled.

~(***This PR depends on #939***)~