### PR TITLE
Temporarily disable bitnodes seeding on the BitcoinCash chain

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1637,7 +1637,9 @@ void ThreadAddressSeeding()
         LogPrintf("Bitnodes API seeding disabled\n");
     else
     {
-        BitnodesAddressSeed();
+        // TODO: re-enable bitnodes seeding once a site is available for the BitcoinCash chain.
+        // BitnodesAddressSeed();
+        LogPrintf("Bitnodes API seeding temporarily disabled\n");
     }
 }
 


### PR DESCRIPTION
There is no bitnodes service for BitcoinCash and therefore
when this section of code is run we end up pulling into  our
peers.dat a list peers that are valid for the legacy chain
and not the BitcoinCash chain. Once a simlilar site is
available we can easily re-enable this feature.