### PR TITLE
[IBD patch 4] Deprioritise slower downloaders

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -410,7 +410,7 @@ bool InitHTTPServer()
 #if LIBEVENT_VERSION_NUMBER >= 0x02010100
     // If -debug=libevent, set full libevent debugging.
     // Otherwise, disable all libevent debugging.
-    if (LogAcceptCategory(LIBEVENT))
+    if (LogAcceptCategory(Logging::LIBEVENT))
         event_enable_debug_logging(EVENT_DBG_ALL);
     else
         event_enable_debug_logging(EVENT_DBG_NONE);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3157,14 +3157,14 @@ static bool ActivateBestChainStep(CValidationState &state,
         if (PV->QuitReceived(this_id, fParallel))
             return false;
 
-        PV->IsReorgInProgress(this_id, true, fParallel); // indicate that this thread has now initiated a re-org
+        // Indicate that this thread has now initiated a re-org
+        PV->IsReorgInProgress(this_id, true, fParallel);
 
-        // Disconnect active blocks which are no longer in the best chain.
+        // Disconnect active blocks which are no longer in the best chain. We do not need to concern ourselves with any
+        // block validation threads that may be running for the chain we are rolling back. They will automatically fail
+        // validation during ConnectBlock() once the chaintip has changed..
         if (!DisconnectTip(state, chainparams.GetConsensus()))
             return false;
-
-        if (fParallel && !fBlocksDisconnected)
-            PV->StopAllValidationThreads(this_id);
 
         fBlocksDisconnected = true;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,15 +107,11 @@ extern std::map<uint256, std::set<uint256> > mapOrphanTransactionsByPrev GUARDED
 int64_t nLastOrphanCheck = GetTime(); // Used in EraseOrphansByTime()
 static uint64_t nBytesOrphanPool = 0; // Current in memory size of the orphan pool.
 
-/** Size of the "block download window": how far ahead of our current height do we fetch?
- *  Larger windows tolerate larger download speed differences between peer, but increase the potential
- *  degree of disordering of blocks on disk (which make reindexing and in the future perhaps pruning
- *  harder). We'll probably want to make this a per-peer adaptive value at some point. */
-static unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
-
 extern CTweak<unsigned int> maxBlocksInTransitPerPeer; // override the above
 extern CTweak<unsigned int> blockDownloadWindow;
 extern CTweak<uint64_t> reindexTypicalBlockSize;
+
+extern unsigned int BLOCK_DOWNLOAD_WINDOW;
 
 extern std::map<CNetAddr, ConnectionHistory> mapInboundConnectionTracker;
 extern CCriticalSection cs_mapInboundConnectionTracker;
@@ -431,125 +427,6 @@ bool PeerHasHeader(CNodeState *state, CBlockIndex *pindex)
         return true;
     return false;
 }
