### PR TITLE
[Core Cherry-pick] Increase open ldb files

### DIFF
--- a/doc/developer-notes.md
+++ b/doc/developer-notes.md
@@ -476,12 +476,12 @@ Subtrees
 
 Several parts of the repository are subtrees of software maintained elsewhere.
 
-Some of these are maintained by active developers of Bitcoin Core, in which case changes should probably go
+Some of these are maintained by active developers of Bitcoin and Bitcoin Cash, in which case changes should probably go
 directly upstream without being PRed directly against the project.  They will be merged back in the next
 subtree merge.
 
 Others are external projects without a tight relationship with our project.  Changes to these should also
-be sent upstream but bugfixes may also be prudent to PR against Bitcoin Core so that they can be integrated
+be sent upstream but bugfixes may also be prudent to PR against Bitcoin Unlimited so that they can be integrated
 quickly.  Cosmetic changes should be purely taken upstream.
 
 There is a tool in contrib/devtools/git-subtree-check.sh to check a subtree directory for consistency with
@@ -700,7 +700,7 @@ A few guidelines for introducing and reviewing new RPC interfaces:
   RPCs whose behavior does *not* depend on the current chainstate may omit this
   call.
 
-  - *Rationale*: In previous versions of Bitcoin Core, the wallet was always
+  - *Rationale*: In previous versions of Bitcoin, the wallet was always
     in-sync with the chainstate (by virtue of them all being updated in the
     same cs_main lock). In order to maintain the behavior that wallet RPCs
     return results as of at least the highest best-known block an RPC

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -38,8 +38,7 @@ static void SetMaxOpenFiles(leveldb::Options *options)
         options->max_open_files = 64;
     }
 #endif
-    LogPrint(BCLog::LEVELDB, "LevelDB using max_open_files=%d (default=%d)\n",
-             options->max_open_files, default_open_files);
+    LOGA("LevelDB using max_open_files=%d (default=%d)\n", options->max_open_files, default_open_files);
 }
 
 static leveldb::Options GetOptions(size_t nCacheSize)

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -15,6 +15,33 @@
 #include <memenv.h>
 #include <stdint.h>
 
+static void SetMaxOpenFiles(leveldb::Options *options)
+{
+    // On most platforms the default setting of max_open_files (which is 1000)
+    // is optimal. On Windows using a large file count is OK because the handles
+    // do not interfere with select() loops. On 64-bit Unix hosts this value is
+    // also OK, because up to that amount LevelDB will use an mmap
+    // implementation that does not use extra file descriptors (the fds are
+    // closed after being mmaped).
+    //
+    // Increasing the value beyond the default is dangerous because LevelDB will
+    // fall back to a non-mmap implementation when the file count is too large.
+    // On 32-bit Unix host we should decrease the value because the handles use
+    // up real fds, and we want to avoid fd exhaustion issues.
+    //
+    // See Bitoin Core PR #12495 for further discussion.
+
+    int default_open_files = options->max_open_files;
+#ifndef WIN32
+    if (sizeof(void*) < 8)
+    {
+        options->max_open_files = 64;
+    }
+#endif
+    LogPrint(BCLog::LEVELDB, "LevelDB using max_open_files=%d (default=%d)\n",
+             options->max_open_files, default_open_files);
+}
+
 static leveldb::Options GetOptions(size_t nCacheSize)
 {
     leveldb::Options options;
@@ -22,13 +49,13 @@ static leveldb::Options GetOptions(size_t nCacheSize)
     options.write_buffer_size = nCacheSize / 4; // up to two write buffers may be held in memory simultaneously
     options.filter_policy = leveldb::NewBloomFilterPolicy(10);
     options.compression = leveldb::kNoCompression;
-    options.max_open_files = 64;
     if (leveldb::kMajorVersion > 1 || (leveldb::kMajorVersion == 1 && leveldb::kMinorVersion >= 16))
     {
         // LevelDB versions before 1.16 consider short writes to be corruption. Only trigger error
         // on corruption in later versions.
         options.paranoid_checks = true;
     }
+    SetMaxOpenFiles(&options);
     return options;
 }
 

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -33,7 +33,7 @@ static void SetMaxOpenFiles(leveldb::Options *options)
 
     int default_open_files = options->max_open_files;
 #ifndef WIN32
-    if (sizeof(void*) < 8)
+    if (sizeof(void *) < 8)
     {
         options->max_open_files = 64;
     }


### PR DESCRIPTION
This is something I've wanted to investigate for a while and looks like someone did a really good job of studying and testing this out.  See : https://github.com/bitcoin/bitcoin/pull/12495

It seems to have a very good improvement on performance although probably for more marginal systems running on spinning disk and that have lower RAM but still, it's a simple fix with large impact.

Also pulled in quite a few developer doc updates that came along with the cherry-pick.