### PR TITLE
Take out the parallel_2 logging when checking each input

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2419,7 +2419,6 @@ bool ConnectBlock(const CBlock &block,
 
                     if ((inOrphanCache) || (!inVerifiedCache && !inOrphanCache))
                     {
-                        LOG(PARALLEL, "parallel_2 checking inputs for tx: %d\n", i);
                         if (inOrphanCache)
                             nOrphansChecked++;
 


### PR DESCRIPTION
This creates a very large number of log entries which we don't
need anymore.