### PR TITLE
[Backport of 945] Take out the parallel_2 logging when checking each input

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2423,7 +2423,6 @@ bool ConnectBlock(const CBlock &block,
 
                     if ((inOrphanCache) || (!inVerifiedCache && !inOrphanCache))
                     {
-                        LogPrint("parallel_2", "checking inputs for tx: %d\n", i);
                         if (inOrphanCache)
                             nOrphansChecked++;
 


### PR DESCRIPTION
This creates a very large number of log entries which we don't
need anymore.