### PR TITLE
Store blocksize in memory within the block [includes PR #960]

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6656,7 +6656,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         // Message consistency checking
         // NOTE: consistency checking is handled by checkblock() which is called during
         //       ProcessNewBlock() during HandleBlockMessage.
-        PV->HandleBlockMessage(pfrom, strCommand, block, inv, nBlockSize);
+        PV->HandleBlockMessage(pfrom, strCommand, block, inv);
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6643,24 +6643,26 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
 
     else if (strCommand == NetMsgType::BLOCK && !fImporting && !fReindex) // Ignore blocks received while importing
     {
-        CBlock block;
-        vRecv >> block;
+        std::shared_ptr<CBlock> block(new CBlock);
+        uint64_t nBlockSize = vRecv.size();
+        vRecv >> *block;
+        DbgAssert(nBlockSize == ::GetSerializeSize(*block, SER_NETWORK, PROTOCOL_VERSION), return true);
 
         CInv inv(MSG_BLOCK, block.GetHash());
         LOG(BLK, "received block %s peer=%d\n", inv.hash.ToString(), pfrom->id);
-        UnlimitedLogBlock(block, inv.hash.ToString(), receiptTime);
+        UnlimitedLogBlock(*block, inv.hash.ToString(), receiptTime);
 
         if (IsChainNearlySyncd()) // BU send the received block out expedited channels quickly
         {
             CValidationState state;
-            if (CheckBlockHeader(block, state, true)) // block header is fine
-                SendExpeditedBlock(block, pfrom);
+            if (CheckBlockHeader(*block, state, true)) // block header is fine
+                SendExpeditedBlock(*block, pfrom);
         }
 
         // Message consistency checking
         // NOTE: consistency checking is handled by checkblock() which is called during
         //       ProcessNewBlock() during HandleBlockMessage.
-        PV->HandleBlockMessage(pfrom, strCommand, block, inv);
+        PV->HandleBlockMessage(pfrom, strCommand, block, inv, nBlockSize);
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3791,11 +3791,6 @@ bool CheckBlock(const CBlock &block, CValidationState &state, bool fCheckPOW, bo
     // because we receive the wrong transactions for it.
 
     // Size limits
-    if (block.nBlockSize == 0)
-        block.nBlockSize = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
-
-    // || block.vtx.size() > MAX_BLOCK_SIZE || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION) >
-    // MAX_BLOCK_SIZE)
     if (block.vtx.empty())
         return state.DoS(100, error("CheckBlock(): size limits failed"), REJECT_INVALID, "bad-blk-length");
 
@@ -3834,7 +3829,7 @@ bool CheckBlock(const CBlock &block, CValidationState &state, bool fCheckPOW, bo
         block.fChecked = true;
 
     // BU: Check whether this block exceeds what we want to relay.
-    block.fExcessive = CheckExcessive(block, block.nBlockSize, nSigOps, nTx, nLargestTx);
+    block.fExcessive = CheckExcessive(block, block.GetBlockSize(), nSigOps, nTx, nLargestTx);
 
     return true;
 }
@@ -4141,9 +4136,8 @@ bool ProcessNewBlock(CValidationState &state,
     bool checked = CheckBlock(*pblock, state);
     if (!checked)
     {
-        int byteLen = ::GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION);
         LOGA("Invalid block: ver:%x time:%d Tx size:%d len:%d\n", pblock->nVersion, pblock->nTime, pblock->vtx.size(),
-            byteLen);
+            pblock->GetBlockSize());
     }
 
     // WARNING: cs_main is not locked here throughout but is released and then re-locked during ActivateBestChain
@@ -6646,7 +6640,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         std::shared_ptr<CBlock> block(new CBlock);
         uint64_t nBlockSize = vRecv.size();
         vRecv >> *block;
-        DbgAssert(nBlockSize == ::GetSerializeSize(*block, SER_NETWORK, PROTOCOL_VERSION), return true);
+        DbgAssert(nBlockSize == block->GetBlockSize(), return true);
 
         CInv inv(MSG_BLOCK, block->GetHash());
         LOG(BLK, "received block %s peer=%d\n", inv.hash.ToString(), pfrom->id);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6648,7 +6648,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         vRecv >> *block;
         DbgAssert(nBlockSize == ::GetSerializeSize(*block, SER_NETWORK, PROTOCOL_VERSION), return true);
 
-        CInv inv(MSG_BLOCK, block.GetHash());
+        CInv inv(MSG_BLOCK, block->GetHash());
         LOG(BLK, "received block %s peer=%d\n", inv.hash.ToString(), pfrom->id);
         UnlimitedLogBlock(*block, inv.hash.ToString(), receiptTime);
 

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -22,7 +22,11 @@ using namespace std;
 static const unsigned int nScriptCheckQueues = 4;
 std::unique_ptr<CParallelValidation> PV;
 
-static void HandleBlockMessageThread(CNode *pfrom, const std::string strCommand, const CBlock block, const CInv inv);
+static void HandleBlockMessageThread(CNode *pfrom,
+    const string strCommand,
+    shared_ptr<CBlock> block,
+    const CInv inv,
+    uint64_t nSizeBlock);
 
 static void AddScriptCheckThreads(int i, CCheckQueue<CScriptCheck> *pqueue)
 {
@@ -280,10 +284,11 @@ void CParallelValidation::WaitForAllValidationThreadsToStop()
 bool CParallelValidation::Enabled() { return GetBoolArg("-parallel", true); }
 void CParallelValidation::InitThread(const boost::thread::id this_id,
     const CNode *pfrom,
-    const CBlock &block,
-    const CInv &inv)
+    shared_ptr<CBlock> block,
+                                     const CInv &inv,
+    uint64_t blockSize)
 {
-    const CBlockHeader &header = block.GetBlockHeader();
+    const CBlockHeader &header = block->GetBlockHeader();
 
     LOCK(cs_blockvalidationthread);
     assert(mapBlockValidationThreads.count(this_id) == 0); // this id should not already be in use
@@ -294,13 +299,14 @@ void CParallelValidation::InitThread(const boost::thread::id this_id,
     mapBlockValidationThreads[this_id].nMostWorkOurFork = header.nBits;
     mapBlockValidationThreads[this_id].nSequenceId = INT_MAX;
     mapBlockValidationThreads[this_id].nStartTime = GetTimeMillis();
-    mapBlockValidationThreads[this_id].nBlockSize = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+    mapBlockValidationThreads[this_id].nBlockSize = blockSize;
     mapBlockValidationThreads[this_id].fQuit = false;
     mapBlockValidationThreads[this_id].nodeid = pfrom->id;
     mapBlockValidationThreads[this_id].fIsValidating = false;
     mapBlockValidationThreads[this_id].fIsReorgInProgress = false;
+
     LOG(PARALLEL, "Launching validation for %s with number of block validation threads running: %d\n",
-        block.GetHash().ToString(), mapBlockValidationThreads.size());
+        block->GetHash().ToString(), mapBlockValidationThreads.size());
 }
 
 void CParallelValidation::Erase(const boost::thread::id this_id)
@@ -435,10 +441,11 @@ void CParallelValidation::ClearOrphanCache(const CBlock &block)
 //  has finished.
 void CParallelValidation::HandleBlockMessage(CNode *pfrom,
     const string &strCommand,
-    const CBlock &block,
-    const CInv &inv)
+                                             std::shared_ptr<CBlock> block,
+                                             const CInv &inv, uint64_t nBlockSize)
 {
-    uint64_t nBlockSize = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+    if (nBlockSize == 0)
+        nBlockSize = ::GetSerializeSize(*block, SER_NETWORK, PROTOCOL_VERSION);
 
     // NOTE: You must not have a cs_main lock before you aquire the semaphore grant or you can end up deadlocking
     // AssertLockNotHeld(cs_main); TODO: need to create this
@@ -472,7 +479,7 @@ void CParallelValidation::HandleBlockMessage(CNode *pfrom,
                     {
                         // Find largest block where the previous block hash matches. Meaning this is a new block and
                         // it's a competitor to to your block.
-                        if ((*iter).second.hashPrevBlock == block.GetBlockHeader().hashPrevBlock)
+                        if ((*iter).second.hashPrevBlock == block->GetBlockHeader().hashPrevBlock)
                         {
                             if ((*iter).second.nBlockSize > nLargestBlockSize)
                             {
@@ -487,7 +494,7 @@ void CParallelValidation::HandleBlockMessage(CNode *pfrom,
                     if (nLargestBlockSize <= nBlockSize)
                     {
                         LOG(PARALLEL, "Block validation terminated - Too many blocks currently being validated: %s\n",
-                            block.GetHash().ToString());
+                            block->GetHash().ToString());
                         return; // new block is rejected and does not enter PV
                     }
                     else if (miLargestBlock != mapBlockValidationThreads.end())
@@ -523,20 +530,19 @@ void CParallelValidation::HandleBlockMessage(CNode *pfrom,
     // only launch block validation in a separate thread if PV is enabled.
     if (PV->Enabled())
     {
-        boost::thread thread(boost::bind(&HandleBlockMessageThread, pfrom, strCommand, block, inv));
+        boost::thread thread(boost::bind(&HandleBlockMessageThread, pfrom, strCommand, block, inv, nBlockSize));
         thread.detach(); // Separate actual thread from the "thread" object so its fine to fall out of scope
     }
     else
     {
-        HandleBlockMessageThread(pfrom, strCommand, block, inv);
+        HandleBlockMessageThread(pfrom, strCommand, block, inv, nBlockSize);
     }
 }
 
-void HandleBlockMessageThread(CNode *pfrom, const string strCommand, const CBlock block, const CInv inv)
+void HandleBlockMessageThread(CNode *pfrom, const string strCommand, shared_ptr<CBlock> block, const CInv inv, uint64_t nSizeBlock)
 {
     int64_t startTime = GetTimeMicros();
     CValidationState state;
-    uint64_t nSizeBlock = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
 
     // Indicate that the thinblock was fully received. At this point we have either a block or a fully reconstructed
     // thinblock but we still need to maintain a mapThinBlocksInFlight entry so that we don't re-request a full block
@@ -549,7 +555,7 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, const CBloc
 
 
     boost::thread::id this_id(boost::this_thread::get_id());
-    PV->InitThread(this_id, pfrom, block, inv); // initialize the mapBlockValidationThread entries
+    PV->InitThread(this_id, pfrom, block, inv, nSizeBlock); // initialize the mapBlockValidationThread entries
 
     // Process all blocks from whitelisted peers, even if not requested,
     // unless we're still syncing with the network.
@@ -559,12 +565,12 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, const CBloc
     const CChainParams &chainparams = Params();
     if (PV->Enabled())
     {
-        ProcessNewBlock(state, chainparams, pfrom, &block, forceProcessing, NULL, true);
+        ProcessNewBlock(state, chainparams, pfrom, block.get(), forceProcessing, NULL, true);
     }
     else
     {
         LOCK(cs_main); // locking cs_main here prevents any other thread from beginning starting a block validation.
-        ProcessNewBlock(state, chainparams, pfrom, &block, forceProcessing, NULL, false);
+        ProcessNewBlock(state, chainparams, pfrom, block.get(), forceProcessing, NULL, false);
     }
 
     int nDoS;
@@ -646,7 +652,7 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, const CBloc
     }
 
     // Erase any txns from the orphan cache that are no longer needed
-    PV->ClearOrphanCache(block);
+    PV->ClearOrphanCache(*block);
 
     // Clear thread data - this must be done before the thread completes or else some other new
     // thread may grab the same thread id and we would end up deleting the entry for the new thread instead.

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -436,17 +436,15 @@ void CParallelValidation::ClearOrphanCache(const CBlock &block)
 
 
 //  HandleBlockMessage launches a HandleBlockMessageThread.  And HandleBlockMessageThread processes each block and
-//  updates
-//  the UTXO if the block has been accepted and the tip updated. We cleanup and release the semaphore after the thread
-//  has finished.
+//  updates the UTXO if the block has been accepted and the tip updated. We cleanup and release the semaphore after
+//  the thread has finished.
 void CParallelValidation::HandleBlockMessage(CNode *pfrom,
     const string &strCommand,
     std::shared_ptr<CBlock> block,
     const CInv &inv,
     uint64_t nBlockSize)
 {
-    if (nBlockSize == 0)
-        nBlockSize = ::GetSerializeSize(*block, SER_NETWORK, PROTOCOL_VERSION);
+    nBlockSize = block->GetBlockSize();
 
     // NOTE: You must not have a cs_main lock before you aquire the semaphore grant or you can end up deadlocking
     // AssertLockNotHeld(cs_main); TODO: need to create this

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -285,7 +285,7 @@ bool CParallelValidation::Enabled() { return GetBoolArg("-parallel", true); }
 void CParallelValidation::InitThread(const boost::thread::id this_id,
     const CNode *pfrom,
     shared_ptr<CBlock> block,
-                                     const CInv &inv,
+    const CInv &inv,
     uint64_t blockSize)
 {
     const CBlockHeader &header = block->GetBlockHeader();
@@ -441,8 +441,9 @@ void CParallelValidation::ClearOrphanCache(const CBlock &block)
 //  has finished.
 void CParallelValidation::HandleBlockMessage(CNode *pfrom,
     const string &strCommand,
-                                             std::shared_ptr<CBlock> block,
-                                             const CInv &inv, uint64_t nBlockSize)
+    std::shared_ptr<CBlock> block,
+    const CInv &inv,
+    uint64_t nBlockSize)
 {
     if (nBlockSize == 0)
         nBlockSize = ::GetSerializeSize(*block, SER_NETWORK, PROTOCOL_VERSION);
@@ -539,7 +540,11 @@ void CParallelValidation::HandleBlockMessage(CNode *pfrom,
     }
 }
 
-void HandleBlockMessageThread(CNode *pfrom, const string strCommand, shared_ptr<CBlock> block, const CInv inv, uint64_t nSizeBlock)
+void HandleBlockMessageThread(CNode *pfrom,
+    const string strCommand,
+    shared_ptr<CBlock> block,
+    const CInv inv,
+    uint64_t nSizeBlock)
 {
     int64_t startTime = GetTimeMicros();
     CValidationState state;

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -116,7 +116,11 @@ public:
     ~CParallelValidation();
 
     /* Initialize mapBlockValidationThreads*/
-    void InitThread(const boost::thread::id this_id, const CNode *pfrom, std::shared_ptr<CBlock> block, const CInv &inv, uint64_t blockSize);
+    void InitThread(const boost::thread::id this_id,
+        const CNode *pfrom,
+        std::shared_ptr<CBlock> block,
+        const CInv &inv,
+        uint64_t blockSize);
 
     /* Initialize a PV session */
     bool Initialize(const boost::thread::id this_id, const CBlockIndex *pindex, const bool fParallel);

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -116,7 +116,7 @@ public:
     ~CParallelValidation();
 
     /* Initialize mapBlockValidationThreads*/
-    void InitThread(const boost::thread::id this_id, const CNode *pfrom, const CBlock &block, const CInv &inv);
+    void InitThread(const boost::thread::id this_id, const CNode *pfrom, std::shared_ptr<CBlock> block, const CInv &inv, uint64_t blockSize);
 
     /* Initialize a PV session */
     bool Initialize(const boost::thread::id this_id, const CBlockIndex *pindex, const bool fParallel);
@@ -168,7 +168,11 @@ public:
     void ClearOrphanCache(const CBlock &block);
 
     /* Process a block message */
-    void HandleBlockMessage(CNode *pfrom, const std::string &strCommand, const CBlock &block, const CInv &inv);
+    void HandleBlockMessage(CNode *pfrom,
+        const std::string &strCommand,
+        std::shared_ptr<CBlock> block,
+        const CInv &inv,
+        uint64_t blockSize = 0); // If blockSize is not supplied it is calculated
 
     // The number of script validation threads
     unsigned int ThreadCount() { return nThreads; }

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -175,8 +175,7 @@ public:
     void HandleBlockMessage(CNode *pfrom,
         const std::string &strCommand,
         std::shared_ptr<CBlock> block,
-        const CInv &inv,
-        uint64_t blockSize = 0); // If blockSize is not supplied it is calculated
+        const CInv &inv);
 
     // The number of script validation threads
     unsigned int ThreadCount() { return nThreads; }

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -25,3 +25,11 @@ std::string CBlock::ToString() const
     }
     return s.str();
 }
+
+uint64_t CBlock::GetBlockSize() const
+{
+    if (nBlockSize == 0)
+        nBlockSize = ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
+    return nBlockSize;
+}
+

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -32,4 +32,3 @@ uint64_t CBlock::GetBlockSize() const
         nBlockSize = ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
     return nBlockSize;
 }
-

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -78,7 +78,7 @@ public:
     // 0.11: mutable std::vector<uint256> vMerkleTree;
     mutable bool fChecked;
     mutable bool fExcessive; // BU: is the block "excessive" (bigger than this node prefers to accept)
-    mutable uint64_t nBlockSize; // BU: length of this block in bytes
+    mutable uint64_t nBlockSize; // Serialized block size in bytes
 
     CBlock() { SetNull(); }
     CBlock(const CBlockHeader &header)
@@ -175,6 +175,10 @@ public:
     }
 
     std::string ToString() const;
+
+    // Return the serialized block size in bytes. This is only done once and then the result stored
+    // in nBlockSize for future reference, saving unncessary and expensive serializations.
+    uint64_t GetBlockSize() const;
 };
 
 

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -846,7 +846,7 @@ bool CXThinBlock::process(CNode *pfrom,
 
     // Process the full block
     PV->HandleBlockMessage(
-        pfrom, strCommand, std::shared_ptr<CBlock>(std::shared_ptr<CBlock>{}, &pfrom->thinBlock), GetInv(), blockSize);
+        pfrom, strCommand, std::shared_ptr<CBlock>(std::shared_ptr<CBlock>{}, &pfrom->thinBlock), GetInv());
 
     return true;
 }

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -194,7 +194,10 @@ bool CThinBlock::process(CNode *pfrom, int nSizeThinBlock)
         thindata.UpdateInBound(nSizeThinBlock, blockSize);
         LOG(THIN, "thin block stats: %s\n", thindata.ToString());
 
-        PV->HandleBlockMessage(pfrom, NetMsgType::THINBLOCK, pfrom->thinBlock, GetInv());
+        // create a non-deleting shared pointer to wrap pfrom->thinBlock.  We know that thinBlock will outlast the
+        // thread because the thread has a node reference.
+        PV->HandleBlockMessage(pfrom, NetMsgType::THINBLOCK,
+            std::shared_ptr<CBlock>(std::shared_ptr<CBlock>{}, &pfrom->thinBlock), GetInv());
     }
     else if (pfrom->thinBlockWaitingForTxns > 0)
     {
@@ -421,7 +424,10 @@ bool CXThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
         thindata.UpdateInBound(nSizeThinBlockTx + pfrom->nSizeThinBlock, blockSize);
         LOG(THIN, "thin block stats: %s\n", thindata.ToString());
 
-        PV->HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, inv);
+        // create a non-deleting shared pointer to wrap pfrom->thinBlock.  We know that thinBlock will outlast the
+        // thread because the thread has a node reference.
+        PV->HandleBlockMessage(
+            pfrom, strCommand, std::shared_ptr<CBlock>(std::shared_ptr<CBlock>{}, &pfrom->thinBlock), inv);
     }
 
     return true;
