### PR TITLE
Automatically determine a more optimal -dbcache setting if none provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you're running an Ubuntu system:
 
 ```sh
 sudo apt-get install software-properties-common
-sudo add-apt-repository ppa:bitcoin-unlimited/bucash
+sudo add-apt-repository ppa:bitcoin-unlimited/bu-ppa
 sudo apt-get update
 sudo apt-get install bitcoind bitcoin-qt
 ```
@@ -52,7 +52,7 @@ sudo apt-get install software-properties-common
 
 ## this not needed if your wallet will use the new
 ## format, or if you're not going to use a wallet at all
-sudo add-apt-repository ppa:bitcoin-unlimited/bucash
+sudo add-apt-repository ppa:bitcoin-unlimited/bu-ppa
 sudo apt-get update
 sudo apt-get install libdb4.8-dev libdb4.8++-dev
 
@@ -68,3 +68,31 @@ sudo make install
 ```
 
 For more detailed explanations on how compile from source just look at doc/build-*.md files (e.g. [here](doc/quick-install.md))
+
+Quick Startup and Initial Node operation
+========================================
+
+### QT or the command line:
+
+There are two modes of operation, one uses the QT UI and the other runs as a daemon from the command line.  The QT version is bitcoin-qt or bitcoin-qt.exe, the command line version is bitcoind or bitcoind.exe. No matter which version you run, when you launch for the first time you will have to complete the intial blockchain sync.
+
+### Initial Sync of the blockchain:
+
+When you first run the node it must first sync the current blockchain.  All block headers are first retrieved and then each block is downloaded, checked and the UTXO finally updated.  This process can take from hours to `weeks` depending on the node configuration, and therefore, node configuration is crucial.
+
+The most important configuration which impacts the speed of the initial sync is the `dbcache` setting.  The larger the dbcache the faster the initial sync will be, therefore, it is vital to make this setting as high as possible.  If you are running on a Windows machine there is an automatically adjusting dbcache setting built in; it will size the dbcache in such a way as to leave only 10% of the physical memory free for other uses.  On Linux and other OS's the sizing is such that one half the physical RAM will be used as dbcache. While these settings, particularly on non Windows setups, are not ideal they will help to improve the initial sync dramatically.
+
+However, even with the automatic configuration of the dbcache setting it is recommended to set one manually if you haven't already done so (see the section below on Startup Configuration). This gives the node operator more control over memory use and in particular for non Windows setups, can further improve the performance of the initial sync.
+
+### Startup configuration:
+
+There are dozens of configuration and node policy options available but the two most important for the initial blockchain sync are as follows.
+
+##### dbcache: As stated above, this setting is crucial to a fast initial sync.  You can set this value from the command line by running
+`bitcoind -dbcache=<your size in MB>`, for example, a 1GB dbcache would be `bitcoind -dbcache=1000`.  Similarly you can also add the setting to the bitcoin.conf file located in your installation folder. In the config file a simlilar entry would be `dbcache=1000`.  When entering the size
+try to give it the maximum that your system can afford while still leaving enough memory for other processes.
+
+##### maxoutconnections: It is generally fine to leave the default outbound connection settings for doing a sync, however, at times some users
+have reported issues with not being able to find enough useful connections. If that happens you can change this setting to override the default.
+For instance `bitcoind -maxoutconnections=30` will give you 30 outbound connections and should be more than enough in the event that the
+node is having difficulty.

--- a/src/coins.h
+++ b/src/coins.h
@@ -270,6 +270,10 @@ public:
     bool Flush();
 
     /**
+     * Empty the coins cache. Used primarily when we're shutting down and want to release memory
+     */
+    void Clear() { cacheCoins.clear(); }
+    /**
      * Remove excess entries from this cache.
      * Entries are trimmed starting from the beginning of the map.  In this way if those entries
      * are needed later they will all be collocated near the the beginning of the leveldb database

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -346,6 +346,12 @@ public:
         leveldb::Slice slKey2(ssKey2.data(), ssKey2.size());
         pdb->CompactRange(&slKey1, &slKey2);
     }
+
+    size_t TotalWriteBufferSize() const
+    {
+        // There can be up to two write buffers so return the total
+        return options.write_buffer_size * 2;
+    }
 };
 
 #endif // BITCOIN_DBWRAPPER_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -193,6 +193,16 @@ void Shutdown()
     RenameThread("bitcoin-shutoff");
     mempool.AddTransactionsUpdated(1);
 
+    {
+        LOCK(cs_main);
+        if (pcoinsTip != nullptr)
+        {
+            // Flush state and clear cache completely to release as much memory as possible before continuing.
+            FlushStateToDisk();
+            pcoinsTip->Clear();
+        }
+    }
+
     StopHTTPRPC();
     StopREST();
     StopRPC();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -87,69 +87,6 @@ static CZMQNotificationInterface *pzmqNotificationInterface = NULL;
 #define MIN_CORE_FILEDESCRIPTORS 150
 #endif
 
-// For Windows we can use the current total available memory, however for other systems we can only use the
-// the physical RAM in our calculations.
-uint64_t nDefaultPhysMem = 1000000000; // if we can't get RAM size then default to an assumed 1GB system memory
-#ifdef WIN32
-#include <windows.h>
-static unsigned long long GetAvailableMemory()
-{
-    MEMORYSTATUSEX status;
-    status.dwLength = sizeof(status);
-    GlobalMemoryStatusEx(&status);
-    if (status.ullAvailPhys > 0)
-    {
-        return status.ullAvailPhys;
-    }
-    else
-    {
-        LOGA("Could not get size of avaialable memory - returning with default\n");
-        return nDefaultPhysMem / 2;
-    }
-}
-#elif __APPLE__
-#include <sys/sysctl.h>
-#include <sys/types.h>
-static unsigned long long GetTotalSystemMemory()
-{
-    int mib[] = {CTL_HW, HW_MEMSIZE};
-    int64_t nPhysMem = 0;
-    size_t nLength = sizeof(nPhysMem);
-
-    if (sysctl(mib, 2, &nPhysMem, &nLength, nullptr, 0))
-    {
-        return nPhysMem;
-    }
-    else
-    {
-        LOGA("Could not get size of physical memory - returning with default\n");
-        return nDefaultPhysMem;
-    }
-}
-#elif __unix__
-#include <unistd.h>
-static unsigned long long GetTotalSystemMemory()
-{
-    long nPages = sysconf(_SC_PHYS_PAGES);
-    long nPageSize = sysconf(_SC_PAGE_SIZE);
-    if (nPages > 0 && nPageSize > 0)
-    {
-        return nPages * nPageSize;
-    }
-    else
-    {
-        LOGA("Could not get size of physical memory - returning with default\n");
-        return nDefaultPhysMem;
-    }
-}
-#else
-static unsigned long long GetTotalSystemMemory()
-{
-    LOGA("Could not get size of physical memory - returning with default\n");
-    return nDefaultPhysMem; // if we can't get RAM size then default to an assumed 1GB system memory
-}
-#endif
-
 /** Used to pass flags to the Bind() function */
 enum BindFlags
 {
@@ -1017,42 +954,10 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
         }
     }
 
-#ifdef WIN32
-    // If using WINDOWS then determine the actual physical memory that is currently available. If the physical memory is
-    // small we use half the available memory. If it's large we use a much as possible but always leave 1GB available.
-    int64_t nMemAvailable = GetAvailableMemory();
-    nMemAvailable = std::max(nMemAvailable / 2, nMemAvailable - (1000 * 1000000));
-#else
-    /** Get total system memory but only use half of it.
-      *  Half of system memory is only used as a basis for the total cache size if and only if the operator has not
-      *  already set a value for -dbcache. This mitigates a common problem whereby new operators are unaware of the
-      *  importance of the dbcache setting and therefore do not size their dbcache appropriately resulting in a very
-     * slow
-      *  initial block sync.
-      */
-    int64_t nMemAvailable = GetTotalSystemMemory() / 2;
-#endif
-    // Convert from bytes to MiB.
-    nMemAvailable = nMemAvailable >> 20;
-
-    // nTotalCache size calculations returned in bytes (convert back from MiB to bytes)
-    int64_t nTotalCache = 0;
-    if (nDefaultDbCache < nMemAvailable)
-        nTotalCache = (GetArg("-dbcache", nMemAvailable) << 20);
-    else
-        nTotalCache = (GetArg("-dbcache", nDefaultDbCache) << 20);
-
-    // cache size calculations
-    nTotalCache = std::max(nTotalCache, nMinDbCache << 20); // total cache cannot be less than nMinDbCache
-    nTotalCache = std::min(nTotalCache, nMaxDbCache << 20); // total cache cannot be greater than nMaxDbcache
-    int64_t nBlockTreeDBCache = nTotalCache / 8;
-    if (nBlockTreeDBCache > (1 << 21) && !GetBoolArg("-txindex", DEFAULT_TXINDEX))
-        nBlockTreeDBCache = (1 << 21); // block tree db cache shouldn't be larger than 2 MiB
-    nTotalCache -= nBlockTreeDBCache;
-    // use 25%-50% of the remainder for disk cache
-    int64_t nCoinDBCache = std::min(nTotalCache / 2, (nTotalCache / 4) + (1 << 23));
-    nTotalCache -= nCoinDBCache;
-    nCoinCacheUsage = nTotalCache; // the rest goes to in-memory cache
+    // Return the initial values for the various in memory caches.
+    int64_t nBlockTreeDBCache = 0;
+    int64_t nCoinDBCache = 0;
+    GetCacheConfiguration(nBlockTreeDBCache, nCoinDBCache, nCoinCacheUsage);
     LOGA("Cache configuration:\n");
     LOGA("* Using %.1fMiB for block index database\n", nBlockTreeDBCache * (1.0 / 1024 / 1024));
     LOGA("* Using %.1fMiB for chain state database\n", nCoinDBCache * (1.0 / 1024 / 1024));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,7 +87,7 @@ bool fRequireStandard = true;
 unsigned int nBytesPerSigOp = DEFAULT_BYTES_PER_SIGOP;
 bool fCheckBlockIndex = false;
 bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
-size_t nCoinCacheUsage = 5000 * 300;
+int64_t nCoinCacheUsage = 0;
 uint64_t nPruneTarget = 0;
 uint32_t nXthinBloomFilterSize = SMALLEST_MAX_BLOOM_FILTER_SIZE;
 
@@ -2626,7 +2626,7 @@ bool FlushStateToDisk(CValidationState &state, FlushStateMode mode)
         {
             nLastSetChain = nNow;
         }
-        size_t cacheSize = pcoinsTip->DynamicMemoryUsage();
+        int64_t cacheSize = pcoinsTip->DynamicMemoryUsage();
         static int64_t nSizeAfterLastFlush = 0;
         // The cache is close to the limit. Try to flush and trim.
         bool fCacheCritical = ((mode == FLUSH_STATE_IF_NEEDED) && (cacheSize > nCoinCacheUsage * 0.995)) ||
@@ -2713,7 +2713,7 @@ bool FlushStateToDisk(CValidationState &state, FlushStateMode mode)
         // As a safeguard, periodically check and correct any drift in the value of cachedCoinsUsage.  While a
         // correction should never be needed, resetting the value allows the node to continue operating, and only
         // an error is reported if the new and old values do not match.
-        if (fPeriodicFlush)
+        if (fPeriodicFlush || nCoinCacheUsage < 0)
             pcoinsTip->ResetCachedCoinUsage();
     }
     catch (const std::runtime_error &e)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2700,7 +2700,7 @@ bool FlushStateToDisk(CValidationState &state, FlushStateMode mode)
             else
             {
                 // Trim, but never trim more than nMaxCacheIncreaseSinceLastFlush
-                size_t nTrimSize = nCoinCacheUsage * .90;
+                int64_t nTrimSize = nCoinCacheUsage * .90;
                 if (nCoinCacheUsage - nMaxCacheIncreaseSinceLastFlush > nTrimSize)
                     nTrimSize = nCoinCacheUsage - nMaxCacheIncreaseSinceLastFlush;
                 pcoinsTip->Trim(nTrimSize);
@@ -4629,7 +4629,7 @@ bool CVerifyDB::VerifyDB(const CChainParams &chainparams, CCoinsView *coinsview,
         }
         // check level 3: check for inconsistencies during memory-only disconnect of tip blocks
         if (nCheckLevel >= 3 && pindex == pindexState &&
-            (coins.DynamicMemoryUsage() + pcoinsTip->DynamicMemoryUsage()) <= nCoinCacheUsage)
+            (int64_t)(coins.DynamicMemoryUsage() + pcoinsTip->DynamicMemoryUsage()) <= nCoinCacheUsage)
         {
             bool fClean = true;
             DisconnectResult res = DisconnectBlock(block, pindex, coins);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@
 #include "expedited.h"
 #include "hash.h"
 #include "init.h"
+#include "memusage.h"
 #include "merkleblock.h"
 #include "net.h"
 #include "nodestate.h"
@@ -2626,6 +2627,7 @@ bool FlushStateToDisk(CValidationState &state, FlushStateMode mode)
         {
             nLastSetChain = nNow;
         }
+
         int64_t cacheSize = pcoinsTip->DynamicMemoryUsage();
         static int64_t nSizeAfterLastFlush = 0;
         // The cache is close to the limit. Try to flush and trim.

--- a/src/main.h
+++ b/src/main.h
@@ -184,7 +184,7 @@ extern bool fRequireStandard;
 extern unsigned int nBytesPerSigOp;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
-extern size_t nCoinCacheUsage;
+extern int64_t nCoinCacheUsage;
 /** A fee rate smaller than this is considered zero fee (for relaying, mining and transaction creation) */
 extern CFeeRate minRelayTxFee;
 /** Absolute maximum transaction fee (in satoshis) used by wallet and mempool (rejects high fee in sendrawtransaction)

--- a/src/main.h
+++ b/src/main.h
@@ -147,7 +147,6 @@ static const int64_t DEFAULT_MAX_TIP_AGE = 24 * 60 * 60;
 static const bool DEFAULT_PERMIT_BAREMULTISIG = true;
 static const unsigned int DEFAULT_BYTES_PER_SIGOP = 20;
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
-static const bool DEFAULT_TXINDEX = false;
 
 static const bool DEFAULT_TESTSAFEMODE = false;
 

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -38,49 +38,6 @@
         </widget>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2_Main">
-         <item>
-          <widget class="QLabel" name="databaseCacheLabel">
-           <property name="text">
-            <string>Size of &amp;database cache</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="buddy">
-            <cstring>databaseCache</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="databaseCache"/>
-         </item>
-         <item>
-          <widget class="QLabel" name="databaseCacheUnitLabel">
-           <property name="text">
-            <string>MB</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_2_Main">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_3_Main">
          <item>
           <widget class="QLabel" name="threadsScriptVerifLabel">

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -38,8 +38,6 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet)
 {
     ui->setupUi(this);
     /* Main elements init */
-    ui->databaseCache->setMinimum(nMinDbCache);
-    ui->databaseCache->setMaximum(nMaxDbCache);
     ui->threadsScriptVerif->setMinimum(-GetNumCores());
     ui->threadsScriptVerif->setMaximum(MAX_SCRIPTCHECK_THREADS);
 
@@ -164,7 +162,6 @@ void OptionsDialog::setModel(OptionsModel *model)
      * them) */
 
     /* Main */
-    connect(ui->databaseCache, SIGNAL(valueChanged(int)), this, SLOT(showRestartWarning()));
     connect(ui->threadsScriptVerif, SIGNAL(valueChanged(int)), this, SLOT(showRestartWarning()));
     /* Wallet */
     connect(ui->spendZeroConfChange, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
@@ -182,7 +179,6 @@ void OptionsDialog::setMapper()
     /* Main */
     mapper->addMapping(ui->bitcoinAtStartup, OptionsModel::StartAtStartup);
     mapper->addMapping(ui->threadsScriptVerif, OptionsModel::ThreadsScriptVerif);
-    mapper->addMapping(ui->databaseCache, OptionsModel::DatabaseCache);
 
     /* Wallet */
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -79,11 +79,6 @@ void OptionsModel::Init(bool resetSettings)
     // by command-line and show this in the UI.
 
     // Main
-    if (!settings.contains("nDatabaseCache"))
-        settings.setValue("nDatabaseCache", (qint64)nDefaultDbCache);
-    if (!SoftSetArg("-dbcache", settings.value("nDatabaseCache").toString().toStdString()))
-        addOverriddenOption("-dbcache");
-
     if (!settings.contains("nThreadsScriptVerif"))
         settings.setValue("nThreadsScriptVerif", DEFAULT_SCRIPTCHECK_THREADS);
     if (!SoftSetArg("-par", settings.value("nThreadsScriptVerif").toString().toStdString()))

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -428,3 +428,105 @@ bool CCoinsViewDB::Upgrade()
 
     return true;
 }
+
+// For Windows we can use the current total available memory, however for other systems we can only use the
+// the physical RAM in our calculations.
+static uint64_t nDefaultPhysMem = 1000000000; // if we can't get RAM size then default to an assumed 1GB system memory
+#ifdef WIN32
+#include <windows.h>
+unsigned long long GetAvailableMemory()
+{
+    MEMORYSTATUSEX status;
+    status.dwLength = sizeof(status);
+    GlobalMemoryStatusEx(&status);
+    if (status.ullAvailPhys > 0)
+    {
+        return status.ullAvailPhys;
+    }
+    else
+    {
+        LOGA("Could not get size of avaialable memory - returning with default\n");
+        return nDefaultPhysMem / 2;
+    }
+}
+#elif __APPLE__
+#include <sys/sysctl.h>
+#include <sys/types.h>
+unsigned long long GetTotalSystemMemory()
+{
+    int mib[] = {CTL_HW, HW_MEMSIZE};
+    int64_t nPhysMem = 0;
+    size_t nLength = sizeof(nPhysMem);
+
+    if (sysctl(mib, 2, &nPhysMem, &nLength, nullptr, 0))
+    {
+        return nPhysMem;
+    }
+    else
+    {
+        LOGA("Could not get size of physical memory - returning with default\n");
+        return nDefaultPhysMem;
+    }
+}
+#elif __unix__
+#include <unistd.h>
+unsigned long long GetTotalSystemMemory()
+{
+    long nPages = sysconf(_SC_PHYS_PAGES);
+    long nPageSize = sysconf(_SC_PAGE_SIZE);
+    if (nPages > 0 && nPageSize > 0)
+    {
+        return nPages * nPageSize;
+    }
+    else
+    {
+        LOGA("Could not get size of physical memory - returning with default\n");
+        return nDefaultPhysMem;
+    }
+}
+#else
+unsigned long long GetTotalSystemMemory()
+{
+    LOGA("Could not get size of physical memory - returning with default\n");
+    return nDefaultPhysMem; // if we can't get RAM size then default to an assumed 1GB system memory
+}
+#endif
+
+void GetCacheConfiguration(int64_t &nBlockTreeDBCache, int64_t &nCoinDBCache, int64_t &nCoinCacheUsage)
+{
+#ifdef WIN32
+    // If using WINDOWS then determine the actual physical memory that is currently available. If the physical memory is
+    // small we use half the available memory. If it's large we use a much as possible but always leave 1GB available.
+    int64_t nMemAvailable = GetAvailableMemory();
+    nMemAvailable = std::max(nMemAvailable / 2, nMemAvailable - (1000 * 1000000));
+#else
+    // Get total system memory but only use half.
+    // - This half of system memory is only used as a basis for the total cache size
+    // - if and only if the operator has not already set a value for -dbcache. This mitigates a common problem
+    // - where new operators are unaware of the importance of the dbcache setting and therefore do not size their
+    // - dbcache correctly resulting in a very slow initial block sync.
+    int64_t nMemAvailable = GetTotalSystemMemory() / 2;
+#endif
+
+    // Convert from bytes to MiB.
+    nMemAvailable = nMemAvailable >> 20;
+
+    // nTotalCache size calculations returned in bytes (convert back from MiB to bytes)
+    int64_t nTotalCache = 0;
+    if (nDefaultDbCache < nMemAvailable)
+        nTotalCache = (GetArg("-dbcache", nMemAvailable) << 20);
+    else
+        nTotalCache = (GetArg("-dbcache", nDefaultDbCache) << 20);
+
+    // cache size calculations
+    nTotalCache = std::max(nTotalCache, nMinDbCache << 20); // total cache cannot be less than nMinDbCache
+    nTotalCache = std::min(nTotalCache, nMaxDbCache << 20); // total cache cannot be greater than nMaxDbcache
+    nBlockTreeDBCache = nTotalCache / 8;
+    if (nBlockTreeDBCache > (1 << 21) && !GetBoolArg("-txindex", DEFAULT_TXINDEX))
+        nBlockTreeDBCache = (1 << 21); // block tree db cache shouldn't be larger than 2 MiB
+    nTotalCache -= nBlockTreeDBCache;
+    // use 25%-50% of the remainder for disk cache
+    nCoinDBCache = std::min(nTotalCache / 2, (nTotalCache / 4) + (1 << 23));
+    nTotalCache -= nCoinDBCache;
+    nCoinCacheUsage = nTotalCache; // the rest goes to in-memory cache
+}

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -577,6 +577,18 @@ void CacheSizeCalculations(int64_t _nTotalCache,
 
 void AdjustCoinCacheSize()
 {
+    // If the operator has not set a dbcache and initial sync is complete then revert back to the default
+    // value for dbcache. This will cause the current coins cache to be immediately trimmed to size.
+    if (IsChainNearlySyncd() && !GetArg("-dbcache", 0))
+    {
+        // Get the default value for nCoinCacheUsage.
+        int64_t dummyBIDiskCache, dummyUtxoDiskCache, nMaxCoinCache = 0;
+        CacheSizeCalculations(nDefaultDbCache, dummyBIDiskCache, dummyUtxoDiskCache, nMaxCoinCache);
+        nCoinCacheUsage = nMaxCoinCache;
+
+        return;
+    }
+
 #ifdef WIN32
     static int64_t nLastDbAdjustment = 0;
     int64_t nNow = GetTimeMicros();

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -575,3 +575,63 @@ void CacheSizeCalculations(int64_t _nTotalCache,
     _nTotalCache -= _nCoinDBCache;
     _nCoinCacheUsage = _nTotalCache;
 }
+
+void AdjustCoinCacheSize()
+{
+#ifdef WIN32
+    static int64_t nLastDbAdjustment = 0;
+    int64_t nNow = GetTimeMicros();
+
+    if (nLastDbAdjustment == 0)
+    {
+        nLastDbAdjustment = nNow;
+    }
+
+    // used to determine if we had previously reduced the nCoinCacheUsage and also to tell us what the last
+    // mem available was when we modified the nCoinCacheUsage.
+    static int64_t nLastMemAvailable = 0;
+
+    // If there is no dbcache setting specified by the node operator then float the dbache setting down or up
+    // based on current available memory.
+    if (!GetArg("-dbcache", 0) && (nNow - nLastDbAdjustment) > 60000000)
+    {
+        int64_t nMemAvailable = GetAvailableMemory();
+        int64_t nUnusedMem = GetTotalSystemMemory() * nDefaultPcntMemUnused / 100;
+
+        // Reduce nCoinCacheUsage if mem available drop below 10%. We don't want to constantly be
+        // triggering a trim or flush every whenever the nMemAvailable crosses the threshold by just a
+        // few bytes, so we'll dampen the triggering of flushing/trimming only if the threshold is crossed by 5%.
+        if (nMemAvailable * 1.05 < nUnusedMem)
+        {
+            // Get the lowest possible default coins cache configuration possible and use this value as a limiter
+            // to prevent the nCoinCacheUsage from falling below this value.
+            int64_t dummyBIDiskCache, dummyUtxoDiskCache, nDefaultCoinCache = 0;
+            GetCacheConfiguration(dummyBIDiskCache, dummyUtxoDiskCache, nDefaultCoinCache, true);
+
+            nCoinCacheUsage = std::max(nDefaultCoinCache, nCoinCacheUsage - (nUnusedMem - nMemAvailable));
+            LOGA("Current cache size: %ld MB, nCoinCacheUsage was reduced by %u MB\n", nCoinCacheUsage / 1000000,
+                (nUnusedMem - nMemAvailable) / 1000000);
+            nLastDbAdjustment = nNow;
+            nLastMemAvailable = nMemAvailable;
+        }
+
+        // Increase nCoinCacheUsage if mem available increases above 10%. We don't want to constantly be
+        // triggering an increase whenever the nMemAvailable crosses the threshold by just a
+        // few bytes, so we'll dampen the increases by triggering only when the threshold is crossed by 5%.
+        else if (nLastMemAvailable && nMemAvailable * 0.95 >= nLastMemAvailable)
+        {
+            // find the max coins cache possible for this configuration.  Use the max int possible for total cache
+            // size to ensure you receive the max cache size possible.
+            int64_t dummyBIDiskCache, dummyUtxoDiskCache, nMaxCoinCache = 0;
+            CacheSizeCalculations(
+                std::numeric_limits<long long>::max(), dummyBIDiskCache, dummyUtxoDiskCache, nMaxCoinCache);
+
+            nCoinCacheUsage = std::min(nMaxCoinCache, nCoinCacheUsage + (nMemAvailable - nLastMemAvailable));
+            LOGA("Current cache size: %ld MB, nCoinCacheUsage was increased by %u MB\n", nCoinCacheUsage / 1000000,
+                (nMemAvailable - nLastMemAvailable) / 1000000);
+            nLastDbAdjustment = nNow;
+            nLastMemAvailable = nMemAvailable;
+        }
+    }
+#endif
+}

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -609,7 +609,7 @@ void AdjustCoinCacheSize()
         // The amount of system memory currently available
         int64_t nMemAvailable = GetAvailableMemory();
         // The amount of memory we need to *keep* available.
-        int64_t nUnusedMem = GetTotalSystemMemory() * nDefaultPcntMemUnused / 100;
+        int64_t nUnusedMem = std::max(GetTotalSystemMemory() * nDefaultPcntMemUnused / 100, nMinMemToKeepAvaialable);
 
         // Make sure we leave enough room for the leveldb write cache's
         if (pcoinsdbview != nullptr && nUnusedMem < pcoinsdbview->TotalWriteBufferSize())

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -434,7 +434,7 @@ bool CCoinsViewDB::Upgrade()
 static uint64_t nDefaultPhysMem = 1000000000; // if we can't get RAM size then default to an assumed 1GB system memory
 #ifdef WIN32
 #include <windows.h>
-unsigned long long GetAvailableMemory()
+uint64_t GetAvailableMemory()
 {
     MEMORYSTATUSEX status;
     status.dwLength = sizeof(status);
@@ -445,11 +445,11 @@ unsigned long long GetAvailableMemory()
     }
     else
     {
-        LOGA("Could not get size of available memory - returning with default\n");
+        LOG(COINDB, "Could not get size of available memory - returning with default\n");
         return nDefaultPhysMem / 2;
     }
 }
-unsigned long long GetTotalSystemMemory()
+uint64_t GetTotalSystemMemory()
 {
     MEMORYSTATUSEX status;
     status.dwLength = sizeof(status);
@@ -460,14 +460,14 @@ unsigned long long GetTotalSystemMemory()
     }
     else
     {
-        LOGA("Could not get size of physical memory - returning with default\n");
+        LOG(COINDB, "Could not get size of physical memory - returning with default\n");
         return nDefaultPhysMem;
     }
 }
 #elif __APPLE__
 #include <sys/sysctl.h>
 #include <sys/types.h>
-unsigned long long GetTotalSystemMemory()
+uint64_t GetTotalSystemMemory()
 {
     int mib[] = {CTL_HW, HW_MEMSIZE};
     int64_t nPhysMem = 0;
@@ -479,13 +479,13 @@ unsigned long long GetTotalSystemMemory()
     }
     else
     {
-        LOGA("Could not get size of physical memory - returning with default\n");
+        LOG(COINDB, "Could not get size of physical memory - returning with default\n");
         return nDefaultPhysMem;
     }
 }
 #elif __unix__
 #include <unistd.h>
-unsigned long long GetTotalSystemMemory()
+uint64_t GetTotalSystemMemory()
 {
     long nPages = sysconf(_SC_PHYS_PAGES);
     long nPageSize = sysconf(_SC_PAGE_SIZE);
@@ -495,14 +495,14 @@ unsigned long long GetTotalSystemMemory()
     }
     else
     {
-        LOGA("Could not get size of physical memory - returning with default\n");
+        LOG(COINDB, "Could not get size of physical memory - returning with default\n");
         return nDefaultPhysMem;
     }
 }
 #else
-unsigned long long GetTotalSystemMemory()
+uint64_t GetTotalSystemMemory()
 {
-    LOGA("Could not get size of physical memory - returning with default\n");
+    LOG(COINDB, "Could not get size of physical memory - returning with default\n");
     return nDefaultPhysMem; // if we can't get RAM size then default to an assumed 1GB system memory
 }
 #endif
@@ -609,7 +609,7 @@ void AdjustCoinCacheSize()
             GetCacheConfiguration(dummyBIDiskCache, dummyUtxoDiskCache, nDefaultCoinCache, true);
 
             nCoinCacheUsage = std::max(nDefaultCoinCache, nCoinCacheUsage - (nUnusedMem - nMemAvailable));
-            LOGA("Current cache size: %ld MB, nCoinCacheUsage was reduced by %u MB\n", nCoinCacheUsage / 1000000,
+            LOG(COINDB, "Current cache size: %ld MB, nCoinCacheUsage was reduced by %u MB\n", nCoinCacheUsage / 1000000,
                 (nUnusedMem - nMemAvailable) / 1000000);
             nLastDbAdjustment = nNow;
             nLastMemAvailable = nMemAvailable;
@@ -627,8 +627,8 @@ void AdjustCoinCacheSize()
                 std::numeric_limits<long long>::max(), dummyBIDiskCache, dummyUtxoDiskCache, nMaxCoinCache);
 
             nCoinCacheUsage = std::min(nMaxCoinCache, nCoinCacheUsage + (nMemAvailable - nLastMemAvailable));
-            LOGA("Current cache size: %ld MB, nCoinCacheUsage was increased by %u MB\n", nCoinCacheUsage / 1000000,
-                (nMemAvailable - nLastMemAvailable) / 1000000);
+            LOG(COINDB, "Current cache size: %ld MB, nCoinCacheUsage was increased by %u MB\n",
+                nCoinCacheUsage / 1000000, (nMemAvailable - nLastMemAvailable) / 1000000);
             nLastDbAdjustment = nNow;
             nLastMemAvailable = nMemAvailable;
         }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -473,7 +473,7 @@ uint64_t GetTotalSystemMemory()
     int64_t nPhysMem = 0;
     size_t nLength = sizeof(nPhysMem);
 
-    if (sysctl(mib, 2, &nPhysMem, &nLength, nullptr, 0))
+    if (sysctl(mib, 2, &nPhysMem, &nLength, nullptr, 0) == 0)
     {
         return nPhysMem;
     }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -79,8 +79,8 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
     CDBBatch batch(db);
     size_t count = 0;
     size_t changed = 0;
-    size_t nBatchSize = 0;
     size_t nBatchWrites = 0;
+    size_t batch_size = nMaxDBBatchSize;
 
     for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();)
     {
@@ -121,12 +121,10 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
             // In order to prevent the spikes in memory usage that used to happen when we prepared large as
             // was possible, we instead break up the batches such that the performance gains for writing to
             // leveldb are still realized but the memory spikes are not seen.
-            nBatchSize += nUsage;
-            if (nBatchSize > nCoinCacheUsage * 0.01)
+            if (batch.SizeEstimate() > batch_size)
             {
                 db.WriteBatch(batch);
                 batch.Clear();
-                nBatchSize = 0;
                 nBatchWrites++;
             }
         }

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -445,8 +445,23 @@ unsigned long long GetAvailableMemory()
     }
     else
     {
-        LOGA("Could not get size of avaialable memory - returning with default\n");
+        LOGA("Could not get size of available memory - returning with default\n");
         return nDefaultPhysMem / 2;
+    }
+}
+unsigned long long GetTotalSystemMemory()
+{
+    MEMORYSTATUSEX status;
+    status.dwLength = sizeof(status);
+    GlobalMemoryStatusEx(&status);
+    if (status.ullTotalPhys > 0)
+    {
+        return status.ullTotalPhys;
+    }
+    else
+    {
+        LOGA("Could not get size of physical memory - returning with default\n");
+        return nDefaultPhysMem;
     }
 }
 #elif __APPLE__
@@ -495,10 +510,10 @@ unsigned long long GetTotalSystemMemory()
 void GetCacheConfiguration(int64_t &nBlockTreeDBCache, int64_t &nCoinDBCache, int64_t &nCoinCacheUsage)
 {
 #ifdef WIN32
-    // If using WINDOWS then determine the actual physical memory that is currently available. If the physical memory is
-    // small we use half the available memory. If it's large we use a much as possible but always leave 1GB available.
+    // If using WINDOWS then determine the actual physical memory that is currently available for dbcaching.
+    // Alway leave 10% of the available RAM unused.
     int64_t nMemAvailable = GetAvailableMemory();
-    nMemAvailable = std::max(nMemAvailable / 2, nMemAvailable - (1000 * 1000000));
+    nMemAvailable = nMemAvailable -  (nMemAvailable * nDefaultPcntMemUnused / 100);
 #else
     // Get total system memory but only use half.
     // - This half of system memory is only used as a basis for the total cache size

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -28,6 +28,8 @@ static const int64_t nDefaultDbCache = 500;
 static const int64_t nMaxDbCache = sizeof(void *) > 4 ? 16384 : 2048;
 //! min. -dbcache in (MiB)
 static const int64_t nMinDbCache = 4;
+//! % of available memory to leave unused by dbcache if/when we dynamically size the dbcache.
+static const int64_t nDefaultPcntMemUnused = 10;
 //! max increase in cache size since the last time we did a full flush
 static const int64_t nMaxCacheIncreaseSinceLastFlush = 512 * 1000 * 1000;
 //! Max memory allocated to block tree DB specific cache, if no -txindex (MiB)

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -32,6 +32,8 @@ static const int64_t nMinDbCache = 4;
 static const int64_t nDefaultPcntMemUnused = 10;
 //! max increase in cache size since the last time we did a full flush
 static const int64_t nMaxCacheIncreaseSinceLastFlush = 512 * 1000 * 1000;
+//! the minimum system memory we always keep free when doing automatic dbcache sizing
+static const uint64_t nMinMemToKeepAvaialable = 300 * 1000 * 1000;
 //! the max size a batch can get before a write to the utxo is made
 static const size_t nMaxDBBatchSize = 16 << 20;
 //! Max memory allocated to block tree DB specific cache, if no -txindex (MiB)

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -16,10 +16,11 @@
 #include <utility>
 #include <vector>
 
-
 class CBlockFileInfo;
 class CBlockIndex;
 class uint256;
+
+static const bool DEFAULT_TXINDEX = false;
 
 //! -dbcache default (MiB)
 static const int64_t nDefaultDbCache = 500;
@@ -37,6 +38,10 @@ static const int64_t nMaxBlockDBCache = 2;
 static const int64_t nMaxBlockDBAndTxIndexCache = 1024;
 //! Max memory allocated to coin DB specific cache (MiB)
 static const int64_t nMaxCoinsDBCache = 8;
+
+unsigned long long GetAvailableMemory();
+unsigned long long GetTotalSystemMemory();
+void GetCacheConfiguration(int64_t &nBlockTreeDBCache, int64_t &nCoinDBCache, int64_t &nCoinCacheUsage);
 
 struct CDiskTxPos : public CDiskBlockPos
 {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -32,6 +32,8 @@ static const int64_t nMinDbCache = 4;
 static const int64_t nDefaultPcntMemUnused = 10;
 //! max increase in cache size since the last time we did a full flush
 static const int64_t nMaxCacheIncreaseSinceLastFlush = 512 * 1000 * 1000;
+//! the max size a batch can get before a write to the utxo is made
+static const size_t nMaxDBBatchSize = 16 << 20;
 //! Max memory allocated to block tree DB specific cache, if no -txindex (MiB)
 static const int64_t nMaxBlockDBCache = 2;
 //! Max memory allocated to block tree DB specific cache, if -txindex (MiB)

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -43,7 +43,10 @@ static const int64_t nMaxCoinsDBCache = 8;
 
 unsigned long long GetAvailableMemory();
 unsigned long long GetTotalSystemMemory();
-void GetCacheConfiguration(int64_t &nBlockTreeDBCache, int64_t &nCoinDBCache, int64_t &nCoinCacheUsage);
+void GetCacheConfiguration(int64_t &nBlockTreeDBCache,
+    int64_t &nCoinDBCache,
+    int64_t &nCoinCacheUsage,
+    bool fDefault = false);
 
 struct CDiskTxPos : public CDiskBlockPos
 {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -41,8 +41,8 @@ static const int64_t nMaxBlockDBAndTxIndexCache = 1024;
 //! Max memory allocated to coin DB specific cache (MiB)
 static const int64_t nMaxCoinsDBCache = 8;
 
-unsigned long long GetAvailableMemory();
-unsigned long long GetTotalSystemMemory();
+uint64_t GetAvailableMemory();
+uint64_t GetTotalSystemMemory();
 void GetCacheConfiguration(int64_t &_nBlockTreeDBCache,
     int64_t &_nCoinDBCache,
     int64_t &_nCoinCacheUsage,

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -41,16 +41,27 @@ static const int64_t nMaxBlockDBAndTxIndexCache = 1024;
 //! Max memory allocated to coin DB specific cache (MiB)
 static const int64_t nMaxCoinsDBCache = 8;
 
+/** Get the current available memory */
 uint64_t GetAvailableMemory();
+/** Get the total physical memory */
 uint64_t GetTotalSystemMemory();
+/** Get the sizes for each of the caches. This is done during init.cpp on startup but also
+ *  later, during dynamic sizing of the coins cache, when need to know the initial startup values.
+ */
 void GetCacheConfiguration(int64_t &_nBlockTreeDBCache,
     int64_t &_nCoinDBCache,
     int64_t &_nCoinCacheUsage,
     bool fDefault = false);
+/** Calculate the various cache sizes. This is primarily used in GetCacheConfiguration() however during
+ *  dynamic sizing of the coins cache we also need to use this function directly.
+ */
 void CacheSizeCalculations(int64_t _nTotalCache,
     int64_t &_nBlockTreeDBCache,
     int64_t &_nCoinDBCache,
     int64_t &_nCoinCacheUsage);
+/** This function is called during FlushStateToDisk.  The coins cache is dynamically sized before any
+ *  checking is done for cache flushing and trimming
+ */
 void AdjustCoinCacheSize();
 
 struct CDiskTxPos : public CDiskBlockPos

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -115,6 +115,9 @@ public:
     //! Attempt to update from an older database format. Returns whether an error occurred.
     bool Upgrade();
     size_t EstimateSize() const override;
+
+    //! Return the current memory allocated for the write buffers
+    size_t TotalWriteBufferSize() const;
 };
 
 /** Specialization of CCoinsViewCursor to iterate over a CCoinsViewDB */

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -51,6 +51,7 @@ void CacheSizeCalculations(int64_t _nTotalCache,
     int64_t &_nBlockTreeDBCache,
     int64_t &_nCoinDBCache,
     int64_t &_nCoinCacheUsage);
+void AdjustCoinCacheSize();
 
 struct CDiskTxPos : public CDiskBlockPos
 {

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -43,10 +43,14 @@ static const int64_t nMaxCoinsDBCache = 8;
 
 unsigned long long GetAvailableMemory();
 unsigned long long GetTotalSystemMemory();
-void GetCacheConfiguration(int64_t &nBlockTreeDBCache,
-    int64_t &nCoinDBCache,
-    int64_t &nCoinCacheUsage,
+void GetCacheConfiguration(int64_t &_nBlockTreeDBCache,
+    int64_t &_nCoinDBCache,
+    int64_t &_nCoinCacheUsage,
     bool fDefault = false);
+void CacheSizeCalculations(int64_t _nTotalCache,
+    int64_t &_nBlockTreeDBCache,
+    int64_t &_nCoinDBCache,
+    int64_t &_nCoinCacheUsage);
 
 struct CDiskTxPos : public CDiskBlockPos
 {


### PR DESCRIPTION
In the past we always defaulted to a 500MB value for -dbcache if the node operator didn't provide one however this value would still cause a node to take up to 3 weeks or more to sync and is thus inadequate. The problem remains in that node operators, both new and experienced, still forget to set the dbcache to it's highest possible before doing an initial sync, wasting valuable time and also developer time in fielding numerous complaints of slow sync.  This PR attempts to remedy that by setting the -dbache to one half the physical memory size "IF" the node operator has not already defined a value in the bitcoin.conf or on startup through the command line.

@gandrewstone can you test on  OSX and verfy it's actually picking up the correct values for physical RAM...thanks.  UNIX and Windows are verified to be working.