### PR TITLE
[Backport] Automatically determine -dbcache setting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,31 @@ sudo make install
 ```
 
 For more detailed explanations on how compile from source just look at doc/build-*.md files (e.g. [here](doc/quick-install.md))
+
+Quick Startup and Initial Node operation
+========================================
+
+### QT or the command line:
+
+There are two modes of operation, one uses the QT UI and the other runs as a daemon from the command line.  The QT version is bitcoin-qt or bitcoin-qt.exe, the command line version is bitcoind or bitcoind.exe. No matter which version you run, when you launch for the first time you will have to complete the intial blockchain sync.
+
+### Initial Sync of the blockchain:
+
+When you first run the node it must first sync the current blockchain.  All block headers are first retrieved and then each block is downloaded, checked and the UTXO finally updated.  This process can take from hours to `weeks` depending on the node configuration, and therefore, node configuration is crucial.
+
+The most important configuration which impacts the speed of the initial sync is the `dbcache` setting.  The larger the dbcache the faster the initial sync will be, therefore, it is vital to make this setting as high as possible.  If you are running on a Windows machine there is an automatically adjusting dbcache setting built in; it will size the dbcache in such a way as to leave only 10% of the physical memory free for other uses.  On Linux and other OS's the sizing is such that one half the physical RAM will be used as dbcache. While these settings, particularly on non Windows setups, are not ideal they will help to improve the initial sync dramatically.
+
+However, even with the automatic configuration of the dbcache setting it is recommended to set one manually if you haven't already done so (see the section below on Startup Configuration). This gives the node operator more control over memory use and in particular for non Windows setups, can further improve the performance of the initial sync.
+
+### Startup configuration:
+
+There are dozens of configuration and node policy options available but the two most important for the initial blockchain sync are as follows.
+
+##### dbcache: As stated above, this setting is crucial to a fast initial sync.  You can set this value from the command line by running
+`bitcoind -dbcache=<your size in MB>`, for example, a 1GB dbcache would be `bitcoind -dbcache=1000`.  Similarly you can also add the setting to the bitcoin.conf file located in your installation folder. In the config file a simlilar entry would be `dbcache=1000`.  When entering the size
+try to give it the maximum that your system can afford while still leaving enough memory for other processes.
+
+##### maxoutconnections: It is generally fine to leave the default outbound connection settings for doing a sync, however, at times some users
+have reported issues with not being able to find enough useful connections. If that happens you can change this setting to override the default.
+For instance `bitcoind -maxoutconnections=30` will give you 30 outbound connections and should be more than enough in the event that the
+node is having difficulty.

--- a/src/coins.h
+++ b/src/coins.h
@@ -270,6 +270,10 @@ public:
     bool Flush();
 
     /**
+     * Empty the coins cache. Used primarily when we're shutting down and want to release memory
+     */
+    void Clear() { cacheCoins.clear(); }
+    /**
      * Remove excess entries from this cache.
      * Entries are trimmed starting from the beginning of the map.  In this way if those entries
      * are needed later they will all be collocated near the the beginning of the leveldb database

--- a/src/dbwrapper.h
+++ b/src/dbwrapper.h
@@ -346,6 +346,12 @@ public:
         leveldb::Slice slKey2(ssKey2.data(), ssKey2.size());
         pdb->CompactRange(&slKey1, &slKey2);
     }
+
+    size_t TotalWriteBufferSize() const
+    {
+        // There can be up to two write buffers so return the total
+        return options.write_buffer_size * 2;
+    }
 };
 
 #endif // BITCOIN_DBWRAPPER_H

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -192,6 +192,16 @@ void Shutdown()
     RenameThread("bitcoin-shutoff");
     mempool.AddTransactionsUpdated(1);
 
+    {
+        LOCK(cs_main);
+        if (pcoinsTip != nullptr)
+        {
+            // Flush state and clear cache completely to release as much memory as possible before continuing.
+            FlushStateToDisk();
+            pcoinsTip->Clear();
+        }
+    }
+
     StopHTTPRPC();
     StopREST();
     StopRPC();
@@ -955,22 +965,14 @@ bool AppInit2(boost::thread_group &threadGroup, CScheduler &scheduler)
         }
     }
 
-    // cache size calculations
-    int64_t nTotalCache = (GetArg("-dbcache", nDefaultDbCache) << 20);
-    nTotalCache = std::max(nTotalCache, nMinDbCache << 20); // total cache cannot be less than nMinDbCache
-    nTotalCache = std::min(nTotalCache, nMaxDbCache << 20); // total cache cannot be greated than nMaxDbcache
-    int64_t nBlockTreeDBCache = nTotalCache / 8;
-    if (nBlockTreeDBCache > (1 << 21) && !GetBoolArg("-txindex", DEFAULT_TXINDEX))
-        nBlockTreeDBCache = (1 << 21); // block tree db cache shouldn't be larger than 2 MiB
-    nTotalCache -= nBlockTreeDBCache;
-    // use 25%-50% of the remainder for disk cache
-    int64_t nCoinDBCache = std::min(nTotalCache / 2, (nTotalCache / 4) + (1 << 23));
-    nTotalCache -= nCoinDBCache;
-    nCoinCacheUsage = nTotalCache; // the rest goes to in-memory cache
-    LogPrintf("Cache configuration:\n");
-    LogPrintf("* Using %.1fMiB for block index database\n", nBlockTreeDBCache * (1.0 / 1024 / 1024));
-    LogPrintf("* Using %.1fMiB for chain state database\n", nCoinDBCache * (1.0 / 1024 / 1024));
-    LogPrintf("* Using %.1fMiB for in-memory UTXO set\n", nCoinCacheUsage * (1.0 / 1024 / 1024));
+    // Return the initial values for the various in memory caches.
+    int64_t nBlockTreeDBCache = 0;
+    int64_t nCoinDBCache = 0;
+    GetCacheConfiguration(nBlockTreeDBCache, nCoinDBCache, nCoinCacheUsage);
+    LOGA("Cache configuration:\n");
+    LOGA("* Using %.1fMiB for block index database\n", nBlockTreeDBCache * (1.0 / 1024 / 1024));
+    LOGA("* Using %.1fMiB for chain state database\n", nCoinDBCache * (1.0 / 1024 / 1024));
+    LOGA("* Using %.1fMiB for in-memory UTXO set\n", nCoinCacheUsage * (1.0 / 1024 / 1024));
 
     bool fLoaded = false;
     while (!fLoaded)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -87,7 +87,7 @@ bool fRequireStandard = true;
 unsigned int nBytesPerSigOp = DEFAULT_BYTES_PER_SIGOP;
 bool fCheckBlockIndex = false;
 bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
-size_t nCoinCacheUsage = 5000 * 300;
+int64_t nCoinCacheUsage = 0;
 uint64_t nPruneTarget = 0;
 uint32_t nXthinBloomFilterSize = SMALLEST_MAX_BLOOM_FILTER_SIZE;
 
@@ -2626,7 +2626,12 @@ bool FlushStateToDisk(CValidationState &state, FlushStateMode mode)
         {
             nLastSetChain = nNow;
         }
-        size_t cacheSize = pcoinsTip->DynamicMemoryUsage();
+
+        // If possible adjust the max size of the coin cache (nCoinCacheUsage) based on current available memory. Do
+        // this before determinining whether to flush the cache or not in the steps that follow.
+        AdjustCoinCacheSize();
+
+        int64_t cacheSize = pcoinsTip->DynamicMemoryUsage();
         static int64_t nSizeAfterLastFlush = 0;
         // The cache is close to the limit. Try to flush and trim.
         bool fCacheCritical = ((mode == FLUSH_STATE_IF_NEEDED) && (cacheSize > nCoinCacheUsage * 0.995)) ||
@@ -2695,7 +2700,7 @@ bool FlushStateToDisk(CValidationState &state, FlushStateMode mode)
             else
             {
                 // Trim, but never trim more than nMaxCacheIncreaseSinceLastFlush
-                size_t nTrimSize = nCoinCacheUsage * .90;
+                int64_t nTrimSize = nCoinCacheUsage * .90;
                 if (nCoinCacheUsage - nMaxCacheIncreaseSinceLastFlush > nTrimSize)
                     nTrimSize = nCoinCacheUsage - nMaxCacheIncreaseSinceLastFlush;
                 pcoinsTip->Trim(nTrimSize);
@@ -2713,7 +2718,7 @@ bool FlushStateToDisk(CValidationState &state, FlushStateMode mode)
         // As a safeguard, periodically check and correct any drift in the value of cachedCoinsUsage.  While a
         // correction should never be needed, resetting the value allows the node to continue operating, and only
         // an error is reported if the new and old values do not match.
-        if (fPeriodicFlush)
+        if (fPeriodicFlush || nCoinCacheUsage < 0)
             pcoinsTip->ResetCachedCoinUsage();
     }
     catch (const std::runtime_error &e)
@@ -4625,7 +4630,7 @@ bool CVerifyDB::VerifyDB(const CChainParams &chainparams, CCoinsView *coinsview,
         }
         // check level 3: check for inconsistencies during memory-only disconnect of tip blocks
         if (nCheckLevel >= 3 && pindex == pindexState &&
-            (coins.DynamicMemoryUsage() + pcoinsTip->DynamicMemoryUsage()) <= nCoinCacheUsage)
+            (int64_t)(coins.DynamicMemoryUsage() + pcoinsTip->DynamicMemoryUsage()) <= nCoinCacheUsage)
         {
             bool fClean = true;
             DisconnectResult res = DisconnectBlock(block, pindex, coins);

--- a/src/main.h
+++ b/src/main.h
@@ -147,7 +147,6 @@ static const int64_t DEFAULT_MAX_TIP_AGE = 24 * 60 * 60;
 static const bool DEFAULT_PERMIT_BAREMULTISIG = true;
 static const unsigned int DEFAULT_BYTES_PER_SIGOP = 20;
 static const bool DEFAULT_CHECKPOINTS_ENABLED = true;
-static const bool DEFAULT_TXINDEX = false;
 
 static const bool DEFAULT_TESTSAFEMODE = false;
 
@@ -184,7 +183,7 @@ extern bool fRequireStandard;
 extern unsigned int nBytesPerSigOp;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
-extern size_t nCoinCacheUsage;
+extern int64_t nCoinCacheUsage;
 /** A fee rate smaller than this is considered zero fee (for relaying, mining and transaction creation) */
 extern CFeeRate minRelayTxFee;
 /** Absolute maximum transaction fee (in satoshis) used by wallet and mempool (rejects high fee in sendrawtransaction)

--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -38,49 +38,6 @@
         </widget>
        </item>
        <item>
-        <layout class="QHBoxLayout" name="horizontalLayout_2_Main">
-         <item>
-          <widget class="QLabel" name="databaseCacheLabel">
-           <property name="text">
-            <string>Size of &amp;database cache</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-           <property name="buddy">
-            <cstring>databaseCache</cstring>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSpinBox" name="databaseCache"/>
-         </item>
-         <item>
-          <widget class="QLabel" name="databaseCacheUnitLabel">
-           <property name="text">
-            <string>MB</string>
-           </property>
-           <property name="textFormat">
-            <enum>Qt::PlainText</enum>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <spacer name="horizontalSpacer_2_Main">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
-         </item>
-        </layout>
-       </item>
-       <item>
         <layout class="QHBoxLayout" name="horizontalLayout_3_Main">
          <item>
           <widget class="QLabel" name="threadsScriptVerifLabel">

--- a/src/qt/optionsdialog.cpp
+++ b/src/qt/optionsdialog.cpp
@@ -38,8 +38,6 @@ OptionsDialog::OptionsDialog(QWidget *parent, bool enableWallet)
 {
     ui->setupUi(this);
     /* Main elements init */
-    ui->databaseCache->setMinimum(nMinDbCache);
-    ui->databaseCache->setMaximum(nMaxDbCache);
     ui->threadsScriptVerif->setMinimum(-GetNumCores());
     ui->threadsScriptVerif->setMaximum(MAX_SCRIPTCHECK_THREADS);
 
@@ -164,7 +162,6 @@ void OptionsDialog::setModel(OptionsModel *model)
      * them) */
 
     /* Main */
-    connect(ui->databaseCache, SIGNAL(valueChanged(int)), this, SLOT(showRestartWarning()));
     connect(ui->threadsScriptVerif, SIGNAL(valueChanged(int)), this, SLOT(showRestartWarning()));
     /* Wallet */
     connect(ui->spendZeroConfChange, SIGNAL(clicked(bool)), this, SLOT(showRestartWarning()));
@@ -182,7 +179,6 @@ void OptionsDialog::setMapper()
     /* Main */
     mapper->addMapping(ui->bitcoinAtStartup, OptionsModel::StartAtStartup);
     mapper->addMapping(ui->threadsScriptVerif, OptionsModel::ThreadsScriptVerif);
-    mapper->addMapping(ui->databaseCache, OptionsModel::DatabaseCache);
 
     /* Wallet */
     mapper->addMapping(ui->spendZeroConfChange, OptionsModel::SpendZeroConfChange);

--- a/src/qt/optionsmodel.cpp
+++ b/src/qt/optionsmodel.cpp
@@ -79,11 +79,6 @@ void OptionsModel::Init(bool resetSettings)
     // by command-line and show this in the UI.
 
     // Main
-    if (!settings.contains("nDatabaseCache"))
-        settings.setValue("nDatabaseCache", (qint64)nDefaultDbCache);
-    if (!SoftSetArg("-dbcache", settings.value("nDatabaseCache").toString().toStdString()))
-        addOverriddenOption("-dbcache");
-
     if (!settings.contains("nThreadsScriptVerif"))
         settings.setValue("nThreadsScriptVerif", DEFAULT_SCRIPTCHECK_THREADS);
     if (!SoftSetArg("-par", settings.value("nThreadsScriptVerif").toString().toStdString()))

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -444,7 +444,7 @@ uint64_t GetAvailableMemory()
     }
     else
     {
-        LOG(COINDB, "Could not get size of available memory - returning with default\n");
+        LogPrint("coindb", "Could not get size of available memory - returning with default\n");
         return nDefaultPhysMem / 2;
     }
 }
@@ -459,7 +459,7 @@ uint64_t GetTotalSystemMemory()
     }
     else
     {
-        LOG(COINDB, "Could not get size of physical memory - returning with default\n");
+        LogPrint("coindb", "Could not get size of physical memory - returning with default\n");
         return nDefaultPhysMem;
     }
 }
@@ -478,7 +478,7 @@ uint64_t GetTotalSystemMemory()
     }
     else
     {
-        LOG(COINDB, "Could not get size of physical memory - returning with default\n");
+        LogPrint("coindb", "Could not get size of physical memory - returning with default\n");
         return nDefaultPhysMem;
     }
 }
@@ -494,14 +494,14 @@ uint64_t GetTotalSystemMemory()
     }
     else
     {
-        LOG(COINDB, "Could not get size of physical memory - returning with default\n");
+        LogPrint("coindb", "Could not get size of physical memory - returning with default\n");
         return nDefaultPhysMem;
     }
 }
 #else
 uint64_t GetTotalSystemMemory()
 {
-    LOG(COINDB, "Could not get size of physical memory - returning with default\n");
+    LogPrint("coindb", "Could not get size of physical memory - returning with default\n");
     return nDefaultPhysMem; // if we can't get RAM size then default to an assumed 1GB system memory
 }
 #endif
@@ -627,8 +627,8 @@ void AdjustCoinCacheSize()
             GetCacheConfiguration(dummyBIDiskCache, dummyUtxoDiskCache, nDefaultCoinCache, true);
 
             nCoinCacheUsage = std::max(nDefaultCoinCache, nCoinCacheUsage - (nUnusedMem - nMemAvailable));
-            LOG(COINDB, "Current cache size: %ld MB, nCoinCacheUsage was reduced by %u MB\n", nCoinCacheUsage / 1000000,
-                (nUnusedMem - nMemAvailable) / 1000000);
+            LogPrint("coindb", "Current cache size: %ld MB, nCoinCacheUsage was reduced by %u MB\n",
+                nCoinCacheUsage / 1000000, (nUnusedMem - nMemAvailable) / 1000000);
             nLastDbAdjustment = nNow;
             nLastMemAvailable = nMemAvailable;
         }
@@ -645,7 +645,7 @@ void AdjustCoinCacheSize()
                 std::numeric_limits<long long>::max(), dummyBIDiskCache, dummyUtxoDiskCache, nMaxCoinCache);
 
             nCoinCacheUsage = std::min(nMaxCoinCache, nCoinCacheUsage + (nMemAvailable - nLastMemAvailable));
-            LOG(COINDB, "Current cache size: %ld MB, nCoinCacheUsage was increased by %u MB\n",
+            LogPrint("coindb", "Current cache size: %ld MB, nCoinCacheUsage was increased by %u MB\n",
                 nCoinCacheUsage / 1000000, (nMemAvailable - nLastMemAvailable) / 1000000);
             nLastDbAdjustment = nNow;
             nLastMemAvailable = nMemAvailable;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -79,8 +79,8 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
     CDBBatch batch(db);
     size_t count = 0;
     size_t changed = 0;
-    size_t nBatchSize = 0;
     size_t nBatchWrites = 0;
+    size_t batch_size = nMaxDBBatchSize;
 
     for (CCoinsMap::iterator it = mapCoins.begin(); it != mapCoins.end();)
     {
@@ -121,12 +121,10 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
             // In order to prevent the spikes in memory usage that used to happen when we prepared large as
             // was possible, we instead break up the batches such that the performance gains for writing to
             // leveldb are still realized but the memory spikes are not seen.
-            nBatchSize += nUsage;
-            if (nBatchSize > nCoinCacheUsage * 0.01)
+            if (batch.SizeEstimate() > batch_size)
             {
                 db.WriteBatch(batch);
                 batch.Clear();
-                nBatchSize = 0;
                 nBatchWrites++;
             }
         }
@@ -149,6 +147,7 @@ CBlockTreeDB::CBlockTreeDB(size_t nCacheSize, bool fMemory, bool fWipe)
 {
 }
 
+size_t CCoinsViewDB::TotalWriteBufferSize() const { return db.TotalWriteBufferSize(); }
 bool CBlockTreeDB::ReadBlockFileInfo(int nFile, CBlockFileInfo &info)
 {
     return Read(make_pair(DB_BLOCK_FILES, nFile), info);
@@ -427,4 +426,230 @@ bool CCoinsViewDB::Upgrade()
     db.CompactRange({DB_COINS, uint256()}, key);
 
     return true;
+}
+
+// For Windows we can use the current total available memory, however for other systems we can only use the
+// the physical RAM in our calculations.
+static uint64_t nDefaultPhysMem = 1000000000; // if we can't get RAM size then default to an assumed 1GB system memory
+#ifdef WIN32
+#include <windows.h>
+uint64_t GetAvailableMemory()
+{
+    MEMORYSTATUSEX status;
+    status.dwLength = sizeof(status);
+    GlobalMemoryStatusEx(&status);
+    if (status.ullAvailPhys > 0)
+    {
+        return status.ullAvailPhys;
+    }
+    else
+    {
+        LOG(COINDB, "Could not get size of available memory - returning with default\n");
+        return nDefaultPhysMem / 2;
+    }
+}
+uint64_t GetTotalSystemMemory()
+{
+    MEMORYSTATUSEX status;
+    status.dwLength = sizeof(status);
+    GlobalMemoryStatusEx(&status);
+    if (status.ullTotalPhys > 0)
+    {
+        return status.ullTotalPhys;
+    }
+    else
+    {
+        LOG(COINDB, "Could not get size of physical memory - returning with default\n");
+        return nDefaultPhysMem;
+    }
+}
+#elif __APPLE__
+#include <sys/sysctl.h>
+#include <sys/types.h>
+uint64_t GetTotalSystemMemory()
+{
+    int mib[] = {CTL_HW, HW_MEMSIZE};
+    int64_t nPhysMem = 0;
+    size_t nLength = sizeof(nPhysMem);
+
+    if (sysctl(mib, 2, &nPhysMem, &nLength, nullptr, 0) == 0)
+    {
+        return nPhysMem;
+    }
+    else
+    {
+        LOG(COINDB, "Could not get size of physical memory - returning with default\n");
+        return nDefaultPhysMem;
+    }
+}
+#elif __unix__
+#include <unistd.h>
+uint64_t GetTotalSystemMemory()
+{
+    long nPages = sysconf(_SC_PHYS_PAGES);
+    long nPageSize = sysconf(_SC_PAGE_SIZE);
+    if (nPages > 0 && nPageSize > 0)
+    {
+        return nPages * nPageSize;
+    }
+    else
+    {
+        LOG(COINDB, "Could not get size of physical memory - returning with default\n");
+        return nDefaultPhysMem;
+    }
+}
+#else
+uint64_t GetTotalSystemMemory()
+{
+    LOG(COINDB, "Could not get size of physical memory - returning with default\n");
+    return nDefaultPhysMem; // if we can't get RAM size then default to an assumed 1GB system memory
+}
+#endif
+
+void GetCacheConfiguration(int64_t &_nBlockTreeDBCache,
+    int64_t &_nCoinDBCache,
+    int64_t &_nCoinCacheUsage,
+    bool fDefault)
+{
+#ifdef WIN32
+    // If using WINDOWS then determine the actual physical memory that is currently available for dbcaching.
+    // Alway leave 10% of the available RAM unused.
+    int64_t nMemAvailable = GetAvailableMemory();
+    nMemAvailable = nMemAvailable - (nMemAvailable * nDefaultPcntMemUnused / 100);
+#else
+    // Get total system memory but only use half.
+    // - This half of system memory is only used as a basis for the total cache size
+    // - if and only if the operator has not already set a value for -dbcache. This mitigates a common problem
+    // - where new operators are unaware of the importance of the dbcache setting and therefore do not size their
+    // - dbcache correctly resulting in a very slow initial block sync.
+    int64_t nMemAvailable = GetTotalSystemMemory() / 2;
+#endif
+
+    // Convert from bytes to MiB.
+    nMemAvailable = nMemAvailable >> 20;
+
+    // nTotalCache size calculations returned in bytes (convert from MiB to bytes)
+    int64_t nTotalCache = 0;
+    if (fDefault)
+    {
+        // With the default flag set we only want the settings returned if the default dbcache were selected.
+        // This is useful in that it gives us the lowest possible dbcache configuration.
+        nTotalCache = nDefaultDbCache << 20;
+    }
+    else if (nDefaultDbCache < nMemAvailable)
+    {
+        // only use the dynamically calculated nMemAvailable if and only if the node operator has not set
+        // a value for dbcache!
+        nTotalCache = (GetArg("-dbcache", nMemAvailable) << 20);
+    }
+    else
+    {
+        nTotalCache = (GetArg("-dbcache", nDefaultDbCache) << 20);
+    }
+
+    // Now that we have the nTotalCache we can calculate all the various cache sizes.
+    CacheSizeCalculations(nTotalCache, _nBlockTreeDBCache, _nCoinDBCache, _nCoinCacheUsage);
+}
+
+void CacheSizeCalculations(int64_t _nTotalCache,
+    int64_t &_nBlockTreeDBCache,
+    int64_t &_nCoinDBCache,
+    int64_t &_nCoinCacheUsage)
+{
+    // make sure total cache is within limits
+    _nTotalCache = std::max(_nTotalCache, nMinDbCache << 20); // total cache cannot be less than nMinDbCache
+    _nTotalCache = std::min(_nTotalCache, nMaxDbCache << 20); // total cache cannot be greater than nMaxDbcache
+
+    // calculate the block index leveldb cache size. It shouldn't be larger than 2 MiB.
+    // NOTE: this is not the same as the in memory block index which is fully stored in memory.
+    _nBlockTreeDBCache = _nTotalCache / 8;
+    if (_nBlockTreeDBCache > (1 << 21) && !GetBoolArg("-txindex", DEFAULT_TXINDEX))
+        _nBlockTreeDBCache = (1 << 21);
+
+    // use 25%-50% of the remainder for the utxo leveldb disk cache
+    _nTotalCache -= _nBlockTreeDBCache;
+    _nCoinDBCache = std::min(_nTotalCache / 2, (_nTotalCache / 4) + (1 << 23));
+
+    // the remainder goes to the in-memory utxo coins cache
+    _nTotalCache -= _nCoinDBCache;
+    _nCoinCacheUsage = _nTotalCache;
+}
+
+void AdjustCoinCacheSize()
+{
+    // If the operator has not set a dbcache and initial sync is complete then revert back to the default
+    // value for dbcache. This will cause the current coins cache to be immediately trimmed to size.
+    if (IsChainNearlySyncd() && !GetArg("-dbcache", 0))
+    {
+        // Get the default value for nCoinCacheUsage.
+        int64_t dummyBIDiskCache, dummyUtxoDiskCache, nMaxCoinCache = 0;
+        CacheSizeCalculations(nDefaultDbCache, dummyBIDiskCache, dummyUtxoDiskCache, nMaxCoinCache);
+        nCoinCacheUsage = nMaxCoinCache;
+
+        return;
+    }
+
+#ifdef WIN32
+    static int64_t nLastDbAdjustment = 0;
+    int64_t nNow = GetTimeMicros();
+
+    if (nLastDbAdjustment == 0)
+    {
+        nLastDbAdjustment = nNow;
+    }
+
+    // used to determine if we had previously reduced the nCoinCacheUsage and also to tell us what the last
+    // mem available was when we modified the nCoinCacheUsage.
+    static int64_t nLastMemAvailable = 0;
+
+    // If there is no dbcache setting specified by the node operator then float the dbache setting down or up
+    // based on current available memory.
+    if (!GetArg("-dbcache", 0) && (nNow - nLastDbAdjustment) > 60000000)
+    {
+        // The amount of system memory currently available
+        int64_t nMemAvailable = GetAvailableMemory();
+        // The amount of memory we need to *keep* available.
+        int64_t nUnusedMem = std::max(GetTotalSystemMemory() * nDefaultPcntMemUnused / 100, nMinMemToKeepAvaialable);
+
+        // Make sure we leave enough room for the leveldb write cache's
+        if (pcoinsdbview != nullptr && nUnusedMem < pcoinsdbview->TotalWriteBufferSize())
+        {
+            nUnusedMem = pcoinsdbview->TotalWriteBufferSize();
+        }
+
+        // Reduce nCoinCacheUsage if mem available gets near the threshold. We have to be more strict about flushing
+        // if we're running low on mem because on marginal systems with smaller RAM we have very little wiggle room.
+        if (nMemAvailable < nUnusedMem * 1.05)
+        {
+            // Get the lowest possible default coins cache configuration possible and use this value as a limiter
+            // to prevent the nCoinCacheUsage from falling below this value.
+            int64_t dummyBIDiskCache, dummyUtxoDiskCache, nDefaultCoinCache = 0;
+            GetCacheConfiguration(dummyBIDiskCache, dummyUtxoDiskCache, nDefaultCoinCache, true);
+
+            nCoinCacheUsage = std::max(nDefaultCoinCache, nCoinCacheUsage - (nUnusedMem - nMemAvailable));
+            LOG(COINDB, "Current cache size: %ld MB, nCoinCacheUsage was reduced by %u MB\n", nCoinCacheUsage / 1000000,
+                (nUnusedMem - nMemAvailable) / 1000000);
+            nLastDbAdjustment = nNow;
+            nLastMemAvailable = nMemAvailable;
+        }
+
+        // Increase nCoinCacheUsage if mem available increases. We don't want to constantly be
+        // triggering an increase whenever the nMemAvailable crosses the threshold by just a
+        // few bytes, so we'll dampen the increases by triggering only when the threshold is crossed by 5%.
+        else if (nLastMemAvailable > 0 && nMemAvailable * 0.95 >= nLastMemAvailable)
+        {
+            // find the max coins cache possible for this configuration.  Use the max int possible for total cache
+            // size to ensure you receive the max cache size possible.
+            int64_t dummyBIDiskCache, dummyUtxoDiskCache, nMaxCoinCache = 0;
+            CacheSizeCalculations(
+                std::numeric_limits<long long>::max(), dummyBIDiskCache, dummyUtxoDiskCache, nMaxCoinCache);
+
+            nCoinCacheUsage = std::min(nMaxCoinCache, nCoinCacheUsage + (nMemAvailable - nLastMemAvailable));
+            LOG(COINDB, "Current cache size: %ld MB, nCoinCacheUsage was increased by %u MB\n",
+                nCoinCacheUsage / 1000000, (nMemAvailable - nLastMemAvailable) / 1000000);
+            nLastDbAdjustment = nNow;
+            nLastMemAvailable = nMemAvailable;
+        }
+    }
+#endif
 }


### PR DESCRIPTION
…ded (#948)

* Kill QT dbcache setting in Options

This setting is of little use since the operator has to restart
the application anyway to make the setting take effect.  By removing
this and only using -dbcache from either the command line or bitcoin.conf
it gives us the ability to automatically configure the dbcache and
also simplifies the configuration process.

* Add functions to determine the max system memory and use them

Use half the total system memory as the value for -dbcache
and use this value if the node operator has not already set
a nummber for -dbcache.  This way we can be pretty sure a node
will get a much better initial sync rather than in the past where
we would only rely on the default of 500MB for -dbcache.

Add getTotalSystemMemory() for UNIX and MACOS

Also return with a default value if physical memory size could
not be determined. We return with a default of 1GB which should
cover any raspberry pi configurations.

Make a more accurate calculation on Windows for memory available

On Windows systems we can know how much of the physical RAM is available
for use and so here we make a more fine grained calculation for the
amount of memory we'll use for the dbcache mechanism. For Windows systems
with large amounts of RAM available we'll use all of it up to the 16GB
maximum allowed for dbcaching, however, we'll always leave 1GB free
to the system for other uses.

* Use an int64_t instead of size_t for nCoinCacheUsage

Because nCoinCacheUsage is size_t, then on 32bit systems when
we assign it a value from 64bit int then we end up with an
incorrect value. This happens during init when the cache sizes
are being calculated.

* Move memory functions to memusage.h in preparation for dynamic dbcache sizing on Windows

* On Windows, dynamically reduce the size of the dbcache if/when needed.

If the available memory falls below 10% then
reduce the size of the dbcache's coin cache.

* Allow the retreival of the lowest default dbcache configuration

This is needed to prevent the coins cache from getting too low
during the process of dynamically changing the dbcache settings.

* On Windows, dynamically increase the size of the dbcache if possible.

* Cleanup FlushStateToDisk by moving the dynamic coin cache adjustment

Create AdjustCoinCacheSize() and use it in FlushStateToDisk and move
the underlying code to txdb.cpp.

* change from LOGA to LOG(COINDB, ...

* Update README.md with instruction on setting up for initial sync.

Describe the importance of the dbcache setting in the initial sync
process. Also touch upon the automatic dbcache configuration as well
as the possible need to set a higher maxoutconnections.

* Add comments for thew new functions in txdb.h

* Fix GetTotalSystemMemory for MacOS

a zero indicates a positive return value for sysctl rather
than a 1

* Use a better size estimate when determining when to batch write

Since the time of the datbase upgrade the batch size was not
being calculated properly and as a result we were not batching
our writes anymore. Here we get the appropriate batch size
estimate and write our batches accordingly.

* On Windows, ensure that there is enough free memory for the write caches

On very marginal nodes we have to at least leave enough memory for the
write caches and also be careful to trim the coins cache more
carefully.

* fix compiler warnings

* Once IBD is complete then trim the coins cache

If the user has not specifiied a dbcache setting then trim
the coins cache to the default size once IBD is completed.

* Flush state and trim coins cache before shutting down

At the beginning of the shutdown process, flush and clear the coins
cache to free up as much memory as possible. This helps to prevent
any runaway exceptions due to a bad alloc during the shutdown process.

* Keep 300MB available for marginal Windows systems