### PR TITLE
Continue to the next node after getting a socket error

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1289,6 +1289,7 @@ void ThreadSocketHandler()
                             if (!pnode->fDisconnect)
                                 LogPrint("net", "Node %s socket closed\n", pnode->addrName.c_str());
                             pnode->fDisconnect = true;
+                            continue;
                         }
                         else if (nBytes < 0)
                         {
@@ -1301,6 +1302,7 @@ void ThreadSocketHandler()
                                     LogPrint("net", "Node %s socket recv error '%s'\n", pnode->addrName.c_str(),
                                         NetworkErrorString(nErr));
                                 pnode->fDisconnect = true;
+                                continue;
                             }
                         }
                     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -675,8 +675,12 @@ int SocketSendData(CNode *pnode)
     // solves spin loop issues where the select does not block but no bytes can be transferred (traffic shaping limited,
     // for example).
     int progress = 0;
-    std::deque<CSerializeData>::iterator it = pnode->vSendMsg.begin();
 
+    // Make sure we haven't already been asked to disconnect
+    if (pnode->fDisconnect)
+        return progress;
+
+    std::deque<CSerializeData>::iterator it = pnode->vSendMsg.begin();
     while (it != pnode->vSendMsg.end())
     {
         const CSerializeData &data = *it;


### PR DESCRIPTION
Do not attempt to read any more bytes from a socket that had
and error and has been issued an fDisconnect.