### PR TITLE
Use Logging namespace to access LogAcceptCategory

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -410,7 +410,7 @@ bool InitHTTPServer()
 #if LIBEVENT_VERSION_NUMBER >= 0x02010100
     // If -debug=libevent, set full libevent debugging.
     // Otherwise, disable all libevent debugging.
-    if (LogAcceptCategory(LIBEVENT))
+    if (LogAcceptCategory(Logging::LIBEVENT))
         event_enable_debug_logging(EVENT_DBG_ALL);
     else
         event_enable_debug_logging(EVENT_DBG_NONE);


### PR DESCRIPTION
LogAcceptCategory and the enum used to define available logging
category is defined inside the Logging namespace. If used directly
outside of util.{h,cpp} reference to such namespace is needed.

This commit fix issue #950