### PR TITLE
sync: Remove superfluous assert(..)

### DIFF
--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -310,7 +310,6 @@ void CSharedCriticalSection::lock_shared()
     {
         boost::unique_lock<boost::mutex> lock(setlock);
         assert(exclusiveOwner != tid);
-        assert(sharedowners.find(tid) == sharedowners.end());
         auto alreadyLocked = sharedowners.find(tid);
         if (alreadyLocked != sharedowners.end())
         {


### PR DESCRIPTION
Please review carefully. Maybe I am missing something here, but the assert(..) looks superfluous and keeps the later code from running.