### PR TITLE
If a node disconnects then reset lastrequesttime ...

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -80,7 +80,6 @@ proxyType nameProxy;
 CCriticalSection cs_proxyInfos;
 
 // moved from main.cpp (now part of nodestate.h)
-std::map<uint256, pair<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight;
 std::map<NodeId, CNodeState> mapNodeState;
 
 set<uint256> setPreVerifiedTxHash;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -289,6 +289,9 @@ void FinalizeNode(NodeId nodeid)
     {
         LOGA("erasing map mapblocksinflight entries\n");
         mapBlocksInFlight.erase(entry.hash);
+
+        // Reset all requests times to zero so that we can immediately re-request these blocks
+        requester.ResetLastRequestTime(entry.hash);
     }
     nPreferredDownload -= state->fPreferredDownload;
     requester.nPeersWithValidatedDownloads -= (state->nBlocksInFlightValidHeaders != 0);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -288,7 +288,7 @@ void FinalizeNode(NodeId nodeid)
     for (const QueuedBlock &entry : state->vBlocksInFlight)
     {
         LOGA("erasing map mapblocksinflight entries\n");
-        mapBlocksInFlight.erase(entry.hash);
+        requester.mapBlocksInFlight.erase(entry.hash);
 
         // Reset all requests times to zero so that we can immediately re-request these blocks
         requester.ResetLastRequestTime(entry.hash);
@@ -302,7 +302,7 @@ void FinalizeNode(NodeId nodeid)
     if (mapNodeState.empty())
     {
         // Do a consistency check after the last peer is removed.  Force consistent state if production code
-        DbgAssert(mapBlocksInFlight.empty(), mapBlocksInFlight.clear());
+        DbgAssert(requester.mapBlocksInFlight.empty(), requester.mapBlocksInFlight.clear());
         DbgAssert(nPreferredDownload == 0, nPreferredDownload = 0);
         DbgAssert(requester.nPeersWithValidatedDownloads == 0, requester.nPeersWithValidatedDownloads = 0);
     }
@@ -4433,7 +4433,7 @@ void UnloadBlockIndex()
     nLastBlockFile = 0;
     nBlockSequenceId = 1;
     mapBlockSource.clear();
-    mapBlocksInFlight.clear();
+    requester.mapBlocksInFlight.clear();
     nPreferredDownload = 0;
     setDirtyBlockIndex.clear();
     setDirtyFileInfo.clear();

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -18,8 +18,6 @@ struct QueuedBlock
     bool fValidatedHeaders; //!< Whether this block has validated headers at the time of request.
 };
 
-extern std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight;
-
 /**
 * Maintain validation-specific state about nodes, protected by cs_main, instead
 * by CNode's own locks. This simplifies asynchronous operation, where

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -533,6 +533,19 @@ bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
     }
 }
 
+void CRequestManager::ResetLastRequestTime(const uint256 &hash)
+{
+    LOCK(cs_objDownloader);
+    OdMap::iterator itemIter = sendBlkIter;
+    itemIter = mapBlkInfo.find(hash);
+    if (itemIter != mapBlkInfo.end())
+    {
+        CUnknownObj &item = itemIter->second;
+        item.outstandingReqs--;
+        item.lastRequestTime = 0;
+    }
+}
+
 void CRequestManager::SendRequests()
 {
     int64_t now = 0;

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -127,6 +127,11 @@ protected:
     bool RequestBlock(CNode *pfrom, CInv obj);
 
 public:
+    // map that tracks current blocks in flight.  Still using cs_main to protect this and is used
+    // in MarkBlockAsInflight and MarkBlockAsReceived.  This is not ideal to still use cs_main here
+    // but is really just temporary as we move more functionality into the request manager.
+    std::map<uint256, std::pair<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight;
+
     // Number of peers from which we're downloading blocks.
     int nPeersWithValidatedDownloads = 0;
 

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -157,6 +157,9 @@ public:
     // Indicate that getting this object was rejected
     void Rejected(const CInv &obj, CNode *from, unsigned char reason = 0);
 
+    // Resets the last request time to zero when a node disconnects and has blocks in flight.
+    void ResetLastRequestTime(const uint256 &hash);
+
     void SendRequests();
 
     // Check whether the last unknown block a peer advertised is not yet known.


### PR DESCRIPTION
for any blocks in flight.

This prevents us from having to wait up to 30 seconds for a re-request
when in fact we just need to do an immediate re-request.

To test is very easy.  Just startup a fresh sync and wait for about 8 or 9 connections.  Then start disconneting a few peers and go to the network traffic tab in the QT console and you can see that the download of blocks is uninterrupted.  Whereas previously you'd get a gap of about 30 seconds.