### PR TITLE
Prune slow peers during initial sync

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6851,11 +6851,11 @@ bool SendMessages(CNode *pto)
         {
             NodeId nodeid = pto->GetId();
             int nInFlight = requester.GetNumBlocksInFlight(nodeid);
-            LOGA("peer=%d, checking disconnect request with %d in flight blocks\n", nodeid, nInFlight);
+            LOG(IBD, "peer=%d, checking disconnect request with %d in flight blocks\n", nodeid, nInFlight);
             if (nInFlight == 0)
             {
                 pto->fDisconnect = true;
-                LOGA("peer=%d, disconnected\n", nodeid);
+                LOG(IBD, "peer=%d, disconnected\n", nodeid);
             }
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6844,6 +6844,9 @@ bool SendMessages(CNode *pto)
 {
     const Consensus::Params &consensusParams = Params().GetConsensus();
     {
+        // First set fDisconnect if appropriate.
+        pto->DisconnectIfBanned();
+
         // Check for an internal disconnect request and if true then set fDisconnect. This would typically happen
         // during initial sync when a peer has a slow connection and we want to disconnect them.  We want to then
         // wait for any blocks that are still in flight before disconnecting, rather than re-requesting them again.
@@ -6858,9 +6861,6 @@ bool SendMessages(CNode *pto)
                 LOG(IBD, "peer=%d, disconnected\n", nodeid);
             }
         }
-
-        // First set fDisconnect if appropriate.
-        pto->DisconnectIfBanned();
 
         // Now exit early if disconnecting or the version handshake is not complete.  We must not send PING or other
         // connection maintenance messages before the handshake is done.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6933,7 +6933,7 @@ bool SendMessages(CNode *pto)
 
         // Check for block download timeout and disconnect node if necessary. Does not require cs_main.
         int64_t nNow = GetTimeMicros();
-        requester.CheckForDownloadTimeout(pto, consensusParams, nNow);
+        requester.DisconnectOnDownloadTimeout(pto, consensusParams, nNow);
 
         TRY_LOCK(cs_main, lockMain); // Acquire cs_main for IsInitialBlockDownload() and CNodeState()
         if (!lockMain)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1940,7 +1940,6 @@ void ThreadOpenConnections()
                     pnode->fAutoOutbound = true;
                     requester.nOutbound++;
                 }
-
             }
         }
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -466,6 +466,10 @@ CNode *ConnectNode(CAddress addrConnect, const char *pszDest, bool fCountFailure
 
 void CNode::CloseSocketDisconnect()
 {
+    // if this is an outbound node that was not added via addenode then decrement the counter.
+    if (fAutoOutbound)
+        requester.nOutbound--;
+
     fDisconnect = true;
     if (hSocket != INVALID_SOCKET)
     {
@@ -1932,7 +1936,11 @@ void ThreadOpenConnections()
                 // We need to use a separate outbound flag so as not to differentiate these outbound
                 // nodes with ones that were added using -addnode -connect-thinblock or -connect.
                 if (pnode)
+                {
                     pnode->fAutoOutbound = true;
+                    requester.nOutbound++;
+                }
+
             }
         }
     }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2813,6 +2813,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
     fBUVersionSent = false;
     fSuccessfullyConnected = false;
     fDisconnect = false;
+    fDisconnectRequest = false;
     nRefCount = 0;
     nSendSize = 0;
     nSendOffset = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -352,7 +352,8 @@ public:
     bool fVerackSent;
     bool fBUVersionSent;
     bool fSuccessfullyConnected;
