### PR TITLE
Makefile.am: Typo fix that broke `make clean` rule

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -473,7 +473,7 @@ libbitcoinconsensus_la_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 
 endif
 #
-CLEANFILES = ($EXTRA_LIBRARIES)
+CLEANFILES = $(EXTRA_LIBRARIES)
 
 CTAES_DIST =  crypto/ctaes/bench.c
 CTAES_DIST += crypto/ctaes/ctaes.c


### PR DESCRIPTION
cherry-pick awemany's "release" fix