### PR TITLE
Port ABC D1293:  "Add basic sanity checking for script pushdata size"

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -57,6 +57,7 @@ BITCOIN_TESTS =\
   test/cashaddrenc_tests.cpp \
   test/coins_tests.cpp \
   test/compress_tests.cpp \
+  test/core_io_tests.cpp \
   test/crypto_tests.cpp \
   test/DoS_tests.cpp \
   test/exploit_tests.cpp \

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -51,6 +51,9 @@ CScript ParseScript(const std::string &s)
     std::vector<std::string> words;
     boost::algorithm::split(words, s, boost::algorithm::is_any_of(" \t\n"), boost::algorithm::token_compress_on);
 
+    size_t push_size = 0, next_push_size = 0;
+    size_t script_size = 0;
+
     for (const auto &w : words)
     {
         if (w.empty())
@@ -59,6 +62,19 @@ CScript ParseScript(const std::string &s)
             // word)
             continue;
         }
+
+        // Check that the expected number of byte where pushed.
+        if (push_size && (result.size() - script_size) != push_size)
+        {
+            throw std::runtime_error("Hex number doesn't match the number of bytes being pushed");
+        }
+
+        // Update script size.
+        script_size = result.size();
+
+        // Make sure we keep track of the size of push operations.
+        push_size = next_push_size;
+        next_push_size = 0;
 
         if (all(w, boost::algorithm::is_digit()) ||
             (boost::algorithm::starts_with(w, "-") &&
@@ -82,6 +98,18 @@ CScript ParseScript(const std::string &s)
 
             // Raw hex data, inserted NOT pushed onto stack:
             std::vector<uint8_t> raw = ParseHex(std::string(w.begin() + 2, w.end()));
+            if (push_size && raw.size() != push_size)
+            {
+                throw std::runtime_error("Hex number doesn't match the "
+                                         "number of bytes being pushed");
+            }
+            // If we have what looks like an immediate push, figure out its
+            // size.
+            if (!push_size && raw.size() == 1 && raw[0] < OP_PUSHDATA1)
+            {
+                next_push_size = raw[0];
+            }
+
             result.insert(result.end(), raw.begin(), raw.end());
             continue;
         }
@@ -99,11 +127,34 @@ CScript ParseScript(const std::string &s)
         if (mapOpNames.count(w))
         {
             // opcode, e.g. OP_ADD or ADD:
-            result << mapOpNames[w];
+            opcodetype op = mapOpNames[w];
+
+            switch (op)
+            {
+            case OP_PUSHDATA1:
+                next_push_size = 1;
+                break;
+            case OP_PUSHDATA2:
+                next_push_size = 2;
+                break;
+            case OP_PUSHDATA4:
+                next_push_size = 4;
+                break;
+            default:
+                break;
+            }
+
+            result << op;
             continue;
         }
 
         throw std::runtime_error("Error parsing script: " + s);
+    }
+
+    // Check that the expected number of byte where pushed.
+    if (push_size && (result.size() - script_size) != push_size)
+    {
+        throw std::runtime_error("Hex number doesn't match the number of bytes being pushed");
     }
 
     return result;

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -48,55 +48,62 @@ CScript ParseScript(const std::string &s)
         }
     }
 
-    vector<string> words;
+    std::vector<std::string> words;
     boost::algorithm::split(words, s, boost::algorithm::is_any_of(" \t\n"), boost::algorithm::token_compress_on);
 
