### PR TITLE
Initialize pindexNewTip at declaration time

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3423,7 +3423,7 @@ static bool ActivateBestChainStep(CValidationState &state,
         nHeight = nTargetHeight;
 
         // Connect new blocks.
-        CBlockIndex *pindexNewTip;
+        CBlockIndex *pindexNewTip = nullptr;
         BOOST_REVERSE_FOREACH (CBlockIndex *pindexConnect, vpindexToConnect)
         {
             // Check if the best chain has changed while we were disconnecting or processing blocks.
@@ -3500,7 +3500,7 @@ static bool ActivateBestChainStep(CValidationState &state,
             break; // stop processing more blocks if the last one was invalid.
 
         // Notify the UI with the new block tip information.
-        if (pindexMostWork->nHeight >= nHeight && pindexNewTip != NULL)
+        if (pindexMostWork->nHeight >= nHeight && pindexNewTip != nullptr)
             uiInterface.NotifyBlockTip(true, pindexNewTip);
 
         if (fContinue)


### PR DESCRIPTION
ths fix this warning:

```
main.cpp: In function 'bool ActivateBestChain(CValidationState&, const
CChainParams&, const CBlock*, bool)':
main.cpp:3504:59: warning: 'pindexNewTip' may be used uninitialized in
this function [-Wmaybe-uninitialized]
             uiInterface.NotifyBlockTip(true, pindexNewTip)
```

Such warning pops up only while using gcc 5.3.0, 4.8.x and 6.3.0
don't emit anything even if the warning is legit.

(thanks to @awemany for the help in tracking down which gcc version
were affected)