### PR TITLE
Create method GetBlockSize() and use it

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3791,11 +3791,6 @@ bool CheckBlock(const CBlock &block, CValidationState &state, bool fCheckPOW, bo
     // because we receive the wrong transactions for it.
 
     // Size limits
-    if (block.nBlockSize == 0)
-        block.nBlockSize = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
-
-    // || block.vtx.size() > MAX_BLOCK_SIZE || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION) >
-    // MAX_BLOCK_SIZE)
     if (block.vtx.empty())
         return state.DoS(100, error("CheckBlock(): size limits failed"), REJECT_INVALID, "bad-blk-length");
 
@@ -3834,7 +3829,7 @@ bool CheckBlock(const CBlock &block, CValidationState &state, bool fCheckPOW, bo
         block.fChecked = true;
 
     // BU: Check whether this block exceeds what we want to relay.
-    block.fExcessive = CheckExcessive(block, block.nBlockSize, nSigOps, nTx, nLargestTx);
+    block.fExcessive = CheckExcessive(block, block.GetBlockSize(), nSigOps, nTx, nLargestTx);
 
     return true;
 }
@@ -4141,9 +4136,8 @@ bool ProcessNewBlock(CValidationState &state,
     bool checked = CheckBlock(*pblock, state);
     if (!checked)
     {
-        int byteLen = ::GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION);
         LOGA("Invalid block: ver:%x time:%d Tx size:%d len:%d\n", pblock->nVersion, pblock->nTime, pblock->vtx.size(),
-            byteLen);
+            pblock->GetBlockSize());
     }
 
     // WARNING: cs_main is not locked here throughout but is released and then re-locked during ActivateBestChain

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -438,7 +438,7 @@ void CParallelValidation::HandleBlockMessage(CNode *pfrom,
     const CBlock &block,
     const CInv &inv)
 {
-    uint64_t nBlockSize = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+    uint64_t nBlockSize = block.GetBlockSize();
 
     // NOTE: You must not have a cs_main lock before you aquire the semaphore grant or you can end up deadlocking
     // AssertLockNotHeld(cs_main); TODO: need to create this
@@ -536,7 +536,7 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, const CBloc
 {
     int64_t startTime = GetTimeMicros();
     CValidationState state;
-    uint64_t nSizeBlock = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+    uint64_t nSizeBlock = block.GetBlockSize();
 
     // Indicate that the thinblock was fully received. At this point we have either a block or a fully reconstructed
     // thinblock but we still need to maintain a mapThinBlocksInFlight entry so that we don't re-request a full block

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -25,3 +25,11 @@ std::string CBlock::ToString() const
     }
     return s.str();
 }
+
+uint64_t CBlock::GetBlockSize() const
+{
+    if (nBlockSize == 0)
+        nBlockSize = ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
+    return nBlockSize;
+}
+

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -32,4 +32,3 @@ uint64_t CBlock::GetBlockSize() const
         nBlockSize = ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
     return nBlockSize;
 }
-

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -78,7 +78,7 @@ public:
     // 0.11: mutable std::vector<uint256> vMerkleTree;
     mutable bool fChecked;
     mutable bool fExcessive; // BU: is the block "excessive" (bigger than this node prefers to accept)
-    mutable uint64_t nBlockSize; // BU: length of this block in bytes
+    mutable uint64_t nBlockSize; // Serialized block size in bytes
 
     CBlock() { SetNull(); }
     CBlock(const CBlockHeader &header)
@@ -175,6 +175,10 @@ public:
     }
 
     std::string ToString() const;
