### PR TITLE
[Backport] IBD patch 4 (#970)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,18 +107,11 @@ extern std::map<uint256, std::set<uint256> > mapOrphanTransactionsByPrev GUARDED
 int64_t nLastOrphanCheck = GetTime(); // Used in EraseOrphansByTime()
 static uint64_t nBytesOrphanPool = 0; // Current in memory size of the orphan pool.
 
-// BU: start block download at low numbers in case our peers are slow when we start
-/** Number of blocks that can be requested at any given time from a single peer. */
-static unsigned int MAX_BLOCKS_IN_TRANSIT_PER_PEER = 1;
-/** Size of the "block download window": how far ahead of our current height do we fetch?
- *  Larger windows tolerate larger download speed differences between peer, but increase the potential
- *  degree of disordering of blocks on disk (which make reindexing and in the future perhaps pruning
- *  harder). We'll probably want to make this a per-peer adaptive value at some point. */
-static unsigned int BLOCK_DOWNLOAD_WINDOW = 256;
-
-extern CTweak<unsigned int> maxBlocksInTransitPerPeer; // override the above
+extern CTweak<unsigned int> maxBlocksInTransitPerPeer;
 extern CTweak<unsigned int> blockDownloadWindow;
 extern CTweak<uint64_t> reindexTypicalBlockSize;
+
+extern unsigned int BLOCK_DOWNLOAD_WINDOW;
 
 extern std::map<CNetAddr, ConnectionHistory> mapInboundConnectionTracker;
 extern CCriticalSection cs_mapInboundConnectionTracker;
@@ -242,8 +235,6 @@ int nPreferredDownload = 0;
 /** Dirty block file entries. */
 std::set<int> setDirtyFileInfo;
 
-/** Number of peers from which we're downloading blocks. */
-int nPeersWithValidatedDownloads = 0;
 } // anon namespace
 
 /** Dirty block index entries. */
@@ -294,13 +285,14 @@ void FinalizeNode(NodeId nodeid)
     if (state->fSyncStarted)
         nSyncStarted--;
 
-    BOOST_FOREACH (const QueuedBlock &entry, state->vBlocksInFlight)
+    for (const QueuedBlock &entry : state->vBlocksInFlight)
     {
+        LOGA("erasing map mapblocksinflight entries\n");
         mapBlocksInFlight.erase(entry.hash);
     }
     nPreferredDownload -= state->fPreferredDownload;
-    nPeersWithValidatedDownloads -= (state->nBlocksInFlightValidHeaders != 0);
-    DbgAssert(nPeersWithValidatedDownloads >= 0, nPeersWithValidatedDownloads = 0);
+    requester.nPeersWithValidatedDownloads -= (state->nBlocksInFlightValidHeaders != 0);
+    DbgAssert(requester.nPeersWithValidatedDownloads >= 0, requester.nPeersWithValidatedDownloads = 0);
 
     mapNodeState.erase(nodeid);
 
@@ -309,128 +301,9 @@ void FinalizeNode(NodeId nodeid)
         // Do a consistency check after the last peer is removed.  Force consistent state if production code
         DbgAssert(mapBlocksInFlight.empty(), mapBlocksInFlight.clear());
         DbgAssert(nPreferredDownload == 0, nPreferredDownload = 0);
-        DbgAssert(nPeersWithValidatedDownloads == 0, nPeersWithValidatedDownloads = 0);
+        DbgAssert(requester.nPeersWithValidatedDownloads == 0, requester.nPeersWithValidatedDownloads = 0);
     }
 }
-
-// Requires cs_main.
-// Returns a bool indicating whether we requested this block.
-bool MarkBlockAsReceived(const uint256 &hash)
-{
-    std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> >::iterator itInFlight =
-        mapBlocksInFlight.find(hash);
-    if (itInFlight != mapBlocksInFlight.end())
-    {
-        // BUIP010 Xtreme Thinblocks: begin section
-        int64_t getdataTime = itInFlight->second.second->nTime;
-        int64_t now = GetTimeMicros();
-        double nResponseTime = (double)(now - getdataTime) / 1000000.0;
-
-        // BU:  calculate avg block response time over last 20 blocks to be used for IBD tuning
-        // start at a higher number so that we don't start jamming IBD when we restart a node sync
-        static double avgResponseTime = 5;
-        static uint8_t blockRange = 20;
-        if (avgResponseTime > 0)
-            avgResponseTime -= (avgResponseTime / blockRange);
-        avgResponseTime += nResponseTime / blockRange;
-        if (avgResponseTime < 0.2)
-        {
-            MAX_BLOCKS_IN_TRANSIT_PER_PEER = 32;
-        }
-        else if (avgResponseTime < 0.5)
-        {
-            MAX_BLOCKS_IN_TRANSIT_PER_PEER = 16;
-        }
-        else if (avgResponseTime < 0.9)
-        {
-            MAX_BLOCKS_IN_TRANSIT_PER_PEER = 8;
-        }
-        else if (avgResponseTime < 1.4)
-        {
-            MAX_BLOCKS_IN_TRANSIT_PER_PEER = 4;
-        }
-        else if (avgResponseTime < 2.0)
-        {
-            MAX_BLOCKS_IN_TRANSIT_PER_PEER = 2;
-        }
-        else
-        {
-            MAX_BLOCKS_IN_TRANSIT_PER_PEER = 1;
-        }
-
-        LogPrint("thin", "Received block %s in %.2f seconds\n", hash.ToString(), nResponseTime);
-        LogPrint("thin", "Average block response time is %.2f seconds\n", avgResponseTime);
-        if (maxBlocksInTransitPerPeer.value != 0)
-        {
-            MAX_BLOCKS_IN_TRANSIT_PER_PEER = maxBlocksInTransitPerPeer.value;
-        }
-        if (blockDownloadWindow.value != 0)
-        {
-            BLOCK_DOWNLOAD_WINDOW = blockDownloadWindow.value;
-        }
-        LogPrint("thin", "BLOCK_DOWNLOAD_WINDOW is %d MAX_BLOCKS_IN_TRANSIT_PER_PEER is %d\n", BLOCK_DOWNLOAD_WINDOW,
-            MAX_BLOCKS_IN_TRANSIT_PER_PEER);
-
-        {
-            LOCK(cs_vNodes);
-            BOOST_FOREACH (CNode *pnode, vNodes)
-            {
-                if (pnode->mapThinBlocksInFlight.size() > 0)
-                {
-                    LOCK(pnode->cs_mapthinblocksinflight);
-                    if (pnode->mapThinBlocksInFlight.count(hash))
-                    {
-                        // Only update thinstats if this is actually a thinblock and not a regular block.
-                        // Sometimes we request a thinblock but then revert to requesting a regular block
-                        // as can happen when the thinblock preferential timer is exceeded.
-                        thindata.UpdateResponseTime(nResponseTime);
-                        break;
-                    }
-                }
-            }
-        }
-        // BUIP010 Xtreme Thinblocks: end section
-        CNodeState *state = State(itInFlight->second.first);
-        state->nBlocksInFlightValidHeaders -= itInFlight->second.second->fValidatedHeaders;
-        if (state->nBlocksInFlightValidHeaders == 0 && itInFlight->second.second->fValidatedHeaders)
-        {
-            // Last validated block on the queue was received.
-            nPeersWithValidatedDownloads--;
-        }
-        if (state->vBlocksInFlight.begin() == itInFlight->second.second)
-        {
-            // First block on the queue was received, update the start download time for the next one
-            state->nDownloadingSince = std::max(state->nDownloadingSince, GetTimeMicros());
-        }
-        state->vBlocksInFlight.erase(itInFlight->second.second);
-        state->nBlocksInFlight--;
-        mapBlocksInFlight.erase(itInFlight);
-        return true;
-    }
-    return false;
-}
-
-// BU MarkBlockAsInFlight moved out of anonymous namespace
-
-/** Check whether the last unknown block a peer advertised is not yet known. */
-void ProcessBlockAvailability(NodeId nodeid)
-{
-    CNodeState *state = State(nodeid);
-    DbgAssert(state != NULL, return ); // node already destructed, nothing to do in production mode
-
-    if (!state->hashLastUnknownBlock.IsNull())
-    {
-        BlockMap::iterator itOld = mapBlockIndex.find(state->hashLastUnknownBlock);
-        if (itOld != mapBlockIndex.end() && itOld->second->nChainWork > 0)
-        {
-            if (state->pindexBestKnownBlock == NULL ||
-                itOld->second->nChainWork >= state->pindexBestKnownBlock->nChainWork)
-                state->pindexBestKnownBlock = itOld->second;
-            state->hashLastUnknownBlock.SetNull();
-        }
-    }
-}
-
 
 // Requires cs_main
 bool PeerHasHeader(CNodeState *state, CBlockIndex *pindex)
@@ -441,181 +314,8 @@ bool PeerHasHeader(CNodeState *state, CBlockIndex *pindex)
         return true;
     return false;
 }