-
-/** Find the last common ancestor two blocks have.
- *  Both pa and pb must be non-NULL. */
-CBlockIndex *LastCommonAncestor(CBlockIndex *pa, CBlockIndex *pb)
-{
-    if (pa->nHeight > pb->nHeight)
-    {
-        pa = pa->GetAncestor(pb->nHeight);
-    }
-    else if (pb->nHeight > pa->nHeight)
-    {
-        pb = pb->GetAncestor(pa->nHeight);
-    }
-
-    while (pa != pb && pa && pb)
-    {
-        pa = pa->pprev;
-        pb = pb->pprev;
-    }
-
-    // Eventually all chain branches meet at the genesis block.
-    assert(pa == pb);
-    return pa;
-}
-
-/** Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks, until it has
- *  at most count entries. */
-static void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<CBlockIndex *> &vBlocks)
-{
-    if (count == 0)
-        return;
-
-    vBlocks.reserve(vBlocks.size() + count);
-    CNodeState *state = State(nodeid);
-    DbgAssert(state != NULL, return );
-
-    // Make sure pindexBestKnownBlock is up to date, we'll need it.
-    requester.ProcessBlockAvailability(nodeid);
-
-    if (state->pindexBestKnownBlock == NULL || state->pindexBestKnownBlock->nChainWork < chainActive.Tip()->nChainWork)
-    {
-        // This peer has nothing interesting.
-        return;
-    }
-
-    if (state->pindexLastCommonBlock == NULL)
-    {
-        // Bootstrap quickly by guessing a parent of our best tip is the forking point.
-        // Guessing wrong in either direction is not a problem.
-        state->pindexLastCommonBlock =
-            chainActive[std::min(state->pindexBestKnownBlock->nHeight, chainActive.Height())];
-    }
-
-    // If the peer reorganized, our previous pindexLastCommonBlock may not be an ancestor
-    // of its current tip anymore. Go back enough to fix that.
-    state->pindexLastCommonBlock = LastCommonAncestor(state->pindexLastCommonBlock, state->pindexBestKnownBlock);
-    if (state->pindexLastCommonBlock == state->pindexBestKnownBlock)
-        return;
-
-    std::vector<CBlockIndex *> vToFetch;
-    CBlockIndex *pindexWalk = state->pindexLastCommonBlock;
-    // Never fetch further than the current chain tip + the block download window.  We need to ensure
-    // the if running in pruning mode we don't download too many blocks ahead and as a result use to
-    // much disk space to store unconnected blocks.
-    int nWindowEnd = chainActive.Height() + BLOCK_DOWNLOAD_WINDOW;
-
-    int nMaxHeight = std::min<int>(state->pindexBestKnownBlock->nHeight, nWindowEnd + 1);
-    while (pindexWalk->nHeight < nMaxHeight)
-    {
-        // Read up to 128 (or more, if more blocks than that are needed) successors of pindexWalk (towards
-        // pindexBestKnownBlock) into vToFetch. We fetch 128, because CBlockIndex::GetAncestor may be as expensive
-        // as iterating over ~100 CBlockIndex* entries anyway.
-        int nToFetch = std::min(nMaxHeight - pindexWalk->nHeight, std::max<int>(count - vBlocks.size(), 128));
-        vToFetch.resize(nToFetch);
-        pindexWalk = state->pindexBestKnownBlock->GetAncestor(pindexWalk->nHeight + nToFetch);
-        vToFetch[nToFetch - 1] = pindexWalk;
-        for (unsigned int i = nToFetch - 1; i > 0; i--)
-        {
-            vToFetch[i - 1] = vToFetch[i]->pprev;
-        }
-
-        // Iterate over those blocks in vToFetch (in forward direction), adding the ones that
-        // are not yet downloaded and not in flight to vBlocks. In the mean time, update
-        // pindexLastCommonBlock as long as all ancestors are already downloaded, or if it's
-        // already part of our chain (and therefore don't need it even if pruned).
-        for (CBlockIndex *pindex : vToFetch)
-        {
-            if (requester.AlreadyAskedFor(pindex->GetBlockHash()))
-                continue;
-
-            if (!pindex->IsValid(BLOCK_VALID_TREE))
-            {
-                // We consider the chain that this peer is on invalid.
-                return;
-            }
-            if (pindex->nStatus & BLOCK_HAVE_DATA || chainActive.Contains(pindex))
-            {
-                if (pindex->nChainTx)
-                    state->pindexLastCommonBlock = pindex;
-            }
-            else
-            {
-                // Return if we've reached the end of the download window.
-                if (pindex->nHeight > nWindowEnd)
-                {
-                    return;
-                }
-
-                // Return if we've reached the end of the number of blocks we can download for this peer.
-                vBlocks.push_back(pindex);
-                if (vBlocks.size() == count)
-                {
-                    return;
-                }
-            }
-        }
-    }
-}
-
 } // anon namespace
 
 void MarkBlockAsInFlight(NodeId nodeid,
@@ -7503,7 +7380,7 @@ bool SendMessages(CNode *pto)
         if (!pto->fDisconnect && !pto->fClient && state.nBlocksInFlight < (int)pto->nMaxBlocksInTransit)
         {
             std::vector<CBlockIndex *> vToDownload;
-            FindNextBlocksToDownload(
+            requester.FindNextBlocksToDownload(
                 pto->GetId(), pto->nMaxBlocksInTransit.load() - state.nBlocksInFlight, vToDownload);
             // LOG(REQ, "IBD AskFor %d blocks from peer=%s\n", vToDownload.size(), pto->GetLogName());
             std::vector<CInv> vGetBlocks;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -293,8 +293,6 @@ void FinalizeNode(NodeId nodeid)
 
     for (const QueuedBlock &entry : state->vBlocksInFlight)
     {
-        printf("erasing map mapblocksinflight entries\n");
-
         LOGA("erasing map mapblocksinflight entries\n");
         mapBlocksInFlight.erase(entry.hash);
     }
@@ -364,7 +362,7 @@ static bool MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
                 pnode->nMaxBlocksInTransit.store(16);
             }
 
-            LOG(THIN, "Average block response time is %.2f seconds\n", pnode->nAvgBlkResponseTime);
+            LOG(THIN | BLK, "Average block response time is %.2f seconds\n", pnode->nAvgBlkResponseTime);
         }
 
         // if there are no blocks in flight then ask for a few more blocks
@@ -379,7 +377,7 @@ static bool MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
         {
             BLOCK_DOWNLOAD_WINDOW = blockDownloadWindow.value;
         }
-        LOG(THIN, "BLOCK_DOWNLOAD_WINDOW is %d nMaxBlocksInTransit is %d\n", BLOCK_DOWNLOAD_WINDOW,
+        LOG(THIN | BLK, "BLOCK_DOWNLOAD_WINDOW is %d nMaxBlocksInTransit is %d\n", BLOCK_DOWNLOAD_WINDOW,
             pnode->nMaxBlocksInTransit.load());
 
         if (IsChainNearlySyncd())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -114,7 +114,7 @@ static unsigned int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 1;
  *  Larger windows tolerate larger download speed differences between peer, but increase the potential
  *  degree of disordering of blocks on disk (which make reindexing and in the future perhaps pruning
  *  harder). We'll probably want to make this a per-peer adaptive value at some point. */
-static unsigned int BLOCK_DOWNLOAD_WINDOW = 256;
+static unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
 
 extern CTweak<unsigned int> maxBlocksInTransitPerPeer; // override the above
 extern CTweak<unsigned int> blockDownloadWindow;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -527,8 +527,11 @@ static void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vec
         // are not yet downloaded and not in flight to vBlocks. In the mean time, update
         // pindexLastCommonBlock as long as all ancestors are already downloaded, or if it's
         // already part of our chain (and therefore don't need it even if pruned).
-        BOOST_FOREACH (CBlockIndex *pindex, vToFetch)
+        for (CBlockIndex *pindex : vToFetch)
         {
+            if (requester.AlreadyAskedFor(pindex->GetBlockHash()))
+                continue;
+
             if (!pindex->IsValid(BLOCK_VALID_TREE))
             {
                 // We consider the chain that this peer is on invalid.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6405,7 +6405,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             // blocks that we need.  Therefore, update block availability for every connected node. If we
             // don't do this, then at the beginning of IBD we will end up only downloading from one peer.
             LOCK(cs_vNodes);
-            for (CNode *pnode: vNodes)
+            for (CNode *pnode : vNodes)
             {
                 UpdateBlockAvailability(pnode->GetId(), pindexLast->GetBlockHash());
             }
@@ -7238,7 +7238,7 @@ bool SendMessages(CNode *pto)
         CNodeState &state = *State(pto->GetId());
 
         // We need to update any newly connected peers with a best header if we are doing an initial sync.
-        // If we don't do this then we'll end up downloading blocks all from one peer. 
+        // If we don't do this then we'll end up downloading blocks all from one peer.
         if (IsInitialBlockDownload() && state.pindexBestKnownBlock == nullptr)
         {
             UpdateBlockAvailability(pto->GetId(), pindexBestHeader->GetBlockHash());
@@ -7547,8 +7547,6 @@ bool SendMessages(CNode *pto)
                         requester.AskForDuringIBD(inv, pto);
                     // LOG(REQ, "AskFor block %s (%d) peer=%s\n", pindex->GetBlockHash().ToString(),
                     //  pindex->nHeight, pto->GetLogName());
-
-
                 }
             }
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -371,6 +371,7 @@ bool MarkBlockAsReceived(const uint256 &hash)
         LOG(THIN, "BLOCK_DOWNLOAD_WINDOW is %d MAX_BLOCKS_IN_TRANSIT_PER_PEER is %d\n", BLOCK_DOWNLOAD_WINDOW,
             MAX_BLOCKS_IN_TRANSIT_PER_PEER);
 
+        if (IsChainNearlySyncd())
         {
             LOCK(cs_vNodes);
             BOOST_FOREACH (CNode *pnode, vNodes)

--- a/src/main.h
+++ b/src/main.h
@@ -105,12 +105,6 @@ static const unsigned int VERACK_TIMEOUT = 60;
 /** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends
  *  less than this number, we reached its tip. Changing this value is a protocol upgrade. */
 static const unsigned int MAX_HEADERS_RESULTS = 2000;
-/** Size of the "block download window": how far ahead of our current height do we fetch?
- *  Larger windows tolerate larger download speed differences between peer, but increase the potential
- *  degree of disordering of blocks on disk (which make reindexing and in the future perhaps pruning
- *  harder). We'll probably want to make this a per-peer adaptive value at some point. */
-// static const unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
-/** Time to wait (in seconds) between writing blocks/block index to disk. */
 static const unsigned int DATABASE_WRITE_INTERVAL = 60 * 60;
 /** Time to wait (in seconds) between flushing chainstate to disk. */
 static const unsigned int DATABASE_FLUSH_INTERVAL = 24 * 60 * 60;

--- a/src/main.h
+++ b/src/main.h
@@ -436,9 +436,6 @@ bool TestLockPointValidity(const LockPoints *lp);
  */
 bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints *lp = NULL, bool useExistingLockPoints = false);
 
-/** Update tracking information about which blocks a peer is assumed to have. */
-void UpdateBlockAvailability(NodeId nodeid, const uint256 &hash);
-
 /**
  * Class that keeps track of number of signature operations
  * and bytes hashed to compute signature hashes.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2111,10 +2111,9 @@ void ThreadMessageHandler()
                 nLastRotation = GetTime();
             }
 
-            vNodesCopy.reserve(vNodes.size());
+            vNodesCopy = vNodes;
             for (CNode *pnode : vNodes)
             {
-                vNodesCopy.push_back(pnode);
                 pnode->AddRef();
             }
         }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2100,22 +2100,10 @@ void ThreadMessageHandler()
         {
             LOCK(cs_vNodes);
             vNodesCopy.reserve(vNodes.size());
-            // Prefer thinBlockCapable nodes when doing communications.
             for (CNode *pnode : vNodes)
             {
-                if (pnode->ThinBlockCapable())
-                {
-                    vNodesCopy.push_back(pnode);
-                    pnode->AddRef();
-                }
-            }
-            for (CNode *pnode : vNodes)
-            {
-                if (!pnode->ThinBlockCapable())
-                {
-                    vNodesCopy.push_back(pnode);
-                    pnode->AddRef();
-                }
+                vNodesCopy.push_back(pnode);
+                pnode->AddRef();
             }
         }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2813,6 +2813,8 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
     nXthinBloomfilterSize = 0;
     addrFromPort = 0; // BU
     nLocalThinBlockBytes = 0;
+    nAvgBlkResponseTime = -1.0;
+    nMaxBlocksInTransit = 16;
 
     nMisbehavior = 0;
     fShouldBan = false;

--- a/src/net.h
+++ b/src/net.h
@@ -79,7 +79,7 @@ static const size_t SETASKFOR_MAX_SZ = 2 * MAX_INV_SZ;
 /** The maximum number of peer connections to maintain. */
 static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 /** BU: The maximum numer of outbound peer connections */
-static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 12;
+static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 16;
 /** BU: The minimum number of xthin nodes to connect */
 static const uint8_t MIN_XTHIN_NODES = 8;
 /** BU: The daily maximum disconnects while searching for xthin nodes to connect */

--- a/src/net.h
+++ b/src/net.h
@@ -392,6 +392,10 @@ public:
     uint32_t nXthinBloomfilterSize; // The maximum xthin bloom filter size (in bytes) that our peer will accept.
     // BUIP010 Xtreme Thinblocks: end section
 
+    CCriticalSection cs_nAvgBlkResponseTime;
+    double nAvgBlkResponseTime;
+    std::atomic<int64_t> nMaxBlocksInTransit;
+
     unsigned short addrFromPort;
 
 protected:

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -11,16 +11,17 @@
 */
 CNodeState::CNodeState()
 {
-    pindexBestKnownBlock = NULL;
+    pindexBestKnownBlock = nullptr;
     hashLastUnknownBlock.SetNull();
-    pindexLastCommonBlock = NULL;
-    pindexBestHeaderSent = NULL;
+    pindexLastCommonBlock = nullptr;
+    pindexBestHeaderSent = nullptr;
     fSyncStarted = false;
     nDownloadingSince = 0;
     nBlocksInFlight = 0;
     nBlocksInFlightValidHeaders = 0;
     fPreferredDownload = false;
     fPreferHeaders = false;
+    fRequestedInitialBlockAvailability = false;
 }
 
 /**
@@ -33,6 +34,6 @@ CNodeState *State(NodeId pnode)
 {
     std::map<NodeId, CNodeState>::iterator it = mapNodeState.find(pnode);
     if (it == mapNodeState.end())
-        return NULL;
+        return nullptr;
     return &it->second;
 }

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -48,6 +48,9 @@ struct CNodeState
     bool fFirstHeadersReceived;
     //! Our current block height at the time we requested GETHEADERS
     int nFirstHeadersExpectedHeight;
+    //! During IBD we need to update the block availabiity for each peer. We do this by requesting a header
+    //  when a peer connects and also when we ask for the initial set of all headers.
+    bool fRequestedInitialBlockAvailability;
 
     std::list<QueuedBlock> vBlocksInFlight;
     //! When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -176,7 +176,8 @@ void CRequestManager::AskForDuringIBD(const CInv &obj, CNode *from, unsigned int
     // add from this node first so that they get requested first.
     AskFor(obj, from, priority);
 
-    LOCK(cs_vNodes);
+    // Must lock cs_objDownloader here and before cs_vNodes to maintain proper locking order.
+    LOCK2(cs_objDownloader, cs_vNodes);
     for (CNode *pnode : vNodes)
     {
         if (pnode == from)

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -372,6 +372,7 @@ bool RequestBlock(CNode *pfrom, CInv obj)
     //        here.
     if (IsChainNearlySyncd() || chainParams.NetworkIDString() == "regtest")
     {
+        LOCK(cs_main);
         BlockMap::iterator idxIt = mapBlockIndex.find(obj.hash);
         if (idxIt == mapBlockIndex.end()) // only request if we don't already have the header
         {

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -625,7 +625,6 @@ void CRequestManager::SendRequests()
         for (auto iter : mapBatchBlockRequests)
         {
             LEAVE_CRITICAL_SECTION(cs_objDownloader);
-            iter.first->PushMessage(NetMsgType::GETDATA, iter.second);
             {
                 LOCK(cs_main);
                 for (auto &inv : iter.second)
@@ -633,6 +632,7 @@ void CRequestManager::SendRequests()
                     MarkBlockAsInFlight(iter.first->GetId(), inv.hash, Params().GetConsensus());
                 }
             }
+            iter.first->PushMessage(NetMsgType::GETDATA, iter.second);
             ENTER_CRITICAL_SECTION(cs_objDownloader);
             LOG(REQ, "Sent batched rqst with %d blocks to node %s\n", iter.second.size(), iter.first->GetLogName());
         }

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -39,6 +39,9 @@ using namespace std;
 
 extern CCriticalSection cs_orphancache; // from main.h
 
+extern CTweak<unsigned int> maxBlocksInTransitPerPeer;
+extern CTweak<unsigned int> blockDownloadWindow;
+
 // Request management
 extern CRequestManager requester;
 
@@ -60,11 +63,6 @@ unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
 
 // defined in main.cpp.  should be moved into a utilities file but want to make rebasing easier
 extern bool CanDirectFetch(const Consensus::Params &consensusParams);
-extern void MarkBlockAsInFlight(NodeId nodeid,
-    const uint256 &hash,
-    const Consensus::Params &consensusParams,
-    CBlockIndex *pindex = nullptr);
-// note mark block as in flight is redundant with the request manager now...
 
 /** Find the last common ancestor two blocks have.
  *  Both pa and pb must be non-NULL. */
@@ -424,7 +422,7 @@ bool CUnknownObj::AddSource(CNode *from)
     return false;
 }
 
-bool RequestBlock(CNode *pfrom, CInv obj)
+bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
 {
     const CChainParams &chainParams = Params();
 
@@ -848,7 +846,8 @@ void CRequestManager::FindNextBlocksToDownload(NodeId nodeid, unsigned int count
     // Make sure pindexBestKnownBlock is up to date, we'll need it.
     requester.ProcessBlockAvailability(nodeid);
 
-    if (state->pindexBestKnownBlock == nullptr || state->pindexBestKnownBlock->nChainWork < chainActive.Tip()->nChainWork)
+    if (state->pindexBestKnownBlock == nullptr ||
+        state->pindexBestKnownBlock->nChainWork < chainActive.Tip()->nChainWork)
     {
         // This peer has nothing interesting.
         return;
@@ -926,4 +925,149 @@ void CRequestManager::FindNextBlocksToDownload(NodeId nodeid, unsigned int count
             }
         }
     }
+}
+
+// indicate whether we requested this block.
+void CRequestManager::MarkBlockAsInFlight(NodeId nodeid,
+    const uint256 &hash,
+    const Consensus::Params &consensusParams,
+    CBlockIndex *pindex)
+{
+    LOCK(cs_main);
+    CNodeState *state = State(nodeid);
+    DbgAssert(state != nullptr, return );
+
+    // If started then clear the thinblock timer used for preferential downloading
+    thindata.ClearThinBlockTimer(hash);
+
+    // BU why mark as received? because this erases it from the inflight list.  Instead we'll check for it
+    // BU removed: MarkBlockAsReceived(hash);
+    std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> >::iterator itInFlight =
+        mapBlocksInFlight.find(hash);
+    if (itInFlight == mapBlocksInFlight.end()) // If it hasn't already been marked inflight...
+    {
+        int64_t nNow = GetTimeMicros();
+        QueuedBlock newentry = {hash, pindex, nNow, pindex != nullptr};
+        std::list<QueuedBlock>::iterator it = state->vBlocksInFlight.insert(state->vBlocksInFlight.end(), newentry);
+        state->nBlocksInFlight++;
+        state->nBlocksInFlightValidHeaders += newentry.fValidatedHeaders;
+        if (state->nBlocksInFlight == 1)
+        {
+            // We're starting a block download (batch) from this peer.
+            state->nDownloadingSince = GetTimeMicros();
+        }
+        if (state->nBlocksInFlightValidHeaders == 1 && pindex != nullptr)
+        {
+            nPeersWithValidatedDownloads++;
+        }
+        mapBlocksInFlight[hash] = std::make_pair(nodeid, it);
+    }
+}
+
+// Returns a bool if successful in indicating we received this block.
+bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
+{
+    AssertLockHeld(cs_main);
+
+    std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> >::iterator itInFlight =
+        mapBlocksInFlight.find(hash);
+    if (itInFlight != mapBlocksInFlight.end())
+    {
+        CNodeState *state = State(itInFlight->second.first);
+        DbgAssert(state != nullptr, return false);
+
+        int64_t getdataTime = itInFlight->second.second->nTime;
+        int64_t now = GetTimeMicros();
+        double nResponseTime = (double)(now - getdataTime) / 1000000.0;
+
+        // calculate avg block response time over a range of blocks to be used for IBD tuning.
+        static uint8_t blockRange = 50;
+        {
+            LOCK(pnode->cs_nAvgBlkResponseTime);
+            if (pnode->nAvgBlkResponseTime < 0)
+                pnode->nAvgBlkResponseTime = 2.0;
+            if (pnode->nAvgBlkResponseTime > 0)
+                pnode->nAvgBlkResponseTime -= (pnode->nAvgBlkResponseTime / blockRange);
+            pnode->nAvgBlkResponseTime += nResponseTime / blockRange;
+
+            if (pnode->nAvgBlkResponseTime < 0.2)
+            {
+                pnode->nMaxBlocksInTransit.store(64);
+            }
+            else if (pnode->nAvgBlkResponseTime < 0.5)
+            {
+                pnode->nMaxBlocksInTransit.store(56);
+            }
+            else if (pnode->nAvgBlkResponseTime < 0.9)
+            {
+                pnode->nMaxBlocksInTransit.store(48);
+            }
+            else if (pnode->nAvgBlkResponseTime < 1.4)
+            {
+                pnode->nMaxBlocksInTransit.store(32);
+            }
+            else if (pnode->nAvgBlkResponseTime < 2.0)
+            {
+                pnode->nMaxBlocksInTransit.store(24);
+            }
+            else
+            {
+                pnode->nMaxBlocksInTransit.store(16);
+            }
+
+            LOG(THIN | BLK, "Average block response time is %.2f seconds\n", pnode->nAvgBlkResponseTime);
+        }
+
+        // if there are no blocks in flight then ask for a few more blocks
+        if (state->nBlocksInFlight <= 0)
+            pnode->nMaxBlocksInTransit.fetch_add(4);
+
+        if (maxBlocksInTransitPerPeer.value != 0)
+        {
+            pnode->nMaxBlocksInTransit.store(maxBlocksInTransitPerPeer.value);
+        }
+        if (blockDownloadWindow.value != 0)
+        {
+            BLOCK_DOWNLOAD_WINDOW = blockDownloadWindow.value;
+        }
+        LOG(THIN | BLK, "BLOCK_DOWNLOAD_WINDOW is %d nMaxBlocksInTransit is %d\n", BLOCK_DOWNLOAD_WINDOW,
+            pnode->nMaxBlocksInTransit.load());
+
+        if (IsChainNearlySyncd())
+        {
+            LOCK(cs_vNodes);
+            for (CNode *pnode : vNodes)
+            {
+                if (pnode->mapThinBlocksInFlight.size() > 0)
+                {
+                    LOCK(pnode->cs_mapthinblocksinflight);
+                    if (pnode->mapThinBlocksInFlight.count(hash))
+                    {
+                        // Only update thinstats if this is actually a thinblock and not a regular block.
+                        // Sometimes we request a thinblock but then revert to requesting a regular block
+                        // as can happen when the thinblock preferential timer is exceeded.
+                        thindata.UpdateResponseTime(nResponseTime);
+                        break;
+                    }
+                }
+            }
+        }
+        // BUIP010 Xtreme Thinblocks: end section
+        state->nBlocksInFlightValidHeaders -= itInFlight->second.second->fValidatedHeaders;
+        if (state->nBlocksInFlightValidHeaders == 0 && itInFlight->second.second->fValidatedHeaders)
+        {
+            // Last validated block on the queue was received.
+            nPeersWithValidatedDownloads--;
+        }
+        if (state->vBlocksInFlight.begin() == itInFlight->second.second)
+        {
+            // First block on the queue was received, update the start download time for the next one
+            state->nDownloadingSince = std::max(state->nDownloadingSince, GetTimeMicros());
+        }
+        state->vBlocksInFlight.erase(itInFlight->second.second);
+        state->nBlocksInFlight--;
+        mapBlocksInFlight.erase(itInFlight);
+        return true;
+    }
+    return false;
 }

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -527,11 +527,6 @@ void CRequestManager::SendRequests()
                             reason = "on disconnect";
                             release = true;
                         }
-                        else if (!IsChainNearlySyncd() && !IsNodePingAcceptable(next.node))
-                        {
-                            reason = "bad ping time";
-                            release = true;
-                        }
                         if (release)
                         {
                             LOCK(cs_vNodes);
@@ -688,40 +683,4 @@ void CRequestManager::SendRequests()
             }
         }
     }