+
+    // Return the serialized block size in bytes. This is only done once and then the result stored
+    // in nBlockSize for future reference, saving unncessary and expensive serializations.
+    uint64_t GetBlockSize() const;
 };
 
 

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -185,7 +185,7 @@ bool CThinBlock::process(CNode *pfrom, int nSizeThinBlock)
     {
         // We have all the transactions now that are in this block: try to reassemble and process.
         pfrom->thinBlockWaitingForTxns = -1;
-        int blockSize = ::GetSerializeSize(pfrom->thinBlock, SER_NETWORK, CBlock::CURRENT_VERSION);
+        int blockSize = pfrom->thinBlock.GetBlockSize();
         LOG(THIN, "Reassembled thinblock for %s (%d bytes). Message was %d bytes, compression ratio %3.2f peer=%s\n",
             pfrom->thinBlock.GetHash().ToString(), blockSize, nSizeThinBlock,
             ((float)blockSize) / ((float)nSizeThinBlock), pfrom->GetLogName());
@@ -409,7 +409,7 @@ bool CXThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
 
         // for compression statistics, we have to add up the size of xthinblock and the re-requested thinBlockTx.
         int nSizeThinBlockTx = msgSize;
-        int blockSize = ::GetSerializeSize(pfrom->thinBlock, SER_NETWORK, CBlock::CURRENT_VERSION);
+        int blockSize = pfrom->thinBlock.GetBlockSize();
         LOG(THIN, "Reassembled xblocktx for %s (%d bytes). Message was %d bytes (thinblock) and %d bytes "
                   "(re-requested tx), compression ratio %3.2f, peer=%s\n",
             pfrom->thinBlock.GetHash().ToString(), blockSize, pfrom->nSizeThinBlock, nSizeThinBlockTx,
@@ -829,7 +829,7 @@ bool CXThinBlock::process(CNode *pfrom,
 
     // We now have all the transactions now that are in this block
     pfrom->thinBlockWaitingForTxns = -1;
-    int blockSize = ::GetSerializeSize(pfrom->thinBlock, SER_NETWORK, CBlock::CURRENT_VERSION);
+    int blockSize = pfrom->thinBlock.GetBlockSize();
     LOG(THIN, "Reassembled xthinblock for %s (%d bytes). Message was %d bytes, compression ratio %3.2f, peer=%s\n",
         pfrom->thinBlock.GetHash().ToString(), blockSize, pfrom->nSizeThinBlock,
         ((float)blockSize) / ((float)pfrom->nSizeThinBlock), pfrom->GetLogName());
@@ -1493,7 +1493,7 @@ void SendXThinBlock(CBlock &block, CNode *pfrom, const CInv &inv)
     if (inv.type == MSG_XTHINBLOCK)
     {
         CXThinBlock xThinBlock(block, pfrom->pThinBlockFilter);
-        int nSizeBlock = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+        int nSizeBlock = block.GetBlockSize();
         if (xThinBlock.collision ==
             true) // If there is a cheapHash collision in this block then send a normal thinblock
         {
@@ -1542,7 +1542,7 @@ void SendXThinBlock(CBlock &block, CNode *pfrom, const CInv &inv)
     else if (inv.type == MSG_THINBLOCK)
     {
         CThinBlock thinBlock(block, *pfrom->pThinBlockFilter);
-        int nSizeBlock = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+        int nSizeBlock = block.GetBlockSize();
         int nSizeThinBlock = ::GetSerializeSize(thinBlock, SER_NETWORK, PROTOCOL_VERSION);
         if (nSizeThinBlock < nSizeBlock)
         { // Only send a thinblock if smaller than a regular block

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -464,7 +464,7 @@ extern void UnlimitedLogBlock(const CBlock &block, const std::string &hash, uint
     if (!blockReceiptLog)
         blockReceiptLog = fopen("blockReceiptLog.txt", "a");
     if (blockReceiptLog) {
-        long int byteLen = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+        long int byteLen = block.GetBlockSize(), SER_NETWORK, PROTOCOL_VERSION);
         CBlockHeader bh = block.GetBlockHeader();
         fprintf(blockReceiptLog, "%" PRIu64 ",%" PRIu64 ",%ld,%ld,%s\n", receiptTime, (uint64_t)bh.nTime, byteLen, block.vtx.size(), hash.c_str());
         fflush(blockReceiptLog);
@@ -624,7 +624,7 @@ void static BitcoinMiner(const CChainParams &chainparams)
             IncrementExtraNonce(pblock, nExtraNonce);
 
             LOGA("Running BitcoinMiner with %u transactions in block (%u bytes)\n", pblock->vtx.size(),
-                ::GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION));
+                pblock->GetBlockSize());
 
             //
             // Search
@@ -1713,9 +1713,6 @@ UniValue validateblocktemplate(const UniValue &params, bool fHelp)
     if (!DecodeHexBlk(block, params[0].get_str()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block decode failed");
 
-    if (block.nBlockSize == 0)
-        block.nBlockSize = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
-
     CBlockIndex *pindexPrev = NULL;
     {
         LOCK(cs_main);
@@ -1737,7 +1734,7 @@ UniValue validateblocktemplate(const UniValue &params, bool fHelp)
 
         const CChainParams &chainparams = Params();
         CValidationState state;
-        if (block.nBlockSize <= BLOCKSTREAM_CORE_MAX_BLOCK_SIZE)
+        if (block.GetBlockSize() <= BLOCKSTREAM_CORE_MAX_BLOCK_SIZE)
         {
             if (!TestConservativeBlockValidity(state, chainparams, block, pindexPrev, false, true))
             {


### PR DESCRIPTION
This creates an in memory nBlockSize, which is then used, after the first time ::GetSerializeSize is called for a block.  This prevents the expensive and repeated ::GetSerializeSize seen throughout the block and thinblock processing.