-
-/** Find the last common ancestor two blocks have.
- *  Both pa and pb must be non-NULL. */
-CBlockIndex *LastCommonAncestor(CBlockIndex *pa, CBlockIndex *pb)
-{
-    if (pa->nHeight > pb->nHeight)
-    {
-        pa = pa->GetAncestor(pb->nHeight);
-    }
-    else if (pb->nHeight > pa->nHeight)
-    {
-        pb = pb->GetAncestor(pa->nHeight);
-    }
-
-    while (pa != pb && pa && pb)
-    {
-        pa = pa->pprev;
-        pb = pb->pprev;
-    }
-
-    // Eventually all chain branches meet at the genesis block.
-    assert(pa == pb);
-    return pa;
-}
-
-/** Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks, until it has
- *  at most count entries. */
-static void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<CBlockIndex *> &vBlocks)
-{
-    if (count == 0)
-        return;
-
-    vBlocks.reserve(vBlocks.size() + count);
-    CNodeState *state = State(nodeid);
-    DbgAssert(state != NULL, return );
-
-    // Make sure pindexBestKnownBlock is up to date, we'll need it.
-    ProcessBlockAvailability(nodeid);
-
-    if (state->pindexBestKnownBlock == NULL || state->pindexBestKnownBlock->nChainWork < chainActive.Tip()->nChainWork)
-    {
-        // This peer has nothing interesting.
-        return;
-    }
-
-    if (state->pindexLastCommonBlock == NULL)
-    {
-        // Bootstrap quickly by guessing a parent of our best tip is the forking point.
-        // Guessing wrong in either direction is not a problem.
-        state->pindexLastCommonBlock =
-            chainActive[std::min(state->pindexBestKnownBlock->nHeight, chainActive.Height())];
-    }
-
-    // If the peer reorganized, our previous pindexLastCommonBlock may not be an ancestor
-    // of its current tip anymore. Go back enough to fix that.
-    state->pindexLastCommonBlock = LastCommonAncestor(state->pindexLastCommonBlock, state->pindexBestKnownBlock);
-    if (state->pindexLastCommonBlock == state->pindexBestKnownBlock)
-        return;
-
-    std::vector<CBlockIndex *> vToFetch;
-    CBlockIndex *pindexWalk = state->pindexLastCommonBlock;
-    // Never fetch further than the current chain tip + the block download window.  We need to ensure
-    // the if running in pruning mode we don't download too many blocks ahead and as a result use to
-    // much disk space to store unconnected blocks.
-    int nWindowEnd = chainActive.Height() + BLOCK_DOWNLOAD_WINDOW;
-
-    int nMaxHeight = std::min<int>(state->pindexBestKnownBlock->nHeight, nWindowEnd + 1);
-    while (pindexWalk->nHeight < nMaxHeight)
-    {
-        // Read up to 128 (or more, if more blocks than that are needed) successors of pindexWalk (towards
-        // pindexBestKnownBlock) into vToFetch. We fetch 128, because CBlockIndex::GetAncestor may be as expensive
-        // as iterating over ~100 CBlockIndex* entries anyway.
-        int nToFetch = std::min(nMaxHeight - pindexWalk->nHeight, std::max<int>(count - vBlocks.size(), 128));
-        vToFetch.resize(nToFetch);
-        pindexWalk = state->pindexBestKnownBlock->GetAncestor(pindexWalk->nHeight + nToFetch);
-        vToFetch[nToFetch - 1] = pindexWalk;
-        for (unsigned int i = nToFetch - 1; i > 0; i--)
-        {
-            vToFetch[i - 1] = vToFetch[i]->pprev;
-        }
-
-        // Iterate over those blocks in vToFetch (in forward direction), adding the ones that
-        // are not yet downloaded and not in flight to vBlocks. In the mean time, update
-        // pindexLastCommonBlock as long as all ancestors are already downloaded, or if it's
-        // already part of our chain (and therefore don't need it even if pruned).
-        BOOST_FOREACH (CBlockIndex *pindex, vToFetch)
-        {
-            if (!pindex->IsValid(BLOCK_VALID_TREE))
-            {
-                // We consider the chain that this peer is on invalid.
-                return;
-            }
-            if (pindex->nStatus & BLOCK_HAVE_DATA || chainActive.Contains(pindex))
-            {
-                if (pindex->nChainTx)
-                    state->pindexLastCommonBlock = pindex;
-            }
-            else
-            {
-                // Return if we've reached the end of the download window.
-                if (pindex->nHeight > nWindowEnd)
-                {
-                    return;
-                }
-
-                // Return if we've reached the end of the number of blocks we can download for this peer.
-                vBlocks.push_back(pindex);
-                if (vBlocks.size() == count)
-                {
-                    return;
-                }
-            }
-        }
-    }
-}
-
 } // anon namespace
 
-/** Update tracking information about which blocks a peer is assumed to have. */
-void UpdateBlockAvailability(NodeId nodeid, const uint256 &hash)
-{
-    CNodeState *state = State(nodeid);
-    DbgAssert(state != NULL, return ); // node already destructed, nothing to do in production mode
-
-    ProcessBlockAvailability(nodeid);
-
-    BlockMap::iterator it = mapBlockIndex.find(hash);
-    if (it != mapBlockIndex.end() && it->second->nChainWork > 0)
-    {
-        // An actually better block was announced.
-        if (state->pindexBestKnownBlock == NULL || it->second->nChainWork >= state->pindexBestKnownBlock->nChainWork)
-            state->pindexBestKnownBlock = it->second;
-    }
-    else
-    {
-        // An unknown block was announced; just assume that the latest one is the best one.
-        state->hashLastUnknownBlock = hash;
-    }
-}
-
-void MarkBlockAsInFlight(NodeId nodeid,
-    const uint256 &hash,
-    const Consensus::Params &consensusParams,
-    CBlockIndex *pindex = NULL)
-{
-    LOCK(cs_main);
-    CNodeState *state = State(nodeid);
-    DbgAssert(state != NULL, return );
-
-    // If started then clear the thinblock timer used for preferential downloading
-    thindata.ClearThinBlockTimer(hash);
-
-    // BU why mark as received? because this erases it from the inflight list.  Instead we'll check for it
-    // BU removed: MarkBlockAsReceived(hash);
-    std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> >::iterator itInFlight =
-        mapBlocksInFlight.find(hash);
-    if (itInFlight == mapBlocksInFlight.end()) // If it hasn't already been marked inflight...
-    {
-        int64_t nNow = GetTimeMicros();
-        QueuedBlock newentry = {hash, pindex, nNow, pindex != NULL};
-        std::list<QueuedBlock>::iterator it = state->vBlocksInFlight.insert(state->vBlocksInFlight.end(), newentry);
-        state->nBlocksInFlight++;
-        state->nBlocksInFlightValidHeaders += newentry.fValidatedHeaders;
-        if (state->nBlocksInFlight == 1)
-        {
-            // We're starting a block download (batch) from this peer.
-            state->nDownloadingSince = GetTimeMicros();
-        }
-        if (state->nBlocksInFlightValidHeaders == 1 && pindex != NULL)
-        {
-            nPeersWithValidatedDownloads++;
-        }
-        mapBlocksInFlight[hash] = std::make_pair(nodeid, it);
-    }
-}
 
 // Requires cs_main
 bool CanDirectFetch(const Consensus::Params &consensusParams)
@@ -3143,14 +2843,14 @@ static bool ActivateBestChainStep(CValidationState &state,
         if (PV->QuitReceived(this_id, fParallel))
             return false;
 
-        PV->IsReorgInProgress(this_id, true, fParallel); // indicate that this thread has now initiated a re-org
+        // Indicate that this thread has now initiated a re-org
+        PV->IsReorgInProgress(this_id, true, fParallel);
 
-        // Disconnect active blocks which are no longer in the best chain.
+        // Disconnect active blocks which are no longer in the best chain. We do not need to concern ourselves with any
+        // block validation threads that may be running for the chain we are rolling back. They will automatically fail
+        // validation during ConnectBlock() once the chaintip has changed..
         if (!DisconnectTip(state, chainparams.GetConsensus()))
             return false;
-
-        if (fParallel && !fBlocksDisconnected)
-            PV->StopAllValidationThreads(this_id);
 
         fBlocksDisconnected = true;
     }
