### PR TITLE
Remove dead code related to SizeForkExpiration consensus parameter

### DIFF
--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -65,7 +65,6 @@ struct Params
     int64_t nPowTargetSpacing;
     int64_t nPowTargetTimespan;
     int64_t DifficultyAdjustmentInterval() const { return nPowTargetTimespan / nPowTargetSpacing; }
-    int64_t SizeForkExpiration() const { return 1514764800; } // BU (classic compatibility) 2018-01-01 00:00:00 GMT
     /** UAHF Aug 1st 2017 block height */
     int uahfHeight;
     /** Block height at which the new DAA becomes active */

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -169,10 +169,6 @@ int32_t UnlimitedComputeBlockVersion(const CBlockIndex *pindexPrev, const Consen
 
     int32_t nVersion = ComputeBlockVersion(pindexPrev, params);
 
-    // turn BIP109 off by default by commenting this out:
-    // if (nTime <= params.SizeForkExpiration())
-    //          nVersion |= FORK_BIT_2MB;
-
     return nVersion;
 }
 


### PR DESCRIPTION
This is a member of the Consensus struct and it has not being used
since October 2017 (0b6d71f1, remove default bip109 flag to define
block version since BUIP005 is used by various blockexplorers).