### PR TITLE
New RPC feature : rollbackchain

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2840,7 +2840,7 @@ bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusPa
 
     // Resurrect mempool transactions from the disconnected block but do not do this step if we are
     // rolling back the chain using the "rollbackchain" rpc command.
-    if(!fRollBack)
+    if (!fRollBack)
     {
         std::vector<uint256> vHashUpdate;
         for (const CTransaction &tx : block.vtx)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2814,7 +2814,7 @@ void static UpdateTip(CBlockIndex *pindexNew)
 
 /** Disconnect chainActive's tip. You probably want to call mempool.removeForReorg and manually re-limit mempool size
  * after this, with cs_main held. */
-bool static DisconnectTip(CValidationState &state, const Consensus::Params &consensusParams)
+bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusParams)
 {
     AssertLockHeld(cs_main);
 

--- a/src/main.h
+++ b/src/main.h
@@ -259,6 +259,8 @@ bool ProcessNewBlock(CValidationState &state,
     bool fForceProcessing,
     CDiskBlockPos *dbp,
     bool fParallel);
+/** Disconnect the current chainActive.Tip() */
+bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusParams);
 /** Check whether enough disk space is available for an incoming block */
 bool CheckDiskSpace(uint64_t nAdditionalBytes = 0);
 /** Open a block file (blk?????.dat) */

--- a/src/main.h
+++ b/src/main.h
@@ -260,7 +260,7 @@ bool ProcessNewBlock(CValidationState &state,
     CDiskBlockPos *dbp,
     bool fParallel);
 /** Disconnect the current chainActive.Tip() */
-bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusParams);
+bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusParams, const bool fRollBack = false);
 /** Check whether enough disk space is available for an incoming block */
 bool CheckDiskSpace(uint64_t nAdditionalBytes = 0);
 /** Open a block file (blk?????.dat) */

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1107,14 +1107,16 @@ UniValue rollbackchain(const UniValue &params, bool fHelp)
     while (chainActive.Height() > nRollBackHeight)
     {
         CValidationState state;
-        if (!DisconnectTip(state, Params().GetConsensus()))
+        // Disconnect the tip and by setting the third param (fRollBack) to true we avoid having to resurrect
+        // the transactions from the block back into the mempool, which saves a great deal of time.
+        if (!DisconnectTip(state, Params().GetConsensus(), true))
             throw JSONRPCError(RPC_DATABASE_ERROR, state.GetRejectReason());
 
         if (!state.IsValid())
             throw JSONRPCError(RPC_DATABASE_ERROR, state.GetRejectReason());
-    }
-    uiInterface.NotifyBlockTip(false, chainActive.Tip());
 
+        uiInterface.NotifyBlockTip(false, chainActive.Tip());
+    }
     return NullUniValue;
 }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1088,9 +1088,10 @@ UniValue rollbackchain(const UniValue &params, bool fHelp)
                             "\nRolls back the blockchain to the height indicated.\n"
                             "\nArguments:\n"
                             "1. blockheight   (int, required) the height that you want to roll the chain \
-                            back to (only maxiumum rollback of " + std::to_string(nLimit) + " blocks allowed)\n"
-                            "\nResult:\n"
-                            "\nExamples:\n" +
+                            back to (only maxiumum rollback of " +
+                            std::to_string(nLimit) + " blocks allowed)\n"
+                                                     "\nResult:\n"
+                                                     "\nExamples:\n" +
                             HelpExampleCli("rollbackchain", "\"blockheight\"") +
                             HelpExampleRpc("rollbackchain", "\"blockheight\""));
 
@@ -1100,11 +1101,10 @@ UniValue rollbackchain(const UniValue &params, bool fHelp)
     LOCK(cs_main);
     uint32_t nRollBack = chainActive.Height() - nRollBackHeight;
     if (nRollBack > nLimit)
-        throw runtime_error("You are attempting to rollback the chain by " + 
-                            std::to_string(nRollBack) + " blocks, however the limit is " + 
-                            std::to_string(nLimit) + " blocks.");
+        throw runtime_error("You are attempting to rollback the chain by " + std::to_string(nRollBack) +
+                            " blocks, however the limit is " + std::to_string(nLimit) + " blocks.");
 
-    while (chainActive.Height() > nRollBackHeight)
+    while ((uint64_t)chainActive.Height() > nRollBackHeight)
     {
         CValidationState state;
         // Disconnect the tip and by setting the third param (fRollBack) to true we avoid having to resurrect

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1073,6 +1073,8 @@ UniValue reconsiderblock(const UniValue &params, bool fHelp)
         throw JSONRPCError(RPC_DATABASE_ERROR, state.GetRejectReason());
     }
 
