### PR TITLE
Check blocks and headers explicitly against the checkpoint hash

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3649,7 +3649,8 @@ bool AcceptBlockHeader(const CBlockHeader &block,
         if (pindexPrev->nStatus & BLOCK_FAILED_MASK)
             return state.DoS(100, error("%s: previous block invalid", __func__), REJECT_INVALID, "bad-prevblk");
 
-        // If the parent block is not the checkpointed block, then we are on the wrong fork so ignore.
+        // If the parent block belongs to the set of checkpointed blocks but it has a mismatched hash,
+        // then we are on the wrong fork so ignore
         assert(pindexPrev);
         if (fCheckpointsEnabled && !CheckAgainstCheckpoint(pindexPrev->nHeight, *pindexPrev->phashBlock, chainparams))
             return error("%s: CheckAgainstCheckpoint(): %s", __func__, state.GetRejectReason().c_str());
@@ -3660,7 +3661,8 @@ bool AcceptBlockHeader(const CBlockHeader &block,
     if (pindex == NULL)
         pindex = AddToBlockIndex(block);
 
-    // If this block is on a non-checkpointed fork, remember the fork but mark it as invalid.
+    // If the block belongs to the set of check-pointed blocks but it has a mismatched hash,
+    // then we are on the wrong fork so ignore
     if (fCheckpointsEnabled && !CheckAgainstCheckpoint(pindex->nHeight, *pindex->phashBlock, chainparams))
     {
         pindex->nStatus |= BLOCK_FAILED_VALID; // block doesn't match checkpoints so invalid

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3496,7 +3496,7 @@ bool CheckBlock(const CBlock &block, CValidationState &state, bool fCheckPOW, bo
     return true;
 }
 
-bool CheckAgainstCheckpoint(unsigned int height,  const uint256 &hash, const CChainParams &chainparams)
+bool CheckAgainstCheckpoint(unsigned int height, const uint256 &hash, const CChainParams &chainparams)
 {
     const CCheckpointData &ckpt = chainparams.Checkpoints();
     const auto &lkup = ckpt.mapCheckpoints.find(height);
@@ -4158,10 +4158,10 @@ bool static LoadBlockIndexDB()
         }
         if (fCheckpointsEnabled && !CheckAgainstCheckpoint(pindex->nHeight, *pindex->phashBlock, chainparams))
         {
-            pindex->nStatus |= BLOCK_FAILED_VALID;  // block doesn't match checkpoints so invalid
+            pindex->nStatus |= BLOCK_FAILED_VALID; // block doesn't match checkpoints so invalid
             pindex->nStatus &= ~BLOCK_VALID_CHAIN;
         }
-        if ((pindex->pprev)&&(pindex->pprev-> nStatus & BLOCK_FAILED_MASK))
+        if ((pindex->pprev) && (pindex->pprev->nStatus & BLOCK_FAILED_MASK))
         {
             // if the parent is invalid I am too
             pindex->nStatus |= BLOCK_FAILED_CHILD;

--- a/src/main.h
+++ b/src/main.h
@@ -510,11 +510,6 @@ bool TestBlockValidity(CValidationState &state,
 // Checks that the provided block is consistent with the chainparam's checkpoints
 bool CheckAgainstCheckpoint(unsigned int height, const uint256 &hash, const CChainParams &chainparams);
 
-// BU needed in unlimited.cpp
-bool CheckIndexAgainstCheckpoint(const CBlockIndex *pindexPrev,
-    CValidationState &state,
-    const CChainParams &chainparams,
-    const uint256 &hash);
 /** Store block on disk. If dbp is non-NULL, the file is known to already reside on disk */
 bool AcceptBlock(CBlock &block, CValidationState &state, CBlockIndex **pindex, bool fRequested, CDiskBlockPos *dbp);
 bool AcceptBlockHeader(const CBlockHeader &block, CValidationState &state, CBlockIndex **ppindex = NULL);

--- a/src/main.h
+++ b/src/main.h
@@ -508,7 +508,7 @@ bool TestBlockValidity(CValidationState &state,
     bool fCheckMerkleRoot = true);
 
 // Checks that the provided block is consistent with the chainparam's checkpoints
-bool CheckAgainstCheckpoint(unsigned int height,  const uint256 &hash, const CChainParams &chainparams);
+bool CheckAgainstCheckpoint(unsigned int height, const uint256 &hash, const CChainParams &chainparams);
 
 // BU needed in unlimited.cpp
 bool CheckIndexAgainstCheckpoint(const CBlockIndex *pindexPrev,

--- a/src/main.h
+++ b/src/main.h
@@ -507,6 +507,9 @@ bool TestBlockValidity(CValidationState &state,
     bool fCheckPOW = true,
     bool fCheckMerkleRoot = true);
 
+// Checks that the provided block is consistent with the chainparam's checkpoints
+bool CheckAgainstCheckpoint(unsigned int height,  const uint256 &hash, const CChainParams &chainparams);
+
 // BU needed in unlimited.cpp
 bool CheckIndexAgainstCheckpoint(const CBlockIndex *pindexPrev,
     CValidationState &state,

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1333,8 +1333,9 @@ bool TestConservativeBlockValidity(CValidationState &state,
 {
     AssertLockHeld(cs_main);
     assert(pindexPrev && pindexPrev == chainActive.Tip());
-    if (fCheckpointsEnabled && !CheckIndexAgainstCheckpoint(pindexPrev, state, chainparams, block.GetHash()))
-        return error("%s: CheckIndexAgainstCheckpoint(): %s", __func__, state.GetRejectReason().c_str());
+    // Ensure that if there is a checkpoint on this height, that this block is the one.
+    if (fCheckpointsEnabled && !CheckAgainstCheckpoint(pindexPrev->nHeight + 1, block.GetHash(), chainparams))
+        return error("%s: CheckAgainstCheckpoint(): %s", __func__, state.GetRejectReason().c_str());
 
     CCoinsViewCache viewNew(pcoinsTip);
     CBlockIndex indexDummy(block);


### PR DESCRIPTION
To ensure that the checkpointed fork is taken.