-}
-
-bool CRequestManager::IsNodePingAcceptable(CNode *pfrom)
-{
-    if (pfrom->nPingUsecTime < ACCEPTABLE_PING_USEC)
-        return true;
-
-    // Calculate average ping time of all nodes
-    uint16_t nValidNodes = 0;
-    std::vector<uint64_t> vPingTimes;
-    LOCK(cs_vNodes);
-    BOOST_FOREACH (CNode *pnode, vNodes)
-    {
-        if (!pnode->fDisconnect && pnode->nPingUsecTime > 0)
-        {
-            nValidNodes++;
-            vPingTimes.push_back(pnode->nPingUsecTime);
-        }
-    }
-    if (nValidNodes < 10) // Take anything if we are poorly connected
-        return true;
-
-    // Calculate Standard Deviation and Mean of Ping Time
-    using namespace boost::accumulators;
-    accumulator_set<double, stats<tag::variance> > acc;
-    acc = for_each(vPingTimes.begin(), vPingTimes.end(), acc);
-    double nMean = mean(acc);
-    double sDeviation = sqrt(variance(acc));
-
-    // If node ping time is greater than the average plus 2 times the standard deviation, or
-    // the pong has not been received, then do not request from this node.
-    if ((pfrom->nPingUsecTime > (int64_t)(nMean + (2 * sDeviation))) || (pfrom->nPingUsecTime == 0))
-    {
-        return false;
-    }
-    return true;
 }

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -632,7 +632,7 @@ void CRequestManager::SendRequests()
             }
             iter.first->PushMessage(NetMsgType::GETDATA, iter.second);
             ENTER_CRITICAL_SECTION(cs_objDownloader);