-    for (std::vector<std::string>::const_iterator w = words.begin(); w != words.end(); ++w)
+    for (const auto &w : words)
     {
-        if (w->empty())
+        if (w.empty())
         {
-            // Empty string, ignore. (boost::split given '' will return one word)
+            // Empty string, ignore. (boost::split given '' will return one
+            // word)
+            continue;
         }
-        else if (all(*w, boost::algorithm::is_digit()) ||
-                 (boost::algorithm::starts_with(*w, "-") &&
-                     all(string(w->begin() + 1, w->end()), boost::algorithm::is_digit())))
+
+        if (all(w, boost::algorithm::is_digit()) ||
+            (boost::algorithm::starts_with(w, "-") &&
+                all(std::string(w.begin() + 1, w.end()), boost::algorithm::is_digit())))
         {
             // Number
-            int64_t n = atoi64(*w);
+            int64_t n = atoi64(w);
             result << n;
+            continue;
         }
-        else if (boost::algorithm::starts_with(*w, "0x") && (w->begin() + 2 != w->end()))
+
+        if (boost::algorithm::starts_with(w, "0x") && (w.begin() + 2 != w.end()))
         {
-            if (IsHex(std::string(w->begin() + 2, w->end())))
-            {
-                // Raw hex data, inserted NOT pushed onto stack:
-                std::vector<uint8_t> raw = ParseHex(std::string(w->begin() + 2, w->end()));
-                result.insert(result.end(), raw.begin(), raw.end());
-            }
-            else
+            if (!IsHex(std::string(w.begin() + 2, w.end())))
             {
                 // Should only arrive here for improperly formatted hex values
                 throw std::runtime_error("Hex numbers expected to be formatted "
                                          "in full-byte chunks (ex: 0x00 "
                                          "instead of 0x0)");
             }
+
+            // Raw hex data, inserted NOT pushed onto stack:
+            std::vector<uint8_t> raw = ParseHex(std::string(w.begin() + 2, w.end()));
+            result.insert(result.end(), raw.begin(), raw.end());
+            continue;
         }
-        else if (w->size() >= 2 && boost::algorithm::starts_with(*w, "'") && boost::algorithm::ends_with(*w, "'"))
+
+        if (w.size() >= 2 && boost::algorithm::starts_with(w, "'") && boost::algorithm::ends_with(w, "'"))
         {
             // Single-quoted string, pushed as data. NOTE: this is poor-man's
-            // parsing, spaces/tabs/newlines in single-quoted strings won't work.
-            std::vector<uint8_t> value(w->begin() + 1, w->end() - 1);
+            // parsing, spaces/tabs/newlines in single-quoted strings won't
+            // work.
+            std::vector<uint8_t> value(w.begin() + 1, w.end() - 1);
             result << value;
+            continue;
         }
-        else if (mapOpNames.count(*w))
+
+        if (mapOpNames.count(w))
         {
             // opcode, e.g. OP_ADD or ADD:
-            result << mapOpNames[*w];
+            result << mapOpNames[w];
+            continue;
         }
-        else
-        {
-            throw runtime_error("script parse error");
-        }
+
+        throw std::runtime_error("Error parsing script: " + s);
     }
 
     return result;

--- a/src/core_read.cpp
+++ b/src/core_read.cpp
@@ -65,18 +65,27 @@ CScript ParseScript(const std::string &s)
             int64_t n = atoi64(*w);
             result << n;
         }
-        else if (boost::algorithm::starts_with(*w, "0x") && (w->begin() + 2 != w->end()) &&
-                 IsHex(string(w->begin() + 2, w->end())))
+        else if (boost::algorithm::starts_with(*w, "0x") && (w->begin() + 2 != w->end()))
         {
-            // Raw hex data, inserted NOT pushed onto stack:
-            std::vector<unsigned char> raw = ParseHex(string(w->begin() + 2, w->end()));
-            result.insert(result.end(), raw.begin(), raw.end());
+            if (IsHex(std::string(w->begin() + 2, w->end())))
+            {
+                // Raw hex data, inserted NOT pushed onto stack:
+                std::vector<uint8_t> raw = ParseHex(std::string(w->begin() + 2, w->end()));
+                result.insert(result.end(), raw.begin(), raw.end());
+            }
+            else
+            {
+                // Should only arrive here for improperly formatted hex values
+                throw std::runtime_error("Hex numbers expected to be formatted "
+                                         "in full-byte chunks (ex: 0x00 "
+                                         "instead of 0x0)");
+            }
         }
         else if (w->size() >= 2 && boost::algorithm::starts_with(*w, "'") && boost::algorithm::ends_with(*w, "'"))
         {
             // Single-quoted string, pushed as data. NOTE: this is poor-man's
             // parsing, spaces/tabs/newlines in single-quoted strings won't work.
-            std::vector<unsigned char> value(w->begin() + 1, w->end() - 1);
+            std::vector<uint8_t> value(w->begin() + 1, w->end() - 1);
             result << value;
         }
         else if (mapOpNames.count(*w))