@@ -839,7 +845,7 @@ bool CXThinBlock::process(CNode *pfrom,
     LOG(THIN, "thin block stats: %s\n", thindata.ToString().c_str());
 
     // Process the full block
-    PV->HandleBlockMessage(pfrom, strCommand, pfrom->thinBlock, GetInv());
+    PV->HandleBlockMessage(pfrom, strCommand, std::shared_ptr<CBlock>(std::shared_ptr<CBlock>{}, &pfrom->thinBlock), GetInv(), blockSize);
 
     return true;
 }

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -845,7 +845,8 @@ bool CXThinBlock::process(CNode *pfrom,
     LOG(THIN, "thin block stats: %s\n", thindata.ToString().c_str());
 
     // Process the full block
-    PV->HandleBlockMessage(pfrom, strCommand, std::shared_ptr<CBlock>(std::shared_ptr<CBlock>{}, &pfrom->thinBlock), GetInv(), blockSize);
+    PV->HandleBlockMessage(
+        pfrom, strCommand, std::shared_ptr<CBlock>(std::shared_ptr<CBlock>{}, &pfrom->thinBlock), GetInv(), blockSize);
 
     return true;
 }

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -185,7 +185,7 @@ bool CThinBlock::process(CNode *pfrom, int nSizeThinBlock)
     {
         // We have all the transactions now that are in this block: try to reassemble and process.
         pfrom->thinBlockWaitingForTxns = -1;
-        int blockSize = ::GetSerializeSize(pfrom->thinBlock, SER_NETWORK, CBlock::CURRENT_VERSION);
+        int blockSize = pfrom->thinBlock.GetBlockSize();
         LOG(THIN, "Reassembled thinblock for %s (%d bytes). Message was %d bytes, compression ratio %3.2f peer=%s\n",
             pfrom->thinBlock.GetHash().ToString(), blockSize, nSizeThinBlock,
             ((float)blockSize) / ((float)nSizeThinBlock), pfrom->GetLogName());
@@ -412,7 +412,7 @@ bool CXThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
 
         // for compression statistics, we have to add up the size of xthinblock and the re-requested thinBlockTx.
         int nSizeThinBlockTx = msgSize;
-        int blockSize = ::GetSerializeSize(pfrom->thinBlock, SER_NETWORK, CBlock::CURRENT_VERSION);
+        int blockSize = pfrom->thinBlock.GetBlockSize();
         LOG(THIN, "Reassembled xblocktx for %s (%d bytes). Message was %d bytes (thinblock) and %d bytes "
                   "(re-requested tx), compression ratio %3.2f, peer=%s\n",
             pfrom->thinBlock.GetHash().ToString(), blockSize, pfrom->nSizeThinBlock, nSizeThinBlockTx,
@@ -835,7 +835,7 @@ bool CXThinBlock::process(CNode *pfrom,
 
     // We now have all the transactions now that are in this block
     pfrom->thinBlockWaitingForTxns = -1;
-    int blockSize = ::GetSerializeSize(pfrom->thinBlock, SER_NETWORK, CBlock::CURRENT_VERSION);
+    int blockSize = pfrom->thinBlock.GetBlockSize();
     LOG(THIN, "Reassembled xthinblock for %s (%d bytes). Message was %d bytes, compression ratio %3.2f, peer=%s\n",
         pfrom->thinBlock.GetHash().ToString(), blockSize, pfrom->nSizeThinBlock,
         ((float)blockSize) / ((float)pfrom->nSizeThinBlock), pfrom->GetLogName());
@@ -1500,7 +1500,7 @@ void SendXThinBlock(CBlock &block, CNode *pfrom, const CInv &inv)
     if (inv.type == MSG_XTHINBLOCK)
     {
         CXThinBlock xThinBlock(block, pfrom->pThinBlockFilter);
-        int nSizeBlock = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+        int nSizeBlock = block.GetBlockSize();
         if (xThinBlock.collision ==
             true) // If there is a cheapHash collision in this block then send a normal thinblock
         {
@@ -1549,7 +1549,7 @@ void SendXThinBlock(CBlock &block, CNode *pfrom, const CInv &inv)
     else if (inv.type == MSG_THINBLOCK)
     {
         CThinBlock thinBlock(block, *pfrom->pThinBlockFilter);
-        int nSizeBlock = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+        int nSizeBlock = block.GetBlockSize();
         int nSizeThinBlock = ::GetSerializeSize(thinBlock, SER_NETWORK, PROTOCOL_VERSION);
         if (nSizeThinBlock < nSizeBlock)
         { // Only send a thinblock if smaller than a regular block

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -464,7 +464,7 @@ extern void UnlimitedLogBlock(const CBlock &block, const std::string &hash, uint
     if (!blockReceiptLog)
         blockReceiptLog = fopen("blockReceiptLog.txt", "a");
     if (blockReceiptLog) {
-        long int byteLen = block.GetBlockSize(), SER_NETWORK, PROTOCOL_VERSION);
+        long int byteLen = block.GetBlockSize();
         CBlockHeader bh = block.GetBlockHeader();
         fprintf(blockReceiptLog, "%" PRIu64 ",%" PRIu64 ",%ld,%ld,%s\n", receiptTime, (uint64_t)bh.nTime, byteLen, block.vtx.size(), hash.c_str());
         fflush(blockReceiptLog);

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -464,7 +464,7 @@ extern void UnlimitedLogBlock(const CBlock &block, const std::string &hash, uint
     if (!blockReceiptLog)
         blockReceiptLog = fopen("blockReceiptLog.txt", "a");
     if (blockReceiptLog) {
-        long int byteLen = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+        long int byteLen = block.GetBlockSize(), SER_NETWORK, PROTOCOL_VERSION);
         CBlockHeader bh = block.GetBlockHeader();
         fprintf(blockReceiptLog, "%" PRIu64 ",%" PRIu64 ",%ld,%ld,%s\n", receiptTime, (uint64_t)bh.nTime, byteLen, block.vtx.size(), hash.c_str());
         fflush(blockReceiptLog);
@@ -624,7 +624,7 @@ void static BitcoinMiner(const CChainParams &chainparams)
             IncrementExtraNonce(pblock, nExtraNonce);
 
             LOGA("Running BitcoinMiner with %u transactions in block (%u bytes)\n", pblock->vtx.size(),
-                ::GetSerializeSize(*pblock, SER_NETWORK, PROTOCOL_VERSION));
+                pblock->GetBlockSize());
 
             //
             // Search
@@ -1713,9 +1713,6 @@ UniValue validateblocktemplate(const UniValue &params, bool fHelp)
     if (!DecodeHexBlk(block, params[0].get_str()))
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "Block decode failed");
 
-    if (block.nBlockSize == 0)
-        block.nBlockSize = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
-
     CBlockIndex *pindexPrev = NULL;
     {
         LOCK(cs_main);
@@ -1737,7 +1734,7 @@ UniValue validateblocktemplate(const UniValue &params, bool fHelp)
 
         const CChainParams &chainparams = Params();
         CValidationState state;
-        if (block.nBlockSize <= BLOCKSTREAM_CORE_MAX_BLOCK_SIZE)
+        if (block.GetBlockSize() <= BLOCKSTREAM_CORE_MAX_BLOCK_SIZE)
         {
             if (!TestConservativeBlockValidity(state, chainparams, block, pindexPrev, false, true))
             {


### PR DESCRIPTION
This simplifies the code and makes it less likely that anyone will use GetSerializeSize() in order to order to obtain the blocksize.  We only need to GetSerializeSize() once and then we can reference the blocksize whenever we need it , as long as the block is in scope.