### PR TITLE
Update thinblock.cpp

### DIFF
--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -159,7 +159,7 @@ bool CThinBlock::process(CNode *pfrom, int nSizeThinBlock)
     }
 
     // Create the mapMissingTx from all the supplied tx's in the xthinblock
-    BOOST_FOREACH (const CTransaction tx, vMissingTx)
+    for (const CTransaction tx : vMissingTx)
         pfrom->mapMissingTx[tx.GetHash().GetCheapHash()] = tx;
 
     {
@@ -338,7 +338,7 @@ bool CXThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     }
 
     // Create the mapMissingTx from all the supplied tx's in the xthinblock
-    BOOST_FOREACH (const CTransaction tx, thinBlockTx.vMissingTx)
+    for (const CTransaction tx : thinBlockTx.vMissingTx)
         pfrom->mapMissingTx[tx.GetHash().GetCheapHash()] = tx;
 
     // Get the full hashes from the xblocktx and add them to the thinBlockHashes vector.  These should
@@ -689,7 +689,7 @@ bool CXThinBlock::process(CNode *pfrom,
     thindata.AddThinBlockBytes(vTxHashes.size() * sizeof(uint64_t), pfrom); // start counting bytes
 
     // Create the mapMissingTx from all the supplied tx's in the xthinblock
-    BOOST_FOREACH (const CTransaction tx, vMissingTx)
+    for (const CTransaction tx : vMissingTx)
         pfrom->mapMissingTx[tx.GetHash().GetCheapHash()] = tx;
 
     // Create a map of all 8 bytes tx hashes pointing to their full tx hash counterpart
@@ -748,7 +748,7 @@ bool CXThinBlock::process(CNode *pfrom,
         {
             // Start gathering the full tx hashes. If some are not available then add them to setHashesToRequest.
             uint256 nullhash;
-            BOOST_FOREACH (const uint64_t &cheapHash, vTxHashes)
+            for (const uint64_t &cheapHash : vTxHashes)
             {
                 if (mapPartialTxHash.find(cheapHash) != mapPartialTxHash.end())
                     pfrom->thinBlockHashes.push_back(mapPartialTxHash[cheapHash]);
@@ -871,7 +871,7 @@ static bool ReconstructBlock(CNode *pfrom, const bool fXVal, int &missingCount, 
 
     // Look for each transaction in our various pools and buffers.
     // With xThinBlocks the vTxHashes contains only the first 8 bytes of the tx hash.
-    BOOST_FOREACH (const uint256 hash, pfrom->thinBlockHashes)
+    for (const uint256 hash : pfrom->thinBlockHashes)
     {
         // Replace the truncated hash with the full hash value if it exists
         CTransaction tx;
@@ -1342,7 +1342,7 @@ bool HaveConnectThinblockNodes()
     vector<string> vNodesIP;
     {
         LOCK(cs_vNodes);
-        BOOST_FOREACH (CNode *pnode, vNodes)
+        for (CNode *pnode : vNodes)
         {
             int pos = pnode->addrName.rfind(":");
             if (pos <= 0)
@@ -1361,7 +1361,7 @@ bool HaveConnectThinblockNodes()
     set<string> nNotCrossConnected;
 
     int nConnectionsOpen = 0;
-    BOOST_FOREACH (const string &strAddrNode, mapMultiArgs["-connect-thinblock"])
+    for (const string &strAddrNode : mapMultiArgs["-connect-thinblock"])
     {
         string strThinblockNode;
         int pos = strAddrNode.rfind(":");
@@ -1369,7 +1369,7 @@ bool HaveConnectThinblockNodes()
             strThinblockNode = strAddrNode;
         else
             strThinblockNode = strAddrNode.substr(0, pos);
-        BOOST_FOREACH (string strAddr, vNodesIP)
+        for (string strAddr : vNodesIP)
         {
             if (strAddr == strThinblockNode)
             {
@@ -1394,7 +1394,7 @@ bool HaveThinblockNodes()
 {
     {
         LOCK(cs_vNodes);
-        BOOST_FOREACH (CNode *pnode, vNodes)
+        for (CNode *pnode : vNodes)
             if (pnode->ThinBlockCapable())
                 return true;
     }
@@ -1417,7 +1417,7 @@ bool CanThinBlockBeDownloaded(CNode *pto)
         // that has invoked -connect-thinblock.
 
         // Check if this node is also a connect-thinblock node
-        BOOST_FOREACH (const string &strAddrNode, mapMultiArgs["-connect-thinblock"])
+        for (const string &strAddrNode : mapMultiArgs["-connect-thinblock"])
             if (pto->addrName == strAddrNode)
                 return true;
     }
@@ -1429,7 +1429,7 @@ void ConnectToThinBlockNodes()
     // Connect to specific addresses
     if (mapArgs.count("-connect-thinblock") && mapMultiArgs["-connect-thinblock"].size() > 0)
     {
-        BOOST_FOREACH (const string &strAddr, mapMultiArgs["-connect-thinblock"])
+        for (const string &strAddr : mapMultiArgs["-connect-thinblock"])
         {
             CAddress addr;
             // NOTE: Because the only nodes we are connecting to here are the ones the user put in their
@@ -1446,7 +1446,7 @@ void CheckNodeSupportForThinBlocks()
     if (IsThinBlocksEnabled())
     {
         // Check that a nodes pointed to with connect-thinblock actually supports thinblocks
-        BOOST_FOREACH (string &strAddr, mapMultiArgs["-connect-thinblock"])
+        for (string &strAddr : mapMultiArgs["-connect-thinblock"])
         {
             CNodeRef node = FindNodeRef(strAddr);
             if (node && !node->ThinBlockCapable())
@@ -1463,7 +1463,7 @@ bool ClearLargestThinBlockAndDisconnect(CNode *pfrom)
 {
     CNode *pLargest = NULL;
     LOCK(cs_vNodes);
-    BOOST_FOREACH (CNode *pnode, vNodes)
+    for (CNode *pnode : vNodes)
     {
         if ((pLargest == NULL) || (pnode->nLocalThinBlockBytes > pLargest->nLocalThinBlockBytes))
             pLargest = pnode;
@@ -1669,7 +1669,7 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
 
                 // Add children.  We don't need to look for parents here since they will all be parents.
                 iter = mempool.mapTx.project<0>(vPriority[i].second);
-                BOOST_FOREACH (CTxMemPool::txiter child, mempool.GetMemPoolChildren(iter))
+                for (CTxMemPool::txiter child : mempool.GetMemPoolChildren(iter))
                 {
                     uint256 childHash = child->GetTx().GetHash();
                     if (!setPriorityMemPoolHashes.count(childHash))
@@ -1715,7 +1715,7 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
 
                     // Add any parent tx's
                     bool fChild = false;
-                    BOOST_FOREACH (CTxMemPool::txiter parent, mempool.GetMemPoolParents(iter))
+                    for (CTxMemPool::txiter parent : mempool.GetMemPoolParents(iter))
                     {
                         fChild = true;
                         uint256 parentHash = parent->GetTx().GetHash();
@@ -1732,7 +1732,7 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
 
                     // Now add any children tx's.
                     bool fHasChildren = false;
-                    BOOST_FOREACH (CTxMemPool::txiter child, mempool.GetMemPoolChildren(iter))
+                    for (CTxMemPool::txiter child : mempool.GetMemPoolChildren(iter))
                     {
                         fHasChildren = true;
                         uint256 childHash = child->GetTx().GetHash();
@@ -1789,7 +1789,7 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
     // TODO: automatically calculate the nGrowthCoefficient from nHoursToGrow, nMinFalsePositve and nMaxFalsePositive
 
     // Count up all the transactions that we'll be putting into the filter, removing any duplicates
-    BOOST_FOREACH (uint256 txHash, setHighScoreMemPoolHashes)
+    for (uint256 txHash : setHighScoreMemPoolHashes)
         if (setPriorityMemPoolHashes.count(txHash))
             setPriorityMemPoolHashes.erase(txHash);
 
@@ -1816,11 +1816,11 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
         mempool.mapTx.size());
 
     // Add the selected tx hashes to the bloom filter
-    BOOST_FOREACH (uint256 txHash, setPriorityMemPoolHashes)
+    for (uint256 txHash : setPriorityMemPoolHashes)
         filterMemPool.insert(txHash);
-    BOOST_FOREACH (uint256 txHash, setHighScoreMemPoolHashes)
+    for (uint256 txHash : setHighScoreMemPoolHashes)
         filterMemPool.insert(txHash);
-    BOOST_FOREACH (uint256 txHash, vOrphanHashes)
+    for (uint256 txHash : vOrphanHashes)
         filterMemPool.insert(txHash);
     uint64_t nSizeFilter = ::GetSerializeSize(filterMemPool, SER_NETWORK, PROTOCOL_VERSION);
     LOG(THIN, "Created bloom filter: %d bytes for block: %s in:%d (ms)\n", nSizeFilter, hash.ToString(),

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -1058,7 +1058,7 @@ string CThinBlockData::ToString()
     return ss.str();
 }
 
-// Calculate the xthin percentage compression over the last 24 hours
+// Calculate the xthin percentage compression over the last 24 hours for inbound blocks
 string CThinBlockData::InBoundPercentToString()
 {
     LOCK(cs_thinblockstats);
@@ -1093,7 +1093,7 @@ string CThinBlockData::InBoundPercentToString()
     return ss.str();
 }
 
-// Calculate the xthin percentage compression over the last 24 hours
+// Calculate the xthin percentage compression over the last 24 hours for outbound blocks
 string CThinBlockData::OutBoundPercentToString()
 {
     LOCK(cs_thinblockstats);
@@ -1145,7 +1145,7 @@ string CThinBlockData::OutBoundBloomFiltersToString()
     ss << "Outbound bloom filter size (last 24hrs) AVG: " << formatInfoUnit(avgBloomSize);
     return ss.str();
 }
-// Calculate the xthin percentage compression over the last 24 hours
+// Calculate the xthin average response time over the last 24 hours
 string CThinBlockData::ResponseTimeToString()
 {
     LOCK(cs_thinblockstats);
@@ -1180,7 +1180,7 @@ string CThinBlockData::ResponseTimeToString()
     return ss.str();
 }
 
-// Calculate the xthin percentage compression over the last 24 hours
+// Calculate the xthin average validation time over the last 24 hours
 string CThinBlockData::ValidationTimeToString()
 {
     LOCK(cs_thinblockstats);
@@ -1215,7 +1215,7 @@ string CThinBlockData::ValidationTimeToString()
     return ss.str();
 }
 
-// Calculate the xthin percentage compression over the last 24 hours
+// Calculate the xthin transaction re-request ratio and counter over the last 24 hours
 string CThinBlockData::ReRequestedTxToString()
 {
     LOCK(cs_thinblockstats);

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -157,7 +157,7 @@ bool CThinBlock::process(CNode *pfrom, int nSizeThinBlock)
     }
 
     // Create the mapMissingTx from all the supplied tx's in the xthinblock
-    for (const CTransaction tx : vMissingTx)
+    for (const CTransaction &tx : vMissingTx)
         pfrom->mapMissingTx[tx.GetHash().GetCheapHash()] = tx;
 
     {
@@ -336,7 +336,7 @@ bool CXThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     }
 
     // Create the mapMissingTx from all the supplied tx's in the xthinblock
-    for (const CTransaction tx : thinBlockTx.vMissingTx)
+    for (const CTransaction &tx : thinBlockTx.vMissingTx)
         pfrom->mapMissingTx[tx.GetHash().GetCheapHash()] = tx;
 
     // Get the full hashes from the xblocktx and add them to the thinBlockHashes vector.  These should
@@ -687,7 +687,7 @@ bool CXThinBlock::process(CNode *pfrom,
     thindata.AddThinBlockBytes(vTxHashes.size() * sizeof(uint64_t), pfrom); // start counting bytes
 
     // Create the mapMissingTx from all the supplied tx's in the xthinblock
-    for (const CTransaction tx : vMissingTx)
+    for (const CTransaction &tx : vMissingTx)
         pfrom->mapMissingTx[tx.GetHash().GetCheapHash()] = tx;
 
     // Create a map of all 8 bytes tx hashes pointing to their full tx hash counterpart
@@ -869,7 +869,7 @@ static bool ReconstructBlock(CNode *pfrom, const bool fXVal, int &missingCount, 
 
     // Look for each transaction in our various pools and buffers.
     // With xThinBlocks the vTxHashes contains only the first 8 bytes of the tx hash.
-    for (const uint256 hash : pfrom->thinBlockHashes)
+    for (const uint256 &hash : pfrom->thinBlockHashes)
     {
         // Replace the truncated hash with the full hash value if it exists
         CTransaction tx;
@@ -969,10 +969,10 @@ double CThinBlockData::average(std::map<int64_t, uint64_t> &map)
         return 0.0;
 
     uint64_t accum = 0U;
-    for (std::pair<int64_t, uint64_t> p : map)
+    for (std::pair<int64_t, uint64_t> const &ref : map)
     {
         // avoid wraparounds
-        accum = std::max(accum, accum + p.second);
+        accum = std::max(accum, accum + ref.second);
     }
     return (double)accum / map.size();
 }
@@ -1368,7 +1368,7 @@ bool HaveConnectThinblockNodes()
             strThinblockNode = strAddrNode;
         else
             strThinblockNode = strAddrNode.substr(0, pos);
-        for (std::string strAddr : vNodesIP)
+        for (std::string &strAddr : vNodesIP)
         {
             if (strAddr == strThinblockNode)
             {
@@ -1788,7 +1788,7 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
     // TODO: automatically calculate the nGrowthCoefficient from nHoursToGrow, nMinFalsePositve and nMaxFalsePositive
 
     // Count up all the transactions that we'll be putting into the filter, removing any duplicates
-    for (uint256 txHash : setHighScoreMemPoolHashes)
+    for (const uint256 &txHash : setHighScoreMemPoolHashes)
         if (setPriorityMemPoolHashes.count(txHash))
             setPriorityMemPoolHashes.erase(txHash);
 
@@ -1815,11 +1815,11 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
         mempool.mapTx.size());
 
     // Add the selected tx hashes to the bloom filter
-    for (uint256 txHash : setPriorityMemPoolHashes)
+    for (const uint256 &txHash : setPriorityMemPoolHashes)
         filterMemPool.insert(txHash);
-    for (uint256 txHash : setHighScoreMemPoolHashes)
+    for (const uint256 &txHash : setHighScoreMemPoolHashes)
         filterMemPool.insert(txHash);
-    for (uint256 txHash : vOrphanHashes)
+    for (const uint256 &txHash : vOrphanHashes)
         filterMemPool.insert(txHash);
     uint64_t nSizeFilter = ::GetSerializeSize(filterMemPool, SER_NETWORK, PROTOCOL_VERSION);
     LOG(THIN, "Created bloom filter: %d bytes for block: %s in:%d (ms)\n", nSizeFilter, hash.ToString(),

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -573,7 +573,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
         }
 
         CValidationState state;
-        CBlockIndex *pIndex = NULL;
+        CBlockIndex *pIndex = nullptr;
         if (!AcceptBlockHeader(thinBlock.header, state, Params(), &pIndex))
         {
             int nDoS;
@@ -1434,7 +1434,7 @@ void ConnectToThinBlockNodes()
             // NOTE: Because the only nodes we are connecting to here are the ones the user put in their
             //      bitcoin.conf/commandline args as "-connect-thinblock", we don't use the semaphore to limit outbound
             //      connections
-            OpenNetworkConnection(addr, false, NULL, strAddr.c_str());
+            OpenNetworkConnection(addr, false, nullptr, strAddr.c_str());
             MilliSleep(500);
         }
     }
@@ -1460,14 +1460,14 @@ void CheckNodeSupportForThinBlocks()
 
 bool ClearLargestThinBlockAndDisconnect(CNode *pfrom)
 {
-    CNode *pLargest = NULL;
+    CNode *pLargest = nullptr;
     LOCK(cs_vNodes);
     for (CNode *pnode : vNodes)
     {
-        if ((pLargest == NULL) || (pnode->nLocalThinBlockBytes > pLargest->nLocalThinBlockBytes))
+        if ((pLargest == nullptr) || (pnode->nLocalThinBlockBytes > pLargest->nLocalThinBlockBytes))
             pLargest = pnode;
     }
-    if (pLargest != NULL)
+    if (pLargest != nullptr)
     {
         thindata.ClearThinBlockData(pLargest, pLargest->thinBlock.GetBlockHeader().GetHash());
         pLargest->fDisconnect = true;


### PR DESCRIPTION
While reviewing #973 I realized that some comments on `src/thinblock.cpp` need to be fixed (`src/graphene.cpp` is based on it). 

While at it I used c++11 range-based for loop rather than  BOOST_FOREACH. As last thing `using namespace std` has been removed so that the use of `std` has been made explicit every where needed (e.g. `max -> std::max`, `vector -> std::vector` etc. etc.). In the file the explicit use of `std::` was already practiced in quite a few places, so now as a result we have an homogeneous style in that regard.  