### PR TITLE
EB or AD update -> miner string update

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -199,7 +199,8 @@ CTweak<bool> walletSignWithForkSig("wallet.useNewSig",
 CTweak<unsigned int> maxTxSize("net.excessiveTx", "Largest transaction size in bytes", DEFAULT_LARGEST_TRANSACTION);
 CTweakRef<unsigned int> eadTweak("net.excessiveAcceptDepth",
     "Excessive block chain acceptance depth in blocks",
-    &excessiveAcceptDepth);
+    &excessiveAcceptDepth,
+    &AcceptDepthValidator);
 CTweakRef<int> maxOutConnectionsTweak("net.maxOutboundConnections",
     "Maximum number of outbound connections",
     &nMaxOutConnections,

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -69,6 +69,14 @@ bool MiningAndExcessiveBlockValidatorRule(const uint64_t newExcessiveBlockSize, 
     LOGA("newMiningBlockSize: %d - newExcessiveBlockSize: %d\n", newMiningBlockSize, newExcessiveBlockSize);
     return (newMiningBlockSize <= newExcessiveBlockSize);
 }
+std::string AcceptDepthValidator(const unsigned int &value, unsigned int *item, bool validate)
+{
+    if (!validate)
+    {
+        settingsToUserAgentString();
+    }
+    return std::string();
+}
 
 std::string ExcessiveBlockValidator(const uint64_t &value, uint64_t *item, bool validate)
 {
@@ -85,7 +93,7 @@ std::string ExcessiveBlockValidator(const uint64_t &value, uint64_t *item, bool 
     }
     else // Do anything to "take" the new value
     {
-        // nothing needed
+        settingsToUserAgentString();
     }
     return std::string();
 }
@@ -220,7 +228,7 @@ std::string FormatCoinbaseMessage(const std::vector<std::string> &comments, cons
             ss << "/" << *it;
         ss << "/";
     }
-    std::string ret = ss.str() + minerComment;
+    std::string ret = ss.str() + customComment;
     return ret;
 }
 

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -81,8 +81,8 @@ extern unsigned int maxMessageSizeMultiplier;
 /** BU Default maximum number of Outbound connections to simultaneously allow*/
 extern int nMaxOutConnections;
 
-extern std::vector<std::string>
-    BUComments; // BU005: Strings specific to the config of this client that should be communicated to other clients
+// BU005: Strings specific to the config of this client that should be communicated to other clients
+extern std::vector<std::string> BUComments;
 extern std::string minerComment; // An arbitrary field that miners can change to annotate their blocks
 
 // BU - Xtreme Thinblocks Auto Mempool Limiter - begin section
@@ -265,6 +265,7 @@ extern CStatHistory<uint64_t, MinValMax<uint64_t> > poolSize;
 
 // Configuration variable validators
 bool MiningAndExcessiveBlockValidatorRule(const uint64_t newExcessiveBlockSize, const uint64_t newMiningBlockSize);
+std::string AcceptDepthValidator(const unsigned int &value, unsigned int *item, bool validate);
 std::string ExcessiveBlockValidator(const uint64_t &value, uint64_t *item, bool validate);
 std::string OutboundConnectionValidator(const int &value, int *item, bool validate);
 std::string SubverValidator(const std::string &value, std::string *item, bool validate);


### PR DESCRIPTION
ensure that the subversion and miner coinbase is updated when EB or AD is updated.  Note that getblocktemplate still caches the template unless tx arrive and 5 sec passed or a new block has arrived.  So you may not see the coinbaseaux string change instantly (and in regression test mode you should trigger a new template by creating a tx).