### PR TITLE
basic may 2018 fork infrastructure

### DIFF
--- a/qa/rpc-tests/forkMay2018.py
+++ b/qa/rpc-tests/forkMay2018.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# This is a template to make creating new QA tests easy.
+# You can also use this template to quickly start and connect a few regtest nodes.
+
+import time
+import sys
+if sys.version_info[0] < 3:
+    raise "Use Python 3"
+import logging
+logging.basicConfig(format='%(asctime)s.%(levelname)s: %(message)s', level=logging.INFO, stream=sys.stdout)
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+
+class ForkTest (BitcoinTestFramework):
+
+    def setup_chain(self, bitcoinConfDict=None, wallets=None):
+        print("Initializing test directory " + self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 4, bitcoinConfDict, wallets)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(2, self.options.tmpdir)
+
+        # Now interconnect the nodes
+        connect_nodes_bi(self.nodes, 0, 1)
+        # Let the framework know if the network is fully connected.
+        # If not, the framework assumes this partition: (0,1) and (2,3)
+        # For more complex partitions, you can't use the self.sync* member functions
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test(self):
+
+        # Advance the time beyond the timeout value
+        cur_time = int(time.time())
+        self.nodes[0].setmocktime(cur_time)
+        self.nodes[1].setmocktime(cur_time)
+
+        self.nodes[0].set("mining.forkMay2018Time=%d" % (cur_time + 10))
+        self.nodes[1].set("mining.forkMay2018Time=%d" % (cur_time + 10))
+
+        ebVal = self.nodes[0].get("net.excessiveBlock")
+
+        ret = self.nodes[1].generate(6)
+        self.sync_blocks()
+        self.nodes[0].generate(6)
+        self.sync_blocks()
+
+        # Not forking yet
+
+        assert(self.nodes[0].get("mining.dataCarrierSize")["mining.dataCarrierSize"] == 83)
+
+        assert_equal(ebVal, self.nodes[0].get("net.excessiveBlock"))
+        assert_equal(ebVal, self.nodes[1].get("net.excessiveBlock"))
+
+        self.nodes[0].setmocktime(cur_time + 20)
+        self.nodes[1].setmocktime(cur_time + 20)
+
+        self.nodes[0].generate(5)
+        self.sync_blocks()
+        assert_equal(ebVal, self.nodes[0].get("net.excessiveBlock"))
+        assert_equal(ebVal, self.nodes[1].get("net.excessiveBlock"))
+
+        self.nodes[0].generate(1)
+        self.sync_blocks()
+
+        # Forked, check that the EB is updated
+        assert(ebVal != self.nodes[0].get("net.excessiveBlock"))
+        assert(ebVal != self.nodes[1].get("net.excessiveBlock"))
+        assert(self.nodes[0].get("net.excessiveBlock")["net.excessiveBlock"] == 32000000)
+        assert(self.nodes[1].get("net.excessiveBlock")["net.excessiveBlock"] == 32000000)
+
+        # check that the block size is updated
+        d = self.nodes[0].get("mining.*lockSize")
+        assert(d["mining.blockSize"] >= d["mining.forkBlockSize"])
+        d = self.nodes[1].get("mining.*lockSize")
+        assert(d["mining.blockSize"] >= d["mining.forkBlockSize"])
+
+        # check that the datacarrier size is updated
+        assert(self.nodes[0].get("mining.dataCarrierSize")["mining.dataCarrierSize"] == 223)
+
+
+if __name__ == '__main__':
+    ForkTest().main()
+
+
+# Create a convenient function for an interactive python debugging session
+def Test():
+    t = ForkTest()
+    bitcoinConf = {
+        "debug": ["net", "blk", "thin", "mempool", "req", "bench", "evict"],
+        "blockprioritysize": 2000000  # we don't want any transactions rejected due to insufficient fees...
+    }
+
+    # you may want these additional flags:
+    # "--srcdir=<out-of-source-build-dir>/debug/src"
+    # "--tmpdir=/ramdisk/test"
+    t.main(["--nocleanup", "--noshutdown"], bitcoinConf, None)

--- a/qa/rpc-tests/forkMay2018.py
+++ b/qa/rpc-tests/forkMay2018.py
@@ -1,10 +1,7 @@
 #!/usr/bin/env python3
-# Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+# Copyright (c) 2018 The Bitcoin Unlimited developers
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
-
-# This is a template to make creating new QA tests easy.
-# You can also use this template to quickly start and connect a few regtest nodes.
 
 import time
 import sys

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -25,6 +25,7 @@
 #include "primitives/block.h"
 #include "requestManager.h"
 #include "rpc/server.h"