-            LOG(REQ, "Sent batched rqst with %d blocks to node %s\n", iter.second.size(), iter.first->GetLogName());
+            LOG(REQ, "Sent batched request with %d blocks to node %s\n", iter.second.size(), iter.first->GetLogName());
         }
 
         LOCK(cs_vNodes);

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -491,7 +491,7 @@ void CRequestManager::SendRequests()
     // asking for one at time. We can do this because there will be no XTHIN requests possible during
     // this time.
     bool fBatchBlockRequests = IsInitialBlockDownload();
-    std::map<CNode *, std::vector<CInv>> mapBatchBlockRequests;
+    std::map<CNode *, std::vector<CInv> > mapBatchBlockRequests;
 
     // Get Blocks
     while (sendBlkIter != mapBlkInfo.end())
@@ -634,7 +634,7 @@ void CRequestManager::SendRequests()
                 }
             }
             ENTER_CRITICAL_SECTION(cs_objDownloader);
-            LOG(REQ, "Sent batched rqst with %d blocks to node %s\n",  iter.second.size(), iter.first->GetLogName());
+            LOG(REQ, "Sent batched rqst with %d blocks to node %s\n", iter.second.size(), iter.first->GetLogName());
         }
 
         LOCK(cs_vNodes);

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -171,6 +171,20 @@ void CRequestManager::AskFor(const std::vector<CInv> &objArray, CNode *from, uns
     }
 }
 
