### PR TITLE
Cleanup Bitcoinunits within the Qt code

### DIFF
--- a/src/qt/bitcoinamountfield.cpp
+++ b/src/qt/bitcoinamountfield.cpp
@@ -24,7 +24,7 @@ class AmountSpinBox : public QAbstractSpinBox
 
 public:
     explicit AmountSpinBox(QWidget *parent)
-        : QAbstractSpinBox(parent), currentUnit(BitcoinUnits::BTC), singleStep(100000) // satoshis
+        : QAbstractSpinBox(parent), currentUnit(BitcoinUnits::BCH), singleStep(100000) // satoshis
     {
         setAlignment(Qt::AlignRight);
 
@@ -91,7 +91,7 @@ public:
             const QFontMetrics fm(fontMetrics());
             int h = lineEdit()->minimumSizeHint().height();
             int w = fm.width(BitcoinUnits::format(
-                BitcoinUnits::BTC, BitcoinUnits::maxMoney(), false, BitcoinUnits::separatorAlways));
+                BitcoinUnits::BCH, BitcoinUnits::maxMoney(), false, BitcoinUnits::separatorAlways));
             w += 2; // cursor blinking space
 
             QStyleOptionSpinBox opt;

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -37,21 +37,12 @@ QString BitcoinUnits::name(int unit)
 {
     switch (unit)
     {
-#ifdef BITCOIN_CASH
     case BTC:
         return QString("BCH");
     case mBTC:
         return QString("mBCH");
     case uBTC:
         return QString::fromUtf8("μBCH");
-#else
-    case BTC:
-        return QString("BTC");
-    case mBTC:
-        return QString("mBTC");
-    case uBTC:
-        return QString::fromUtf8("μBTC");
-#endif
     default:
         return QString("???");
     }

--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -14,9 +14,9 @@ BitcoinUnits::BitcoinUnits(QObject *parent) : QAbstractListModel(parent), unitli
 QList<BitcoinUnits::Unit> BitcoinUnits::availableUnits()
 {
     QList<BitcoinUnits::Unit> unitlist;
-    unitlist.append(BTC);
-    unitlist.append(mBTC);
-    unitlist.append(uBTC);
+    unitlist.append(BCH);
+    unitlist.append(mBCH);
+    unitlist.append(uBCH);
     return unitlist;
 }
 
@@ -24,9 +24,9 @@ bool BitcoinUnits::valid(int unit)
 {
     switch (unit)
     {
-    case BTC:
-    case mBTC:
-    case uBTC:
+    case BCH:
+    case mBCH:
+    case uBCH:
         return true;
     default:
         return false;
@@ -37,11 +37,11 @@ QString BitcoinUnits::name(int unit)
 {
     switch (unit)
     {
-    case BTC:
+    case BCH:
         return QString("BCH");
-    case mBTC:
+    case mBCH:
         return QString("mBCH");
-    case uBTC:
+    case uBCH:
         return QString::fromUtf8("μBCH");
     default:
         return QString("???");
@@ -52,11 +52,11 @@ QString BitcoinUnits::description(int unit)
 {
     switch (unit)
     {
-    case BTC:
+    case BCH:
         return QString("Bitcoins");
-    case mBTC:
+    case mBCH:
         return QString("Milli-Bitcoins (1 / 1" THIN_SP_UTF8 "000)");
-    case uBTC:
+    case uBCH:
         return QString("Micro-Bitcoins (1 / 1" THIN_SP_UTF8 "000" THIN_SP_UTF8 "000)");
     default:
         return QString("???");
@@ -67,11 +67,11 @@ qint64 BitcoinUnits::factor(int unit)
 {
     switch (unit)
     {
-    case BTC:
+    case BCH:
         return 100000000;
-    case mBTC:
+    case mBCH:
         return 100000;
-    case uBTC:
+    case uBCH:
         return 100;
     default:
         return 100000000;
@@ -82,11 +82,11 @@ int BitcoinUnits::decimals(int unit)
 {
     switch (unit)
     {
-    case BTC:
+    case BCH:
         return 8;
-    case mBTC:
+    case mBCH:
         return 5;
-    case uBTC:
+    case uBCH:
         return 2;
     default:
         return 0;

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -57,9 +57,9 @@ public:
      */
     enum Unit
     {
-        BTC,
-        mBTC,
-        uBTC
+        BCH,
+        mBCH,
+        uBCH
     };
 
     enum SeparatorStyle

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -617,7 +617,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog *dialog)
     }
 
     // actually update labels
-    int nDisplayUnit = BitcoinUnits::BTC;
+    int nDisplayUnit = BitcoinUnits::BCH;
     if (model && model->getOptionsModel())
         nDisplayUnit = model->getOptionsModel()->getDisplayUnit();
 

--- a/src/qt/forms/coincontroldialog.ui
+++ b/src/qt/forms/coincontroldialog.ui
@@ -132,7 +132,7 @@
           <enum>Qt::ActionsContextMenu</enum>
          </property>
          <property name="text">
-          <string notr="true">0.00 BTC</string>
+          <string notr="true">0.00 BCH</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -206,7 +206,7 @@
           <enum>Qt::ActionsContextMenu</enum>
          </property>
          <property name="text">
-          <string notr="true">0.00 BTC</string>
+          <string notr="true">0.00 BCH</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -286,7 +286,7 @@
           <enum>Qt::ActionsContextMenu</enum>
          </property>
          <property name="text">
-          <string notr="true">0.00 BTC</string>
+          <string notr="true">0.00 BCH</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
@@ -321,7 +321,7 @@
           <enum>Qt::ActionsContextMenu</enum>
          </property>
          <property name="text">
-          <string notr="true">0.00 BTC</string>
+          <string notr="true">0.00 BCH</string>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -230,7 +230,7 @@ bool parseBitcoinURI(const QString &scheme, const QUrl &uri, SendCoinsRecipient 
         {
             if (!i->second.isEmpty())
             {
-                if (!BitcoinUnits::parse(BitcoinUnits::BTC, i->second, &rv.amount))
+                if (!BitcoinUnits::parse(BitcoinUnits::BCH, i->second, &rv.amount))
                 {
                     return false;
                 }
@@ -275,7 +275,7 @@ QString formatBitcoinURI(const Config &cfg, const SendCoinsRecipient &info)
     if (info.amount)
     {
         ret += QString("?amount=%1")
-                   .arg(BitcoinUnits::format(BitcoinUnits::BTC, info.amount, false, BitcoinUnits::separatorNever));
+                   .arg(BitcoinUnits::format(BitcoinUnits::BCH, info.amount, false, BitcoinUnits::separatorNever));
         paramCount++;
     }
 

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -59,7 +59,7 @@ void OptionsModel::Init(bool resetSettings)
 
     // Display
     if (!settings.contains("nDisplayUnit"))
-        settings.setValue("nDisplayUnit", BitcoinUnits::BTC);
+        settings.setValue("nDisplayUnit", BitcoinUnits::BCH);
     nDisplayUnit = settings.value("nDisplayUnit").toInt();
 
     if (!settings.contains("strThirdPartyTxUrls"))

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -27,7 +27,7 @@ class TxViewDelegate : public QAbstractItemDelegate
     Q_OBJECT
 public:
     TxViewDelegate(const PlatformStyle *platformStyle)
-        : QAbstractItemDelegate(), unit(BitcoinUnits::BTC), platformStyle(platformStyle)
+        : QAbstractItemDelegate(), unit(BitcoinUnits::BCH), platformStyle(platformStyle)
     {
     }
 
@@ -239,7 +239,7 @@ void OverviewPage::setWalletModel(WalletModel *model)
         connect(model, SIGNAL(notifyWatchonlyChanged(bool)), this, SLOT(updateWatchOnlyLabels(bool)));
     }
 
-    // update the display unit, to not use the default ("BTC")
+    // update the display unit, to not use the default ("BCH")
     updateDisplayUnit();
 }
 

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -106,7 +106,7 @@ void SendCoinsEntry::clear()
     ui->memoTextLabel_s->clear();
     ui->payAmount_s->clear();
 
-    // update the display unit, to not use the default ("BTC")
+    // update the display unit, to not use the default ("BCH")
     updateDisplayUnit();
 }
 


### PR DESCRIPTION
The first commit removes the define that determined if BTC or BCH was the text for the display label. It is now set to use only BCH. There is no equivalent commit to be made in either the BitcoinCore or BitcoinCore1.0 branches as they never had this switch. 

Second and third commit might be overkill. Can revert if requested. They change any remaining reference from BitcoinUnits::BTC to BitcoinUnits::BCH purely for consistency with the QString text in BitcoinUnits::name. 