### PR TITLE
Ensure that EB and datacarrier size are set properly after a node restart

### DIFF
--- a/qa/rpc-tests/may152018-forkactivation_1.py
+++ b/qa/rpc-tests/may152018-forkactivation_1.py
@@ -104,11 +104,11 @@ class ForkTest (BitcoinTestFramework):
         assert(self.nodes[0].get("net.excessiveBlock")["net.excessiveBlock"] == 32000000)
         assert(self.nodes[1].get("net.excessiveBlock")["net.excessiveBlock"] == 32000000)
 
-        # check that the block size is still updated
+        # check that the block size did NOT get updated.
         d = self.nodes[0].get("mining.*lockSize")
-        assert(d["mining.blockSize"] >= d["mining.forkBlockSize"])
+        assert(d["mining.blockSize"] == 2000000)
         d = self.nodes[1].get("mining.*lockSize")
-        assert(d["mining.blockSize"] >= d["mining.forkBlockSize"])
+        assert(d["mining.blockSize"] == 2000000)
 
         # check that the datacarrier size is still updated
         assert(self.nodes[0].get("mining.dataCarrierSize")["mining.dataCarrierSize"] == 223)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1131,6 +1131,21 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
         mempool.ReadFeeEstimates(est_filein);
     fFeeEstimatesInitialized = true;
 
+    // Set the EB/MG and datacarrier size if we have restarted after the fork has already happened.
+    // It is possible that we need to override the old settings in QT and bitcoin.conf.
+    if (IsMay152018Enabled(chainparams.GetConsensus(), chainActive.Tip()))
+    {
+        // Bump the accepted block size to 32MB and the default generated size to 8MB
+        if (miningForkEB.value > excessiveBlockSize)
+            excessiveBlockSize = miningForkEB.value;
+        if (miningForkMG.value > maxGeneratedBlock)
+            maxGeneratedBlock = miningForkMG.value;
+        settingsToUserAgentString();
+        // Bump OP_RETURN size:
+        if (nMaxDatacarrierBytes < MAX_OP_RETURN_MAY2018)
+            nMaxDatacarrierBytes = MAX_OP_RETURN_MAY2018;
+    }
+
 // ********************************************************* Step 7: load wallet
 
 #ifdef ENABLE_WALLET

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1131,11 +1131,11 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
         mempool.ReadFeeEstimates(est_filein);
     fFeeEstimatesInitialized = true;
 
-    // Set the EB/MG and datacarrier size if we have restarted after the fork has already happened.
+    // Set the EB and datacarrier size if we have restarted after the fork has already happened.
     // It is possible that we need to override the old settings in QT and bitcoin.conf.
     if (IsMay152018Enabled(chainparams.GetConsensus(), chainActive.Tip()))
     {
-        // Bump the accepted block size to 32MB and the default generated size to 8MB
+        // Bump the accepted block size to 32MB
         if (miningForkEB.value > excessiveBlockSize)
             excessiveBlockSize = miningForkEB.value;
         settingsToUserAgentString();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1138,8 +1138,6 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
         // Bump the accepted block size to 32MB and the default generated size to 8MB
         if (miningForkEB.value > excessiveBlockSize)
             excessiveBlockSize = miningForkEB.value;
-        if (miningForkMG.value > maxGeneratedBlock)
-            maxGeneratedBlock = miningForkMG.value;
         settingsToUserAgentString();
         // Bump OP_RETURN size:
         if (nMaxDatacarrierBytes < MAX_OP_RETURN_MAY2018)

--- a/src/main.h
+++ b/src/main.h
@@ -571,6 +571,9 @@ static const unsigned int REJECT_WRONG_FORK = 0x103;
 
 CBlockIndex *FindMostWorkChain();
 
+/** Test if fork is active */
+bool IsMay152018Enabled(const Consensus::Params &consensusparams, const CBlockIndex *pindexPrev);
+
 // BU cleaning up at destuction time creates many global variable dependencies.  Instead clean up in a function called
 // in main()
 #if 0

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -22,7 +22,7 @@ int64_t GetTime()
     if (nMockTime)
         return nMockTime;
 
-    time_t now = time(NULL);
+    time_t now = time(nullptr);
     assert(now > 0);
     return now;
 }


### PR DESCRIPTION
After the fork if a node restarts we need to make sure that the settings
are properly enabled during intitialization.