+void CRequestManager::AskForDuringIBD(const CInv &obj, CNode *from, unsigned int priority)
+{
+    // add from this node first so that they get requested first.
+    AskFor(obj, from, priority);
+
+    LOCK(cs_vNodes);
+    for (CNode *pnode : vNodes)
+    {
+        if (pnode == from)
+            continue;
+
+        AskFor(obj, pnode, priority);
+    }
+}
 
 // Indicate that we got this object, from and bytes are optional (for node performance tracking)
 void CRequestManager::Received(const CInv &obj, CNode *from, int bytes)

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -192,6 +192,16 @@ void CRequestManager::AskForDuringIBD(const std::vector<CInv> &objArray, CNode *
     }
 }
 
+bool CRequestManager::AlreadyAskedFor(const uint256 &hash)
+{
+    LOCK(cs_objDownloader);
+    OdMap::iterator item = mapBlkInfo.find(hash);
+    if (item != mapBlkInfo.end())
+        return true;
+
+    return false;
+}
+
 // Indicate that we got this object, from and bytes are optional (for node performance tracking)
 void CRequestManager::Received(const CInv &obj, CNode *from, int bytes)
 {

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -561,9 +561,11 @@ void CRequestManager::SendRequests()
 
                     if (fBatchBlockRequests)
                     {
+                        {
+                            LOCK(cs_vNodes);
+                            next.node->AddRef();
+                        }
                         mapBatchBlockRequests[next.node].push_back(obj);
-                        LOCK(cs_vNodes);
-                        next.node->AddRef();
                     }
                     else
                     {

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -155,6 +155,10 @@ public:
 
     // Update tracking information about which blocks a peer is assumed to have.
     void UpdateBlockAvailability(NodeId nodeid, const uint256 &hash);
+
+    // Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks, until it has
+    // at most count entries.
+    void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<CBlockIndex *> &vBlocks);
 };
 
 

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -135,6 +135,10 @@ public:
     // request another group of blocks that are already in flight.
     void AskForDuringIBD(const std::vector<CInv> &objArray, CNode *from, unsigned int priority = 0);
 
