### PR TITLE
Fix ref counting for batched block requests.

### DIFF
--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -621,6 +621,8 @@ void CRequestManager::SendRequests()
 
                     if (fBatchBlockRequests)
                     {
+                        // Only add one ref per node with a vector of batched blocks
+                        if (mapBatchBlockRequests.find(next.node) == mapBatchBlockRequests.end())
                         {
                             LOCK(cs_vNodes);
                             next.node->AddRef();


### PR DESCRIPTION
We only have to add one ref for each unique node rather than for each
block going into the batched request. We were grossly over adding
refs here.