### PR TITLE
use cs_objDownloader to lock mapBlocksInFlight

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -321,10 +321,16 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats)
     stats.nMisbehavior = node->nMisbehavior;
     stats.nSyncHeight = state->pindexBestKnownBlock ? state->pindexBestKnownBlock->nHeight : -1;
     stats.nCommonHeight = state->pindexLastCommonBlock ? state->pindexLastCommonBlock->nHeight : -1;
-    BOOST_FOREACH (const QueuedBlock &queue, state->vBlocksInFlight)
+    for (const QueuedBlock &queue : state->vBlocksInFlight)
     {
-        if (queue.pindex)
-            stats.vHeightInFlight.push_back(queue.pindex->nHeight);
+        // lookup block by hash to find height
+        BlockMap::iterator mi = mapBlockIndex.find(queue.hash);
+        if (mi != mapBlockIndex.end())
+        {
+            CBlockIndex *pindex = (*mi).second;
+            if (pindex)
+                stats.vHeightInFlight.push_back(pindex->nHeight);
+        }
     }
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -276,17 +276,13 @@ void FinalizeNode(NodeId nodeid)
         requester.ResetLastRequestTime(entry.hash);
     }
     nPreferredDownload -= state->fPreferredDownload;
-    requester.nPeersWithValidatedDownloads -= (state->nBlocksInFlightValidHeaders != 0);
-    DbgAssert(requester.nPeersWithValidatedDownloads >= 0, requester.nPeersWithValidatedDownloads = 0);
 
     mapNodeState.erase(nodeid);
-
     if (mapNodeState.empty())
     {
         // Do a consistency check after the last peer is removed.  Force consistent state if production code
         DbgAssert(requester.MapBlocksInFlightEmpty(), requester.MapBlocksInFlightClear());
         DbgAssert(nPreferredDownload == 0, nPreferredDownload = 0);
-        DbgAssert(requester.nPeersWithValidatedDownloads == 0, requester.nPeersWithValidatedDownloads = 0);
     }
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -270,7 +270,7 @@ void FinalizeNode(NodeId nodeid)
     for (const QueuedBlock &entry : state->vBlocksInFlight)
     {
         LOGA("erasing map mapblocksinflight entries\n");
-        requester.mapBlocksInFlight.erase(entry.hash);
+        requester.MapBlocksInFlightErase(entry.hash);
 
         // Reset all requests times to zero so that we can immediately re-request these blocks
         requester.ResetLastRequestTime(entry.hash);
@@ -284,7 +284,7 @@ void FinalizeNode(NodeId nodeid)
     if (mapNodeState.empty())
     {
         // Do a consistency check after the last peer is removed.  Force consistent state if production code
-        DbgAssert(requester.mapBlocksInFlight.empty(), requester.mapBlocksInFlight.clear());
+        DbgAssert(requester.MapBlocksInFlightEmpty(), requester.MapBlocksInFlightClear());
         DbgAssert(nPreferredDownload == 0, nPreferredDownload = 0);
         DbgAssert(requester.nPeersWithValidatedDownloads == 0, requester.nPeersWithValidatedDownloads = 0);
     }
@@ -4297,7 +4297,7 @@ void UnloadBlockIndex()
     nLastBlockFile = 0;
     nBlockSequenceId = 1;
     mapBlockSource.clear();
-    requester.mapBlocksInFlight.clear();
+    requester.MapBlocksInFlightClear();
     nPreferredDownload = 0;
     setDirtyBlockIndex.clear();
     setDirtyFileInfo.clear();

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -22,7 +22,6 @@ CNodeState::CNodeState(CAddress addrIn, std::string addrNameIn) : address(addrIn
     fRequestedInitialBlockAvailability = false;
     nDownloadingSince = 0;
     nBlocksInFlight = 0;
-    nBlocksInFlightValidHeaders = 0;
     fPreferredDownload = false;
     fPreferHeaders = false;
 }

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -13,7 +13,6 @@
 struct QueuedBlock
 {
     uint256 hash;
-    CBlockIndex *pindex; //!< Optional.
     int64_t nTime; //! Time of "getdata" request in microseconds.
     bool fValidatedHeaders; //!< Whether this block has validated headers at the time of request.
 };

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -14,7 +14,6 @@ struct QueuedBlock
 {
     uint256 hash;
     int64_t nTime; //! Time of "getdata" request in microseconds.
-    bool fValidatedHeaders; //!< Whether this block has validated headers at the time of request.
 };
 
 /**
@@ -53,7 +52,6 @@ struct CNodeState
     //! When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.
     int64_t nDownloadingSince;
     int nBlocksInFlight;
-    int nBlocksInFlightValidHeaders;
     //! Whether we consider this a preferred download peer.
     bool fPreferredDownload;
     //! Whether this peer wants invs or headers (when possible) for block announcements.

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -959,7 +959,7 @@ void CRequestManager::MarkBlockAsInFlight(NodeId nodeid,
     if (itInFlight == mapBlocksInFlight.end()) // If it hasn't already been marked inflight...
     {
         int64_t nNow = GetTimeMicros();
-        QueuedBlock newentry = {hash, pindex, nNow, pindex != nullptr};
+        QueuedBlock newentry = {hash, nNow, pindex != nullptr};
         std::list<QueuedBlock>::iterator it = state->vBlocksInFlight.insert(state->vBlocksInFlight.end(), newentry);
         state->nBlocksInFlight++;
         state->nBlocksInFlightValidHeaders += newentry.fValidatedHeaders;

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -128,9 +128,6 @@ protected:
     bool RequestBlock(CNode *pfrom, CInv obj);
 
 public:
-    // Number of peers from which we're downloading blocks.
-    int nPeersWithValidatedDownloads = 0;
-
     CRequestManager();
 
     // Get this object from somewhere, asynchronously.


### PR DESCRIPTION
We still need cs_main to lock MarkBlocksAsInFlight/MarkBlocksAsReceived but this is a step in the right direction. Once this is in we should be able to either change nodestate or take out the tracking of QueuedBlock's from nodestate and put it directly in the requeste manager.