+    // Did we already ask for this block. We need to do this during IBD to make sure we don't ask for another set
+    // of the same blocks.
+    bool AlreadyAskedFor(const uint256 &hash);
+
     // Indicate that we got this object, from and bytes are optional (for node performance tracking)
     void Received(const CInv &obj, CNode *from, int bytes = 0);
 

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -120,7 +120,13 @@ protected:
     CLeakyBucket requestPacer;
     CLeakyBucket blockPacer;
 
+    // Request a single block.
+    bool RequestBlock(CNode *pfrom, CInv obj);
+
 public:
+    // Number of peers from which we're downloading blocks.
+    int nPeersWithValidatedDownloads = 0;
+
     CRequestManager();
 
     // Get this object from somewhere, asynchronously.
@@ -159,6 +165,15 @@ public:
     // Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks, until it has
     // at most count entries.
     void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<CBlockIndex *> &vBlocks);
+
+    // Returns a bool indicating whether we requested this block.
+    void MarkBlockAsInFlight(NodeId nodeid,
+        const uint256 &hash,
+        const Consensus::Params &consensusParams,
+        CBlockIndex *pindex = nullptr);
+
+    // Returns a bool if successful in indicating we received this block.
+    bool MarkBlockAsReceived(const uint256 &hash, CNode *pnode);
 };
 
 

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -133,7 +133,7 @@ public:
     // can give us the blocks we need and so we tell the request manager about these sources. Otherwise the request
     // manager may not be able to re-request blocks from anyone after a timeout and we also need to be able to not
     // request another group of blocks that are already in flight.
