### PR TITLE
Update wget dependency in native Windows build env setup script

### DIFF
--- a/build-aux/mingw/install-toolchain.sh
+++ b/build-aux/mingw/install-toolchain.sh
@@ -38,19 +38,19 @@ cd "$DEPS_ROOT"
 
 # Use the v1.12 wget client to download & install the v1.19 version
 # don't download if already downloaded
-if [ ! -e wget-1.19.1-win32.zip ]
+if [ ! -e wget-1.19.4-win32.zip ]
 then
-	wget --no-check-certificate https://eternallybored.org/misc/wget/releases/old/wget-1.19.1-win32.zip -O "$DEPS_ROOT/wget-1.19.1-win32.zip"
+	wget --no-check-certificate https://eternallybored.org/misc/wget/releases/wget-1.19.4-win32.zip -O "$DEPS_ROOT/wget-1.19.4-win32.zip"
 	# Verify downloaded file's hash
 	# NOTE: This hash was self computed as it was not provided by the author
-	# v2016.04.08 sha256=eab20c797098c9e9a9753b2bdb530ed8758bbdb1f4a9a434bff48ea8840c5bee
-	check_hash eab20c797098c9e9a9753b2bdb530ed8758bbdb1f4a9a434bff48ea8840c5bee "$DEPS_ROOT/wget-1.19.1-win32.zip"
+	# v1.19.4 win32 sha256=b1a7e4ba4ab7f78e588c1186f2a5d7e1726628a5a66c645e41f8105b7cf5f61c
+	check_hash b1a7e4ba4ab7f78e588c1186f2a5d7e1726628a5a66c645e41f8105b7cf5f61c "$DEPS_ROOT/wget-1.19.4-win32.zip"
 fi
 # don't extract if already extracted
-if [ ! -d wget-1.19.1-win32 ]
+if [ ! -d wget-1.19.4-win32 ]
 then
-	"$CMD_7ZIP" x wget-1.19.1-win32.zip -aoa -o"$DEPS_ROOT/wget-1.19.1-win32"
-	cd "$DEPS_ROOT/wget-1.19.1-win32"
+	"$CMD_7ZIP" x wget-1.19.4-win32.zip -aoa -o"$DEPS_ROOT/wget-1.19.4-win32"
+	cd "$DEPS_ROOT/wget-1.19.4-win32"
 	cp wget.exe "$MSYS_BIN/wget.exe"
 fi
 #pause for debugging purposes


### PR DESCRIPTION
This bumps Windows wget version from 1.19.1 to 1.19.4.

Update was required as the source website now disables direct downloads of all old releases by URL, breaking the toolchain setup script.  Only the latest release version is downloadable by URL, old release URLs automatically redirect to the index page.  This means that anytime the author releases a new version, scripts will break again until patched.  I am looking into alternate solutions as a more permanent fix, this PR is just a band-aid to get the scripts working again for the time being.

This issue only affects first-time build environment setup when running the `config-mingw.bat` script.

NOTE: A new version of wget is required as the 1.12 version that comes with the MinGW Windows installer doesn't support TLS.