--- a/src/test/core_io_tests.cpp
+++ b/src/test/core_io_tests.cpp
@@ -1,0 +1,27 @@
+// Copyright (c) 2018 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "core_io.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+#include <string>
+
+BOOST_FIXTURE_TEST_SUITE(core_io_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(parse_hex_test) {
+    std::string s = "0x";
+    BOOST_CHECK_THROW(ParseScript(s), std::runtime_error);
+
+    for (int numZeroes = 1; numZeroes <= 32; numZeroes++) {
+        s += "0";
+        if (numZeroes % 2 == 0) {
+            BOOST_CHECK_NO_THROW(ParseScript(s));
+        } else {
+            BOOST_CHECK_THROW(ParseScript(s), std::runtime_error);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/core_io_tests.cpp
+++ b/src/test/core_io_tests.cpp
@@ -6,6 +6,7 @@
 #include "test/test_bitcoin.h"
 
 #include <boost/test/unit_test.hpp>
+
 #include <string>
 
 BOOST_FIXTURE_TEST_SUITE(core_io_tests, BasicTestingSetup)
@@ -22,6 +23,25 @@ BOOST_AUTO_TEST_CASE(parse_hex_test) {
             BOOST_CHECK_THROW(ParseScript(s), std::runtime_error);
         }
     }
+}
+
+BOOST_AUTO_TEST_CASE(parse_push_test) {
+    BOOST_CHECK_NO_THROW(ParseScript("0x01 0x01"));
+    BOOST_CHECK_NO_THROW(ParseScript("0x01 XOR"));
+    BOOST_CHECK_NO_THROW(ParseScript("0x01 1"));
+    BOOST_CHECK_NO_THROW(ParseScript("0x01 ''"));
+    BOOST_CHECK_NO_THROW(ParseScript("0x02 0x0101"));
+    BOOST_CHECK_NO_THROW(ParseScript("0x02 42"));
+    BOOST_CHECK_NO_THROW(ParseScript("0x02 'a'"));
+
+    BOOST_CHECK_THROW(ParseScript("0x01 0x0101"), std::runtime_error);
+    BOOST_CHECK_THROW(ParseScript("0x01 42"), std::runtime_error);
+    BOOST_CHECK_THROW(ParseScript("0x02 0x01"), std::runtime_error);
+    BOOST_CHECK_THROW(ParseScript("0x02 XOR"), std::runtime_error);
+    BOOST_CHECK_THROW(ParseScript("0x02 1"), std::runtime_error);
+    BOOST_CHECK_THROW(ParseScript("0x02 ''"), std::runtime_error);
+    BOOST_CHECK_THROW(ParseScript("0x02 0x010101"), std::runtime_error);
+    BOOST_CHECK_THROW(ParseScript("0x02 'ab'"), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/data/script_tests.json
+++ b/src/test/data/script_tests.json
@@ -17,8 +17,8 @@
 ["  1  2  ", "2 EQUALVERIFY 1 EQUAL", "P2SH,STRICTENC", "OK"],
 
 ["1", "", "P2SH,STRICTENC", "OK"],
-["0x02 0x01 0x00", "", "P2SH,STRICTENC", "OK", "all bytes are significant, not only the last one"],
-["0x09 0x00000000 0x00000000 0x10", "", "P2SH,STRICTENC", "OK", "equals zero when cast to Int64"],
+["0x02 0x0100", "", "P2SH,STRICTENC", "OK", "all bytes are significant, not only the last one"],
+["0x09 0x000000000000000010", "", "P2SH,STRICTENC", "OK", "equals zero when cast to Int64"],
 
 ["0x01 0x0b", "11 EQUAL", "P2SH,STRICTENC", "OK", "push 1 byte"],
 ["0x02 0x417a", "'Az' EQUAL", "P2SH,STRICTENC", "OK"],
@@ -73,7 +73,7 @@
 ["0", "IF RETURN ENDIF 1", "P2SH,STRICTENC", "OK", "RETURN only works if executed"],
 
 ["1 1", "VERIFY", "P2SH,STRICTENC", "OK"],
-["1 0x05 0x01 0x00 0x00 0x00 0x00", "VERIFY", "P2SH,STRICTENC", "OK", "values >4 bytes can be cast to boolean"],
+["1 0x05 0x0100000000", "VERIFY", "P2SH,STRICTENC", "OK", "values >4 bytes can be cast to boolean"],
 ["1 0x01 0x80", "IF 0 ENDIF", "P2SH,STRICTENC", "OK", "negative 0 is false"],
 
 ["10 0 11 TOALTSTACK DROP FROMALTSTACK", "ADD 21 EQUAL", "P2SH,STRICTENC", "OK"],
@@ -348,7 +348,7 @@
 ["2147483647", "0x04 0xFFFFFF7F EQUAL", "P2SH,STRICTENC", "OK"],
 ["2147483648", "0x05 0x0000008000 EQUAL", "P2SH,STRICTENC", "OK"],
 ["549755813887", "0x05 0xFFFFFFFF7F EQUAL", "P2SH,STRICTENC", "OK"],
-["549755813888", "0x06 0xFFFFFFFF7F EQUAL", "P2SH,STRICTENC", "OK"],
+["549755813888", "0x06 0x000000008000 EQUAL", "P2SH,STRICTENC", "OK"],
 ["9223372036854775807", "0x08 0xFFFFFFFFFFFFFF7F EQUAL", "P2SH,STRICTENC", "OK"],
 ["-1", "0x01 0x81 EQUAL", "P2SH,STRICTENC", "OK", "Numbers are little-endian with the MSB being a sign bit"],
 ["-127", "0x01 0xFF EQUAL", "P2SH,STRICTENC", "OK"],


### PR DESCRIPTION
The aim of this changeset is to make more difficult to introduce in the json test suite especially the ones related to script pushdata size ops. 

This is a port of  https://reviews.bitcoinabc.org/D1293 and its dependencies (D1290 and D1292).

D1290: Give more descriptive error when parsing partial-byte hex values 
D1292: Refactor ParseScript logic to remove `else` conditions 
D1293: Add basic sanity checking for script pushdata size