### PR TITLE
removed the switch for DEFAULT_BLOCK_MAX_SIZE as requested

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -16,12 +16,7 @@
 class CCoinsViewCache;
 
 /** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
-#ifdef BITCOIN_CASH
 static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 2000000;
-#else
-// BU: crank the default up to the minimum  max defined in all clients.
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = BLOCKSTREAM_CORE_MAX_BLOCK_SIZE;
-#endif
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 
 /** Default for -blockprioritysize, a 5% maximum space for zero/low-fee transactions **/


### PR DESCRIPTION
removed the switch for DEFAULT_BLOCK_MAX_SIZE as requested by @ptschip 