@@ -4152,7 +3852,7 @@ bool ProcessNewBlock(CValidationState &state,
     {
         LOCK(cs_main);
         uint256 hash = pblock->GetHash();
-        bool fRequested = MarkBlockAsReceived(hash);
+        bool fRequested = requester.MarkBlockAsReceived(hash, pfrom);
         fRequested |= fForceProcessing;
         if (!checked)
         {
@@ -5875,7 +5575,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
 
             if (inv.type == MSG_BLOCK)
             {
-                UpdateBlockAvailability(pfrom->GetId(), inv.hash);
+                requester.UpdateBlockAvailability(pfrom->GetId(), inv.hash);
                 // RE !IsInitialBlockDownload(): We do not want to get the block if the system is executing the initial
                 // block download because
                 // blocks are stored in block files in the order of arrival.  So grabbing blocks "early" will cause new
@@ -6311,7 +6011,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
 
                 // update hashLastUnknownBlock so that we'll be able to download the block from this peer even
                 // if we receive the headers, which will connect this one, from a different peer.
-                UpdateBlockAvailability(pfrom->GetId(), hash);
+                requester.UpdateBlockAvailability(pfrom->GetId(), hash);
             }
 
             hashLastBlock = header.GetHash();
@@ -6391,7 +6091,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         }
 
         if (pindexLast)
-            UpdateBlockAvailability(pfrom->GetId(), pindexLast->GetBlockHash());
+            requester.UpdateBlockAvailability(pfrom->GetId(), pindexLast->GetBlockHash());
 
         if (nCount == MAX_HEADERS_RESULTS && pindexLast)
         {
@@ -6401,10 +6101,59 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             LogPrint("net", "more getheaders (%d) to end to peer=%s (startheight:%d)\n", pindexLast->nHeight,
                 pfrom->GetLogName(), pfrom->nStartingHeight);
             pfrom->PushMessage(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexLast), uint256());
+
+            // During the process of IBD we need to update block availability for every connected peer. To do that we
+            // request, from each NODE_NETWORK peer, a header that matches the last blockhash found in this recent set
+            // of headers. Once the reqeusted header is received then the block availability for this peer will get
+            // updated.
+            if (IsInitialBlockDownload())
+            {
+                // To maintain locking order with cs_main we have to addrefs for each node and then release
+                // the lock on cs_vNodes before aquiring cs_main further down.
+                std::vector<CNode *> vNodesCopy;
+                {
+                    LOCK(cs_vNodes);
+                    vNodesCopy = vNodes;
+                    for (CNode *pnode : vNodes)
+                    {
+                        pnode->AddRef();
+                    }
+                }
+
+                for (CNode *pnode : vNodesCopy)
+                {
+                    if (!pnode->fClient && pnode != pfrom)
+                    {
+                        LOCK(cs_main);
+                        CNodeState *state = State(pfrom->GetId());
+                        DbgAssert(state != nullptr, ); // do not return, we need to release refs later.
+                        if (state == nullptr)
+                            continue;
+
+                        if (state->pindexBestKnownBlock == nullptr ||
+                            pindexLast->nChainWork > state->pindexBestKnownBlock->nChainWork)
+                        {
+                            // We only want one single header so we pass a null for CBlockLocator.
+                            pnode->PushMessage(NetMsgType::GETHEADERS, CBlockLocator(), pindexLast->GetBlockHash());
+                            LOG(NET | BLK, "Requesting header for blockavailability, peer=%s block=%s height=%d\n",
+                                pnode->GetLogName(), pindexLast->GetBlockHash().ToString().c_str(),
+                                pindexBestHeader->nHeight);
+                        }
+                    }
+                }
+
+                // release refs
+                {
+                    LOCK(cs_vNodes);
+                    for (CNode *pnode : vNodesCopy)
+                        pnode->Release();
+                }
+            }
         }
 
         bool fCanDirectFetch = CanDirectFetch(chainparams.GetConsensus());
         CNodeState *nodestate = State(pfrom->GetId());
+        DbgAssert(nodestate != nullptr, return false);
 
         // During the initial peer handshake we must receive the initial headers which should be greater
         // than or equal to our block height at the time of requesting GETHEADERS. This is because the peer has
@@ -6436,7 +6185,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         {
             // Set tweak value.  Mostly used in testing direct fetch.
             if (maxBlocksInTransitPerPeer.value != 0)
-                MAX_BLOCKS_IN_TRANSIT_PER_PEER = maxBlocksInTransitPerPeer.value;
+                pfrom->nMaxBlocksInTransit.store(maxBlocksInTransitPerPeer.value);
 
             std::vector<CBlockIndex *> vToFetch;
             CBlockIndex *pindexWalk = pindexLast;
@@ -6463,7 +6212,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                 // We don't care about how many blocks are in flight.  We just need to make sure we don't
                 // ask for more than the maximum allowed per peer because the request manager will take care
                 // of any duplicate requests.
-                if (nAskFor >= MAX_BLOCKS_IN_TRANSIT_PER_PEER)
+                if (nAskFor >= pfrom->nMaxBlocksInTransit.load())
                 {
                     LogPrint("net", "Large reorg, could only direct fetch %d blocks\n", nAskFor);
                     break;
@@ -7234,9 +6983,8 @@ bool SendMessages(CNode *pto)
         CNodeState &state = *State(pto->GetId());
 
         // If a sync has been started check whether we received the first batch of headers requested within the timeout
-        // period.
-        // If not then disconnect and ban the node and a new node will automatically be selected to start the headers
-        // download.
+        // period. If not then disconnect and ban the node and a new node will automatically be selected to start the
+        // headers download.
         if ((state.fSyncStarted) && (state.fSyncStartTime < GetTime() - INITIAL_HEADERS_TIMEOUT) &&
             (!state.fFirstHeadersReceived) && !pto->fWhitelisted)
         {
@@ -7273,6 +7021,7 @@ bool SendMessages(CNode *pto)
                     state.fSyncStarted = true;
                     state.fSyncStartTime = GetTime();
                     state.fFirstHeadersReceived = false;
+                    state.fRequestedInitialBlockAvailability = true;
                     state.nFirstHeadersExpectedHeight = pindexBestHeader->nHeight;
                     nSyncStarted++;
 
@@ -7280,6 +7029,24 @@ bool SendMessages(CNode *pto)
                         pto->GetLogName(), pto->nStartingHeight);
                     pto->PushMessage(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexStart), uint256());
                 }
+            }
+        }
+
+        // During IBD and when a new NODE_NETWORK peer connects we have to ask for if it has our best header in order
+        // to update our block availability. We only want/need to do this only once per peer (if the initial batch of
+        // headers has still not been etirely donwnloaded yet then the block availability will be updated during that
+        // process rather than here).
+        if (IsInitialBlockDownload() && !state.fRequestedInitialBlockAvailability &&
+            state.pindexBestKnownBlock == nullptr && !fReindex && !fImporting)
+        {
+            if (!pto->fClient)
+            {
+                state.fRequestedInitialBlockAvailability = true;
+
+                // We only want one single header so we pass a null CBlockLocator.
+                pto->PushMessage(NetMsgType::GETHEADERS, CBlockLocator(), pindexBestHeader->GetBlockHash());
+                LOG(NET | BLK, "Requesting header for initial blockavailability, peer=%s block=%s height=%d\n",
+                    pto->GetLogName(), pindexBestHeader->GetBlockHash().ToString().c_str(), pindexBestHeader->nHeight);
             }
         }
 
@@ -7306,7 +7073,7 @@ bool SendMessages(CNode *pto)
             std::vector<CBlock> vHeaders;
             bool fRevertToInv = (!state.fPreferHeaders || pto->vBlockHashesToAnnounce.size() > MAX_BLOCKS_TO_ANNOUNCE);
             CBlockIndex *pBestIndex = NULL; // last header queued for delivery
