### PR TITLE
remove cs_main from requestmanager block requesting

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6888,6 +6888,10 @@ bool SendMessages(CNode *pto)
             }
         }
 
+        // Check for block download timeout and disconnect node if necessary. Does not require cs_main.
+        int64_t nNow = GetTimeMicros();
+        requester.CheckForDownloadTimeout(pto, consensusParams, nNow);
+
         TRY_LOCK(cs_main, lockMain); // Acquire cs_main for IsInitialBlockDownload() and CNodeState()
         if (!lockMain)
         {
@@ -6902,7 +6906,6 @@ bool SendMessages(CNode *pto)
         }
 
         // Address refresh broadcast
-        int64_t nNow = GetTimeMicros();
         if (!IsInitialBlockDownload() && pto->nNextLocalAddrSend < nNow)
         {
             AdvertiseLocal(pto);
@@ -7218,11 +7221,6 @@ bool SendMessages(CNode *pto)
                 }
             }
         }
-
-
-        // Check for block download timeout and disconnect node if necessary
-        requester.CheckForDownloadTimeout(pto, state, consensusParams, nNow);
-
 
         //
         // Message: getdata (blocks)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -264,13 +264,15 @@ void FinalizeNode(NodeId nodeid)
     if (state->fSyncStarted)
         nSyncStarted--;
 
-    for (const QueuedBlock &entry : state->vBlocksInFlight)
+    std::vector<uint256> vBlocksInFlight;
+    requester.GetBlocksInFlight(vBlocksInFlight, nodeid);
+    for (const uint256 &hash : vBlocksInFlight)
     {
         // Erase mapblocksinflight entries for this node.
-        requester.MapBlocksInFlightErase(entry.hash, nodeid);
+        requester.MapBlocksInFlightErase(hash, nodeid);
 
         // Reset all requests times to zero so that we can immediately re-request these blocks
-        requester.ResetLastRequestTime(entry.hash);
+        requester.ResetLastRequestTime(hash);
     }
     nPreferredDownload -= state->fPreferredDownload;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -314,10 +314,13 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats)
     stats.nMisbehavior = node->nMisbehavior;
     stats.nSyncHeight = state->pindexBestKnownBlock ? state->pindexBestKnownBlock->nHeight : -1;
     stats.nCommonHeight = state->pindexLastCommonBlock ? state->pindexLastCommonBlock->nHeight : -1;