-    void AskForDuringIBD(const CInv &obj, CNode *from, unsigned int priority = 0);
+    void AskForDuringIBD(const std::vector<CInv> &objArray, CNode *from, unsigned int priority = 0);
 
     // Indicate that we got this object, from and bytes are optional (for node performance tracking)
     void Received(const CInv &obj, CNode *from, int bytes = 0);

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -145,9 +145,6 @@ public:
     void Rejected(const CInv &obj, CNode *from, unsigned char reason = 0);
 
     void SendRequests();
-
-    // Indicates whether a node ping time is acceptable relative to the overall average of all nodes.
-    bool IsNodePingAcceptable(CNode *pnode);
 };
 
 

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -149,6 +149,12 @@ public:
     void Rejected(const CInv &obj, CNode *from, unsigned char reason = 0);
 
     void SendRequests();
+
+    // Check whether the last unknown block a peer advertised is not yet known.
+    void ProcessBlockAvailability(NodeId nodeid);
+
+    // Update tracking information about which blocks a peer is assumed to have.
+    void UpdateBlockAvailability(NodeId nodeid, const uint256 &hash);
 };
 
 

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -129,6 +129,12 @@ public:
     // Get these objects from somewhere, asynchronously.
     void AskFor(const std::vector<CInv> &objArray, CNode *from, unsigned int priority = 0);
 