-            ProcessBlockAvailability(pto->id); // ensure pindexBestKnownBlock is up-to-date
+            requester.ProcessBlockAvailability(pto->id); // ensure pindexBestKnownBlock is up-to-date
 
             if (!fRevertToInv)
             {
@@ -7504,7 +7271,7 @@ bool SendMessages(CNode *pto)
         {
             QueuedBlock &queuedBlock = state.vBlocksInFlight.front();
             int nOtherPeersWithValidatedDownloads =
-                nPeersWithValidatedDownloads - (state.nBlocksInFlightValidHeaders > 0);
+                requester.nPeersWithValidatedDownloads - (state.nBlocksInFlightValidHeaders > 0);
             if (nNow > state.nDownloadingSince +
                            consensusParams.nPowTargetSpacing *
                                (BLOCK_DOWNLOAD_TIMEOUT_BASE +
@@ -7519,27 +7286,36 @@ bool SendMessages(CNode *pto)
         //
         // Message: getdata (blocks)
         //
-        std::vector<CInv> vGetData;
-        if (!pto->fDisconnect && !pto->fClient && state.nBlocksInFlight < (int)MAX_BLOCKS_IN_TRANSIT_PER_PEER)
+        if (!pto->fDisconnect && !pto->fClient && state.nBlocksInFlight < (int)pto->nMaxBlocksInTransit)
         {
             std::vector<CBlockIndex *> vToDownload;
-            FindNextBlocksToDownload(pto->GetId(), MAX_BLOCKS_IN_TRANSIT_PER_PEER - state.nBlocksInFlight, vToDownload);
-            // LogPrint("req", "IBD AskFor %d blocks from peer=%s\n", vToDownload.size(), pto->GetLogName());
-            BOOST_FOREACH (CBlockIndex *pindex, vToDownload)
+            requester.FindNextBlocksToDownload(
+                pto->GetId(), pto->nMaxBlocksInTransit.load() - state.nBlocksInFlight, vToDownload);
+            // LOG(REQ, "IBD AskFor %d blocks from peer=%s\n", vToDownload.size(), pto->GetLogName());
+            std::vector<CInv> vGetBlocks;
+            for (CBlockIndex *pindex : vToDownload)
             {
                 CInv inv(MSG_BLOCK, pindex->GetBlockHash());
                 if (!AlreadyHave(inv))
                 {
-                    requester.AskFor(inv, pto);
-                    // LogPrint("req", "AskFor block %s (%d) peer=%s\n", pindex->GetBlockHash().ToString(),
-                    //  pindex->nHeight, pto->GetLogName());
+                    vGetBlocks.emplace_back(inv);
+                    // LOG(REQ, "AskFor block %s (%d) peer=%s\n", pindex->GetBlockHash().ToString(),
+                    //     pindex->nHeight, pto->GetLogName());
                 }
+            }
+            if (!vGetBlocks.empty())
+            {
+                if (!IsInitialBlockDownload())
+                    requester.AskFor(vGetBlocks, pto);
+                else
+                    requester.AskForDuringIBD(vGetBlocks, pto);
             }
         }
 
         //
         // Message: getdata (non-blocks)
         //
+        std::vector<CInv> vGetData;
         while (!pto->fDisconnect && !pto->mapAskFor.empty() && (*pto->mapAskFor.begin()).first <= nNow)
         {
             const CInv &inv = (*pto->mapAskFor.begin()).second;

--- a/src/main.h
+++ b/src/main.h
@@ -105,12 +105,6 @@ static const unsigned int VERACK_TIMEOUT = 60;
 /** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends
  *  less than this number, we reached its tip. Changing this value is a protocol upgrade. */
 static const unsigned int MAX_HEADERS_RESULTS = 2000;
-/** Size of the "block download window": how far ahead of our current height do we fetch?
- *  Larger windows tolerate larger download speed differences between peer, but increase the potential
- *  degree of disordering of blocks on disk (which make reindexing and in the future perhaps pruning
- *  harder). We'll probably want to make this a per-peer adaptive value at some point. */
-// static const unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
-/** Time to wait (in seconds) between writing blocks/block index to disk. */
 static const unsigned int DATABASE_WRITE_INTERVAL = 60 * 60;
 /** Time to wait (in seconds) between flushing chainstate to disk. */
 static const unsigned int DATABASE_FLUSH_INTERVAL = 24 * 60 * 60;
@@ -435,9 +429,6 @@ bool TestLockPointValidity(const LockPoints *lp);
  * See consensus/consensus.h for flag definitions.
  */
 bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints *lp = NULL, bool useExistingLockPoints = false);
-
-/** Update tracking information about which blocks a peer is assumed to have. */
-void UpdateBlockAvailability(NodeId nodeid, const uint256 &hash);
 
 /**
  * Class that keeps track of number of signature operations

--- a/src/net.h
+++ b/src/net.h
@@ -79,7 +79,7 @@ static const size_t SETASKFOR_MAX_SZ = 2 * MAX_INV_SZ;
 /** The maximum number of peer connections to maintain. */
 static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
 /** BU: The maximum numer of outbound peer connections */
-static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 12;
+static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 16;
 /** BU: The minimum number of xthin nodes to connect */
 static const uint8_t MIN_XTHIN_NODES = 8;
 /** BU: The minimum number of BitcoinCash nodes to connect */
@@ -395,6 +395,10 @@ public:
     uint64_t nGetXthinLastTime; // The last time a get_xthin request was made
     uint32_t nXthinBloomfilterSize; // The maximum xthin bloom filter size (in bytes) that our peer will accept.
     // BUIP010 Xtreme Thinblocks: end section
+
+    CCriticalSection cs_nAvgBlkResponseTime;
+    double nAvgBlkResponseTime;
+    std::atomic<int64_t> nMaxBlocksInTransit;
 
     unsigned short addrFromPort;
 

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -11,16 +11,17 @@
 */
 CNodeState::CNodeState()
 {
-    pindexBestKnownBlock = NULL;
+    pindexBestKnownBlock = nullptr;
     hashLastUnknownBlock.SetNull();
-    pindexLastCommonBlock = NULL;
-    pindexBestHeaderSent = NULL;
+    pindexLastCommonBlock = nullptr;
+    pindexBestHeaderSent = nullptr;
     fSyncStarted = false;
     nDownloadingSince = 0;
     nBlocksInFlight = 0;
     nBlocksInFlightValidHeaders = 0;
     fPreferredDownload = false;
     fPreferHeaders = false;
+    fRequestedInitialBlockAvailability = false;
 }
 
 /**
@@ -33,6 +34,6 @@ CNodeState *State(NodeId pnode)
 {
     std::map<NodeId, CNodeState>::iterator it = mapNodeState.find(pnode);
     if (it == mapNodeState.end())
-        return NULL;
+        return nullptr;
     return &it->second;
 }

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -48,6 +48,9 @@ struct CNodeState
     bool fFirstHeadersReceived;
     //! Our current block height at the time we requested GETHEADERS
     int nFirstHeadersExpectedHeight;
+    //! During IBD we need to update the block availabiity for each peer. We do this by requesting a header
+    //  when a peer connects and also when we ask for the initial set of all headers.
+    bool fRequestedInitialBlockAvailability;
 
     std::list<QueuedBlock> vBlocksInFlight;
     //! When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -589,8 +589,8 @@ void CRequestManager::SendRequests()
                         if (next.node->fDisconnect)
                         {
                             LOCK(cs_vNodes);
-                            LogPrint("req", "ReqMgr: %s removed block ref to %s count %d (%s).\n", item.obj.ToString(),
-                                next.node->GetLogName(), next.node->GetRefCount(), reason);
+                            LogPrint("req", "ReqMgr: %s removed block ref to %s count %d\n", item.obj.ToString(),
+                                next.node->GetLogName(), next.node->GetRefCount());
                             next.node->Release();
                             next.node = nullptr; // force the loop to get another node
                         }
@@ -681,7 +681,7 @@ void CRequestManager::SendRequests()
                     MarkBlockAsInFlight(iter.first->GetId(), inv.hash, Params().GetConsensus());
                 }
                 iter.first->PushMessage(NetMsgType::GETDATA, iter.second);
-                LOG(REQ, "Sent batched request with %d blocks to node %s\n", iter.second.size(),
+                LogPrint("req", "Sent batched request with %d blocks to node %s\n", iter.second.size(),
                     iter.first->GetLogName());
             }
         }
@@ -1017,7 +1017,8 @@ bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
                 pnode->nMaxBlocksInTransit.store(16);
             }
 
-            LOG(THIN | BLK, "Average block response time is %.2f seconds\n", pnode->nAvgBlkResponseTime);
+            LogPrint("thin", "Average block response time is %.2f seconds\n", pnode->nAvgBlkResponseTime);
+            LogPrint("blk", "Average block response time is %.2f seconds\n", pnode->nAvgBlkResponseTime);
         }
 
         // if there are no blocks in flight then ask for a few more blocks
@@ -1032,7 +1033,9 @@ bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
         {
             BLOCK_DOWNLOAD_WINDOW = blockDownloadWindow.value;
         }
-        LOG(THIN | BLK, "BLOCK_DOWNLOAD_WINDOW is %d nMaxBlocksInTransit is %d\n", BLOCK_DOWNLOAD_WINDOW,
+        LogPrint("thin", "BLOCK_DOWNLOAD_WINDOW is %d nMaxBlocksInTransit is %d\n", BLOCK_DOWNLOAD_WINDOW,
+            pnode->nMaxBlocksInTransit.load());
+        LogPrint("blk", "BLOCK_DOWNLOAD_WINDOW is %d nMaxBlocksInTransit is %d\n", BLOCK_DOWNLOAD_WINDOW,
             pnode->nMaxBlocksInTransit.load());
 
         if (IsChainNearlySyncd())

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -12,6 +12,7 @@
 #include "leakybucket.h"
 #include "main.h"
 #include "net.h"
+#include "nodestate.h"
 #include "parallel.h"
 #include "primitives/block.h"
 #include "rpc/server.h"
@@ -38,6 +39,9 @@ using namespace std;
 
 extern CCriticalSection cs_orphancache; // from main.h
 
+extern CTweak<unsigned int> maxBlocksInTransitPerPeer;
+extern CTweak<unsigned int> blockDownloadWindow;
+
 // Request management
 extern CRequestManager requester;
 
@@ -51,14 +55,39 @@ unsigned int txReqRetryInterval = MIN_TX_REQUEST_RETRY_INTERVAL;
 unsigned int MIN_BLK_REQUEST_RETRY_INTERVAL = DEFAULT_MIN_BLK_REQUEST_RETRY_INTERVAL;
 unsigned int blkReqRetryInterval = MIN_BLK_REQUEST_RETRY_INTERVAL;
 
+/** Size of the "block download window": how far ahead of our current height do we fetch?
+ *  Larger windows tolerate larger download speed differences between peer, but increase the potential
+ *  degree of disordering of blocks on disk (which make reindexing and in the future perhaps pruning
+ *  harder). We'll probably want to make this a per-peer adaptive value at some point. */
+unsigned int BLOCK_DOWNLOAD_WINDOW = 1024;
 
 // defined in main.cpp.  should be moved into a utilities file but want to make rebasing easier
 extern bool CanDirectFetch(const Consensus::Params &consensusParams);
-extern void MarkBlockAsInFlight(NodeId nodeid,
-    const uint256 &hash,
-    const Consensus::Params &consensusParams,
-    CBlockIndex *pindex = NULL);
-// note mark block as in flight is redundant with the request manager now...
+
+/** Find the last common ancestor two blocks have.
+ *  Both pa and pb must be non-NULL. */
+static CBlockIndex *LastCommonAncestor(CBlockIndex *pa, CBlockIndex *pb)
+{
+    if (pa->nHeight > pb->nHeight)
+    {
+        pa = pa->GetAncestor(pb->nHeight);
+    }
+    else if (pb->nHeight > pa->nHeight)
+    {
+        pb = pb->GetAncestor(pa->nHeight);
+    }
+
+    while (pa != pb && pa && pb)
+    {
+        pa = pa->pprev;
+        pb = pb->pprev;
+    }
+
+    // Eventually all chain branches meet at the genesis block.
+    assert(pa == pb);
+    return pa;
+}
+
 
 CRequestManager::CRequestManager()
     : inFlightTxns("reqMgr/inFlight", STAT_OP_MAX), receivedTxns("reqMgr/received"), rejectedTxns("reqMgr/rejected"),
@@ -164,13 +193,64 @@ void CRequestManager::AskFor(const CInv &obj, CNode *from, unsigned int priority
 // Get these objects from somewhere, asynchronously.
 void CRequestManager::AskFor(const std::vector<CInv> &objArray, CNode *from, unsigned int priority)
 {
-    unsigned int sz = objArray.size();
-    for (unsigned int nInv = 0; nInv < sz; nInv++)
+    // In order to maintain locking order, we must lock cs_objDownloader first and before possibly taking cs_vNodes.
+    // Also, locking here prevents anyone from asking again for any of these objects again before we've notified the
+    // request manager of them all. In addition this helps keep blocks batached and requests for batches of blocks
+    // in a better order.
+    LOCK(cs_objDownloader);
+    for (auto &inv : objArray)
     {
-        AskFor(objArray[nInv], from, priority);
+        AskFor(inv, from, priority);
     }
 }
 
+void CRequestManager::AskForDuringIBD(const std::vector<CInv> &objArray, CNode *from, unsigned int priority)
+{
+    // must maintain correct locking order:  cs_main, then cs_objDownloader, then cs_vNodes.
+    AssertLockHeld(cs_main);
+
+    // This is block and peer that was selected in FindNextBlocksToDownload() so we want to add it as a block
+    // source first so that it gets requested first.
+    LOCK(cs_objDownloader);
+    AskFor(objArray, from, priority);
+
+    // Add the other peers as potential sources in the event the RequestManager needs to make a re-request
+    // for this block. Only add NETWORK nodes that have block availability.
+    LOCK(cs_vNodes);
+    for (CNode *pnode : vNodes)
+    {
+        // skip the peer we added above
+        if (pnode == from)
+            continue;
+        // skip non NETWORK nodes
+        if (pnode->fClient)
+            continue;
+
+        // Make sure pindexBestKnownBlock is up to date.
+        ProcessBlockAvailability(pnode->id);
+
+        // check block availability for this peer and only askfor a block if it is available.
+        CNodeState *state = State(pnode->id);
+        if (state != nullptr)
+        {
+            if (state->pindexBestKnownBlock != nullptr &&
+                state->pindexBestKnownBlock->nChainWork > chainActive.Tip()->nChainWork)
+            {
+                AskFor(objArray, pnode, priority);
+            }
+        }
+    }
+}
+
+bool CRequestManager::AlreadyAskedFor(const uint256 &hash)
+{
+    LOCK(cs_objDownloader);
+    OdMap::iterator item = mapBlkInfo.find(hash);
+    if (item != mapBlkInfo.end())
+        return true;
+
+    return false;
+}
 
 // Indicate that we got this object, from and bytes are optional (for node performance tracking)
 void CRequestManager::Received(const CInv &obj, CNode *from, int bytes)
@@ -316,6 +396,7 @@ CNodeRequestData::CNodeRequestData(CNode *n)
     desirability -= latency;
 }
 
+// requires cs_objDownloader
 bool CUnknownObj::AddSource(CNode *from)
 {
     // node is not in the request list
@@ -341,7 +422,7 @@ bool CUnknownObj::AddSource(CNode *from)
     return false;
 }
 
-bool RequestBlock(CNode *pfrom, CInv obj)
+bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
 {
     const CChainParams &chainParams = Params();
 
@@ -358,6 +439,7 @@ bool RequestBlock(CNode *pfrom, CInv obj)
     //        here.
     if (IsChainNearlySyncd() || chainParams.NetworkIDString() == "regtest")
     {
+        LOCK(cs_main);
         BlockMap::iterator idxIt = mapBlockIndex.find(obj.hash);
         if (idxIt == mapBlockIndex.end()) // only request if we don't already have the header
         {
@@ -452,7 +534,6 @@ bool RequestBlock(CNode *pfrom, CInv obj)
     }
 }
 
-
 void CRequestManager::SendRequests()
 {
     int64_t now = 0;
@@ -474,6 +555,12 @@ void CRequestManager::SendRequests()
         txReqRetryInterval *= (12 * 2);
     }
 
+    // When we are still doing an initial sync we want to batch request the blocks instead of just
+    // asking for one at time. We can do this because there will be no XTHIN requests possible during
+    // this time.
+    bool fBatchBlockRequests = IsInitialBlockDownload();
+    std::map<CNode *, std::vector<CInv> > mapBatchBlockRequests;
+
     // Get Blocks
     while (sendBlkIter != mapBlkInfo.end())
     {
@@ -492,45 +579,25 @@ void CRequestManager::SendRequests()
             {
                 CNodeRequestData next;
                 // Go thru the availableFrom list, looking for the first node that isn't disconnected
-                while (!item.availableFrom.empty() && (next.node == NULL))
+                while (!item.availableFrom.empty() && (next.node == nullptr))
                 {
                     next = item.availableFrom.front(); // Grab the next location where we can find this object.
                     item.availableFrom.pop_front();
-                    if (next.node != NULL)
+                    if (next.node != nullptr)
                     {
-                        // Do not request from this node if it was disconnected or the node pingtime is far beyond
-                        // acceptable during initial block download.
-                        // We only check pingtime during IBD because we don't want to lock vNodes too often and when the
-                        // chain is syncd, waiting
-                        // just 5 seconds for a timeout is not an issue, however waiting for a slow node during IBD can
-                        // really slow down the process.
-                        //   TODO: Eventually when we move away from vNodes or have a different mechanism for tracking
-                        //   ping times we can include
-                        //   this filtering in all our requests for blocks and transactions.
-                        bool release = false;
-                        std::string reason;
+                        // Do not request from this node if it was disconnected
                         if (next.node->fDisconnect)
-                        {
-                            reason = "on disconnect";
-                            release = true;
-                        }
-                        else if (!IsChainNearlySyncd() && !IsNodePingAcceptable(next.node))
-                        {
-                            reason = "bad ping time";
-                            release = true;
-                        }
-                        if (release)
                         {
                             LOCK(cs_vNodes);
                             LogPrint("req", "ReqMgr: %s removed block ref to %s count %d (%s).\n", item.obj.ToString(),
                                 next.node->GetLogName(), next.node->GetRefCount(), reason);
                             next.node->Release();
-                            next.node = NULL; // force the loop to get another node
+                            next.node = nullptr; // force the loop to get another node
                         }
                     }
                 }
 
-                if (next.node != NULL)
+                if (next.node != nullptr)
                 {
                     // If item.lastRequestTime is true then we've requested at least once and we'll try a re-request
                     if (item.lastRequestTime)
@@ -542,20 +609,33 @@ void CRequestManager::SendRequests()
                     item.outstandingReqs++;
                     int64_t then = item.lastRequestTime;
                     item.lastRequestTime = now;
-                    LEAVE_CRITICAL_SECTION(cs_objDownloader); // item and itemIter are now invalid
-                    bool reqblkResult = RequestBlock(next.node, obj);
-                    ENTER_CRITICAL_SECTION(cs_objDownloader);
-                    if (!reqblkResult)
+
+                    if (fBatchBlockRequests)
                     {
-                        // having released cs_objDownloader, item and itemiter may be invalid.
-                        // So in the rare case that we could not request the block we need to
-                        // find the item again (if it exists) and set the tracking back to what it was
-                        itemIter = mapBlkInfo.find(obj.hash);
-                        if (itemIter != mapBlkInfo.end())
                         {
-                            item = itemIter->second;
-                            item.outstandingReqs--;
-                            item.lastRequestTime = then;
+                            LOCK(cs_vNodes);
+                            next.node->AddRef();
+                        }
+                        mapBatchBlockRequests[next.node].push_back(obj);
+                    }
+                    else
+                    {
+                        LEAVE_CRITICAL_SECTION(cs_objDownloader); // item and itemIter are now invalid
+                        bool reqblkResult = RequestBlock(next.node, obj);
+                        ENTER_CRITICAL_SECTION(cs_objDownloader);
+
+                        if (!reqblkResult)
+                        {
+                            // having released cs_objDownloader, item and itemiter may be invalid.
+                            // So in the rare case that we could not request the block we need to
+                            // find the item again (if it exists) and set the tracking back to what it was
+                            itemIter = mapBlkInfo.find(obj.hash);
+                            if (itemIter != mapBlkInfo.end())
+                            {
+                                item = itemIter->second;
+                                item.outstandingReqs--;
+                                item.lastRequestTime = then;
+                            }
                         }
                     }
 
@@ -571,7 +651,7 @@ void CRequestManager::SendRequests()
                     // LogPrint("req", "ReqMgr: %s removed block ref to %d count %d\n", obj.ToString(),
                     //    next.node->GetId(), next.node->GetRefCount());
                     next.node->Release();
-                    next.node = NULL;
+                    next.node = nullptr;
                 }
                 else
                 {
@@ -587,6 +667,32 @@ void CRequestManager::SendRequests()
                 cleanup(itemIter);
             }
         }
+    }
+    // send batched requests if any.
+    if (fBatchBlockRequests && !mapBatchBlockRequests.empty())
+    {
+        LEAVE_CRITICAL_SECTION(cs_objDownloader);
+        {
+            for (auto iter : mapBatchBlockRequests)
+            {
+                LOCK(cs_main);
+                for (auto &inv : iter.second)
+                {
+                    MarkBlockAsInFlight(iter.first->GetId(), inv.hash, Params().GetConsensus());
+                }
+                iter.first->PushMessage(NetMsgType::GETDATA, iter.second);
+                LOG(REQ, "Sent batched request with %d blocks to node %s\n", iter.second.size(),
+                    iter.first->GetLogName());
+            }
+        }
+        ENTER_CRITICAL_SECTION(cs_objDownloader);
+
+        LOCK(cs_vNodes);
+        for (auto iter : mapBatchBlockRequests)
+        {
+            iter.first->Release();
+        }
+        mapBatchBlockRequests.clear();
     }
 
     // Get Transactions
@@ -628,11 +734,11 @@ void CRequestManager::SendRequests()
                 {
                     CNodeRequestData next;
                     // Go thru the availableFrom list, looking for the first node that isn't disconnected
-                    while (!item.availableFrom.empty() && (next.node == NULL))
+                    while (!item.availableFrom.empty() && (next.node == nullptr))
                     {
                         next = item.availableFrom.front(); // Grab the next location where we can find this object.
                         item.availableFrom.pop_front();
-                        if (next.node != NULL)
+                        if (next.node != nullptr)
                         {
                             if (next.node->fDisconnect) // Node was disconnected so we can't request from it
                             {
@@ -640,12 +746,12 @@ void CRequestManager::SendRequests()
                                 LogPrint("req", "ReqMgr: %s removed tx ref to %d count %d (on disconnect).\n",
                                     item.obj.ToString(), next.node->GetId(), next.node->GetRefCount());
                                 next.node->Release();
-                                next.node = NULL; // force the loop to get another node
+                                next.node = nullptr; // force the loop to get another node
                             }
                         }
                     }
 
-                    if (next.node != NULL)
+                    if (next.node != nullptr)
                     {
                         CInv obj = item.obj;
                         if (1)
@@ -666,7 +772,7 @@ void CRequestManager::SendRequests()
                             LogPrint("req", "ReqMgr: %s removed tx ref to %d count %d\n", obj.ToString(),
                                 next.node->GetId(), next.node->GetRefCount());
                             next.node->Release();
-                            next.node = NULL;
+                            next.node = nullptr;
                         }
                         inFlight++;
                         inFlightTxns << inFlight;
@@ -677,38 +783,293 @@ void CRequestManager::SendRequests()
     }
 }
 
-bool CRequestManager::IsNodePingAcceptable(CNode *pfrom)
+// Check whether the last unknown block a peer advertised is not yet known.
+void CRequestManager::ProcessBlockAvailability(NodeId nodeid)
 {
-    if (pfrom->nPingUsecTime < ACCEPTABLE_PING_USEC)
-        return true;
+    AssertLockHeld(cs_main);
 
-    // Calculate average ping time of all nodes
-    uint16_t nValidNodes = 0;
-    std::vector<uint64_t> vPingTimes;
-    LOCK(cs_vNodes);
-    BOOST_FOREACH (CNode *pnode, vNodes)
+    CNodeState *state = State(nodeid);
+    DbgAssert(state != nullptr, return );
+
+    if (!state->hashLastUnknownBlock.IsNull())
     {
-        if (!pnode->fDisconnect && pnode->nPingUsecTime > 0)
+        BlockMap::iterator itOld = mapBlockIndex.find(state->hashLastUnknownBlock);
+        if (itOld != mapBlockIndex.end() && itOld->second->nChainWork > 0)
         {
-            nValidNodes++;
-            vPingTimes.push_back(pnode->nPingUsecTime);
+            if (state->pindexBestKnownBlock == nullptr ||
+                itOld->second->nChainWork >= state->pindexBestKnownBlock->nChainWork)
+            {
+                state->pindexBestKnownBlock = itOld->second;
+            }
+            state->hashLastUnknownBlock.SetNull();
         }
     }
-    if (nValidNodes < 10) // Take anything if we are poorly connected
-        return true;
+}
 
-    // Calculate Standard Deviation and Mean of Ping Time
-    using namespace boost::accumulators;
-    accumulator_set<double, stats<tag::variance> > acc;
-    acc = for_each(vPingTimes.begin(), vPingTimes.end(), acc);
-    double nMean = mean(acc);
-    double sDeviation = sqrt(variance(acc));
+// Update tracking information about which blocks a peer is assumed to have.
+void CRequestManager::UpdateBlockAvailability(NodeId nodeid, const uint256 &hash)
+{
+    AssertLockHeld(cs_main);
 
-    // If node ping time is greater than the average plus 2 times the standard deviation, or
-    // the pong has not been received, then do not request from this node.
-    if ((pfrom->nPingUsecTime > (int64_t)(nMean + (2 * sDeviation))) || (pfrom->nPingUsecTime == 0))
+    CNodeState *state = State(nodeid);
+    DbgAssert(state != nullptr, return );
+
+    ProcessBlockAvailability(nodeid);
+
+    BlockMap::iterator it = mapBlockIndex.find(hash);
+    if (it != mapBlockIndex.end() && it->second->nChainWork > 0)
     {
-        return false;
+        // An actually better block was announced.
+        if (state->pindexBestKnownBlock == nullptr || it->second->nChainWork >= state->pindexBestKnownBlock->nChainWork)
+        {
+            state->pindexBestKnownBlock = it->second;
+        }
     }
-    return true;
+    else
+    {
+        // An unknown block was announced; just assume that the latest one is the best one.
+        state->hashLastUnknownBlock = hash;
+    }
+}
+
+// Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks, until it has
+// at most count entries.
+void CRequestManager::FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<CBlockIndex *> &vBlocks)
+{
+    AssertLockHeld(cs_main);
+
+    if (count == 0)
+        return;
+
+    vBlocks.reserve(vBlocks.size() + count);
+    CNodeState *state = State(nodeid);
+    DbgAssert(state != nullptr, return );
+
+    // Make sure pindexBestKnownBlock is up to date, we'll need it.
+    requester.ProcessBlockAvailability(nodeid);
+
+    if (state->pindexBestKnownBlock == nullptr ||
+        state->pindexBestKnownBlock->nChainWork < chainActive.Tip()->nChainWork)
+    {
+        // This peer has nothing interesting.
+        return;
+    }
+
+    if (state->pindexLastCommonBlock == nullptr)
+    {
+        // Bootstrap quickly by guessing a parent of our best tip is the forking point.
+        // Guessing wrong in either direction is not a problem.
+        state->pindexLastCommonBlock =
+            chainActive[std::min(state->pindexBestKnownBlock->nHeight, chainActive.Height())];
+    }
+
+    // If the peer reorganized, our previous pindexLastCommonBlock may not be an ancestor
+    // of its current tip anymore. Go back enough to fix that.
+    state->pindexLastCommonBlock = LastCommonAncestor(state->pindexLastCommonBlock, state->pindexBestKnownBlock);
+    if (state->pindexLastCommonBlock == state->pindexBestKnownBlock)
+        return;
+
+    std::vector<CBlockIndex *> vToFetch;
+    CBlockIndex *pindexWalk = state->pindexLastCommonBlock;
+    // Never fetch further than the current chain tip + the block download window.  We need to ensure
+    // the if running in pruning mode we don't download too many blocks ahead and as a result use to
+    // much disk space to store unconnected blocks.
+    int nWindowEnd = chainActive.Height() + BLOCK_DOWNLOAD_WINDOW;
+
+    int nMaxHeight = std::min<int>(state->pindexBestKnownBlock->nHeight, nWindowEnd + 1);
+    while (pindexWalk->nHeight < nMaxHeight)
+    {
+        // Read up to 128 (or more, if more blocks than that are needed) successors of pindexWalk (towards
+        // pindexBestKnownBlock) into vToFetch. We fetch 128, because CBlockIndex::GetAncestor may be as expensive
+        // as iterating over ~100 CBlockIndex* entries anyway.
+        int nToFetch = std::min(nMaxHeight - pindexWalk->nHeight, std::max<int>(count - vBlocks.size(), 128));
+        vToFetch.resize(nToFetch);
+        pindexWalk = state->pindexBestKnownBlock->GetAncestor(pindexWalk->nHeight + nToFetch);
+        vToFetch[nToFetch - 1] = pindexWalk;
+        for (unsigned int i = nToFetch - 1; i > 0; i--)
+        {
+            vToFetch[i - 1] = vToFetch[i]->pprev;
+        }
+
+        // Iterate over those blocks in vToFetch (in forward direction), adding the ones that
+        // are not yet downloaded and not in flight to vBlocks. In the mean time, update
+        // pindexLastCommonBlock as long as all ancestors are already downloaded, or if it's
+        // already part of our chain (and therefore don't need it even if pruned).
+        for (CBlockIndex *pindex : vToFetch)
+        {
+            if (requester.AlreadyAskedFor(pindex->GetBlockHash()))
+                continue;
+
+            if (!pindex->IsValid(BLOCK_VALID_TREE))
+            {
+                // We consider the chain that this peer is on invalid.
+                return;
+            }
+            if (pindex->nStatus & BLOCK_HAVE_DATA || chainActive.Contains(pindex))
+            {
+                if (pindex->nChainTx)
+                    state->pindexLastCommonBlock = pindex;
+            }
+            else
+            {
+                // Return if we've reached the end of the download window.
+                if (pindex->nHeight > nWindowEnd)
+                {
+                    return;
+                }
+
+                // Return if we've reached the end of the number of blocks we can download for this peer.
+                vBlocks.push_back(pindex);
+                if (vBlocks.size() == count)
+                {
+                    return;
+                }
+            }
+        }
+    }
+}
+
+// indicate whether we requested this block.
+void CRequestManager::MarkBlockAsInFlight(NodeId nodeid,
+    const uint256 &hash,
+    const Consensus::Params &consensusParams,
+    CBlockIndex *pindex)
+{
+    LOCK(cs_main);
+    CNodeState *state = State(nodeid);
+    DbgAssert(state != nullptr, return );
+
+    // If started then clear the thinblock timer used for preferential downloading
+    thindata.ClearThinBlockTimer(hash);
+
+    // BU why mark as received? because this erases it from the inflight list.  Instead we'll check for it
+    // BU removed: MarkBlockAsReceived(hash);
+    std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> >::iterator itInFlight =
+        mapBlocksInFlight.find(hash);
+    if (itInFlight == mapBlocksInFlight.end()) // If it hasn't already been marked inflight...
+    {
+        int64_t nNow = GetTimeMicros();
+        QueuedBlock newentry = {hash, pindex, nNow, pindex != nullptr};
+        std::list<QueuedBlock>::iterator it = state->vBlocksInFlight.insert(state->vBlocksInFlight.end(), newentry);
+        state->nBlocksInFlight++;
+        state->nBlocksInFlightValidHeaders += newentry.fValidatedHeaders;
+        if (state->nBlocksInFlight == 1)
+        {
+            // We're starting a block download (batch) from this peer.
+            state->nDownloadingSince = GetTimeMicros();
+        }
+        if (state->nBlocksInFlightValidHeaders == 1 && pindex != nullptr)
+        {
+            nPeersWithValidatedDownloads++;
+        }
+        mapBlocksInFlight[hash] = std::make_pair(nodeid, it);
+    }
+}
+
+// Returns a bool if successful in indicating we received this block.
+bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
+{
+    AssertLockHeld(cs_main);
+
+    std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> >::iterator itInFlight =
+        mapBlocksInFlight.find(hash);
+    if (itInFlight != mapBlocksInFlight.end())
+    {
+        CNodeState *state = State(itInFlight->second.first);
+        DbgAssert(state != nullptr, return false);
+
+        int64_t getdataTime = itInFlight->second.second->nTime;
+        int64_t now = GetTimeMicros();
+        double nResponseTime = (double)(now - getdataTime) / 1000000.0;
+
+        // calculate avg block response time over a range of blocks to be used for IBD tuning.
+        static uint8_t blockRange = 50;
+        {
+            LOCK(pnode->cs_nAvgBlkResponseTime);
+            if (pnode->nAvgBlkResponseTime < 0)
+                pnode->nAvgBlkResponseTime = 2.0;
+            if (pnode->nAvgBlkResponseTime > 0)
+                pnode->nAvgBlkResponseTime -= (pnode->nAvgBlkResponseTime / blockRange);
+            pnode->nAvgBlkResponseTime += nResponseTime / blockRange;
+
+            if (pnode->nAvgBlkResponseTime < 0.2)
+            {
+                pnode->nMaxBlocksInTransit.store(64);
+            }
+            else if (pnode->nAvgBlkResponseTime < 0.5)
+            {
+                pnode->nMaxBlocksInTransit.store(56);
+            }
+            else if (pnode->nAvgBlkResponseTime < 0.9)
+            {
+                pnode->nMaxBlocksInTransit.store(48);
+            }
+            else if (pnode->nAvgBlkResponseTime < 1.4)
+            {
+                pnode->nMaxBlocksInTransit.store(32);
+            }
+            else if (pnode->nAvgBlkResponseTime < 2.0)
+            {
+                pnode->nMaxBlocksInTransit.store(24);
+            }
+            else
+            {
+                pnode->nMaxBlocksInTransit.store(16);
+            }
+
+            LOG(THIN | BLK, "Average block response time is %.2f seconds\n", pnode->nAvgBlkResponseTime);
+        }
+
+        // if there are no blocks in flight then ask for a few more blocks
+        if (state->nBlocksInFlight <= 0)
+            pnode->nMaxBlocksInTransit.fetch_add(4);
+
+        if (maxBlocksInTransitPerPeer.value != 0)
+        {
+            pnode->nMaxBlocksInTransit.store(maxBlocksInTransitPerPeer.value);
+        }
+        if (blockDownloadWindow.value != 0)
+        {
+            BLOCK_DOWNLOAD_WINDOW = blockDownloadWindow.value;
+        }
+        LOG(THIN | BLK, "BLOCK_DOWNLOAD_WINDOW is %d nMaxBlocksInTransit is %d\n", BLOCK_DOWNLOAD_WINDOW,
+            pnode->nMaxBlocksInTransit.load());
+
+        if (IsChainNearlySyncd())
+        {
+            LOCK(cs_vNodes);
+            for (CNode *pnode : vNodes)
+            {
+                if (pnode->mapThinBlocksInFlight.size() > 0)
+                {
+                    LOCK(pnode->cs_mapthinblocksinflight);
+                    if (pnode->mapThinBlocksInFlight.count(hash))
+                    {
+                        // Only update thinstats if this is actually a thinblock and not a regular block.
+                        // Sometimes we request a thinblock but then revert to requesting a regular block
+                        // as can happen when the thinblock preferential timer is exceeded.
+                        thindata.UpdateResponseTime(nResponseTime);
+                        break;
+                    }
+                }
+            }
+        }
+        // BUIP010 Xtreme Thinblocks: end section
+        state->nBlocksInFlightValidHeaders -= itInFlight->second.second->fValidatedHeaders;
+        if (state->nBlocksInFlightValidHeaders == 0 && itInFlight->second.second->fValidatedHeaders)
+        {
+            // Last validated block on the queue was received.
+            nPeersWithValidatedDownloads--;
+        }
+        if (state->vBlocksInFlight.begin() == itInFlight->second.second)
+        {
+            // First block on the queue was received, update the start download time for the next one
+            state->nDownloadingSince = std::max(state->nDownloadingSince, GetTimeMicros());
+        }
+        state->vBlocksInFlight.erase(itInFlight->second.second);
+        state->nBlocksInFlight--;
+        mapBlocksInFlight.erase(itInFlight);
+        return true;
+    }
+    return false;
 }

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -120,7 +120,13 @@ protected:
     CLeakyBucket requestPacer;
     CLeakyBucket blockPacer;
 
+    // Request a single block.
+    bool RequestBlock(CNode *pfrom, CInv obj);
+
 public:
+    // Number of peers from which we're downloading blocks.
+    int nPeersWithValidatedDownloads = 0;
+
     CRequestManager();
 
     // Get this object from somewhere, asynchronously.
@@ -128,6 +134,16 @@ public:
 
     // Get these objects from somewhere, asynchronously.
     void AskFor(const std::vector<CInv> &objArray, CNode *from, unsigned int priority = 0);
+
+    // Get these objects from somewhere, asynchronously during IBD. During IBD we must assume every peer connected
+    // can give us the blocks we need and so we tell the request manager about these sources. Otherwise the request
+    // manager may not be able to re-request blocks from anyone after a timeout and we also need to be able to not
+    // request another group of blocks that are already in flight.
+    void AskForDuringIBD(const std::vector<CInv> &objArray, CNode *from, unsigned int priority = 0);
+
+    // Did we already ask for this block. We need to do this during IBD to make sure we don't ask for another set
+    // of the same blocks.
+    bool AlreadyAskedFor(const uint256 &hash);
 
     // Indicate that we got this object, from and bytes are optional (for node performance tracking)
     void Received(const CInv &obj, CNode *from, int bytes = 0);
@@ -140,8 +156,24 @@ public:
 
     void SendRequests();
 
-    // Indicates whether a node ping time is acceptable relative to the overall average of all nodes.
-    bool IsNodePingAcceptable(CNode *pnode);
+    // Check whether the last unknown block a peer advertised is not yet known.
+    void ProcessBlockAvailability(NodeId nodeid);
+
+    // Update tracking information about which blocks a peer is assumed to have.
+    void UpdateBlockAvailability(NodeId nodeid, const uint256 &hash);
+
+    // Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks, until it has
+    // at most count entries.
+    void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<CBlockIndex *> &vBlocks);
+
+    // Returns a bool indicating whether we requested this block.
+    void MarkBlockAsInFlight(NodeId nodeid,
+        const uint256 &hash,
+        const Consensus::Params &consensusParams,
+        CBlockIndex *pindex = nullptr);
+
+    // Returns a bool if successful in indicating we received this block.
+    bool MarkBlockAsReceived(const uint256 &hash, CNode *pnode);
 };
 
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -108,17 +108,6 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK())));
     obj.push_back(Pair("status",        statusStrings.GetPrintable()));
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));
-    CBlockIndex *cashFork = chainActive.Tip();
-    if (cashFork) cashFork = cashFork->GetAncestor(BITCOIN_CASH_FORK_HEIGHT);
-    std::string fork="Bitcoin";
-    if (cashFork && cashFork->phashBlock)
-    {
-        if (*cashFork->phashBlock == bitcoinCashForkBlockHash)
-        {
-            fork = "Bitcoin Cash";
-        }
-    }
-    obj.push_back(Pair("fork", fork));
 
     return obj;
 }

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -594,7 +594,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, string strComm
         }
 
         inv.hash = pIndex->GetBlockHash();