+    uiInterface.NotifyBlockTip(false, chainActive.Tip());
+
     return NullUniValue;
 }
 
@@ -1101,7 +1103,7 @@ UniValue rollbackchain(const UniValue &params, bool fHelp)
         if (!state.IsValid())
             throw JSONRPCError(RPC_DATABASE_ERROR, state.GetRejectReason());
     }
-    uiInterface.NotifyBlockTip(true, chainActive.Tip());
+    uiInterface.NotifyBlockTip(false, chainActive.Tip());
 
     return NullUniValue;
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1087,8 +1087,8 @@ UniValue rollbackchain(const UniValue &params, bool fHelp)
                             "1. blockheight   (int, required) the height that you want to roll the chain back to\n"
                             "\nResult:\n"
                             "\nExamples:\n" +
-                            HelpExampleCli("rollbackchain", "\"block height\"") +
-                            HelpExampleRpc("rollbackchain", "\"block height\""));
+                            HelpExampleCli("rollbackchain", "\"blockheight\"") +
+                            HelpExampleRpc("rollbackchain", "\"blockheight\""));
 
     std::string strHeight = params[0].get_str();
     uint64_t nRollBackHeight = boost::lexical_cast<uint64_t>(strHeight);
@@ -1097,7 +1097,7 @@ UniValue rollbackchain(const UniValue &params, bool fHelp)
     while (chainActive.Height() > nRollBackHeight)
     {
         CValidationState state;
-        if (!DisconnectTip(state,  Params().GetConsensus()))
+        if (!DisconnectTip(state, Params().GetConsensus()))
             throw JSONRPCError(RPC_DATABASE_ERROR, state.GetRejectReason());
 
         if (!state.IsValid())

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1080,11 +1080,15 @@ UniValue reconsiderblock(const UniValue &params, bool fHelp)
 
 UniValue rollbackchain(const UniValue &params, bool fHelp)
 {
+    // In case of operator error, limit the rollback to 100 blocks
+    uint32_t nLimit = 100;
+
     if (fHelp || params.size() != 1)
-        throw runtime_error("rollbackchain \"block height\"\n"
+        throw runtime_error("rollbackchain \"blockheight\"\n"
                             "\nRolls back the blockchain to the height indicated.\n"
                             "\nArguments:\n"
-                            "1. blockheight   (int, required) the height that you want to roll the chain back to\n"
+                            "1. blockheight   (int, required) the height that you want to roll the chain \
+                            back to (only maxiumum rollback of " + std::to_string(nLimit) + " blocks allowed)\n"
                             "\nResult:\n"
                             "\nExamples:\n" +
                             HelpExampleCli("rollbackchain", "\"blockheight\"") +
@@ -1094,6 +1098,12 @@ UniValue rollbackchain(const UniValue &params, bool fHelp)
     uint64_t nRollBackHeight = boost::lexical_cast<uint64_t>(strHeight);
 
     LOCK(cs_main);
+    uint32_t nRollBack = chainActive.Height() - nRollBackHeight;
+    if (nRollBack > nLimit)
+        throw runtime_error("You are attempting to rollback the chain by " + 
+                            std::to_string(nRollBack) + " blocks, however the limit is " + 
+                            std::to_string(nLimit) + " blocks.");
+
     while (chainActive.Height() > nRollBackHeight)
     {
         CValidationState state;

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -41,7 +41,7 @@ static const CRPCConvertParam vRPCConvertParams[] = {
     {"importprivkey", 2}, {"importaddress", 2}, {"importaddress", 3}, {"importpubkey", 2}, {"verifychain", 0},
     {"verifychain", 1}, {"keypoolrefill", 0}, {"getrawmempool", 0}, {"estimatefee", 0}, {"estimatepriority", 0},
     {"estimatesmartfee", 0}, {"estimatesmartpriority", 0}, {"prioritisetransaction", 1}, {"prioritisetransaction", 2},
-    {"setban", 2}, {"setban", 3},
+    {"setban", 2}, {"setban", 3}, {"rollbackchain", 1},
 };
 
 class CRPCConvertTable


### PR DESCRIPTION
This is a "hidden" feature in the same way as reconsiderblock or invalidateblock are also hidden features that do not show up in the "help" list of RPC calls.  Rolling back the chain can be useful in testing and also has real application for node operators that are trying to get back onto the correct chain either after a failed fork attempt;  the operator can roll the chain back before the fork point and then invalidate and reconsider the chains they wish to follow.  

This can also be useful in fork testing..when the tester can repeatedly roll the chain back to before the fork point and then try to join with the correct fork once again.

To use the feature simply to  "rollbackchain <chainheight to roll back to>" 