### PR TITLE
QA Core ports

### DIFF
--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -382,7 +382,7 @@ class NodeConn(asyncore.dispatcher):
 
     def send_message(self, message, pushbuf=False):
         if self.state != "connected" and not pushbuf:
-            return
+            raise IOError('Not connected, no pushbuf')
         self.show_debug_msg("Send %s" % repr(message))
         command = message.command
         data = message.serialize()

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -46,6 +46,8 @@ PORT_MIN = 11000
 # The number of ports to "reserve" for p2p and rpc, each
 PORT_RANGE = 5000
 
+BITCOIND_PROC_WAIT_TIMEOUT = 60
+
 
 class PortSeed:
     # Must be initialized with a unique integer for each process
@@ -361,7 +363,7 @@ def stop_node(node, i):
         node.stop()
     except http.client.CannotSendRequest as e:
         print("WARN: Unable to stop node: " + repr(e))
-    bitcoind_processes[i].wait()
+    bitcoind_processes[i].wait(timeout=BITCOIND_PROC_WAIT_TIMEOUT)
     del bitcoind_processes[i]
 
 def stop_nodes(nodes):
@@ -379,7 +381,7 @@ def set_node_times(nodes, t):
 def wait_bitcoinds():
     # Wait for all bitcoinds to cleanly exit
     for bitcoind in bitcoind_processes.values():
-        bitcoind.wait()
+        bitcoind.wait(timeout=BITCOIND_PROC_WAIT_TIMEOUT)
     bitcoind_processes.clear()
 
 def connect_nodes(from_connection, node_num):

--- a/src/addrman.cpp
+++ b/src/addrman.cpp
@@ -392,8 +392,8 @@ CAddrInfo CAddrMan::Select_(bool newOnly)
             int nKBucketPos = RandomInt(ADDRMAN_BUCKET_SIZE);
             while (vvTried[nKBucket][nKBucketPos] == -1)
             {
-                nKBucket = (nKBucket + insecure_rand()) % ADDRMAN_TRIED_BUCKET_COUNT;
-                nKBucketPos = (nKBucketPos + insecure_rand()) % ADDRMAN_BUCKET_SIZE;
+                nKBucket = (nKBucket + insecure_rand.rand32()) % ADDRMAN_TRIED_BUCKET_COUNT;
+                nKBucketPos = (nKBucketPos + insecure_rand.rand32()) % ADDRMAN_BUCKET_SIZE;
             }
             int nId = vvTried[nKBucket][nKBucketPos];
             assert(mapInfo.count(nId) == 1);
@@ -416,8 +416,8 @@ CAddrInfo CAddrMan::Select_(bool newOnly)
             int nUBucketPos = RandomInt(ADDRMAN_BUCKET_SIZE);
             while (vvNew[nUBucket][nUBucketPos] == -1)
             {
-                nUBucket = (nUBucket + insecure_rand()) % ADDRMAN_NEW_BUCKET_COUNT;
-                nUBucketPos = (nUBucketPos + insecure_rand()) % ADDRMAN_BUCKET_SIZE;
+                nUBucket = (nUBucket + insecure_rand.rand32()) % ADDRMAN_NEW_BUCKET_COUNT;
+                nUBucketPos = (nUBucketPos + insecure_rand.rand32()) % ADDRMAN_BUCKET_SIZE;
             }
             int nId = vvNew[nUBucket][nUBucketPos];
             assert(mapInfo.count(nId) == 1);

--- a/src/addrman.h
+++ b/src/addrman.h
@@ -195,6 +195,9 @@ protected:
     //! secret key to randomize bucket select with
     uint256 nKey;
 
+    //! Source of random numbers for randomization in inner loops
+    FastRandomContext insecure_rand;
+
     //! Find an entry.
     CAddrInfo *Find(const CNetAddr &addr, int *pnId = NULL);
 

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -17,6 +17,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <future>
 #include <signal.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -35,10 +36,6 @@
 #endif
 #endif
 
-#include <boost/algorithm/string/case_conv.hpp> // for to_lower()
-#include <boost/foreach.hpp>
-#include <boost/scoped_ptr.hpp>
-
 /** Maximum size of http request (request line + headers) */
 static const size_t MAX_HEADERS_SIZE = 8192;
 
