### PR TITLE
Define for CURRENCY_UNIT is no longer needed

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -30,11 +30,7 @@
 #endif
 
 // These globals are needed here so bitcoin-cli can link
-#ifdef BITCOIN_CASH
 const std::string CURRENCY_UNIT = "BCH";
-#else
-const std::string CURRENCY_UNIT = "BTC";
-#endif
 const std::string DEFAULT_TOR_CONTROL = "127.0.0.1:9051";
 const char DEFAULT_RPCCONNECT[] = "127.0.0.1";
 


### PR DESCRIPTION
The define for CURRENCY_UNIT is no longer needed in the BCH code base. Both Core branches have CURRENCY_UNIT strictly defined to BTC now, so the BUCash code should have CURRENCY_UNIT just defined to BCH. 