### PR TITLE
Prevent the premature adjustment of the coins cache size

### DIFF
--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -579,7 +579,7 @@ void AdjustCoinCacheSize()
 {
     // If the operator has not set a dbcache and initial sync is complete then revert back to the default
     // value for dbcache. This will cause the current coins cache to be immediately trimmed to size.
-    if (IsChainNearlySyncd() && !GetArg("-dbcache", 0))
+    if (!IsInitialBlockDownload() && !GetArg("-dbcache", 0) && chainActive.Tip())
     {
         // Get the default value for nCoinCacheUsage.
         int64_t dummyBIDiskCache, dummyUtxoDiskCache, nMaxCoinCache = 0;


### PR DESCRIPTION
When a user hasn't selected a dbcache size then auto adjustment
takes place.  However what was happening is that the final step,
when the chain is nearly syncd, was getting executed right at the
beginning of sync and causing the coinscache to be auto sized very
small, with subsequent performance issues of repeated flushing of
the coins cache.  The solution here is just to make sure that
chaingActive.Tip() exists and we also switched from IsChainNearlySyncd
to !IsInitialBlockDownload because during the very initial part of sync
the IsChainNearlySyncd() can return true as blocks are processed right
up to the point where we have downloaded headers.