@@ -46,12 +43,12 @@ static const size_t MAX_HEADERS_SIZE = 8192;
 class HTTPWorkItem : public HTTPClosure
 {
 public:
-    HTTPWorkItem(HTTPRequest *req, const std::string &path, const HTTPRequestHandler &func)
-        : req(req), path(path), func(func)
+    HTTPWorkItem(std::unique_ptr<HTTPRequest> req, const std::string &path, const HTTPRequestHandler &func)
+        : req(std::move(req)), path(path), func(func)
     {
     }
     void operator()() { func(req.get(), path); }
-    boost::scoped_ptr<HTTPRequest> req;
+    std::unique_ptr<HTTPRequest> req;
 
 private:
     std::string path;
@@ -66,10 +63,9 @@ class WorkQueue
 {
 private:
     /** Mutex protects entire object */
-    CWaitableCriticalSection cs;
-    CConditionVariable cond;
-    /* XXX in C++11 we can use std::unique_ptr here and avoid manual cleanup */
-    std::deque<WorkItem *> queue;
+    std::mutex cs;
+    std::condition_variable cond;
+    std::deque<std::unique_ptr<WorkItem> > queue;
     bool running;
     size_t maxDepth;
     int numThreads;
@@ -81,12 +77,12 @@ private:
         WorkQueue &wq;
         ThreadCounter(WorkQueue &w) : wq(w)
         {
-            boost::lock_guard<boost::mutex> lock(wq.cs);
+            std::lock_guard<std::mutex> lock(wq.cs);
             wq.numThreads += 1;
         }
         ~ThreadCounter()
         {
-            boost::lock_guard<boost::mutex> lock(wq.cs);
+            std::lock_guard<std::mutex> lock(wq.cs);
             wq.numThreads -= 1;
             wq.cond.notify_all();
         }
@@ -94,26 +90,19 @@ private:
 
 public:
     WorkQueue(size_t maxDepth) : running(true), maxDepth(maxDepth), numThreads(0) {}
-    /*( Precondition: worker threads have all stopped
+    /** Precondition: worker threads have all stopped
      * (call WaitExit)
      */
-    ~WorkQueue()
-    {
-        while (!queue.empty())
-        {
-            delete queue.front();
-            queue.pop_front();
-        }
-    }
+    ~WorkQueue() {}
     /** Enqueue a work item */
     bool Enqueue(WorkItem *item)
     {
-        boost::unique_lock<boost::mutex> lock(cs);
+        std::unique_lock<std::mutex> lock(cs);
         if (queue.size() >= maxDepth)
         {
             return false;
         }
-        queue.push_back(item);
+        queue.emplace_back(std::unique_ptr<WorkItem>(item));
         cond.notify_one();
         return true;
     }
@@ -123,31 +112,30 @@ public:
         ThreadCounter count(*this);
         while (running)
         {
-            WorkItem *i = 0;
+            std::unique_ptr<WorkItem> i;
             {
-                boost::unique_lock<boost::mutex> lock(cs);
+                std::unique_lock<std::mutex> lock(cs);
                 while (running && queue.empty())
                     cond.wait(lock);
                 if (!running)
                     break;
-                i = queue.front();
+                i = std::move(queue.front());
                 queue.pop_front();
             }
             (*i)();
-            delete i;
         }
     }
     /** Interrupt and exit loops */
     void Interrupt()
     {
-        boost::unique_lock<boost::mutex> lock(cs);
+        std::unique_lock<std::mutex> lock(cs);
         running = false;
         cond.notify_all();
     }
     /** Wait for worker threads to exit */
     void WaitExit()
     {
-        boost::unique_lock<boost::mutex> lock(cs);
+        std::unique_lock<std::mutex> lock(cs);
         while (numThreads > 0)
             cond.wait(lock);
     }
@@ -155,7 +143,7 @@ public:
     /** Return current depth of queue */
     size_t Depth()
     {
-        boost::unique_lock<boost::mutex> lock(cs);
+        std::unique_lock<std::mutex> lock(cs);
         return queue.size();
     }
 };
@@ -192,7 +180,7 @@ static bool ClientAllowed(const CNetAddr &netaddr)
 {
     if (!netaddr.IsValid())
         return false;
-    BOOST_FOREACH (const CSubNet &subnet, rpc_allow_subnets)
+    for (const CSubNet &subnet : rpc_allow_subnets)
         if (subnet.Match(netaddr))
             return true;
     return false;
@@ -207,7 +195,7 @@ static bool InitHTTPAllowList()
     if (mapMultiArgs.count("-rpcallowip"))
     {
         const std::vector<std::string> &vAllow = mapMultiArgs["-rpcallowip"];
-        BOOST_FOREACH (std::string strAllow, vAllow)
+        for (std::string strAllow : vAllow)
         {
             CSubNet subnet(strAllow);
             if (!subnet.IsValid())
@@ -223,7 +211,7 @@ static bool InitHTTPAllowList()
         }
     }
     std::string strAllowed;
-    BOOST_FOREACH (const CSubNet &subnet, rpc_allow_subnets)
+    for (const CSubNet &subnet : rpc_allow_subnets)
         strAllowed += subnet.ToString() + " ";
     LOG(HTTP, "Allowing HTTP connections from: %s\n", strAllowed);
     return true;
@@ -295,12 +283,16 @@ static void http_request_cb(struct evhttp_request *req, void *arg)
     // Dispatch to worker thread
     if (i != iend)
     {
-        std::unique_ptr<HTTPWorkItem> item(new HTTPWorkItem(hreq.release(), path, i->handler));
+        std::unique_ptr<HTTPWorkItem> item(new HTTPWorkItem(std::move(hreq), path, i->handler));
         assert(workQueue);
         if (workQueue->Enqueue(item.get()))
             item.release(); /* if true, queue took ownership */
         else
+        {
+            LOGA("WARNING: request rejected because http work queue depth exceeded, it can be increased with the "
+                 "-rpcworkqueue= setting\n");
             item->req->WriteReply(HTTP_INTERNAL, "Work queue depth exceeded");
+        }
     }
     else
     {
@@ -316,13 +308,14 @@ static void http_reject_request_cb(struct evhttp_request *req, void *)
 }
 
 /** Event dispatcher thread */
-static void ThreadHTTP(struct event_base *base, struct evhttp *http)
+static bool ThreadHTTP(struct event_base *base, struct evhttp *http)
 {
     RenameThread("bitcoin-http");
     LOG(HTTP, "Entering http event loop\n");
     event_base_dispatch(base);
     // Event loop will be interrupted by InterruptHTTPServer()
     LOG(HTTP, "Exited http event loop\n");
+    return event_base_got_break(base) == 0;
 }
 
 /** Bind HTTP server to specified addresses */
@@ -460,17 +453,23 @@ bool InitHTTPServer()
     return true;
 }
 
