### PR TITLE
Simplify UAHF activation code even further

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2753,7 +2753,6 @@ void static UpdateTip(CBlockIndex *pindexNew)
         Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), chainActive.Tip()),
         pcoinsTip->DynamicMemoryUsage() * (1.0 / (1 << 20)), pcoinsTip->GetCacheSize());
 
-    UpdateUAHFGlobals(pindexNew);
     cvBlockChange.notify_all();
 
     // Check the version of the last 100 blocks to see if we need to upgrade:

--- a/src/uahf_fork.cpp
+++ b/src/uahf_fork.cpp
@@ -21,20 +21,6 @@ static const std::string ANTI_REPLAY_MAGIC_VALUE = "Bitcoin: A Peer-to-Peer Elec
 std::vector<unsigned char> invalidOpReturn =
     std::vector<unsigned char>(std::begin(ANTI_REPLAY_MAGIC_VALUE), std::end(ANTI_REPLAY_MAGIC_VALUE));
 
-bool UpdateUAHFGlobals(CBlockIndex *activeTip)
-{
-    if (activeTip)
-    {
-        if (UAHFforkAtNextBlock(activeTip->nHeight))
-        {
-            excessiveBlockSize = miningForkEB.value;
-            maxGeneratedBlock = miningForkMG.value;
-            return true;
-        }
-    }
-    return false;
-}
-
 bool ValidateUAHFBlock(const CBlock &block, CValidationState &state, int nHeight)
 {
     // Validate transactions are HF compatible

--- a/src/uahf_fork.h
+++ b/src/uahf_fork.h
@@ -29,9 +29,6 @@ extern bool ValidateUAHFBlock(const CBlock &block, CValidationState &state, int 
 // Return true if this transaction is invalid on the UAHF fork due to a special OP_RETURN code
 extern bool IsTxOpReturnInvalid(const CTransaction &tx);
 
-// Update global variables based on whether the next block is the fork block
-extern bool UpdateUAHFGlobals(CBlockIndex *activeTip);
-
 // Return true if this transaction can only be committed post-fork
 extern bool IsTxUAHFOnly(const CTxMemPoolEntry &tx);
 

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -30,7 +30,7 @@ enum
     DEFAULT_EXCESSIVE_ACCEPT_DEPTH = 12, // Default is 12 to make it very expensive for a minority hash power to get
     // lucky, and potentially drive a block that the rest of the network sees as
     // "excessive" onto the blockchain.
-    DEFAULT_EXCESSIVE_BLOCK_SIZE = 16000000,
+    DEFAULT_EXCESSIVE_BLOCK_SIZE = 8000000, // per UAHF spec REQ-4-1, EB has to be at least 8MB at startup
     DEFAULT_MAX_MESSAGE_SIZE_MULTIPLIER = 16, // Allowed messages lengths will be this * the excessive block size
     DEFAULT_COINBASE_RESERVE_SIZE = 1000,
     MAX_COINBASE_SCRIPTSIG_SIZE = 100,


### PR DESCRIPTION
Since Aug 1st fork (UAHF) has been successfully activated, initialized
EB and MG as per UAHF specification (REQ-4-1, REQ-4-2 respectively) at
startup.

In the process remove UpdateUAHFGlobals cause it is not needed anymore.