### PR TITLE
[IBD patch3] batch block requests in the request manager when we can

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,7 +114,7 @@ static unsigned int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 1;
  *  Larger windows tolerate larger download speed differences between peer, but increase the potential
  *  degree of disordering of blocks on disk (which make reindexing and in the future perhaps pruning
  *  harder). We'll probably want to make this a per-peer adaptive value at some point. */
-static unsigned int BLOCK_DOWNLOAD_WINDOW = 256;
+static unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
 
 extern CTweak<unsigned int> maxBlocksInTransitPerPeer; // override the above
 extern CTweak<unsigned int> blockDownloadWindow;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6405,7 +6405,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             // blocks that we need.  Therefore, update block availability for every connected node. If we
             // don't do this, then at the beginning of IBD we will end up only downloading from one peer.
             LOCK(cs_vNodes);
-            for (CNode *pnode: vNodes)
+            for (CNode *pnode : vNodes)
             {
                 UpdateBlockAvailability(pnode->GetId(), pindexLast->GetBlockHash());
             }
@@ -7238,7 +7238,7 @@ bool SendMessages(CNode *pto)
         CNodeState &state = *State(pto->GetId());
 
         // We need to update any newly connected peers with a best header if we are doing an initial sync.
-        // If we don't do this then we'll end up downloading blocks all from one peer. 
+        // If we don't do this then we'll end up downloading blocks all from one peer.
         if (IsInitialBlockDownload() && state.pindexBestKnownBlock == nullptr)
         {
             UpdateBlockAvailability(pto->GetId(), pindexBestHeader->GetBlockHash());
@@ -7547,8 +7547,6 @@ bool SendMessages(CNode *pto)
                         requester.AskForDuringIBD(inv, pto);
                     // LOG(REQ, "AskFor block %s (%d) peer=%s\n", pindex->GetBlockHash().ToString(),
                     //  pindex->nHeight, pto->GetLogName());
-
-
                 }
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -371,6 +371,7 @@ bool MarkBlockAsReceived(const uint256 &hash)
         LOG(THIN, "BLOCK_DOWNLOAD_WINDOW is %d MAX_BLOCKS_IN_TRANSIT_PER_PEER is %d\n", BLOCK_DOWNLOAD_WINDOW,
             MAX_BLOCKS_IN_TRANSIT_PER_PEER);
 
+        if (IsChainNearlySyncd())
         {
             LOCK(cs_vNodes);
             BOOST_FOREACH (CNode *pnode, vNodes)

--- a/src/net.h
+++ b/src/net.h
@@ -79,7 +79,7 @@ static const size_t SETASKFOR_MAX_SZ = 2 * MAX_INV_SZ;
 /** The maximum number of peer connections to maintain. */
 static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 /** BU: The maximum numer of outbound peer connections */
-static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 12;
+static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 16;
 /** BU: The minimum number of xthin nodes to connect */
 static const uint8_t MIN_XTHIN_NODES = 8;
 /** BU: The daily maximum disconnects while searching for xthin nodes to connect */

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -176,7 +176,8 @@ void CRequestManager::AskForDuringIBD(const CInv &obj, CNode *from, unsigned int
     // add from this node first so that they get requested first.
     AskFor(obj, from, priority);
 
-    LOCK(cs_vNodes);
+    // Must lock cs_objDownloader here and before cs_vNodes to maintain proper locking order.
+    LOCK2(cs_objDownloader, cs_vNodes);
     for (CNode *pnode : vNodes)
     {
         if (pnode == from)

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -372,6 +372,7 @@ bool RequestBlock(CNode *pfrom, CInv obj)
     //        here.
     if (IsChainNearlySyncd() || chainParams.NetworkIDString() == "regtest")
     {
+        LOCK(cs_main);
         BlockMap::iterator idxIt = mapBlockIndex.find(obj.hash);
         if (idxIt == mapBlockIndex.end()) // only request if we don't already have the header
         {

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -527,11 +527,6 @@ void CRequestManager::SendRequests()
                             reason = "on disconnect";
                             release = true;
                         }
-                        else if (!IsChainNearlySyncd() && !IsNodePingAcceptable(next.node))
-                        {
-                            reason = "bad ping time";
-                            release = true;
-                        }
                         if (release)
                         {
                             LOCK(cs_vNodes);
@@ -688,40 +683,4 @@ void CRequestManager::SendRequests()
             }
         }
     }
-}
-
-bool CRequestManager::IsNodePingAcceptable(CNode *pfrom)
-{
-    if (pfrom->nPingUsecTime < ACCEPTABLE_PING_USEC)
-        return true;
-
-    // Calculate average ping time of all nodes
-    uint16_t nValidNodes = 0;
-    std::vector<uint64_t> vPingTimes;
-    LOCK(cs_vNodes);
-    BOOST_FOREACH (CNode *pnode, vNodes)
-    {
-        if (!pnode->fDisconnect && pnode->nPingUsecTime > 0)
-        {
-            nValidNodes++;
-            vPingTimes.push_back(pnode->nPingUsecTime);
-        }
-    }
-    if (nValidNodes < 10) // Take anything if we are poorly connected
-        return true;
-
-    // Calculate Standard Deviation and Mean of Ping Time
-    using namespace boost::accumulators;
-    accumulator_set<double, stats<tag::variance> > acc;
-    acc = for_each(vPingTimes.begin(), vPingTimes.end(), acc);
-    double nMean = mean(acc);
-    double sDeviation = sqrt(variance(acc));
-
-    // If node ping time is greater than the average plus 2 times the standard deviation, or
-    // the pong has not been received, then do not request from this node.
-    if ((pfrom->nPingUsecTime > (int64_t)(nMean + (2 * sDeviation))) || (pfrom->nPingUsecTime == 0))
-    {
-        return false;
-    }
-    return true;
 }

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -491,7 +491,7 @@ void CRequestManager::SendRequests()
     // asking for one at time. We can do this because there will be no XTHIN requests possible during
     // this time.
     bool fBatchBlockRequests = IsInitialBlockDownload();
-    std::map<CNode *, std::vector<CInv>> mapBatchBlockRequests;
+    std::map<CNode *, std::vector<CInv> > mapBatchBlockRequests;
 
     // Get Blocks
     while (sendBlkIter != mapBlkInfo.end())
@@ -634,7 +634,7 @@ void CRequestManager::SendRequests()
                 }
             }
             ENTER_CRITICAL_SECTION(cs_objDownloader);