-        UpdateBlockAvailability(pfrom->GetId(), inv.hash);
+        requester.UpdateBlockAvailability(pfrom->GetId(), inv.hash);
 
         // Return early if we already have the block data
         if (pIndex->nStatus & BLOCK_HAVE_DATA)

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -39,17 +39,9 @@ enum
         30, // Default for the number of days in the past we check scripts during initial block download
 
     MAX_HEADER_REQS_DURING_IBD = 3,
-// if the blockchain is this far (in seconds) behind the current time, only request headers from a single
-// peer.  This makes IBD more efficient.  We make BITCOIN_CASH more lenient here because mining could be
-// more erratic and this node is likely to connect to non-BCC nodes.
-#ifdef BITCOIN_CASH
-    SINGLE_PEER_REQUEST_MODE_AGE = (7 * 24 * 60 * 60),
-#else
+    // if the blockchain is this far (in seconds) behind the current time, only request headers from a single
+    // peer.  This makes IBD more efficient.
     SINGLE_PEER_REQUEST_MODE_AGE = (24 * 60 * 60),
-#endif
-
-    BITCOIN_CASH_FORK_HEIGHT = 478559,
-
 };
 
 class CBlock;


### PR DESCRIPTION
* Update the block availaibility for all nodes during IBD

One of the problems with IBD is that we end up downloading
blocks from the same peer. This is because after downloading
all the headers at startup the block availability is only
being updated for that peer. We need to assume that all connected
or newly connected peers have the blocks that we need but we
only do this during IBD or when IsInitialBlockDownload() is true.

