### PR TITLE
Fix warnings on ReadOrderPos and WriteOrderPos

### DIFF
--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -131,7 +131,7 @@ struct CRecipient
 typedef std::map<std::string, std::string> mapValue_t;
 
 
-static void ReadOrderPos(int64_t &nOrderPos, mapValue_t &mapValue)
+inline void ReadOrderPos(int64_t &nOrderPos, mapValue_t &mapValue)
 {
     if (!mapValue.count("n"))
     {
@@ -142,7 +142,7 @@ static void ReadOrderPos(int64_t &nOrderPos, mapValue_t &mapValue)
 }
 
 
-static void WriteOrderPos(const int64_t &nOrderPos, mapValue_t &mapValue)
+inline void WriteOrderPos(const int64_t &nOrderPos, mapValue_t &mapValue)
 {
     if (nOrderPos == -1)
         return;


### PR DESCRIPTION
Remove static from ReadOrderPos and WriteOrderPos declaration
cause there's no other place in the code same functions defined
with the same signature.

Add inline to lower the overhead of executing this functions and
to make possible to define those in the header without the linker
complaining when you include wallet.h header in other compilation
units.

Those are the kind of warnings produced on an amd64 Ubuntu machine
running gcc 7.2.0:

```
In file included from init.cpp:49:0:
wallet/wallet.h:145:13: warning: ‘void WriteOrderPos(const int64_t&, mapValue_t&)’ defined but not used [-Wunused-function]
 static void WriteOrderPos(const int64_t &nOrderPos, mapValue_t &mapValue)
             ^~~~~~~~~~~~~
wallet/wallet.h:134:13: warning: ‘void ReadOrderPos(int64_t&, mapValue_t&)’ defined but not used [-Wunused-function]
 static void ReadOrderPos(int64_t &nOrderPos, mapValue_t &mapValue)
             ^~~~~~~~~~~~
```