+#include "script/standard.h"
 #include "stat.h"
 #include "thinblock.h"
 #include "timedata.h"
@@ -175,6 +176,9 @@ CTweakRef<uint64_t> miningBlockSize("mining.blockSize",
     "mining.coinbaseReserve.",
     &maxGeneratedBlock,
     &MiningBlockSizeValidator);
+CTweakRef<unsigned int> maxDataCarrierTweak("mining.dataCarrierSize",
+    "Maximum size of OP_RETURN data script in bytes.",
+    &nMaxDatacarrierBytes);
 
 CTweak<uint64_t> miningForkTime("mining.forkMay2018Time",
     "Time in seconds since the epoch to initiate a hard fork scheduled on 15th May 2018.",
@@ -186,10 +190,10 @@ CTweak<bool> unsafeGetBlockTemplate("mining.unsafeGetBlockTemplate",
 
 CTweak<uint64_t> miningForkEB("mining.forkExcessiveBlock",
     "Set the excessive block to this value at the time of the fork.",
-    8000000); // 8MB, uahf-technical-spec.md REQ-4-1
+    32000000); // May2018 HF proposed max block size
 CTweak<uint64_t> miningForkMG("mining.forkBlockSize",
     "Set the maximum block generation size to this value at the time of the fork.",
-    2000000); // 2MB, uahf-technical-spec.md REQ-4-2
+    8000000);
 
 CTweak<bool> walletSignWithForkSig("wallet.useNewSig",
     "Once the fork occurs, sign transactions using the new signature scheme so that they will only be valid on the "

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3444,6 +3444,19 @@ bool ActivateBestChain(CValidationState &state, const CChainParams &chainparams,
     } while (pindexMostWork->nChainWork > chainActive.Tip()->nChainWork);
     CheckBlockIndex(chainparams.GetConsensus());
 
+    // Activate May 2018 HF rules
+    if (chainActive.Tip()->IsforkActiveOnNextBlock(miningForkTime.value))
+    {
+        // Bump the accepted block size to 32MB and the default generated size to 8MB
+        if (miningForkEB.value > excessiveBlockSize)
+            excessiveBlockSize = miningForkEB.value;
+        if (miningForkMG.value > maxGeneratedBlock)
+            maxGeneratedBlock = miningForkMG.value;
+        settingsToUserAgentString();
+        // Bump OP_RETURN size:
+        if (nMaxDatacarrierBytes < MAX_OP_RETURN_MAY2018)
+            nMaxDatacarrierBytes = MAX_OP_RETURN_MAY2018;
+    }
     return true;
 }
 

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -29,6 +29,7 @@ public:
 };
 
 static const unsigned int MAX_OP_RETURN_RELAY = 83; //! bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
+static const unsigned int MAX_OP_RETURN_MAY2018 = 223; //! 220 bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
 extern bool fAcceptDatacarrier;
 extern unsigned nMaxDatacarrierBytes;
 

--- a/src/uahf_fork.h
+++ b/src/uahf_fork.h
@@ -46,9 +46,6 @@ extern bool UAHFforkAtNextBlock(int height);
 // Is the fork active on the next block?
 extern bool IsUAHFforkActiveOnNextBlock(int height);
 
-extern CTweak<uint64_t> miningForkTime;
-extern CTweak<uint64_t> miningForkEB;
-extern CTweak<uint64_t> miningForkMG;
 extern CTweak<bool> walletSignWithForkSig;
 
 #endif

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -282,4 +282,12 @@ extern std::list<CStatBase *> mallocedStats;
 extern CCriticalSection cs_blockvalidationthread;
 void InterruptBlockValidationThreads();
 
+// Fork configuration
+/** This specifies the MTP time of the next fork */
+extern CTweak<uint64_t> miningForkTime;
+/** This specifies the minimum excessive block setting at the fork point */
+extern CTweak<uint64_t> miningForkEB;
+/** This specifies the minimum max block size at the fork point */
+extern CTweak<uint64_t> miningForkMG;
+
 #endif


### PR DESCRIPTION
The PR set the following during the HF:
   32MB excessive block size
   max generate size to 8MB
   increases the OP_RETURN script size to 223 bytes

A basic HF QA test is created, but this test only validates that the hard fork time properly sets the configuration.  It does not test that the configuration settings work. Testing these will be added in a separate PR. 

Its important to get the basic HF trigger committed soon so it can be used in the cashInterop project.