* Increase the block download window to 1024

This helps to keep IBD moving forward when we have a peer
that may be serving us blocks more slowly.  And now that
blockvailability is being updated correctly we are getting blocks
from all connected peers so the chance of having a slow peer
is now much higher.

* Reset the single peer request mode age to 24 hours

One week isn't needed anymore because the new DAA is working
well and we're not falling behind in terms of blocks mined
per day.

* Remove the check for node ping in the request manager

This feature is causing occasional hangups during IBD and
is not really effective in selecting peers especially during
IBD. Since it is not used when the chain is sync'd then there
is no need for this feature to remain which only adds another
level of complexity to IBD. KISS can be applied here for a better
IBD experience.

* Only update xthin stats when IsChainNearlySyncd()

There is no need to lock vNodes and check all peers for
thinblocks in flight unless we are IsChainNearlySyncd() because
we would not have asked for any xthins if !IsChainNearlySyncd().

This is an expensive operation and which makes a performance hit
during IBD.

* Disconnect non NETWORK nodes during initial sync

We only want to have nodes we can download the full
blockchain from, connected to us while we do our initial sync.

* Increase the default max outbound connections to 16

Having a few more outbound connections can help especially
during the process of IBD.

* During IBD, batch the block reqeusts if possible.

By batching the blocks together we save a little bandwidth
and time in requesting blocks.

