### PR TITLE
Correct socket select error on Windows

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -8,6 +8,10 @@
 #include "config/bitcoin-config.h"
 #endif
 
+// must include first to ensure FD_SETSIZE is correctly set
+// otherwise the default of 64 may be used on Windows
+#include "compat.h"
+
 #include "net.h"
 
 #include "addrman.h"

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -4,6 +4,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+// must include first to ensure FD_SETSIZE is correctly set
+// otherwise the default of 64 may be used on Windows
+#include "compat.h"
+
 #include "netbase.h"
 
 #include "random.h"

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -8,6 +8,8 @@
 #include "config/bitcoin-config.h"
 #endif
 
+#include "compat.h"
+
 #include "util.h"
 
 #include "chainparamsbase.h"
@@ -711,7 +713,7 @@ bool TruncateFile(FILE *file, unsigned int length)
 int RaiseFileDescriptorLimit(int nMinFD)
 {
 #if defined(WIN32)
-    return 2048;
+    return FD_SETSIZE;
 #else
     struct rlimit limitFD;
     if (getrlimit(RLIMIT_NOFILE, &limitFD) != -1)


### PR DESCRIPTION
On Windows builds, if more than 64 connections are open, the FD_SET macro would cause memory writes beyond the array bounds of the fd_set being written to.  This was because include ordering caused the fd_set typedef to be create before FD_SETSIZE was defined as 1024 in `compat.h`, thus using the default 64 instead.

The fix was to explicitly include `compat.h` as the first include in the source files which use fd_sets.