### PR TITLE
Changing over to  new log system

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -112,6 +112,7 @@ To add a new log category:
 
 // Log Categories:
 // 64 Bits: (Define unique bits, not 'normal' numbers)
+//TODO Before replace make better labels:
 enum
 {
     NONE = 0x0, // No logging


### PR DESCRIPTION
The labels for the log categories are too short. (util.h)
Please provide suggestions before the global replace of the log system. 
In a form that is easy to search and replace , such as: 
PRT PARTCK
CDB COINDB 
etc.

Here is the mapping between the labels and current log system strings:

{ \
    {NONE, "none"}, \
    {ALL, "all"}, \
    {THN, "thin"}, \
    {MEP, "mempool"}, \
    {CDB, "coindb"}, \
    {TOR, "tor"}, \
    {NET, "net"}, \
    {ADR, "addrman"}, \
    {LIB, "libevent"}, \
    {HTP, "http"}, \
    {RPC, "rpc"}, \
    {PRT, "partitioncheck"}, \
    {BNC, "bench"}, \
    {PRN, "prune"}, \
    {RDX, "reindex"}, \
    {MPR, "mempoolrej"}, \
    {BLK, "blk"}, \
    {EVC, "evict"}, \
    {PRL, "parallel"}, \
    {RND, "rand"}, \
    {REQ, "req"}, \
    {BLM, "bloom"}, \
    {LCK, "lck"}, \
    {PRX, "proxy"}, \
    {DBS, "db"}, \
    {SLC, "selectcoins"}, \
    {EST, "estimatefee"} \
} \

