### PR TITLE
Clear strMiscWarning if triggering condition is not valid anymore

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2513,6 +2513,18 @@ void static UpdateTip(CBlockIndex *pindexNew)
                 fWarned = true;
             }
         }
+        else
+        {
+            // clear warning in case unknown block version descrease under 50% of the last 100 mined blocks
+            if (fWarned &&
+                strMiscWarning ==
+                    _("Warning: Unknown block versions being mined! It's possible unknown rules are in effect"))
+            {
+                strMiscWarning = "";
+                AlertNotify(strMiscWarning);
+                fWarned = false;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
In case the condition (i.e. more than 50% of he last 100 blocks has an unknown
version) that triggered this warn:

"Unknown block versions being mined! It's possible unknown rules are in
effect"

is not valid anymore, just clear the condition and set fWarned flag to
false.