### PR TITLE
Allow a nonstandard tx to be submitted via the sendrawtransaction RPC call

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -358,6 +358,18 @@ bool IsDAAEnabled(const Consensus::Params &consensusparams, const CBlockIndex *p
  */
 bool AreFreeTxnsDisallowed();
 
+/** Communicate what class of transaction is acceptable to add to the memory pool
+ */
+enum class TransactionClass
+{
+    INVALID,
+    DEFAULT,
+    STANDARD,
+    NONSTANDARD
+};
+
+TransactionClass ParseTransactionClass(const std::string &s);
+
 /** (try to) add transaction to memory pool **/
 bool AcceptToMemoryPool(CTxMemPool &pool,
     CValidationState &state,
@@ -365,7 +377,8 @@ bool AcceptToMemoryPool(CTxMemPool &pool,
     bool fLimitFree,
     bool *pfMissingInputs,
     bool fOverrideMempoolLimit = false,
-    bool fRejectAbsurdFee = false);
+    bool fRejectAbsurdFee = false,
+    TransactionClass allowedTx = TransactionClass::DEFAULT);
 
 /** Convert CValidationState to a human-readable message for logging */
 std::string FormatStateMessage(const CValidationState &state);


### PR DESCRIPTION
Since there are currently no templates defined for the extended opcodes, this node will reject these transactions as nonstandard (so the extended opcodes can only be used as P2SH formatted tx).  This RPC allows a user or miner to override this behavior, allowing specific transactions to be placed in the mempool even if they are nonstandard.  This will allow layer 2 applications to integrate with miners to allow some mining of nonstandard tx.