This method can then be applied to batching transactions which
should make a very good improvement during periods where transaction
rates are high.

* Replace missing cs_main lock

* fix formatting

* Fix locking order issue with cs_objectDownloader and cs_vNodes

cs_objectDownloader must be locked first to prevent a possible
deaklock.

* Fix formatting

* Use Logging namespace to access LogAcceptCategory

LogAcceptCategory and the enum used to define available logging
category is defined inside the Logging namespace. If used directly
outside of util.{h,cpp} reference to such namespace is needed.

This commit fix issue #950

* Don't favor XTHIN nodes when sending messages

This has a negative effect on IBD

* Use more descriptive variable names for nodes we are disconnecting

ptemp1 and ptemp2 are getting hard to follow. We'll say what they are:

pNonXthinNode and pNonNodeNetwork

* Take the cs_objDownloader lock earlier when requesting multiple objects

This prevents anyone else from asking for these same objects before
we've notified the request manager of their existence. This could happen
for in stance during IBD where we look for the next blocks to download
but before we've notified the request manager of them all we then
go back and possibly request them again.

Also keeping the lock here allows the request manager to prepare
a better batch request of blocks and thereby keep a better order
of block requests.

* Call MarkBlocksAsInFlight() before asking for blocks

This ensures you don't receive any blocks back before you mark the block
in flight as could happen on regtest.

