### PR TITLE
add consts for floweethehub

### DIFF
--- a/doc/release-notes-bucash.md
+++ b/doc/release-notes-bucash.md
@@ -1,0 +1,232 @@
+Release Notes for Bitcoin Unlimited Cash Edition 1.3.0.0
+=========================================================
+
+Bitcoin Unlimited Cash Edition version 1.3.0.0 is now available from:
+
+  <https://bitcoinunlimited.info/download>
+
+Please report bugs using the issue tracker at github:
+
+  <https://github.com/BitcoinUnlimited/BitcoinUnlimited/issues>
+
+This is a major release version based of Bitcoin Unlimited compatible
+with the Bitcoin Cash specifications you could find here:
+
+https://github.com/bitcoincashorg/spec/blob/master/uahf-technical-spec.md (Aug 1st Protocol Upgrade, bucash 1.1.0.0)
+https://github.com/bitcoincashorg/spec/blob/master/nov-13-hardfork-spec.md (Nov 13th Protocol Upgrade, bucash 1.1.2.0)
+https://github.com/bitcoincashorg/spec/blob/master/may-2018-hardfork.md (May 15th Protocol Upgrade, bucash 1.3.0.0)
+
+
+
+Upgrading
+---------
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes for older versions), then run the
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
+
+If you are upgrading from a release older than 1.1.2.0, your UTXO database will be converted
+to a new format. This step could take a variable amount of time that will depend
+on the performance of the hardware you are using.
+
+Downgrade
+---------
+
+In case you decide to downgrade from BUcash 1.2.0.1 to a version older than 1.1.2.0
+will need to run the old release using `-reindex` option so that the
+UTXO will be rebuild using the previous format. Mind you that downgrading to version
+lower than 1.1.2.0 you will be split from the rest of the network that are following
+the rules activated Nov 13th 2017 protocol upgrade.
+
+Main Changes
+------------
+
+- May 15th 2018 protocol upgrade, at the median time past (MTP) time of 1526400000 (Tue May 15 12:00:00 UTC, 2018) this new features will introduced:
+	- OP_RETURN data carrier size increases to 220 bytes
+	- Increase the maximum blocksize (EB) to 32,000,000 bytes
+	- Re-activate the following opcodes: OP_CAT, OP_AND, OP_OR, OP_XOR, OP_DIV, OP_MOD
+	- Activate these new opcodes: OP_SPLIT to replace OP_SUBSTR, OP_NUM2BIN, OP_BIN2NUM
+- New RPC command listtransactionsfrom
+- Add new OP_DATASIGVERIFY (currently disabled)
+- Increase LevelDB performance on Linux 32 bit machine (port from Core)
+- QA enhancements (port from Core)
+- Improve XTHIN machinery by the use of shared txn
+- Greatly improve initial blocks download (IBD) performances
+- Automatically determine a more optimal -dbcache setting if none provided
+- Improve Request Manager functionalities
+
+Commit details
+--------------
+
+- `aba7387a3` Fix several tests in script_tests.json (Shammah Chancellor)
+- `9e4d451be` fix for #1035: blocknotify (#1037) (ptschip)
+- `d8bf8c422` add cumulative chain work to 'getchaintips' (gandrewstone)
+- `a51fd31d1` Move requester.sendrequests() to just before the place where we sleep. (ptschip)
+- `8e68a25e1` Check blocks and headers explicitly against the checkpoint hash (#1030) (gandrewstone)
+- `2f61f0964` Update copyright date on all file under src/ (sickpig)
+- `013f64db7` add listtransactionsfrom to the args conversion list (#1031) (gandrewstone)
+- `6170b0558` Update wget dependency in native Windows build env setup script (Justaphf)
+- `b73e9564e` Bump version to 1.3.0.0 (sickpig)
+- `dee4bfbd7` rely exclusively on the request manager for managing txn requests (#1017) (ptschip)
+- `f84e54d89` use cs_objDownloader to lock mapBlocksInFlight (#1022) (ptschip)
+- `d45cc2381` add changed implementation to spec (gandrewstone)
+- `4bf1a8928` switch signature type byte to the end of the pushed signature.  Add additional tests and check exact test return codes. (gandrewstone)
+- `f5b105420` add listtransactionsfrom RPC call that behaves like listtransactions probably should have originally ('from' index 0 is the oldest transaction) (gandrewstone)
+- `eccd0d7ed` Initilize counter to a random value. (sickpig)
+- `cc1028de7` Prevent the premature adjustment of the coins cache size (ptschip)
+- `6ebc73ec5` remove duplicate fork activation logic (gandrewstone)
+- `f00aeeced` Make both May fork tests have similar names to avoid confusion. (ptschip)
+- `b4d386bde` Move activation for EB, MG and data carrier size to UpdateTip (ptschip)
+- `7648f0bb7` Use may152018 rather than monolith to describe files and variables (ptschip)
+- `1ff2cf290` Fix branding in developer doc (ptschip)
+- `43a60fe88` remove unnecessary print statement from python test (ptschip)
+- `a769ca2d2` Fix abc-monolith-acitivation.py test failures (ptschip)
+- `5f4d34c3c` Set Monolith opcode enable script flag if monolith enabled (Daniel Connolly)
+- `0facaf79e` Add support for DIV and MOD opcodes (Jason B. Cox)
+- `5136489ff` Add support for SPLIT opcodes (joshuayabut)
+- `a5d9cdcb4` Add support for CAT (joshuayabut)
+- `e3750749c` Refactored existing monolith_opcodes tests (Jason B. Cox)
+- `52d4e1088` Implement support for NUM2BIN (deadalnix)
+- `65d5d58d1` Refactor opcode test to reduce redundancy (deadalnix)
+- `49d96caee` Add support for BIN2NUM opcode (deadalnix)
+- `54db51bc1` Simplify IsOpcodeDisabled (deadalnix)
+- `ee18fa742` Add support for AND, OR and XOR opcodes (deadalnix)
+- `f60a14bc3` Refactor MinimalizeBigEndianArray t be part of CScriptNum (deadalnix)
+- `f74611198` Ensure that CScriptNum is self contained. (deadalnix)
+- `91f92cf0e` Add function to trim leading array zeros maintaining MSB. (Jason B. Cox)
+- `15b1bd10a` Pull minimal check out of CScriptNum constr. into IsMinimalArray (Shammah Chancellor)
+- `33fe10340` Add helper function for disabled opcodes (Shammah Chancellor)
+- `ccc1ffba7` Cleanup scriptflags in unit tests (ptschip)
+- `4171184b3` Add a flag to gate opcodes activation for the new HF (deadalnix)
+- `ce1472782` Explode disabled opcode if into a switch (deadalnix)
+- `c7b05822e` Add missing test cases in script_tests.cpp (deadalnix)
+- `143bab69a` Prepare for re-enabled opcodes for the May 2018 protocol upgrade (Daniel Connolly)
+- `1a9c9cc6d` Fix bug in ClearOphanCache() (ptschip)
+- `a281657b5` Use CBlockRef in other places (ptschip)
+- `24c8b0395` Use p for pointer notation to signify these are shared pointers to blocks (ptschip)
+- `be573930d` Introduce CBlockRef typedef and MakeBlockRef() and use them. (ptschip)
+- `22b59f60d` add -conf path before launching bitcoind (Samuel Kwok)
+- `eb2d3a661` control which config params add to bitcoin.conf (Samuel Kwok)
+- `3d674c084` switch from LogPrint to LOG message (ptschip)
+- `190a3442d` Increase LevelDB max_open_files unless on 32-bit Unix. (Evan Klitzke)
+- `d99f72021` In unlimited.cpp reference mapOrphanTransations by the orphanpool singeton (ptschip)
+- `efae8487a` Update the calculation of maxAllowedSize to reflect shared pointer use (ptschip)
+- `2bc6211b9` Add the size of the shared txn pointers to the orphanpool size (ptschip)
+- `8507ded63` Make unit tests work with the new orphan pool singleton (ptschip)
+- `7ff80f653` Add comments to orphanpool.h (ptschip)
+- `ea8ae51a9` Use emplace for inserting elements into the orphan pool (ptschip)
+- `cedff4dc5` Move orphan functions out of main.cpp (ptschip)
+- `8b659d6e5` Use shared pointers in the orphan cache (ptschip)
+- `afe8c8f8e` Lower the maximum size a thinblock can be before we stop processing. (ptschip)
+- `ec32856d1` Use CTransactionRef in mapMissingTx for xthins (ptschip)
+- `f85091585` Start using CTransactionRef when reconstructing an XTHIN (ptschip)
+- `9b3c684a0` Fix GetTransaction() (ptschip)
+- `c3be5619b` Introduce convenience type CTransactionRef (sipa)
+- `767dbb083` Make CBlock::vtx a vector of shared_ptr<CTransaction> (sipa)
+- `bb1002382` Add deserializing constructors to CTransaction and CMutableTransaction (sipa)
+- `b8a86d887` Add serialization for unique_ptr and shared_ptr (sipa)
+- `4ae8089fb` Move mapBlocksInflight to the request manager (ptschip)
+- `42d7d43d7` If a node disconnects then reset lastrequesttime for any blocks in flight (ptschip)
+- `8745a932c` Use C++11 range based loops and nullptr's (ptschip)
+- `cb86320af` Use emplace for inserting a new blockvalidationthread entry (ptschip)
+- `8ec03a48e` Remove references to requester singleton in RequestManager.cpp (ptschip)
+- `2c6eab70e` Enforce the use of Qt5 at configure script level (sickpig)
+- `da27ab3ea` Append CLIENT_VERSION_BUILD to Apple's CFBundleGetInfoString (sickpig)
+- `9dd8b90dc` Properly set up VERSION var for the win installer (sickpig)
+- `62ea24cf7` Add CLIENT_VERSION_BUILD to AC_INIT (sickpig)
+- `75df382d6` add enable/disable to datasigverify and count sigops. (gandrewstone)
+- `f5e8c0045` Clear warn in QT and getinfo if initial conditions is not valid anymore (#993) (sickpig)
+- `330553f4a` Partial port of XT PR #319 from dagurval/qa-cherries (dgenr8)
+- `442805625` Port XT #315 from dagurval/28-01-httpserver (dgenr8)
+- `ba3423edf` Port Core #8166: src/test: Do not shadow local variables (laanwj)
+- `edeb49eab` Ccorrect human-readable fork time in comment (dgenr8)
+- `8992e345f` Port Core #7888: prevector: fix 2 bugs in currently unreached code paths (laanwj)
+- `3d6b95491` Kill insecure_random and associated global state (laanwj)
+- `b2ee649e7` fPreferHeaders should be false when initialized (ptschip)
+- `d855c2883` Remove parameter nodeid from InitializeNode() (ptschip)
+- `4b9598788` Add a couple of DbgAsserts for if state is NULL (ptschip)
+- `849ef6163` Switch from fSyncStartTime to nSyncStartTime (ptschip)
+- `26942665c` Use a proper constructor for CNodeState (ptschip)
+- `ef79dea10` Switch from pnode to nId (ptschip)
+- `28e4929f4` Initialize all variables for CNodeState (ptschip)
+- `924c27a8b` Update May 15, 2018 fork activation time as per spec draft (#987) (sickpig)
+- `829437ee5` Allow -rpcconnect in bitoin.conf, Fixes #990 (ptschip)
+- `d8aecc78a` Fix compiler warning on uint64_t to int comparison (ptschip)
+- `954ae6b40` [consensus] Pin P2SH activation to block 173805 on mainnet (John Newbery)
+- `a43d77ab3` Update chainparams for regest so that BIP34 is activated (ptschip)
+- `b407feb88` Consensus: Remove ISM (NicolasDorier)
+- `b1853eb6d` Pull script verify flags calculation out of ConnectBlock (Matt Corallo)
+- `22192741f` Move checking of blockdownload timeout to the request manager (ptschip)
+- `f7f227e72` Fix for rollbackchain() (#994) (ptschip)
+- `52238c64a` Remove dead code related to SizeForkExpiration consensus parameter (sickpig)
+- `c1f201405` clean up accepnonstdtxn flag by removing redundant global and making chainparams API correct (gandrewstone)
+- `f7cb6ffbb` [IBD patch 4] Deprioritise slower downloaders (#970) (ptschip)
+- `dbe128827` add OP_RETURN to list of imported opcodes since we use it (#985) (gandrewstone)
+- `715aabfc1` Automatically determine a more optimal -dbcache setting if none provided (#948) (ptschip)
+- `e9c49ff65` sync: Remove superfluous assert(..) (Awemany)
+- `a48397293` update datasigverify as per feedback (gandrewstone)
+- `ccd8e889f` move spec to be standalone rather than a pull request in the re-enable op_codes spec (gandrewstone)
+- `0aa71ea70` Update QT build instructions (ptschip)
+- `3bf63aece` fix copyright date, and remove inapplicable comment (gandrewstone)
+- `77969c13d` Use references in range based for loops (ptschip)
+- `3b0359633` Make sure lock on cs_main isn't held before aquiring semaphore grant (sickpig)
+- `b88136e25` Add ability to assert a lock is not held in DEBUG_LOCKORDER (Matt Corallo)
+- `0ba50e39d` Use C++11 nullptr keyword rather than NULL macro (sickpig)
+- `b21911c74` Remove using namespace std from thinblock.cpp (sickpig)
+- `24b645189` Substitute BOOST_FOREACH with c++11 range-based for loop (sickpig)
+- `11852363b` Fix comments for some xthin stat gathering methods (sickpig)
+- `b11e9d7e4` remove unnecessary arg (gandrewstone)
+- `925ced865` add ability to specify different binary files/directories for each client (gandrewstone)
+- `6e8564a87` basic may 2018 fork infrastructure (gandrewstone)
+- `6ffb81e6b` ensure that the subversion and miner coinbase is updated when EB or AD is updated (gandrewstone)
+- `f12ccf059` Use Logging namespace to access LogAcceptCategory (sickpig)
+- `a1d26e83e` Add a few ui messages to startup when opening databases (ptschip)
+- `c4db28f24` Makefile.am: Typo fix that broke `make clean` rule (awemany)
+- `1bf53307c` OP_DATASIGVERIFY reference implementation (gandrewstone)
+- `b39dd57ed` Remove the redundantblocksize argument from HandBlockMessage (ptschip)
+- `9c4414d20` Use GetBlockSize() in place of ::GetSerializedSize (ptschip)
+- `0394fc695` Create block method GetBlockSize() (ptschip)
+- `a28ee85d3` Scripts to help automate first-time setup of the mingw dev environment on Windows. (#85) (Justaphf)
+- `fe425dc63` Explicitly mark fall-through cases (sickpig)
+- `dcf43cf9d` change to pointer type (ptschip)
+- `c08e038d5` convert CBlock to a shared pointer to limit copying of a block (gandrewstone)
+- `e8e1d02e8` Fix warnings on ReadOrderPos and WriteOrderPos (sickpig)
+- `b3ca26c44` Only run data gathering  code if BENCH logging is enabled. (ptschip)
+- `9d38d55c8` Change log message from LogPrintf to LOG(NET, ... (ptschip)
+- `7e6db6810` net: initialize socket to avoid closing random fd's (theuni)
+- `466d14aef` If there is nothing to trim then do not continue (ptschip)
+- `c2f41c97d` Prevent potential integer underflow of nTrimHeight (ptschip)
+- `49243d0be` Replace BOOST_FOREACH and NULL, in SendMessages, with C++11 notation (ptschip)
+- `4164aa386` Remove duplicate section of code (ptschip)
+- `c0f806f4b` change mempool to use a non-recursive shared lock (gandrewstone)
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- Andrea Suisani
+- Andrew Stone
+- awemany
+- Justaphf
+- Peter Tschipper
+- Pieter Wuille
+- Samuel Kwok
+- Tom Harding
+
+We have backported an amount of changes from other projects, namely Bitcoin Core, Bitcoin ABC and Bitcoin XT.
+
+Following all the indirect contributors whose work has been imported via the above backports:
+
+- Amaury Séchet
+- Wladimir J. van der Laan
+- Shammah Chancellor
+- Matt Corallo
+- NicolasDorier
+- Cory Fields
+- Daniel Connolly
+- Evan Klitzke
+- Jason B. Cox
+- John Newbery
+- joshuayabut

--- a/doc/release-notes-bucash.md
+++ b/doc/release-notes-bucash.md
@@ -33,7 +33,7 @@ on the performance of the hardware you are using.
 Downgrade
 ---------
 
-In case you decide to downgrade from BUcash 1.2.0.1 to a version older than 1.1.2.0
+In case you decide to downgrade from BUcash 1.2.0.1, or greater, to a version older than 1.1.2.0
 will need to run the old release using `-reindex` option so that the
 UTXO will be rebuild using the previous format. Mind you that downgrading to version
 lower than 1.1.2.0 you will be split from the rest of the network that are following

--- a/doc/release-notes/release-notes-bucash1.3.0.0.md
+++ b/doc/release-notes/release-notes-bucash1.3.0.0.md
@@ -16,6 +16,8 @@ https://github.com/bitcoincashorg/spec/blob/master/uahf-technical-spec.md (Aug 1
 https://github.com/bitcoincashorg/spec/blob/master/nov-13-hardfork-spec.md (Nov 13th Protocol Upgrade, bucash 1.1.2.0)
 https://github.com/bitcoincashorg/spec/blob/master/may-2018-hardfork.md (May 15th Protocol Upgrade, bucash 1.3.0.0)
 
+
+
 Upgrading
 ---------
 
@@ -31,7 +33,7 @@ on the performance of the hardware you are using.
 Downgrade
 ---------
 
-In case you decide to downgrade from BUcash 1.2.0.1 to a version older than 1.1.2.0
+In case you decide to downgrade from BUcash 1.2.0.1, or greater, to a version older than 1.1.2.0
 will need to run the old release using `-reindex` option so that the
 UTXO will be rebuild using the previous format. Mind you that downgrading to version
 lower than 1.1.2.0 you will be split from the rest of the network that are following
@@ -209,6 +211,7 @@ Thanks to everyone who directly contributed to this release:
 - awemany
 - Justaphf
 - Peter Tschipper
+- Pieter Wuille
 - Samuel Kwok
 - Tom Harding
 
@@ -227,4 +230,3 @@ Following all the indirect contributors whose work has been imported via the abo
 - Jason B. Cox
 - John Newbery
 - joshuayabut
-- Pieter Wuille

--- a/doc/release-notes/release-notes-bucash1.3.0.0.md
+++ b/doc/release-notes/release-notes-bucash1.3.0.0.md
@@ -1,0 +1,230 @@
+Release Notes for Bitcoin Unlimited Cash Edition 1.3.0.0
+=========================================================
+
+Bitcoin Unlimited Cash Edition version 1.3.0.0 is now available from:
+
+  <https://bitcoinunlimited.info/download>
+
+Please report bugs using the issue tracker at github:
+
+  <https://github.com/BitcoinUnlimited/BitcoinUnlimited/issues>
+
+This is a major release version based of Bitcoin Unlimited compatible
+with the Bitcoin Cash specifications you could find here:
+
+https://github.com/bitcoincashorg/spec/blob/master/uahf-technical-spec.md (Aug 1st Protocol Upgrade, bucash 1.1.0.0)
+https://github.com/bitcoincashorg/spec/blob/master/nov-13-hardfork-spec.md (Nov 13th Protocol Upgrade, bucash 1.1.2.0)
+https://github.com/bitcoincashorg/spec/blob/master/may-2018-hardfork.md (May 15th Protocol Upgrade, bucash 1.3.0.0)
+
+Upgrading
+---------
+
+If you are running an older version, shut it down. Wait until it has completely
+shut down (which might take a few minutes for older versions), then run the
+installer (on Windows) or just copy over /Applications/Bitcoin-Qt (on Mac) or
+bitcoind/bitcoin-qt (on Linux).
+
+If you are upgrading from a release older than 1.1.2.0, your UTXO database will be converted
+to a new format. This step could take a variable amount of time that will depend
+on the performance of the hardware you are using.
+
+Downgrade
+---------
+
+In case you decide to downgrade from BUcash 1.2.0.1 to a version older than 1.1.2.0
+will need to run the old release using `-reindex` option so that the
+UTXO will be rebuild using the previous format. Mind you that downgrading to version
+lower than 1.1.2.0 you will be split from the rest of the network that are following
+the rules activated Nov 13th 2017 protocol upgrade.
+
+Main Changes
+------------
+
+- May 15th 2018 protocol upgrade, at the median time past (MTP) time of 1526400000 (Tue May 15 12:00:00 UTC, 2018) this new features will introduced:
+	- OP_RETURN data carrier size increases to 220 bytes
+	- Increase the maximum blocksize (EB) to 32,000,000 bytes
+	- Re-activate the following opcodes: OP_CAT, OP_AND, OP_OR, OP_XOR, OP_DIV, OP_MOD
+	- Activate these new opcodes: OP_SPLIT to replace OP_SUBSTR, OP_NUM2BIN, OP_BIN2NUM
+- New RPC command listtransactionsfrom
+- Add new OP_DATASIGVERIFY (currently disabled)
+- Increase LevelDB performance on Linux 32 bit machine (port from Core)
+- QA enhancements (port from Core)
+- Improve XTHIN machinery by the use of shared txn
+- Greatly improve initial blocks download (IBD) performances
+- Automatically determine a more optimal -dbcache setting if none provided
+- Improve Request Manager functionalities
+
+Commit details
+--------------
+
+- `aba7387a3` Fix several tests in script_tests.json (Shammah Chancellor)
+- `9e4d451be` fix for #1035: blocknotify (#1037) (ptschip)
+- `d8bf8c422` add cumulative chain work to 'getchaintips' (gandrewstone)
+- `a51fd31d1` Move requester.sendrequests() to just before the place where we sleep. (ptschip)
+- `8e68a25e1` Check blocks and headers explicitly against the checkpoint hash (#1030) (gandrewstone)
+- `2f61f0964` Update copyright date on all file under src/ (sickpig)
+- `013f64db7` add listtransactionsfrom to the args conversion list (#1031) (gandrewstone)
+- `6170b0558` Update wget dependency in native Windows build env setup script (Justaphf)
+- `b73e9564e` Bump version to 1.3.0.0 (sickpig)
+- `dee4bfbd7` rely exclusively on the request manager for managing txn requests (#1017) (ptschip)
+- `f84e54d89` use cs_objDownloader to lock mapBlocksInFlight (#1022) (ptschip)
+- `d45cc2381` add changed implementation to spec (gandrewstone)
+- `4bf1a8928` switch signature type byte to the end of the pushed signature.  Add additional tests and check exact test return codes. (gandrewstone)
+- `f5b105420` add listtransactionsfrom RPC call that behaves like listtransactions probably should have originally ('from' index 0 is the oldest transaction) (gandrewstone)
+- `eccd0d7ed` Initilize counter to a random value. (sickpig)
+- `cc1028de7` Prevent the premature adjustment of the coins cache size (ptschip)
+- `6ebc73ec5` remove duplicate fork activation logic (gandrewstone)
+- `f00aeeced` Make both May fork tests have similar names to avoid confusion. (ptschip)
+- `b4d386bde` Move activation for EB, MG and data carrier size to UpdateTip (ptschip)
+- `7648f0bb7` Use may152018 rather than monolith to describe files and variables (ptschip)
+- `1ff2cf290` Fix branding in developer doc (ptschip)
+- `43a60fe88` remove unnecessary print statement from python test (ptschip)
+- `a769ca2d2` Fix abc-monolith-acitivation.py test failures (ptschip)
+- `5f4d34c3c` Set Monolith opcode enable script flag if monolith enabled (Daniel Connolly)
+- `0facaf79e` Add support for DIV and MOD opcodes (Jason B. Cox)
+- `5136489ff` Add support for SPLIT opcodes (joshuayabut)
+- `a5d9cdcb4` Add support for CAT (joshuayabut)
+- `e3750749c` Refactored existing monolith_opcodes tests (Jason B. Cox)
+- `52d4e1088` Implement support for NUM2BIN (deadalnix)
+- `65d5d58d1` Refactor opcode test to reduce redundancy (deadalnix)
+- `49d96caee` Add support for BIN2NUM opcode (deadalnix)
+- `54db51bc1` Simplify IsOpcodeDisabled (deadalnix)
+- `ee18fa742` Add support for AND, OR and XOR opcodes (deadalnix)
+- `f60a14bc3` Refactor MinimalizeBigEndianArray t be part of CScriptNum (deadalnix)
+- `f74611198` Ensure that CScriptNum is self contained. (deadalnix)
+- `91f92cf0e` Add function to trim leading array zeros maintaining MSB. (Jason B. Cox)
+- `15b1bd10a` Pull minimal check out of CScriptNum constr. into IsMinimalArray (Shammah Chancellor)
+- `33fe10340` Add helper function for disabled opcodes (Shammah Chancellor)
+- `ccc1ffba7` Cleanup scriptflags in unit tests (ptschip)
+- `4171184b3` Add a flag to gate opcodes activation for the new HF (deadalnix)
+- `ce1472782` Explode disabled opcode if into a switch (deadalnix)
+- `c7b05822e` Add missing test cases in script_tests.cpp (deadalnix)
+- `143bab69a` Prepare for re-enabled opcodes for the May 2018 protocol upgrade (Daniel Connolly)
+- `1a9c9cc6d` Fix bug in ClearOphanCache() (ptschip)
+- `a281657b5` Use CBlockRef in other places (ptschip)
+- `24c8b0395` Use p for pointer notation to signify these are shared pointers to blocks (ptschip)
+- `be573930d` Introduce CBlockRef typedef and MakeBlockRef() and use them. (ptschip)
+- `22b59f60d` add -conf path before launching bitcoind (Samuel Kwok)
+- `eb2d3a661` control which config params add to bitcoin.conf (Samuel Kwok)
+- `3d674c084` switch from LogPrint to LOG message (ptschip)
+- `190a3442d` Increase LevelDB max_open_files unless on 32-bit Unix. (Evan Klitzke)
+- `d99f72021` In unlimited.cpp reference mapOrphanTransations by the orphanpool singeton (ptschip)
+- `efae8487a` Update the calculation of maxAllowedSize to reflect shared pointer use (ptschip)
+- `2bc6211b9` Add the size of the shared txn pointers to the orphanpool size (ptschip)
+- `8507ded63` Make unit tests work with the new orphan pool singleton (ptschip)
+- `7ff80f653` Add comments to orphanpool.h (ptschip)
+- `ea8ae51a9` Use emplace for inserting elements into the orphan pool (ptschip)
+- `cedff4dc5` Move orphan functions out of main.cpp (ptschip)
+- `8b659d6e5` Use shared pointers in the orphan cache (ptschip)
+- `afe8c8f8e` Lower the maximum size a thinblock can be before we stop processing. (ptschip)
+- `ec32856d1` Use CTransactionRef in mapMissingTx for xthins (ptschip)
+- `f85091585` Start using CTransactionRef when reconstructing an XTHIN (ptschip)
+- `9b3c684a0` Fix GetTransaction() (ptschip)
+- `c3be5619b` Introduce convenience type CTransactionRef (sipa)
+- `767dbb083` Make CBlock::vtx a vector of shared_ptr<CTransaction> (sipa)
+- `bb1002382` Add deserializing constructors to CTransaction and CMutableTransaction (sipa)
+- `b8a86d887` Add serialization for unique_ptr and shared_ptr (sipa)
+- `4ae8089fb` Move mapBlocksInflight to the request manager (ptschip)
+- `42d7d43d7` If a node disconnects then reset lastrequesttime for any blocks in flight (ptschip)
+- `8745a932c` Use C++11 range based loops and nullptr's (ptschip)
+- `cb86320af` Use emplace for inserting a new blockvalidationthread entry (ptschip)
+- `8ec03a48e` Remove references to requester singleton in RequestManager.cpp (ptschip)
+- `2c6eab70e` Enforce the use of Qt5 at configure script level (sickpig)
+- `da27ab3ea` Append CLIENT_VERSION_BUILD to Apple's CFBundleGetInfoString (sickpig)
+- `9dd8b90dc` Properly set up VERSION var for the win installer (sickpig)
+- `62ea24cf7` Add CLIENT_VERSION_BUILD to AC_INIT (sickpig)
+- `75df382d6` add enable/disable to datasigverify and count sigops. (gandrewstone)
+- `f5e8c0045` Clear warn in QT and getinfo if initial conditions is not valid anymore (#993) (sickpig)
+- `330553f4a` Partial port of XT PR #319 from dagurval/qa-cherries (dgenr8)
+- `442805625` Port XT #315 from dagurval/28-01-httpserver (dgenr8)
+- `ba3423edf` Port Core #8166: src/test: Do not shadow local variables (laanwj)
+- `edeb49eab` Ccorrect human-readable fork time in comment (dgenr8)
+- `8992e345f` Port Core #7888: prevector: fix 2 bugs in currently unreached code paths (laanwj)
+- `3d6b95491` Kill insecure_random and associated global state (laanwj)
+- `b2ee649e7` fPreferHeaders should be false when initialized (ptschip)
+- `d855c2883` Remove parameter nodeid from InitializeNode() (ptschip)
+- `4b9598788` Add a couple of DbgAsserts for if state is NULL (ptschip)
+- `849ef6163` Switch from fSyncStartTime to nSyncStartTime (ptschip)
+- `26942665c` Use a proper constructor for CNodeState (ptschip)
+- `ef79dea10` Switch from pnode to nId (ptschip)
+- `28e4929f4` Initialize all variables for CNodeState (ptschip)
+- `924c27a8b` Update May 15, 2018 fork activation time as per spec draft (#987) (sickpig)
+- `829437ee5` Allow -rpcconnect in bitoin.conf, Fixes #990 (ptschip)
+- `d8aecc78a` Fix compiler warning on uint64_t to int comparison (ptschip)
+- `954ae6b40` [consensus] Pin P2SH activation to block 173805 on mainnet (John Newbery)
+- `a43d77ab3` Update chainparams for regest so that BIP34 is activated (ptschip)
+- `b407feb88` Consensus: Remove ISM (NicolasDorier)
+- `b1853eb6d` Pull script verify flags calculation out of ConnectBlock (Matt Corallo)
+- `22192741f` Move checking of blockdownload timeout to the request manager (ptschip)
+- `f7f227e72` Fix for rollbackchain() (#994) (ptschip)
+- `52238c64a` Remove dead code related to SizeForkExpiration consensus parameter (sickpig)
+- `c1f201405` clean up accepnonstdtxn flag by removing redundant global and making chainparams API correct (gandrewstone)
+- `f7cb6ffbb` [IBD patch 4] Deprioritise slower downloaders (#970) (ptschip)
+- `dbe128827` add OP_RETURN to list of imported opcodes since we use it (#985) (gandrewstone)
+- `715aabfc1` Automatically determine a more optimal -dbcache setting if none provided (#948) (ptschip)
+- `e9c49ff65` sync: Remove superfluous assert(..) (Awemany)
+- `a48397293` update datasigverify as per feedback (gandrewstone)
+- `ccd8e889f` move spec to be standalone rather than a pull request in the re-enable op_codes spec (gandrewstone)
+- `0aa71ea70` Update QT build instructions (ptschip)
+- `3bf63aece` fix copyright date, and remove inapplicable comment (gandrewstone)
+- `77969c13d` Use references in range based for loops (ptschip)
+- `3b0359633` Make sure lock on cs_main isn't held before aquiring semaphore grant (sickpig)
+- `b88136e25` Add ability to assert a lock is not held in DEBUG_LOCKORDER (Matt Corallo)
+- `0ba50e39d` Use C++11 nullptr keyword rather than NULL macro (sickpig)
+- `b21911c74` Remove using namespace std from thinblock.cpp (sickpig)
+- `24b645189` Substitute BOOST_FOREACH with c++11 range-based for loop (sickpig)
+- `11852363b` Fix comments for some xthin stat gathering methods (sickpig)
+- `b11e9d7e4` remove unnecessary arg (gandrewstone)
+- `925ced865` add ability to specify different binary files/directories for each client (gandrewstone)
+- `6e8564a87` basic may 2018 fork infrastructure (gandrewstone)
+- `6ffb81e6b` ensure that the subversion and miner coinbase is updated when EB or AD is updated (gandrewstone)
+- `f12ccf059` Use Logging namespace to access LogAcceptCategory (sickpig)
+- `a1d26e83e` Add a few ui messages to startup when opening databases (ptschip)
+- `c4db28f24` Makefile.am: Typo fix that broke `make clean` rule (awemany)
+- `1bf53307c` OP_DATASIGVERIFY reference implementation (gandrewstone)
+- `b39dd57ed` Remove the redundantblocksize argument from HandBlockMessage (ptschip)
+- `9c4414d20` Use GetBlockSize() in place of ::GetSerializedSize (ptschip)
+- `0394fc695` Create block method GetBlockSize() (ptschip)
+- `a28ee85d3` Scripts to help automate first-time setup of the mingw dev environment on Windows. (#85) (Justaphf)
+- `fe425dc63` Explicitly mark fall-through cases (sickpig)
+- `dcf43cf9d` change to pointer type (ptschip)
+- `c08e038d5` convert CBlock to a shared pointer to limit copying of a block (gandrewstone)
+- `e8e1d02e8` Fix warnings on ReadOrderPos and WriteOrderPos (sickpig)
+- `b3ca26c44` Only run data gathering  code if BENCH logging is enabled. (ptschip)
+- `9d38d55c8` Change log message from LogPrintf to LOG(NET, ... (ptschip)
+- `7e6db6810` net: initialize socket to avoid closing random fd's (theuni)
+- `466d14aef` If there is nothing to trim then do not continue (ptschip)
+- `c2f41c97d` Prevent potential integer underflow of nTrimHeight (ptschip)
+- `49243d0be` Replace BOOST_FOREACH and NULL, in SendMessages, with C++11 notation (ptschip)
+- `4164aa386` Remove duplicate section of code (ptschip)
+- `c0f806f4b` change mempool to use a non-recursive shared lock (gandrewstone)
+
+Credits
+=======
+
+Thanks to everyone who directly contributed to this release:
+
+- Andrea Suisani
+- Andrew Stone
+- awemany
+- Justaphf
+- Peter Tschipper
+- Samuel Kwok
+- Tom Harding
+
+We have backported an amount of changes from other projects, namely Bitcoin Core, Bitcoin ABC and Bitcoin XT.
+
+Following all the indirect contributors whose work has been imported via the above backports:
+
+- Amaury Séchet
+- Wladimir J. van der Laan
+- Shammah Chancellor
+- Matt Corallo
+- NicolasDorier
+- Cory Fields
+- Daniel Connolly
+- Evan Klitzke
+- Jason B. Cox
+- John Newbery
+- joshuayabut
+- Pieter Wuille

--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -70,12 +70,13 @@ class AuthServiceProxy(object):
     __id_count = 0
 
     # ensure_ascii: escape unicode as \uXXXX, passed to json.dumps
-    def __init__(self, service_url, service_name=None, timeout=HTTP_TIMEOUT, connection=None, ensure_ascii=True):
+    def __init__(self, service_url, service_name=None, timeout=HTTP_TIMEOUT, connection=None, ensure_ascii=True, miningCapable=None):
         self.__timeout = timeout
         self.__service_url = service_url
         self._service_name = service_name
         self.ensure_ascii = ensure_ascii # can be toggled on the fly by tests
         self.__url = urlparse.urlparse(service_url)
+        self.miningCapable = miningCapable
         if self.__url.port is None:
             port = 80
         else:

--- a/qa/rpc-tests/test_framework/coverage.py
+++ b/qa/rpc-tests/test_framework/coverage.py
@@ -59,6 +59,9 @@ class AuthServiceProxyWrapper(object):
     def url(self):
         return self.auth_service_proxy_instance.url
 
+    @property
+    def miningCapable(self):
+        return self.auth_service_proxy_instance.miningCapable
 
 def get_filename(dirname, n_node):
     """

--- a/qa/rpc-tests/test_framework/floweeconst.py
+++ b/qa/rpc-tests/test_framework/floweeconst.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php
+
+#
+# Const for Floweethehub integration
+#
+BITCOIN_CONF = "flowee.conf"  #see SettingsDefaults.h
+HUB_LOG = "hub.log"           # debug.log is used by other clients
+BCD_HUB_PATH = "/hub/debug/src/bitcoind"
+NODE_NUM = 3               # node3 is for Hub
+CONF_IN_CACHE = "cache/node" + str(NODE_NUM) + "/" + BITCOIN_CONF
+# unrecoginized parameters by flowee
+FILTER_PARAM_KEYS = ['usecashaddr', 'maxlimitertxfee', 'debug']

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -31,6 +31,8 @@ import logging
 
 from . import coverage
 from .authproxy import AuthServiceProxy, JSONRPCException
+# Constants for floweethehub (see floweeconst.py)
+from .floweeconst import *
 
 COVERAGE_DIR = None
 
@@ -47,7 +49,6 @@ PORT_MIN = 11000
 PORT_RANGE = 5000
 
 BITCOIND_PROC_WAIT_TIMEOUT = 60
-
 
 class PortSeed:
     # Must be initialized with a unique integer for each process
@@ -84,7 +85,7 @@ def enable_coverage(dirname):
     COVERAGE_DIR = dirname
 
 
-def get_rpc_proxy(url, node_number, timeout=None):
+def get_rpc_proxy(url, node_number, timeout=None, miningCapable=True):
     """
     Args:
         url (str): URL of the RPC server to call
@@ -92,6 +93,7 @@ def get_rpc_proxy(url, node_number, timeout=None):
 
     Kwargs:
         timeout (int): HTTP timeout in seconds
+        miningCapable (bool): mining Capability (all client are True, except Floweethehub or "hub")
 
     Returns:
         AuthServiceProxy. convenience object for making RPC calls.
@@ -100,6 +102,10 @@ def get_rpc_proxy(url, node_number, timeout=None):
     proxy_kwargs = {}
     if timeout is not None:
         proxy_kwargs['timeout'] = timeout
+    if miningCapable is not None:
+        if hub_is_running(node_number):  # node 3
+            miningCapable = False
+        proxy_kwargs['miningCapable'] = miningCapable
 
     proxy = AuthServiceProxy(url, **proxy_kwargs)
     proxy.url = url  # store URL on proxy for info
@@ -148,6 +154,14 @@ def sync_blocks(rpc_connections, wait=1,verbose=1):
             break
         time.sleep(wait)
 
+def hub_is_running(node_num):
+    """
+    Check if hub is running
+    INPUT:
+        node_num : node number of the self.bins
+    """
+    return node_num == NODE_NUM and os.path.isfile(os.path.join(os.getcwd(), CONF_IN_CACHE))
+
 def sync_mempools(rpc_connections, wait=1,verbose=1):
     """
     Wait until everybody has the same transactions in their memory
@@ -170,18 +184,42 @@ def sync_mempools(rpc_connections, wait=1,verbose=1):
             break
         time.sleep(wait)
 
+def filterUnsupportedParams(defaults, param_keys=FILTER_PARAM_KEYS):
+    """
+    Method to filter out the unrecognized parameters by setting NoConfiValue
+    obj as the value of the parameter as key of the dict. 
+    Input:
+        defaults : default list containing unrecognized parameter(s)
+        param_keys : parameter(s) to be removed from the default list
+    """
+    removeParams = {}
+    removeParams = {el:NoConfigValue() for el in param_keys}
+    defaults.update(removeParams)
+    return defaults
+
 bitcoind_processes = {}
 
-def initialize_datadir(dirname, n,bitcoinConfDict=None,wallet=None):
+def initialize_datadir(dirname, n, bitcoinConfDict=None, wallet=None, bins=None):
     datadir = os.path.join(dirname, "node"+str(n))
     if not os.path.isdir(datadir):
         os.makedirs(datadir)
 
     defaults = {"server":1, "discover":0, "regtest":1,"rpcuser":"rt","rpcpassword":"rt",
                 "port":p2p_port(n),"rpcport":str(rpc_port(n)),"listenonion":0,"maxlimitertxfee":0,"usecashaddr":1}
+
     if bitcoinConfDict: defaults.update(bitcoinConfDict)
 
-    with open(os.path.join(datadir, "bitcoin.conf"), 'w') as f:
+    file = "bitcoin.conf"
+    if bins:
+        if BCD_HUB_PATH in bins[n]:
+            defaults = filterUnsupportedParams(defaults)
+            file = BITCOIN_CONF
+    else:
+        if hub_is_running(n):
+            defaults = filterUnsupportedParams(defaults)
+            file = BITCOIN_CONF
+
+    with open(os.path.join(datadir, file), 'w') as f:
         for (key,val) in defaults.items():
           if isinstance(val, NoConfigValue):
             pass
@@ -241,7 +279,7 @@ def initialize_chain(test_dir,bitcoinConfDict=None,wallets=None, bins=None):
 
         # Create cache directories, run bitcoinds:
         for i in range(4):
-            datadir=initialize_datadir("cache", i,bitcoinConfDict)
+            datadir=initialize_datadir("cache", i, bitcoinConfDict, wallets, bins)
             if bins:
                 args = [ bins[i], "-keypool=1", "-datadir="+datadir ]
             else:
@@ -271,19 +309,25 @@ def initialize_chain(test_dir,bitcoinConfDict=None,wallets=None, bins=None):
         block_time = get_mocktime() - (201 * 10 * 60)
         for i in range(2):
             for peer in range(4):
-                for j in range(25):
-                    set_node_times(rpcs, block_time)
-                    rpcs[peer].generate(1)
-                    block_time += 10*60
-                # Must sync before next peer starts generating blocks
-                sync_blocks(rpcs)
+                if rpcs[peer].miningCapable:   # if generate needs two parameters, then skip calling generate(1)
+                    for j in range(25):
+                        set_node_times(rpcs, block_time)
+                        rpcs[peer].generate(1)
+                        block_time += 10*60
+                    # Must sync before next peer starts generating blocks
+                    sync_blocks(rpcs)
 
         # Shut them down, and clean up cache directories:
         stop_nodes(rpcs)
         wait_bitcoinds()
         disable_mocktime()
         for i in range(4):
-            os.remove(log_filename("cache", i, "debug.log"))
+            if bins:
+                if BCD_HUB_PATH in bins[i]:
+                    print("logfilename = ", log_filename("cache", i, HUB_LOG))
+                    os.remove(log_filename("cache", i, HUB_LOG))
+                else:
+                    os.remove(log_filename("cache", i, "debug.log"))
             os.remove(log_filename("cache", i, "db.log"))
             os.remove(log_filename("cache", i, "peers.dat"))
             os.remove(log_filename("cache", i, "fee_estimates.dat"))
@@ -332,8 +376,6 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
         binary = os.getenv("BITCOIND", "bitcoind")
     # RPC tests still depend on free transactions
     args = [ binary, "-datadir="+datadir, "-rest", "-mocktime="+str(get_mocktime()) ] # // BU removed, "-keypool=1","-blockprioritysize=50000" ]
-    # need for some client and no harm to include for all; otherwise bitcoind starts on mainnet listening at port 8332
-    args.append("-conf="+ os.path.join(datadir, "bitcoin.conf"))
     if extra_args is not None: args.extend(extra_args)
     bitcoind_processes[i] = subprocess.Popen(args)
     if os.getenv("PYTHON_DEBUG", ""):
@@ -343,7 +385,6 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     if os.getenv("PYTHON_DEBUG", ""):
         print("start_node: RPC succesfully started")
     proxy = get_rpc_proxy(url, i, timeout=timewait)
-
     if COVERAGE_DIR:
         coverage.write_all_rpc_commands(COVERAGE_DIR, proxy)
 

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -94,6 +94,7 @@ BITCOIN_TESTS =\
   test/streams_tests.cpp \
   test/test_bitcoin.cpp \
   test/test_bitcoin.h \
+  test/test_random.h \
   test/thinblock_tests.cpp \
   test/thinblock_data_tests.cpp \
   test/thinblock_util_tests.cpp \

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -7,7 +7,7 @@
 #include "consensus/validation.h"
 #include "main.h"
 #include "test/test_bitcoin.h"
-#include "test_random.h"
+#include "test/test_random.h"
 #include "uint256.h"
 #include "undo.h"
 

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -11,7 +11,7 @@
 #include "crypto/sha256.h"
 #include "crypto/sha512.h"
 #include "test/test_bitcoin.h"
-#include "test_random.h"
+#include "test/test_random.h"
 #include "utilstrencodings.h"
 
 #include <vector>

--- a/src/test/merkle_tests.cpp
+++ b/src/test/merkle_tests.cpp
@@ -5,7 +5,7 @@
 
 #include "consensus/merkle.h"
 #include "test/test_bitcoin.h"
-#include "test_random.h"
+#include "test/test_random.h"
 
 #include <boost/test/unit_test.hpp>
 

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -11,7 +11,7 @@
 #include "streams.h"
 #include "test/test_bitcoin.h"
 #include "test/test_bitcoin.h"
-#include "test_random.h"
+#include "test/test_random.h"
 #include "uint256.h"
 #include "version.h"
 

--- a/src/test/prevector_tests.cpp
+++ b/src/test/prevector_tests.cpp
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "prevector.h"
-#include "test_random.h"
+#include "test/test_random.h"
 #include <vector>
 
 #include "serialize.h"

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -13,7 +13,7 @@
 #include "serialize.h"
 #include "streams.h"
 #include "test/test_bitcoin.h"
-#include "test_random.h"
+#include "test/test_random.h"
 #include "util.h"
 #include "utilstrencodings.h"
 #include "version.h"

--- a/src/test/skiplist_tests.cpp
+++ b/src/test/skiplist_tests.cpp
@@ -5,7 +5,7 @@
 
 #include "chain.h"
 #include "test/test_bitcoin.h"
-#include "test_random.h"
+#include "test/test_random.h"
 #include "util.h"
 
 #include <vector>

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -9,7 +9,7 @@
 #include "primitives/transaction.h"
 #include "sync.h"
 #include "test/test_bitcoin.h"
-#include "test_random.h"
+#include "test/test_random.h"
 #include "utilmoneystr.h"
 #include "utilstrencodings.h"
 

--- a/src/test/versionbits_tests.cpp
+++ b/src/test/versionbits_tests.cpp
@@ -11,7 +11,7 @@
 #include "main.h"
 #include "random.h"
 #include "test/test_bitcoin.h"
-#include "test_random.h"
+#include "test/test_random.h"
 
 #include <boost/test/unit_test.hpp>
 


### PR DESCRIPTION
Changes required for integrating Floweethehub to cashInterOp project

1. using non-standard files:  flowee.conf and hub.log  (instead of bitcoin.conf and debug.log)
2. generate() interface changes: requires two arguments : "blocks", and "pubkey"   (other clients only require "blocks"
3. filter out unrecognized opt parameters (usecashaddr, maxlimitertxfee, and debug)