### PR TITLE
Updates for Floweethehub

### DIFF
--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -70,12 +70,13 @@ class AuthServiceProxy(object):
     __id_count = 0
 
     # ensure_ascii: escape unicode as \uXXXX, passed to json.dumps
-    def __init__(self, service_url, service_name=None, timeout=HTTP_TIMEOUT, connection=None, ensure_ascii=True):
+    def __init__(self, service_url, service_name=None, timeout=HTTP_TIMEOUT, connection=None, ensure_ascii=True, miningCapable=None):
         self.__timeout = timeout
         self.__service_url = service_url
         self._service_name = service_name
         self.ensure_ascii = ensure_ascii # can be toggled on the fly by tests
         self.__url = urlparse.urlparse(service_url)
+        self.miningCapable = miningCapable
         if self.__url.port is None:
             port = 80
         else:

--- a/qa/rpc-tests/test_framework/coverage.py
+++ b/qa/rpc-tests/test_framework/coverage.py
@@ -59,6 +59,9 @@ class AuthServiceProxyWrapper(object):
     def url(self):
         return self.auth_service_proxy_instance.url
 
+    @property
+    def miningCapable(self):
+        return self.auth_service_proxy_instance.miningCapable
 
 def get_filename(dirname, n_node):
     """

--- a/qa/rpc-tests/test_framework/floweeconst.py
+++ b/qa/rpc-tests/test_framework/floweeconst.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php
+
+#
+# Const for Floweethehub integration
+#
+BITCOIN_CONF = "flowee.conf"  #see SettingsDefaults.h
+HUB_LOG = "hub.log"           # debug.log is used by other clients
+BCD_HUB_PATH = "/hub/debug/src/bitcoind"
+NODE_NUM = 3               # node3 is for Hub
+CONF_IN_CACHE = "cache/node" + str(NODE_NUM) + "/" + BITCOIN_CONF
+# unrecoginized parameters by flowee
+FILTER_PARAM_KEYS = ['usecashaddr', 'maxlimitertxfee', 'debug']


### PR DESCRIPTION
Changes required for integrating Floweethehub to cashInterOp project

1. using non-standard files: flowee.conf and hub.log (instead of bitcoin.conf and debug.log)
2. generate() interface changes: requires two arguments : "blocks", and "pubkey" (other clients only require "blocks"
3. filter out unrecognized opt parameters (usecashaddr, maxlimitertxfee, and debug)