+    // Get these objects from somewhere, asynchronously during IBD. During IBD we must assume every peer connected
+    // can give us the blocks we need and so we tell the request manager about these sources. Otherwise the request
+    // manager may not be able to re-request blocks from anyone after a timeout and we also need to be able to not
+    // request another group of blocks that are already in flight.
+    void AskForDuringIBD(const CInv &obj, CNode *from, unsigned int priority = 0);
+
     // Indicate that we got this object, from and bytes are optional (for node performance tracking)
     void Received(const CInv &obj, CNode *from, int bytes = 0);
 

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -599,7 +599,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
         }
 
         inv.hash = pIndex->GetBlockHash();
-        UpdateBlockAvailability(pfrom->GetId(), inv.hash);
+        requester.UpdateBlockAvailability(pfrom->GetId(), inv.hash);
 
         // Return early if we already have the block data
         if (pIndex->nStatus & BLOCK_HAVE_DATA)

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -41,9 +41,7 @@ enum
     MAX_HEADER_REQS_DURING_IBD = 3,
     // if the blockchain is this far (in seconds) behind the current time, only request headers from a single
     // peer.  This makes IBD more efficient.
-    // TODO: since the new DAA cash mining is no more erratic than bitcoin legacy.
-    // Wouldn't been better to set it back to what it was? (i.e. 24 * 60 * 60)
-    SINGLE_PEER_REQUEST_MODE_AGE = (7 * 24 * 60 * 60),
+    SINGLE_PEER_REQUEST_MODE_AGE = (24 * 60 * 60),
 };
 
 class CBlock;


### PR DESCRIPTION
Here we adjust the max blocks in flight per peer based on it's historical download response times.  This way we ask for more blocks from faster peers.