-            LOG(REQ, "Sent batched rqst with %d blocks to node %s\n",  iter.second.size(), iter.first->GetLogName());
+            LOG(REQ, "Sent batched rqst with %d blocks to node %s\n", iter.second.size(), iter.first->GetLogName());
         }
 
         LOCK(cs_vNodes);

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -171,6 +171,20 @@ void CRequestManager::AskFor(const std::vector<CInv> &objArray, CNode *from, uns
     }
 }
 
+void CRequestManager::AskForDuringIBD(const CInv &obj, CNode *from, unsigned int priority)
+{
+    // add from this node first so that they get requested first.
+    AskFor(obj, from, priority);
+
+    LOCK(cs_vNodes);
+    for (CNode *pnode : vNodes)
+    {
+        if (pnode == from)
+            continue;
+
+        AskFor(obj, pnode, priority);
+    }
+}
 
 // Indicate that we got this object, from and bytes are optional (for node performance tracking)
 void CRequestManager::Received(const CInv &obj, CNode *from, int bytes)

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -133,7 +133,7 @@ public:
     // can give us the blocks we need and so we tell the request manager about these sources. Otherwise the request
     // manager may not be able to re-request blocks from anyone after a timeout and we also need to be able to not
     // request another group of blocks that are already in flight.
-    void AskForDuringIBD(const CInv &obj, CNode *from, unsigned int priority = 0);
+    void AskForDuringIBD(const std::vector<CInv> &objArray, CNode *from, unsigned int priority = 0);
 
     // Indicate that we got this object, from and bytes are optional (for node performance tracking)
     void Received(const CInv &obj, CNode *from, int bytes = 0);

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -145,9 +145,6 @@ public:
     void Rejected(const CInv &obj, CNode *from, unsigned char reason = 0);
 
     void SendRequests();
-
-    // Indicates whether a node ping time is acceptable relative to the overall average of all nodes.
-    bool IsNodePingAcceptable(CNode *pnode);
 };
 
 

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -129,6 +129,12 @@ public:
     // Get these objects from somewhere, asynchronously.
     void AskFor(const std::vector<CInv> &objArray, CNode *from, unsigned int priority = 0);
 
+    // Get these objects from somewhere, asynchronously during IBD. During IBD we must assume every peer connected
+    // can give us the blocks we need and so we tell the request manager about these sources. Otherwise the request
+    // manager may not be able to re-request blocks from anyone after a timeout and we also need to be able to not
+    // request another group of blocks that are already in flight.
+    void AskForDuringIBD(const CInv &obj, CNode *from, unsigned int priority = 0);
+
     // Indicate that we got this object, from and bytes are optional (for node performance tracking)
     void Received(const CInv &obj, CNode *from, int bytes = 0);
 

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -41,9 +41,7 @@ enum
     MAX_HEADER_REQS_DURING_IBD = 3,
     // if the blockchain is this far (in seconds) behind the current time, only request headers from a single
     // peer.  This makes IBD more efficient.
-    // TODO: since the new DAA cash mining is no more erratic than bitcoin legacy.
-    // Wouldn't been better to set it back to what it was? (i.e. 24 * 60 * 60)
-    SINGLE_PEER_REQUEST_MODE_AGE = (7 * 24 * 60 * 60),
+    SINGLE_PEER_REQUEST_MODE_AGE = (24 * 60 * 60),
 };
 
 class CBlock;


### PR DESCRIPTION
This improves the speed of IBD and save a little bandwidth.  More importantly this process can also be applied to batching txn requests which should help to improve throughput.