-boost::thread threadHTTP;
+std::thread threadHTTP;
+std::future<bool> threadResult;
 
 bool StartHTTPServer()
 {
     LOG(HTTP, "Starting HTTP server\n");
     int rpcThreads = std::max((long)GetArg("-rpcthreads", DEFAULT_HTTP_THREADS), 1L);
     LOGA("HTTP: starting %d worker threads\n", rpcThreads);
-    threadHTTP = boost::thread(boost::bind(&ThreadHTTP, eventBase, eventHTTP));
+    std::packaged_task<bool(event_base *, evhttp *)> task(ThreadHTTP);
+    threadResult = task.get_future();
+    threadHTTP = std::thread(std::move(task), eventBase, eventHTTP);
 
     for (int i = 0; i < rpcThreads; i++)
-        boost::thread(boost::bind(&HTTPWorkQueueRun, workQueue));
+    {
+        std::thread rpc_worker(HTTPWorkQueueRun, workQueue);
+        rpc_worker.detach();
+    }
     return true;
 }
 
@@ -480,7 +479,7 @@ void InterruptHTTPServer()
     if (eventHTTP)
     {
         // Unlisten sockets
-        BOOST_FOREACH (evhttp_bound_socket *socket, boundSockets)
+        for (evhttp_bound_socket *socket : boundSockets)
         {
             evhttp_del_accept_socket(eventHTTP, socket);
         }
@@ -503,23 +502,21 @@ void StopHTTPServer()
     if (eventBase)
     {
         LOG(HTTP, "Waiting for HTTP event thread to exit\n");
-// Give event loop a few seconds to exit (to send back last RPC responses), then break it
-// Before this was solved with event_base_loopexit, but that didn't work as expected in
-// at least libevent 2.0.21 and always introduced a delay. In libevent
-// master that appears to be solved, so in the future that solution
-// could be used again (if desirable).
-// (see discussion in https://github.com/bitcoin/bitcoin/pull/6990)
-#if BOOST_VERSION >= 105000
-        if (!threadHTTP.try_join_for(boost::chrono::milliseconds(2000)))
+        // Exit the event loop as soon as there are no active events.
+        event_base_loopexit(eventBase, nullptr);
+        // Give event loop a few seconds to exit (to send back last RPC responses), then break it
+        // Before this was solved with event_base_loopexit, but that didn't work as expected in
+        // at least libevent 2.0.21 and always introduced a delay. In libevent
+        // master that appears to be solved, so in the future that solution
+        // could be used again (if desirable).
+        // (see discussion in https://github.com/bitcoin/bitcoin/pull/6990)
+        if (threadResult.valid() &&
+            threadResult.wait_for(std::chrono::milliseconds(2000)) == std::future_status::timeout)
         {
-#else
-        if (!threadHTTP.timed_join(boost::posix_time::milliseconds(2000)))
-        {
-#endif
             LOGA("HTTP event loop did not exit within allotted time, sending loopbreak\n");
             event_base_loopbreak(eventBase);
-            threadHTTP.join();
         }
+        threadHTTP.join();
     }
     if (eventHTTP)
     {
@@ -544,7 +541,7 @@ static void httpevent_callback_fn(evutil_socket_t, short, void *data)
         delete self;
 }
 
-HTTPEvent::HTTPEvent(struct event_base *base, bool deleteWhenTriggered, const boost::function<void(void)> &handler)
+HTTPEvent::HTTPEvent(struct event_base *base, bool deleteWhenTriggered, const std::function<void(void)> &handler)
     : deleteWhenTriggered(deleteWhenTriggered), handler(handler)
 {
     ev = event_new(base, -1, 0, httpevent_callback_fn, this);
@@ -553,7 +550,7 @@ HTTPEvent::HTTPEvent(struct event_base *base, bool deleteWhenTriggered, const bo
 HTTPEvent::~HTTPEvent() { event_free(ev); }
 void HTTPEvent::trigger(struct timeval *tv)
 {
-    if (tv == NULL)
+    if (tv == nullptr)
         event_active(ev, 0, 0); // immediately trigger event in main thread
     else
         evtimer_add(ev, tv); // trigger after timeval passed
@@ -621,7 +618,7 @@ void HTTPRequest::WriteReply(int nStatus, const std::string &strReply)
     assert(evb);
     evbuffer_add(evb, strReply.data(), strReply.size());
     HTTPEvent *ev = new HTTPEvent(
-        eventBase, true, boost::bind(evhttp_send_reply, req, nStatus, (const char *)NULL, (struct evbuffer *)NULL));
+        eventBase, true, std::bind(evhttp_send_reply, req, nStatus, (const char *)NULL, (struct evbuffer *)NULL));
     ev->trigger(0);
     replySent = true;
     req = 0; // transferred back to main thread

--- a/src/httpserver.h
+++ b/src/httpserver.h
@@ -6,9 +6,7 @@
 #ifndef BITCOIN_HTTPSERVER_H
 #define BITCOIN_HTTPSERVER_H
 
-#include <boost/function.hpp>
-#include <boost/scoped_ptr.hpp>
-#include <boost/thread.hpp>
+#include <functional>
 #include <stdint.h>
 #include <string>
 
@@ -36,7 +34,7 @@ void InterruptHTTPServer();
 void StopHTTPServer();
 
 /** Handler for requests to a certain HTTP path */
-typedef boost::function<void(HTTPRequest *req, const std::string &)> HTTPRequestHandler;
+typedef std::function<void(HTTPRequest *req, const std::string &)> HTTPRequestHandler;
 /** Register handler for prefix.
  * If multiple handlers match a prefix, the first-registered one will
  * be invoked.
@@ -134,7 +132,7 @@ public:
      * deleteWhenTriggered deletes this event object after the event is triggered (and the handler called)
      * handler is the handler to call when the event is triggered.
      */
-    HTTPEvent(struct event_base *base, bool deleteWhenTriggered, const boost::function<void(void)> &handler);
+    HTTPEvent(struct event_base *base, bool deleteWhenTriggered, const std::function<void(void)> &handler);
     ~HTTPEvent();
 
     /** Trigger the event. If tv is 0, trigger it immediately. Otherwise trigger it after
@@ -143,7 +141,7 @@ public:
     void trigger(struct timeval *tv);
 
     bool deleteWhenTriggered;
-    boost::function<void(void)> handler;
+    std::function<void(void)> handler;
 
 private:
     struct event *ev;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5333,16 +5333,17 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             if (fListen && !IsInitialBlockDownload())
             {
                 CAddress addr = GetLocalAddress(&pfrom->addr);
+                FastRandomContext insecure_rand;
                 if (addr.IsRoutable())
                 {
                     LOG(NET, "ProcessMessages: advertising address %s\n", addr.ToString());
-                    pfrom->PushAddress(addr);
+                    pfrom->PushAddress(addr, insecure_rand);
                 }
                 else if (IsPeerAddrLocalGood(pfrom))
                 {
                     addr.SetIP(pfrom->addrLocal);
                     LOG(NET, "ProcessMessages: advertising address %s\n", addr.ToString());
-                    pfrom->PushAddress(addr);
+                    pfrom->PushAddress(addr, insecure_rand);
                 }
             }
 
@@ -5488,6 +5489,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         std::vector<CAddress> vAddrOk;
         int64_t nNow = GetAdjustedTime();
         int64_t nSince = nNow - 10 * 60;
+        FastRandomContext insecure_rand;
         BOOST_FOREACH (CAddress &addr, vAddr)
         {
             boost::this_thread::interruption_point();
@@ -5524,7 +5526,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                     int nRelayNodes = fReachable ? 2 : 1; // limited relaying of addresses outside our network(s)
                     for (std::multimap<uint256, CNode *>::iterator mi = mapMix.begin();
                          mi != mapMix.end() && nRelayNodes-- > 0; ++mi)
-                        ((*mi).second)->PushAddress(addr);
+                        ((*mi).second)->PushAddress(addr, insecure_rand);
                 }
             }
             // Do not store addresses outside our network
@@ -6461,8 +6463,9 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
 
         pfrom->vAddrToSend.clear();
         std::vector<CAddress> vAddr = addrman.GetAddr();
+        FastRandomContext insecure_rand;
         BOOST_FOREACH (const CAddress &addr, vAddr)
-            pfrom->PushAddress(addr);
+            pfrom->PushAddress(addr, insecure_rand);
     }
 
 
@@ -7205,6 +7208,7 @@ bool SendMessages(CNode *pto)
         // Message: inventory
         //
 
+        FastRandomContext insecure_rand;
         std::vector<CInv> vInvWait;
         std::vector<CInv> vInvSend;
         {
@@ -7244,7 +7248,7 @@ bool SendMessages(CNode *pto)
                         if (fSendTrickle)
                         {
                             // 1/4 of tx invs blast to all immediately
-                            if ((insecure_rand() & 3) != 0)
+                            if ((insecure_rand.rand32() & 3) != 0)
                             {
                                 vInvWait.push_back(inv);
                                 continue;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -237,7 +237,8 @@ void AdvertiseLocal(CNode *pnode)
         if (addrLocal.IsRoutable())
         {
             // BU logs too often: LOGA("AdvertiseLocal: advertising address %s\n", addrLocal.ToString());
-            pnode->PushAddress(addrLocal);
+            FastRandomContext insecure_rand;
+            pnode->PushAddress(addrLocal, insecure_rand);
         }
     }
 }

--- a/src/net.h
+++ b/src/net.h
@@ -529,7 +529,7 @@ public:
     }
 
     void AddAddressKnown(const CAddress &addr) { addrKnown.insert(addr.GetKey()); }
-    void PushAddress(const CAddress &addr)
+    void PushAddress(const CAddress &_addr, FastRandomContext &insecure_rand)
     {
         // Known checking here is only to save space from duplicates.
         // SendMessages will filter it again for knowns that were added
@@ -538,7 +538,7 @@ public:
         {
             if (vAddrToSend.size() >= MAX_ADDR_TO_SEND)
             {
-                vAddrToSend[insecure_rand() % vAddrToSend.size()] = addr;
+                vAddrToSend[insecure_rand.rand32() % vAddrToSend.size()] = addr;
             }
             else
             {

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -11,6 +11,8 @@
 #include "util.h"
 #include "utilstrencodings.h"
 
+#include <atomic>
+
 #ifdef HAVE_GETADDRINFO_A
 #include <netdb.h>
 #endif

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -668,8 +668,8 @@ static bool ConnectThroughProxy(const proxyType &proxy,
     if (proxy.randomize_credentials)
     {
         ProxyCredentials random_auth;
-        random_auth.username = strprintf("%i", insecure_rand());
-        random_auth.password = strprintf("%i", insecure_rand());
+        static std::atomic_int counter;
+        random_auth.username = random_auth.password = strprintf("%i", counter++);
         if (!Socks5(strDest, (unsigned short)port, &random_auth, hSocket))
             return false;
     }

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -26,7 +26,6 @@
 
 #include <boost/algorithm/string/case_conv.hpp> // for to_lower()
 #include <boost/algorithm/string/predicate.hpp> // for startswith() and endswith()
-#include <boost/thread.hpp>
 
 #if !defined(HAVE_MSG_NOSIGNAL) && !defined(MSG_NOSIGNAL)
 #define MSG_NOSIGNAL 0

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -6,6 +6,7 @@
 #define BITCOIN_POLICYESTIMATOR_H
 
 #include "amount.h"
+#include "random.h"
 #include "uint256.h"
 
 #include <map>

--- a/src/prevector.h
+++ b/src/prevector.h
@@ -400,10 +400,9 @@ public:
     const T &operator[](size_type pos) const { return *item_ptr(pos); }
     void resize(size_type new_size)
     {
-        while (size() > new_size)
+        if (size() > new_size)
         {
-            item_ptr(size() - 1)->~T();
-            _size--;
+            erase(item_ptr(new_size), end());
         }
         if (new_size > capacity())
         {
@@ -476,14 +475,7 @@ public:
         }
     }
 
-    iterator erase(iterator pos)
-    {
-        (*pos).~T();
-        memmove(&(*pos), &(*pos) + 1, ((char *)&(*end())) - ((char *)(1 + &(*pos))));
-        _size--;
-        return pos;
-    }
-
+    iterator erase(iterator pos) { return erase(pos, pos + 1); }
     iterator erase(iterator first, iterator last)
     {
         // Erase is not allowed to the change the object's capacity. That means
@@ -515,22 +507,14 @@ public:
         _size++;
     }
 
-    void pop_back() { _size--; }
+    void pop_back() { erase(end() - 1, end()); }
     T &front() { return *item_ptr(0); }
     const T &front() const { return *item_ptr(0); }
     T &back() { return *item_ptr(size() - 1); }
     const T &back() const { return *item_ptr(size() - 1); }
     void swap(prevector<N, T, Size, Diff> &other)
     {
-        if (_size & other._size & 1)
-        {
-            std::swap(_union.capacity, other._union.capacity);
-            std::swap(_union.indirect, other._union.indirect);
-        }
-        else
-        {
-            std::swap(_union, other._union);
-        }
+        std::swap(_union, other._union);
         std::swap(_size, other._size);
     }
 

--- a/src/random.cpp
+++ b/src/random.cpp
@@ -122,31 +122,6 @@ uint256 GetRandHash()
     return hash;
 }
 
-uint32_t insecure_rand_Rz = 11;
-uint32_t insecure_rand_Rw = 11;
-void seed_insecure_rand(bool fDeterministic)
-{
-    // The seed values have some unlikely fixed points which we avoid.
-    if (fDeterministic)
-    {
-        insecure_rand_Rz = insecure_rand_Rw = 11;
-    }
-    else
-    {
-        uint32_t tmp;
-        do
-        {
-            GetRandBytes((unsigned char *)&tmp, 4);
-        } while (tmp == 0 || tmp == 0x9068ffffU);
-        insecure_rand_Rz = tmp;
-        do
-        {
-            GetRandBytes((unsigned char *)&tmp, 4);
-        } while (tmp == 0 || tmp == 0x464fffffU);
-        insecure_rand_Rw = tmp;
-    }
-}
-
 FastRandomContext::FastRandomContext(bool fDeterministic)
 {
     // The seed values have some unlikely fixed points which we avoid.

--- a/src/random.h
+++ b/src/random.h
@@ -26,12 +26,6 @@ int GetRandInt(int nMax);
 uint256 GetRandHash();
 
 /**
- * Seed insecure_rand using the random pool.
- * @param Deterministic Use a deterministic seed
- */
-void seed_insecure_rand(bool fDeterministic = false);
-
-/**
  * Fast randomness source. This is seeded once with secure random data, but
  * is completely deterministic and insecure after that.
  * This class is not thread-safe.
@@ -103,17 +97,5 @@ static const ssize_t NUM_OS_RANDOM_BYTES = 32;
  * GetStrongRandBytes instead.
  */
 void GetOSRand(unsigned char *ent32);
-
-/** Check that OS randomness is available and returning the requested number
- * of bytes.
- */
-extern uint32_t insecure_rand_Rz;
-extern uint32_t insecure_rand_Rw;
-static inline uint32_t insecure_rand(void)
-{
-    insecure_rand_Rz = 36969 * (insecure_rand_Rz & 65535) + (insecure_rand_Rz >> 16);
-    insecure_rand_Rw = 18000 * (insecure_rand_Rw & 65535) + (insecure_rand_Rw >> 16);
-    return (insecure_rand_Rw << 16) + insecure_rand_Rz;
-}
 
 #endif // BITCOIN_RANDOM_H

--- a/src/test/addrman_tests.cpp
+++ b/src/test/addrman_tests.cpp
@@ -22,7 +22,7 @@ public:
     void MakeDeterministic()
     {
         nKey.SetNull();
-        seed_insecure_rand(true);
+        insecure_rand = FastRandomContext(true);
     }
 
     int RandomInt(int nMax)

--- a/src/test/base58_tests.cpp
+++ b/src/test/base58_tests.cpp
@@ -84,7 +84,7 @@ private:
     std::string exp_addrType;
 
 public:
-    TestAddrTypeVisitor(const std::string &exp_addrType) : exp_addrType(exp_addrType) {}
+    TestAddrTypeVisitor(const std::string &_exp_addrType) : exp_addrType(_exp_addrType) {}
     bool operator()(const CKeyID &id) const { return (exp_addrType == "pubkey"); }
     bool operator()(const CScriptID &id) const { return (exp_addrType == "script"); }
     bool operator()(const CNoDestination &no) const { return (exp_addrType == "none"); }
@@ -97,7 +97,7 @@ private:
     std::vector<unsigned char> exp_payload;
 
 public:
-    TestPayloadVisitor(std::vector<unsigned char> &exp_payload) : exp_payload(exp_payload) {}
+    TestPayloadVisitor(std::vector<unsigned char> &_exp_payload) : exp_payload(_exp_payload) {}
     bool operator()(const CKeyID &id) const
     {
         uint160 exp_key(exp_payload);

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -6,8 +6,8 @@
 #include "coins.h"
 #include "consensus/validation.h"
 #include "main.h"
-#include "random.h"
 #include "test/test_bitcoin.h"
+#include "test_random.h"
 #include "uint256.h"
 #include "undo.h"
 

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -10,8 +10,8 @@
 #include "crypto/sha1.h"
 #include "crypto/sha256.h"
 #include "crypto/sha512.h"
-#include "random.h"
 #include "test/test_bitcoin.h"
+#include "test_random.h"
 #include "utilstrencodings.h"
 
 #include <vector>

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -4,8 +4,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "consensus/merkle.h"
-#include "random.h"
 #include "test/test_bitcoin.h"
+#include "test_random.h"
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -477,8 +477,8 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     SetMockTime(0);
     mempool.clear();
 
-    BOOST_FOREACH (CTransaction *tx, txFirst)
-        delete tx;
+    BOOST_FOREACH (CTransaction *_tx, txFirst)
+        delete _tx;
 
     fCheckpointsEnabled = true;
 }

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -22,7 +22,7 @@ public:
     void MakeDeterministic()
     {
         nKey.SetNull();
-        seed_insecure_rand(true);
+        insecure_rand = FastRandomContext(true);
     }
 };
 

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -10,6 +10,8 @@
 #include "serialize.h"
 #include "streams.h"
 #include "test/test_bitcoin.h"
+#include "test/test_bitcoin.h"
+#include "test_random.h"
 #include "uint256.h"
 #include "version.h"
 

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -41,9 +41,9 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
     seed_insecure_rand(false);
     static const unsigned int nTxCounts[] = {1, 4, 7, 17, 56, 100, 127, 256, 312, 513, 1000, 4095};
 
-    for (int n = 0; n < 12; n++)
+    for (int i = 0; i < 12; i++)
     {
-        unsigned int nTx = nTxCounts[n];
+        unsigned int nTx = nTxCounts[i];
 
         // build a block with some dummy transactions
         CBlock block;

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -21,9 +21,11 @@ class prevector_tester
 {
     typedef std::vector<T> realtype;
     realtype real_vector;
+    realtype real_vector_alt;
 
     typedef prevector<N, T> pretype;
     pretype pre_vector;
+    pretype pre_vector_alt;
 
     typedef typename pretype::size_type Size;
 
@@ -174,6 +176,13 @@ public:
         pre_vector.shrink_to_fit();
         test();
     }
+
+    void swap()
+    {
+        real_vector.swap(real_vector_alt);
+        pre_vector.swap(pre_vector_alt);
+        test();
+    }
 };
 
 BOOST_AUTO_TEST_CASE(PrevectorTestInt)
@@ -244,13 +253,17 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
             {
                 test.update(insecure_rand() % test.size(), insecure_rand());
             }
-            if (((r >> 11) & 1024) == 11)
+            if (((r >> 11) % 1024) == 11)
             {
                 test.clear();
             }
-            if (((r >> 21) & 512) == 12)
+            if (((r >> 21) % 512) == 12)
             {
                 test.assign(insecure_rand() % 32, insecure_rand());
+            }
+            if (((r >> 15) % 64) == 3)
+            {
+                test.swap();
             }
         }
     }

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "prevector.h"
-#include "random.h"
+#include "test_random.h"
 #include <vector>
 
 #include "serialize.h"

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -228,9 +228,9 @@ BOOST_AUTO_TEST_CASE(PrevectorTestInt)
             {
                 int values[4];
                 int num = 1 + (insecure_rand() % 4);
-                for (int i = 0; i < num; i++)
+                for (int k = 0; k < num; k++)
                 {
-                    values[i] = insecure_rand();
+                    values[k] = insecure_rand();
                 }
                 test.insert_range(insecure_rand() % (test.size() + 1), values, values + num);
             }

--- a/src/test/scheduler_tests.cpp
+++ b/src/test/scheduler_tests.cpp
@@ -49,8 +49,6 @@ static void MicroSleep(uint64_t n)
 
 BOOST_AUTO_TEST_CASE(manythreads)
 {
-    seed_insecure_rand(false);
-
     // Stress test: hundreds of microsecond-scheduled tasks,
     // serviced by 10 threads.
     //
@@ -65,7 +63,7 @@ BOOST_AUTO_TEST_CASE(manythreads)
 
     boost::mutex counterMutex[10];
     int counter[10] = {0};
-    boost::random::mt19937 rng(insecure_rand());
+    boost::random::mt19937 rng(42);
     boost::random::uniform_int_distribution<> zeroToNine(0, 9);
     boost::random::uniform_int_distribution<> randomMsec(-11, 1000);
     boost::random::uniform_int_distribution<> randomDelta(-1000, 1000);

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -8,12 +8,12 @@
 #include "data/sighash.json.h"
 #include "hash.h"
 #include "main.h" // For CheckTransaction
-#include "random.h"
 #include "script/interpreter.h"
 #include "script/script.h"
 #include "serialize.h"
 #include "streams.h"
 #include "test/test_bitcoin.h"
+#include "test_random.h"
 #include "util.h"
 #include "utilstrencodings.h"
 #include "version.h"

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -4,8 +4,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "chain.h"
-#include "random.h"
 #include "test/test_bitcoin.h"
+#include "test_random.h"
 #include "util.h"
 
 #include <vector>

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -32,6 +32,7 @@
 #include <boost/thread.hpp>
 
 CClientUIInterface uiInterface; // Declared but not defined in ui_interface.h
+FastRandomContext insecure_rand_ctx(true);
 
 extern bool fPrintToConsole;
 extern void noui_connect();

--- a/src/test/test_random.h
+++ b/src/test/test_random.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TEST_RANDOM_H
+#define BITCOIN_TEST_RANDOM_H
+
+#include "random.h"
+
+extern FastRandomContext insecure_rand_ctx;
+
+static inline void seed_insecure_rand(bool fDeterministic = false)
+{
+    insecure_rand_ctx = FastRandomContext(fDeterministic);
+}
+
+static inline uint32_t insecure_rand(void)
+{
+    return insecure_rand_ctx.rand32();
+}
+
+#endif

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -7,9 +7,9 @@
 
 #include "clientversion.h"
 #include "primitives/transaction.h"
-#include "random.h"
 #include "sync.h"
 #include "test/test_bitcoin.h"
+#include "test_random.h"
 #include "utilmoneystr.h"
 #include "utilstrencodings.h"
 

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -5,11 +5,13 @@
 
 #include "versionbits.h"
 #include "chain.h"
+#include "chain.h"
 #include "chainparams.h"
 #include "consensus/params.h"
 #include "main.h"
 #include "random.h"
 #include "test/test_bitcoin.h"
+#include "test_random.h"
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -1612,7 +1612,7 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
     bool fDeterministic)
 {
     int64_t nStartTimer = GetTimeMillis();
-    seed_insecure_rand(fDeterministic);
+    FastRandomContext insecure_rand(fDeterministic);
     std::set<uint256> setHighScoreMemPoolHashes;
     std::set<uint256> setPriorityMemPoolHashes;
 
@@ -1808,7 +1808,7 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
         nFPRate = nMaxFalsePositive;
 
     uint32_t nMaxFilterSize = std::max(SMALLEST_MAX_BLOOM_FILTER_SIZE, pfrom->nXthinBloomfilterSize);
-    filterMemPool = CBloomFilter(nElements, nFPRate, insecure_rand(), BLOOM_UPDATE_ALL, nMaxFilterSize);
+    filterMemPool = CBloomFilter(nElements, nFPRate, insecure_rand.rand32(), BLOOM_UPDATE_ALL, nMaxFilterSize);
     LOG(THIN, "FPrate: %f Num elements in bloom filter:%d high priority txs:%d high fee txs:%d orphans:%d total "
               "txs in mempool:%d\n",
         nFPRate, nElements, setPriorityMemPoolHashes.size(), setHighScoreMemPoolHashes.size(), vOrphanHashes.size(),

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -825,7 +825,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
     if (nCheckFrequency == 0)
         return;
 
-    if (insecure_rand() >= nCheckFrequency)
+    if (GetRand(std::numeric_limits<uint32_t>::max()) >= nCheckFrequency)
         return;
 
     uint64_t checkTotal = 0;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -13,6 +13,7 @@
 #include "amount.h"
 #include "coins.h"
 #include "primitives/transaction.h"
+#include "random.h"
 #include "sync.h"
 
 #undef foreach

--- a/src/wallet/test/crypto_tests.cpp
+++ b/src/wallet/test/crypto_tests.cpp
@@ -2,7 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-#include "random.h"
+#include "test/test_random.h"
 #include "utilstrencodings.h"
 #include "test/test_bitcoin.h"
 #include "wallet/crypter.h"

--- a/src/wallet/test/walletdb_tests.cpp
+++ b/src/wallet/test/walletdb_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "test/test_bitcoin.h"
-#include "random.h"
+#include "test_random.h"
 #include "fs.h"
 
 #include "wallet/wallet.h"

--- a/src/wallet/test/walletdb_tests.cpp
+++ b/src/wallet/test/walletdb_tests.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "test/test_bitcoin.h"
-#include "test_random.h"
+#include "test/test_random.h"
 #include "fs.h"
 
 #include "wallet/wallet.h"

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1819,7 +1819,7 @@ static void ApproximateBestSubset(vector<pair<CAmount, pair<const CWalletTx *, u
     vfBest.assign(vValue.size(), true);
     nBest = nTotalLower;
 
-    seed_insecure_rand();
+    FastRandomContext insecure_rand;
 
     for (int nRep = 0; nRep < iterations && nBest != nTargetValue; nRep++)
     {
@@ -1836,7 +1836,7 @@ static void ApproximateBestSubset(vector<pair<CAmount, pair<const CWalletTx *, u
                 // that the rng is fast. We do not use a constant random sequence,
                 // because there may be some privacy improvement by making
                 // the selection random.
-                if (nPass == 0 ? insecure_rand() & 1 : !vfIncluded[i])
+                if (nPass == 0 ? insecure_rand.rand32() & 1 : !vfIncluded[i])
                 {
                     nTotal += vValue[i].first;
                     vfIncluded[i] = true;


### PR DESCRIPTION
Again leveraging @dagurval's work on XT (https://github.com/bitcoinxt/bitcoinxt/pull/319) in porting a series of improvements on QA frameworks 

bitcoin/bitcoin#8047 - [qa] test_framework: Set wait-timeout for bitcoind procs
bitcoin/bitcoin#8095 - Test framework: only cleanup on successful test runs
bitcoin/bitcoin#8214 - [qa] mininode: fail on send_message instead of silent return

_**depends on #1005**_