* Add/release node refs when making batch requests

We need to track the node refs correctly so we don't get disconnected
before we're done our work.

* Don't ask for the same blocks twice when doing IBD

If we've already asked for a block, we don't have to ask for it
again in FindNextBlocksToDownload(), instead we can rely o the request
manager handle potential re-requests.

* Calculate MaxBlocksInTransitPerPeer, but on an individual node basis

Before we were using the overall resonse times regardless of
which peer they came from. This made the selection of how many
blocks to donwload at one time not responsive to faster or
slower nodes.  By tracking response times on a per node basis
we can deprioritize slower downloaders and get more blocks
from the faster nodes.

In HEADERS net processing, remove MAX_BLOCKS_IN_TRANSIT_PER_PEER

  This has been replaced with pnode->nMaxBlocksInTransitPerPeer

use atomic store, load, fetch_add

* Fixes #941: Rotate vNodes by one peer every 60 seconds when sending messages

We do this only during IBD and this has the effect of distributing
the load more evenly between the peers. Previously, because we are
using PV, the very first peer to connect would always be favored and
we would end up downloading a disproportionate amount of blocks from
that peer during IBD.  However, we still will download more from
some peers based on their download response time performance.

* Small net optimization when sending messages

Just copy the entire vector rather than bothering to allocate
memory and then push_back for each entry as we iteration through
vNodes.

Make sure to LOCK vNodes then add the ref

* Fix getchaintips.py spurious failures

The hang results from a  PV bug which is caused by a condition where
threads that are waiting for validation are forced to quit during chain
tip rollback.  We don't in fact have to force any threads to quit since
any validation threads on the current chain will fail automatically
once we disconnect the tip.  And then the waiting block validation
thread for the new chain can still continue without being inadvertanly
forced to quit.

* Do not to use an incorrect or invalid state

Use the node id from the iterator rather than looking up state
by the node we think we just passed in. Just in case they don't match
for some reason.

Also DbgAssert if the state is NULL and return false if we assert.

* Small edit to logprint

Add category BLK to logprint

remove printf

* During IBD only request blocks from peers that have block availability

Request from peers that are NODE_NETWORK and have demonstrated that
they have the blocks that we need.

Also move ProcessBlockAvailablity and UpdateBlockAvailabilty to
RequestManager.cpp

* Move FindNextBlocksToDownload() to the requestManager.cpp

Also change all NULL's to nullptr.

* Move MarkBlockAsInFlight() and MarkBlockAsReceived() to requestManager.cpp

This ia a Move only.  Alhtough there are edits in order to
bring these into the requestManager class structure there
are no logic changes.

C++ nullptr replaces NULL's

* Update block availablity during the process of downloading headers

During initial sync we have to download a set of all headers but
we also need to update the block availabiity for each connected
peer so that when the request manager starts downloading blocks
it can have the correct list of peers that have available blocks
to download from, rather than just assuming every peer has all
blocks.

* EXIT cs_objDownloader earlier.

We don't have to repeatedly take and release the locks.
Just do it once for all items in the entire batch request.

* Only ask for headers to updateblockavailability if chain work is behind

When doing the initial request for headers and we're in the process
of also updating the block availability for each connected peer we
only need to ask for a header if any peer is actually behind in
terms of chain work. This prevents first of all requesting
headers we don't need but also any possible attack where we're being
fed an invalid group of headers which then causes us to request
large number of additional headers.