### PR TITLE
Explicitly mark fall-through cases

### DIFF
--- a/src/hash.cpp
+++ b/src/hash.cpp
@@ -48,8 +48,10 @@ unsigned int MurmurHash3(unsigned int nHashSeed, const std::vector<unsigned char
         {
         case 3:
             k1 ^= tail[2] << 16;
+        // FALLTHROUGH
         case 2:
             k1 ^= tail[1] << 8;
+        // FALLTHROUGH
         case 1:
             k1 ^= tail[0];
             k1 *= c1;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -495,7 +495,7 @@ static bool rest_getutxos(HTTPRequest *req, const std::string &strURIPart)
         std::vector<unsigned char> strRequestV = ParseHex(strRequestMutable);
         strRequestMutable.assign(strRequestV.begin(), strRequestV.end());
     }
-
+    // FALLTHROUGH
     case RF_BINARY:
     {
         try

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -669,7 +669,8 @@ UniValue getblocktemplate(const UniValue &params, bool fHelp)
         case THRESHOLD_LOCKED_IN:
             // Ensure bit is set in block version
             pblock->nVersion |= VersionBitsMask(consensusParams, pos);
-        // FALL THROUGH to get vbavailable set...
+        // FALLTHROUGH
+        // to get vbavailable set...
         case THRESHOLD_STARTED:
         {
             const struct BIP9DeploymentInfo &vbinfo = VersionBitsDeploymentInfo[pos];


### PR DESCRIPTION
Explicitly mark a case branch as fall-through when it is the
intended behaviour. When using gcc 7.2 all fall-through branhces
that are not marked produce a warning like this one:

```
hash.cpp: In function 'unsigned int MurmurHash3(unsigned int, const std::vector<unsigned char>&)':
hash.cpp:50:16: warning: this statement may fall through [-Wimplicit-fallthrough=]
             k1 ^= tail[2] << 16;
             ~~~^~~~~~~~~~~~~~~~
hash.cpp:51:9: note: here
         case 2:
         ^~~~
```
More info about the matter at hand could be found here:

https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/

This changeset is not taking care of external project code imported
via subtree (e.g. leveldb, univalue, etc. etc.)

I wanted to thanks freetrader for pointing out similar work done
in BitcoinABC back in July 2017.