### PR TITLE
Allow -rpcconnect in bitoin.conf, Fixes #990

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -630,7 +630,10 @@ static void addRpcServerOptions(AllowedArgs &allowedArgs)
         .addDebugArg("rpcworkqueue=<n>", requiredInt,
             strprintf("Set the depth of the work queue to service RPC calls (default: %d)", DEFAULT_HTTP_WORKQUEUE))
         .addDebugArg("rpcservertimeout=<n>", requiredInt,
-            strprintf("Timeout during HTTP requests (default: %d)", DEFAULT_HTTP_SERVER_TIMEOUT));
+            strprintf("Timeout during HTTP requests (default: %d)", DEFAULT_HTTP_SERVER_TIMEOUT))
+        // Although a node does not use rpcconnect it must be allowed because BitcoinCli also uses the same config file
+        .addDebugArg("rpcconnect=<ip>", requiredStr,
+            strprintf(_("Send commands to node running on <ip> (default: %s)"), DEFAULT_RPCCONNECT));
 }
 
 static void addUiOptions(AllowedArgs &allowedArgs)


### PR DESCRIPTION
Although this option is not used by a node it must be allowed
because bitcoinCli also uses the same config file.

Make the option hidden from the help menu for node operators
because they won't be using it.