### PR TITLE
Move checking of blockdownload timeout to the request manager

### DIFF
--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1072,3 +1072,31 @@ bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
     }
     return false;
 }
+
+
+void CRequestManager::CheckForDownloadTimeout(CNode *pnode,
+    const CNodeState &state,
+    const Consensus::Params &consensusParams,
+    int64_t nNow)
+{
+    AssertLockHeld(cs_main);
+
+    // In case there is a block that has been in flight from this peer for 2 + 0.5 * N times the block interval
+    // (with N the number of peers from which we're downloading validated blocks), disconnect due to timeout.
+    // We compensate for other peers to prevent killing off peers due to our own downstream link
+    // being saturated. We only count validated in-flight blocks so peers can't advertise non-existing block hashes
+    // to unreasonably increase our timeout.
+    if (!pnode->fDisconnect && state.vBlocksInFlight.size() > 0)
+    {
+        int nOtherPeersWithValidatedDownloads = nPeersWithValidatedDownloads - (state.nBlocksInFlightValidHeaders > 0);
+        if (nNow >
+            state.nDownloadingSince +
+                consensusParams.nPowTargetSpacing *
+                    (BLOCK_DOWNLOAD_TIMEOUT_BASE + BLOCK_DOWNLOAD_TIMEOUT_PER_PEER * nOtherPeersWithValidatedDownloads))
+        {
+            LOGA("Timeout downloading block %s from peer=%d, disconnecting\n",
+                state.vBlocksInFlight.front().hash.ToString(), pnode->id);
+            pnode->fDisconnect = true;
+        }
+    }
+}

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -26,8 +26,11 @@ successful receipt, "requester.Rejected(...)" to indicate a bad object (request 
 
 #ifndef REQUEST_MANAGER_H
 #define REQUEST_MANAGER_H
+
 #include "net.h"
+#include "nodestate.h"
 #include "stat.h"
+
 // When should I request a tx from someone else (in microseconds). cmdline/bitcoin.conf: -txretryinterval
 extern unsigned int txReqRetryInterval;
 extern unsigned int MIN_TX_REQUEST_RETRY_INTERVAL;
@@ -174,6 +177,12 @@ public:
 
     // Returns a bool if successful in indicating we received this block.
     bool MarkBlockAsReceived(const uint256 &hash, CNode *pnode);
+
+    // Check for block download timeout and disconnect node if necessary.
+    void CheckForDownloadTimeout(CNode *pnode,
+        const CNodeState &state,
+        const Consensus::Params &consensusParams,
+        int64_t nNow);
 };
 
 


### PR DESCRIPTION
More cleanup of code out of main.cpp and putting block handling
code in the request manager.

There are no logic changes .... just a move, and the assignment of &queuedblock was taken out as it's only rarely if ever done, we only use it when printing out the block hash if a node was disconnected.