-    bool fDisconnect;
+    std::atomic<bool> fDisconnect;
+    std::atomic<bool> fDisconnectRequest;
     // We use fRelayTxes for two purposes -
     // a) it allows us to not relay tx invs before receiving the peer's version message
     // b) the peer may tell us in its version message that we should not relay tx invs

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1122,7 +1122,7 @@ bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
                 if (requester.nOutbound >= nMaxOutConnections - 1 && IsInitialBlockDownload() &&
                     nIterations > nOverallRange && pnode->nAvgBlkResponseTime > nOverallAverageResponseTime * 4)
                 {
-                    LOGA("disconnecting %s because too slow , overall avg %d peer avg %d\n", pnode->GetLogName(),
+                    LOG(IBD, "disconnecting %s because too slow , overall avg %d peer avg %d\n", pnode->GetLogName(),
                         nOverallAverageResponseTime, pnode->nAvgBlkResponseTime);
                     pnode->fDisconnectRequest = true;
                     // We must not return here but continue in order

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1099,7 +1099,7 @@ bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
             // Get the average value for overall average response time (s) of all nodes.
             {
                 LOCK(cs_overallaverage);
-                int nOverallRange = blockRange * nMaxOutConnections;
+                uint32_t nOverallRange = blockRange * nMaxOutConnections;
                 if (nIterations <= nOverallRange)
                     nIterations++;
                 if (nIterations > nOverallRange)

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1251,7 +1251,7 @@ int CRequestManager::GetNumBlocksInFlight(NodeId nodeid)
     return mapRequestManagerNodeState[nodeid].nBlocksInFlight;
 }
 
-void CRequestManager::CheckForDownloadTimeout(CNode *pnode, const Consensus::Params &consensusParams, int64_t nNow)
+void CRequestManager::DisconnectOnDownloadTimeout(CNode *pnode, const Consensus::Params &consensusParams, int64_t nNow)
 {
     // In case there is a block that has been in flight from this peer for 2 + 0.5 * N times the block interval
     // (with N the number of peers from which we're downloading validated blocks), disconnect due to timeout.

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1119,8 +1119,8 @@ bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
                 // disconnecting.
                 //
                 // We disconnect a peer only if their average response time is more than 4 times the overall average.
-                if (requester.nOutbound >= nMaxOutConnections - 1 && IsInitialBlockDownload() &&
-                    nIterations > nOverallRange && pnode->nAvgBlkResponseTime > nOverallAverageResponseTime * 4)
+                if (nOutbound >= nMaxOutConnections - 1 && IsInitialBlockDownload() && nIterations > nOverallRange &&
+                    pnode->nAvgBlkResponseTime > nOverallAverageResponseTime * 4)
                 {
                     LOG(IBD, "disconnecting %s because too slow , overall avg %d peer avg %d\n", pnode->GetLogName(),
                         nOverallAverageResponseTime, pnode->nAvgBlkResponseTime);

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -102,7 +102,7 @@ CRequestManager::CRequestManager()
       blockPacer(64, 32) // Max and average # of block requests that can be made per second
 {
     inFlight = 0;
-    // maxInFlight = 256;
+    nOutbound = 0;
 
     sendIter = mapTxnInfo.end();
     sendBlkIter = mapBlkInfo.end();
@@ -1112,7 +1112,7 @@ bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
                 // to drain the queue for any blocks that are still returning.  This prevents us from having to
                 // re-request all those blocks
                 // again.
-                if (vNodes.size() >= nMaxOutConnections - 1 && IsInitialBlockDownload() &&
+                if (requester.nOutbound >= nMaxOutConnections - 1 && IsInitialBlockDownload() &&
                     nIterations > nOverallRange && pnode->nAvgBlkResponseTime > nOverallAverageResponseTime * 4)
                 {
                     LOGA("disconnecting %s because too slow , overall avg %d peer avg %d\n", pnode->GetLogName(),

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -207,7 +207,10 @@ public:
     void MapBlocksInFlightErase(const uint256 &hash, NodeId nodeid);
     bool MapBlocksInFlightEmpty();
     void MapBlocksInFlightClear();
+
+    // Methods for handling mapRequestManagerNodeState which is protected.
     void GetBlocksInFlight(std::vector<uint256> &vBlocksInFlight, NodeId nodeid);
+    int GetNumBlocksInFlight(NodeId nodeid);
 
     // Remove a request manager node from the nodestate map.
     void RemoveNodeState(NodeId nodeid)

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -135,7 +135,6 @@ protected:
     OdMap::iterator sendBlkIter;
 
     int inFlight;
-    // int maxInFlight;
     CStatHistory<int> inFlightTxns;
     CStatHistory<int> receivedTxns;
     CStatHistory<int> rejectedTxns;
@@ -151,6 +150,9 @@ protected:
 
 public:
     CRequestManager();
+
+    // How many outbound nodes are we connected to.
+    std::atomic<int32_t> nOutbound;
 
     // Get this object from somewhere, asynchronously.
     void AskFor(const CInv &obj, CNode *from, unsigned int priority = 0);

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -220,7 +220,7 @@ public:
     }
 
     // Check for block download timeout and disconnect node if necessary.
-    void CheckForDownloadTimeout(CNode *pnode, const Consensus::Params &consensusParams, int64_t nNow);
+    void DisconnectOnDownloadTimeout(CNode *pnode, const Consensus::Params &consensusParams, int64_t nNow);
 };
 
 

--- a/src/util.h
+++ b/src/util.h
@@ -150,7 +150,8 @@ enum
 
     SELECTCOINS = 0x1000000,
     ZMQ = 0x2000000,
-    QT = 0x4000000
+    QT = 0x4000000,
+    IBD = 0x8000000
 };
 
 // Add corresponding lower case string for the category:
@@ -161,7 +162,7 @@ enum
             {PARTITIONCHECK, "partitioncheck"}, {BENCH, "bench"}, {PRUNE, "prune"}, {REINDEX, "reindex"},       \
             {MEMPOOLREJ, "mempoolrej"}, {BLK, "blk"}, {EVICT, "evict"}, {PARALLEL, "parallel"}, {RAND, "rand"}, \
             {REQ, "req"}, {BLOOM, "bloom"}, {LCK, "lck"}, {PROXY, "proxy"}, {DBASE, "dbase"},                   \
-            {SELECTCOINS, "selectcoins"}, {ESTIMATEFEE, "estimatefee"}, {QT, "qt"},                             \
+            {SELECTCOINS, "selectcoins"}, {ESTIMATEFEE, "estimatefee"}, {QT, "qt"}, {IBD, "ibd"},               \
         {                                                                                                       \
             ZMQ, "zmq"                                                                                          \
         }                                                                                                       \


### PR DESCRIPTION
This is built on top of #1036 and requires 1036 to be merged in first.

Downloaders are pruned once all the outbound connections slots are full (minus 1). So once we hit 15 outbound peers we'll start looking for slow peers.  If we get one we issue a disconnect request.  Rather than disconnecting right away, a disconnect request will allow all the current blocks in flight for that peer to return before issuing an actual disconnect.  If the peer is hung then it will take up to 10 mins to finally disconnect the peer and hence we allow up to two disconnect requests at a time and never let our outbound peers go below (16 -2) 14.