-    for (const QueuedBlock &queue : state->vBlocksInFlight)
+
+    std::vector<uint256> vBlocksInFlight;
+    requester.GetBlocksInFlight(vBlocksInFlight, nodeid);
+    for (const uint256 &hash : vBlocksInFlight)
     {
         // lookup block by hash to find height
-        BlockMap::iterator mi = mapBlockIndex.find(queue.hash);
+        BlockMap::iterator mi = mapBlockIndex.find(hash);
         if (mi != mapBlockIndex.end())
         {
             CBlockIndex *pindex = (*mi).second;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -266,8 +266,8 @@ void FinalizeNode(NodeId nodeid)
 
     for (const QueuedBlock &entry : state->vBlocksInFlight)
     {
-        LOGA("erasing map mapblocksinflight entries\n");
-        requester.MapBlocksInFlightErase(entry.hash);
+        // Erase mapblocksinflight entries for this node.
+        requester.MapBlocksInFlightErase(entry.hash, nodeid);
 
         // Reset all requests times to zero so that we can immediately re-request these blocks
         requester.ResetLastRequestTime(entry.hash);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -277,6 +277,7 @@ void FinalizeNode(NodeId nodeid)
     nPreferredDownload -= state->fPreferredDownload;
 
     mapNodeState.erase(nodeid);
+    requester.RemoveNodeState(nodeid);
     if (mapNodeState.empty())
     {
         // Do a consistency check after the last peer is removed.  Force consistent state if production code

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -22,7 +22,6 @@ CNodeState::CNodeState(CAddress addrIn, std::string addrNameIn) : address(addrIn
     fRequestedInitialBlockAvailability = false;
     fPreferredDownload = false;
     fPreferHeaders = false;
-    nBlocksInFlight = 0;
 }
 
 /**

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -20,10 +20,9 @@ CNodeState::CNodeState(CAddress addrIn, std::string addrNameIn) : address(addrIn
     fFirstHeadersReceived = false;
     nFirstHeadersExpectedHeight = -1;
     fRequestedInitialBlockAvailability = false;
-    nDownloadingSince = 0;
-    nBlocksInFlight = 0;
     fPreferredDownload = false;
     fPreferHeaders = false;
+    nBlocksInFlight = 0;
 }
 
 /**

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -44,8 +44,6 @@ struct CNodeState
     bool fPreferredDownload;
     //! Whether this peer wants invs or headers (when possible) for block announcements.
     bool fPreferHeaders;
-    //! How many blocks are currently in flight and requested by this node.
-    int nBlocksInFlight;
 
     CNodeState(CAddress addrIn, std::string addrNameIn);
 };

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -9,13 +9,6 @@
 
 #include "net.h" // For NodeId
 
-/** Blocks that are in flight, and that are in the queue to be downloaded. Protected by cs_main. */
-struct QueuedBlock
-{
-    uint256 hash;
-    int64_t nTime; //! Time of "getdata" request in microseconds.
-};
-
 /**
 * Maintain validation-specific state about nodes, protected by cs_main, instead
 * by CNode's own locks. This simplifies asynchronous operation, where
@@ -47,15 +40,12 @@ struct CNodeState
     //! During IBD we need to update the block availabiity for each peer. We do this by requesting a header
     //  when a peer connects and also when we ask for the initial set of all headers.
     bool fRequestedInitialBlockAvailability;
-
-    std::list<QueuedBlock> vBlocksInFlight;
-    //! When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.
-    int64_t nDownloadingSince;
-    int nBlocksInFlight;
     //! Whether we consider this a preferred download peer.
     bool fPreferredDownload;
     //! Whether this peer wants invs or headers (when possible) for block announcements.
     bool fPreferHeaders;
+    //! How many blocks are currently in flight and requested by this node.
+    int nBlocksInFlight;
 
     CNodeState(CAddress addrIn, std::string addrNameIn);
 };

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1205,6 +1205,7 @@ void CRequestManager::CheckForDownloadTimeout(CNode *pnode,
     // We compensate for other peers to prevent killing off peers due to our own downstream link
     // being saturated. We only count validated in-flight blocks so peers can't advertise non-existing block hashes
     // to unreasonably increase our timeout.
+    LOCK(cs_objDownloader);
     NodeId nodeid = pnode->GetId();
     if (!pnode->fDisconnect && mapRequestManagerNodeState[nodeid].vBlocksInFlight.size() > 0)
     {

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1055,6 +1055,9 @@ void CRequestManager::MarkBlockAsInFlight(NodeId nodeid, const uint256 &hash)
 // Returns a bool if successful in indicating we received this block.
 bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
 {
+    if (!pnode)
+        return false;
+
     LOCK(cs_objDownloader);
     NodeId nodeid = pnode->GetId();
     std::map<uint256, std::map<NodeId, std::list<QueuedBlock>::iterator> >::iterator itInFlight =

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1122,6 +1122,32 @@ bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
     return false;
 }
 
+void CRequestManager::MapBlocksInFlightErase(const uint256 &hash, NodeId nodeid)
+{
+    // If there are more than one block in flight for the same block hash then we only remove
+    // the entry for this particular node, otherwise entirely remove the hash from mapBlocksInFlight.
+    LOCK(cs_objDownloader);
+    if (mapBlocksInFlight.count(hash) && mapBlocksInFlight[hash].size() > 1)
+    {
+        mapBlocksInFlight[hash].erase(nodeid);
+    }
+    else
+    {
+        mapBlocksInFlight.erase(hash);
+    }
+}
+
+bool CRequestManager::MapBlocksInFlightEmpty()
+{
+    LOCK(cs_objDownloader);
+    return mapBlocksInFlight.empty();
+}
+
+void CRequestManager::MapBlocksInFlightClear()
+{
+    LOCK(cs_objDownloader);
+    mapBlocksInFlight.clear();
+}
 
 void CRequestManager::CheckForDownloadTimeout(CNode *pnode,
     const CNodeState &state,

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1187,14 +1187,9 @@ void CRequestManager::MapBlocksInFlightClear()
 void CRequestManager::GetBlocksInFlight(std::vector<uint256> &vBlocksInFlight, NodeId nodeid)
 {
     LOCK(cs_objDownloader);
-    for (auto iter : mapBlocksInFlight)
+    for (auto iter : mapRequestManagerNodeState[nodeid].vBlocksInFlight)
     {
-        for (auto &iter2 : iter.second)
-        {
-            // Get blocks in flight for this peer only.
-            if (nodeid == iter2.first)
-                vBlocksInFlight.emplace_back(iter.first);
-        }
+        vBlocksInFlight.emplace_back(iter.hash);
     }
 }
 

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1068,7 +1068,7 @@ bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
         std::map<NodeId, CRequestManagerNodeState>::iterator it = mapRequestManagerNodeState.find(nodeid);
         DbgAssert(it != mapRequestManagerNodeState.end(), return false);
         CRequestManagerNodeState *state = &it->second;
-        
+
         int64_t getdataTime = mapBlocksInFlight[hash][nodeid]->nTime;
         int64_t now = GetTimeMicros();
         double nResponseTime = (double)(now - getdataTime) / 1000000.0;
@@ -1196,9 +1196,7 @@ void CRequestManager::GetBlocksInFlight(std::vector<uint256> &vBlocksInFlight, N
     }
 }
 
-void CRequestManager::CheckForDownloadTimeout(CNode *pnode,
-    const Consensus::Params &consensusParams,
-    int64_t nNow)
+void CRequestManager::CheckForDownloadTimeout(CNode *pnode, const Consensus::Params &consensusParams, int64_t nNow)
 {
     // In case there is a block that has been in flight from this peer for 2 + 0.5 * N times the block interval
     // (with N the number of peers from which we're downloading validated blocks), disconnect due to timeout.

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1173,13 +1173,11 @@ void CRequestManager::MapBlocksInFlightErase(const uint256 &hash, NodeId nodeid)
     // If there are more than one block in flight for the same block hash then we only remove
     // the entry for this particular node, otherwise entirely remove the hash from mapBlocksInFlight.
     LOCK(cs_objDownloader);
-    if (mapBlocksInFlight.count(hash) && mapBlocksInFlight[hash].size() > 1)
+    std::map<uint256, std::map<NodeId, std::list<QueuedBlock>::iterator> >::iterator itHash =
+        mapBlocksInFlight.find(hash);
+    if (itHash != mapBlocksInFlight.end())
     {
-        mapBlocksInFlight[hash].erase(nodeid);
-    }
-    else
-    {
-        mapBlocksInFlight.erase(hash);
+        itHash->second.erase(nodeid);
     }
 }
 

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1149,6 +1149,20 @@ void CRequestManager::MapBlocksInFlightClear()
     mapBlocksInFlight.clear();
 }
 
+void CRequestManager::GetBlocksInFlight(std::vector<uint256> &vBlocksInFlight, NodeId nodeid)
+{
+    LOCK(cs_objDownloader);
+    for (auto iter : mapBlocksInFlight)
+    {
+        for (auto &iter2 : iter.second)
+        {
+            // Get blocks in flight for this peer only.
+            if (nodeid == iter2.first)
+                vBlocksInFlight.emplace_back(iter.first);
+        }
+    }
+}
+
 void CRequestManager::CheckForDownloadTimeout(CNode *pnode,
     const CNodeState &state,
     const Consensus::Params &consensusParams,

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1167,12 +1167,9 @@ void CRequestManager::GetBlocksInFlight(std::vector<uint256> &vBlocksInFlight, N
 }
 
 void CRequestManager::CheckForDownloadTimeout(CNode *pnode,
-    const CNodeState &state,
     const Consensus::Params &consensusParams,
     int64_t nNow)
 {
-    AssertLockHeld(cs_main);
-
     // In case there is a block that has been in flight from this peer for 2 + 0.5 * N times the block interval
     // (with N the number of peers from which we're downloading validated blocks), disconnect due to timeout.
     // We compensate for other peers to prevent killing off peers due to our own downstream link

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -183,6 +183,7 @@ public:
     void MapBlocksInFlightErase(const uint256 &hash, NodeId nodeid);
     bool MapBlocksInFlightEmpty();
     void MapBlocksInFlightClear();
+    void GetBlocksInFlight(std::vector<uint256> &vBlocksInFlight, NodeId nodeid);
 
     // Check for block download timeout and disconnect node if necessary.
     void CheckForDownloadTimeout(CNode *pnode,

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -196,10 +196,7 @@ public:
     void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<CBlockIndex *> &vBlocks);
 
     // Returns a bool indicating whether we requested this block.
-    void MarkBlockAsInFlight(NodeId nodeid,
-        const uint256 &hash,
-        const Consensus::Params &consensusParams,
-        CBlockIndex *pindex = nullptr);
+    void MarkBlockAsInFlight(NodeId nodeid, const uint256 &hash);
 
     // Returns a bool if successful in indicating we received this block.
     bool MarkBlockAsReceived(const uint256 &hash, CNode *pnode);

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -107,6 +107,9 @@ struct CRequestManagerNodeState
     // When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.
     int64_t nDownloadingSince;
 
+    // How many blocks are currently in flight and requested by this node.
+    int nBlocksInFlight;
+
     CRequestManagerNodeState();
 };
 
@@ -185,8 +188,11 @@ public:
     // Update tracking information about which blocks a peer is assumed to have.
     void UpdateBlockAvailability(NodeId nodeid, const uint256 &hash);
 
-    // Update pindexLastCommonBlock and add not-in-flight missing successors to vBlocks, until it has
-    // at most count entries.
+    // Request the next blocks. Mostly this will get exucuted during IBD but sometimes even
+    // when the chain is syncd a block will get request via this method.
+    void RequestNextBlocksToDownload(CNode *pto);
+
+    // This gets called from RequestNextBlocksToDownload
     void FindNextBlocksToDownload(NodeId nodeid, unsigned int count, std::vector<CBlockIndex *> &vBlocks);
 
     // Returns a bool indicating whether we requested this block.

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -206,7 +206,6 @@ public:
 
     // Check for block download timeout and disconnect node if necessary.
     void CheckForDownloadTimeout(CNode *pnode,
-        const CNodeState &state,
         const Consensus::Params &consensusParams,
         int64_t nNow);
 };

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -92,6 +92,24 @@ public:
     bool AddSource(CNode *from); // returns true if the source did not already exist
 };
 
+// The following structs are used for tracking the internal requestmanager nodestate.
+struct QueuedBlock
+{
+    uint256 hash;
+    int64_t nTime; //! Time of "getdata" request in microseconds.
+};
+struct CRequestManagerNodeState
+{
+    // An ordered list of blocks currently in flight.  We could use mapBlocksInFlight to get the same
+    // data but then we'd have to iterate through the entire map to find what we're looking for.
+    std::list<QueuedBlock> vBlocksInFlight;
+
+    // When the first entry in vBlocksInFlight started downloading. Don't care when vBlocksInFlight is empty.
+    int64_t nDownloadingSince;
+
+    CRequestManagerNodeState();
+};
+
 class CRequestManager
 {
 protected:
@@ -107,6 +125,7 @@ protected:
     OdMap mapTxnInfo;
     OdMap mapBlkInfo;
     std::map<uint256, std::map<NodeId, std::list<QueuedBlock>::iterator> > mapBlocksInFlight;
+    std::map<NodeId, CRequestManagerNodeState> mapRequestManagerNodeState;
     CCriticalSection cs_objDownloader; // protects mapTxnInfo, mapBlkInfo and mapBlocksInFlight
 
     OdMap::iterator sendIter;

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -180,30 +180,9 @@ public:
     bool MarkBlockAsReceived(const uint256 &hash, CNode *pnode);
 
     // Methods for handling mapBlocksInFlight which is protected.
-    void MapBlocksInFlightErase(const uint256 &hash, NodeId nodeid)
-    {
-        // If there are more than one block in flight for the same block hash then we only remove
-        // the entry for this particular node, otherwise entirely remove the hash from mapBlocksInFlight.
-        LOCK(cs_objDownloader);
-        if (mapBlocksInFlight.count(hash) && mapBlocksInFlight[hash].size() > 1)
-        {
-            mapBlocksInFlight[hash].erase(nodeid);
-        }
-        else
-        {
-            mapBlocksInFlight.erase(hash);
-        }
-    }
-    bool MapBlocksInFlightEmpty()
-    {
-        LOCK(cs_objDownloader);
-        return mapBlocksInFlight.empty();
-    }
-    void MapBlocksInFlightClear()
-    {
-        LOCK(cs_objDownloader);
-        mapBlocksInFlight.clear();
-    }
+    void MapBlocksInFlightErase(const uint256 &hash, NodeId nodeid);
+    bool MapBlocksInFlightEmpty();
+    void MapBlocksInFlightClear();
 
     // Check for block download timeout and disconnect node if necessary.
     void CheckForDownloadTimeout(CNode *pnode,

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -210,6 +210,8 @@ public:
     void MapBlocksInFlightClear();
     void GetBlocksInFlight(std::vector<uint256> &vBlocksInFlight, NodeId nodeid);
 
+    // Remove a request manager node from the nodestate map.
+    void RemoveNodeState(NodeId nodeid) { mapRequestManagerNodeState.erase(nodeid); }
     // Check for block download timeout and disconnect node if necessary.
     void CheckForDownloadTimeout(CNode *pnode,
         const Consensus::Params &consensusParams,

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -208,7 +208,12 @@ public:
     void GetBlocksInFlight(std::vector<uint256> &vBlocksInFlight, NodeId nodeid);
 
     // Remove a request manager node from the nodestate map.
-    void RemoveNodeState(NodeId nodeid) { mapRequestManagerNodeState.erase(nodeid); }
+    void RemoveNodeState(NodeId nodeid)
+    {
+        LOCK(cs_objDownloader);
+        mapRequestManagerNodeState.erase(nodeid);
+    }
+
     // Check for block download timeout and disconnect node if necessary.
     void CheckForDownloadTimeout(CNode *pnode,
         const Consensus::Params &consensusParams,

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -215,9 +215,7 @@ public:
     }
 
     // Check for block download timeout and disconnect node if necessary.
-    void CheckForDownloadTimeout(CNode *pnode,
-        const Consensus::Params &consensusParams,
-        int64_t nNow);
+    void CheckForDownloadTimeout(CNode *pnode, const Consensus::Params &consensusParams, int64_t nNow);
 };
 
 


### PR DESCRIPTION
Somewhat of a long process to get the last of cs_main out.  The last central problem being getting  QueuedBlock out of nodestate.cpp/h which ended up being quite more work than I thought.  Several commits here although most of them are quite small.  It's hard to see a huge benefit with the variability of runs but I did have one test run where we got to 80K blocks in the first minute...that's the best I've ever seen.

All block requesting is now entirely encapsulated in the request manager.

Next steps after this is to tackle cs_vNodes and try to make a significant reduction is use withing the request manager.