### PR TITLE
Make nBlockSize private in block.h

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3625,13 +3625,13 @@ bool ContextualCheckBlock(const CBlock &block, CValidationState &state, CBlockIn
     // TODO: check if we can remove the second conditions since on regtest uahHeight is 0
     if (pindexPrev && UAHFforkAtNextBlock(pindexPrev->nHeight) && (pindexPrev->nHeight > 1))
     {
-        DbgAssert(block.nBlockSize, );
-        if (block.nBlockSize <= BLOCKSTREAM_CORE_MAX_BLOCK_SIZE)
+        DbgAssert(block.GetBlockSize(), );
+        if (block.GetBlockSize() <= BLOCKSTREAM_CORE_MAX_BLOCK_SIZE)
         {
             uint256 hash = block.GetHash();
             return state.DoS(100,
                 error("%s: UAHF fork block (%s, height %d) must exceed %d, but this block is %d bytes", __func__,
-                                 hash.ToString(), nHeight, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE, block.nBlockSize),
+                                 hash.ToString(), nHeight, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE, block.GetBlockSize()),
                 REJECT_INVALID, "bad-blk-too-small");
         }
     }
@@ -3897,7 +3897,7 @@ bool ProcessNewBlock(CValidationState &state,
 
         LOG(BENCH,
             "ProcessNewBlock, time: %d, block: %s, len: %d, numTx: %d, maxVin: %llu, maxVout: %llu, maxTx:%llu\n",
-            end - start, pblock->GetHash().ToString(), pblock->nBlockSize, pblock->vtx.size(), maxVin, maxVout,
+            end - start, pblock->GetHash().ToString(), pblock->GetBlockSize(), pblock->vtx.size(), maxVin, maxVout,
             maxTxSize);
         LOG(BENCH, "tx: %s, vin: %llu, vout: %llu, len: %d\n", txIn.GetHash().ToString(), txIn.vin.size(),
             txIn.vout.size(), ::GetSerializeSize(txIn, SER_NETWORK, PROTOCOL_VERSION));

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -162,7 +162,7 @@ CBlockTemplate *BlockAssembler::CreateNewBlock(const CScript &scriptPubKeyIn)
         tmpl = CreateNewBlock(scriptPubKeyIn, false);
 
     // If the block is too small we need to drop back to the 1MB ruleset
-    if ((!tmpl) || (tmpl->block.nBlockSize <= BLOCKSTREAM_CORE_MAX_BLOCK_SIZE))
+    if ((!tmpl) || (tmpl->block.GetBlockSize() <= BLOCKSTREAM_CORE_MAX_BLOCK_SIZE))
     {
         tmpl = CreateNewBlock(scriptPubKeyIn, true);
     }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -70,6 +70,10 @@ public:
 
 class CBlock : public CBlockHeader
 {
+private:
+    // memory only
+    mutable uint64_t nBlockSize; // Serialized block size in bytes
+
 public:
     // network and disk
     std::vector<CTransactionRef> vtx;
@@ -78,7 +82,6 @@ public:
     // 0.11: mutable std::vector<uint256> vMerkleTree;
     mutable bool fChecked;
     mutable bool fExcessive; // BU: is the block "excessive" (bigger than this node prefers to accept)
-    mutable uint64_t nBlockSize; // Serialized block size in bytes
 
     CBlock() { SetNull(); }
     CBlock(const CBlockHeader &header)

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -177,11 +177,11 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
         BOOST_CHECK(pblocktemplate);
         BOOST_CHECK(pblocktemplate->block.fExcessive == false);
-        BOOST_CHECK(pblocktemplate->block.nBlockSize <= maxGeneratedBlock);
+        BOOST_CHECK(pblocktemplate->block.GetBlockSize() <= maxGeneratedBlock);
         unsigned int blockSize = ::GetSerializeSize(pblocktemplate->block, SER_NETWORK, CBlock::CURRENT_VERSION);
         BOOST_CHECK(blockSize <= maxGeneratedBlock);
         // printf("%lu %lu <= %lu\n", (long unsigned int) blockSize, (long unsigned int)
-        // pblocktemplate->block.nBlockSize, (long unsigned int) maxGeneratedBlock);
+        // pblocktemplate->block.GetBlockSize(), (long unsigned int) maxGeneratedBlock);
         delete pblocktemplate;
     }
 
@@ -200,12 +200,12 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
         BOOST_CHECK(pblocktemplate);
         BOOST_CHECK(pblocktemplate->block.fExcessive == false);
-        BOOST_CHECK(pblocktemplate->block.nBlockSize <= maxGeneratedBlock - 4);
+        BOOST_CHECK(pblocktemplate->block.GetBlockSize() <= maxGeneratedBlock - 4);
         unsigned int blockSize = ::GetSerializeSize(pblocktemplate->block, SER_NETWORK, CBlock::CURRENT_VERSION);
         BOOST_CHECK(blockSize <= maxGeneratedBlock - 4);
         minRoom = std::min(minRoom, maxGeneratedBlock - blockSize);
         // printf("%lu %lu <= %lu\n", (long unsigned int) blockSize, (long unsigned int)
-        // pblocktemplate->block.nBlockSize, (long unsigned int) maxGeneratedBlock);
+        // pblocktemplate->block.GetBlockSize(), (long unsigned int) maxGeneratedBlock);
         delete pblocktemplate;
     }
 
@@ -229,12 +229,12 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
         BOOST_CHECK(pblocktemplate);
         BOOST_CHECK(pblocktemplate->block.fExcessive == false);
-        BOOST_CHECK(pblocktemplate->block.nBlockSize <= maxGeneratedBlock - 2);
+        BOOST_CHECK(pblocktemplate->block.GetBlockSize() <= maxGeneratedBlock - 2);
         unsigned int blockSize = ::GetSerializeSize(pblocktemplate->block, SER_NETWORK, CBlock::CURRENT_VERSION);
         BOOST_CHECK(blockSize <= maxGeneratedBlock - 2);
         minRoom = std::min(minRoom, maxGeneratedBlock - blockSize);
         // printf("%lu %lu (miner comment is %d) <= %lu\n", (long unsigned int) blockSize, (long unsigned int)
-        // pblocktemplate->block.nBlockSize, i%100, (long unsigned int) maxGeneratedBlock);
+        // pblocktemplate->block.GetBlockSize(), i%100, (long unsigned int) maxGeneratedBlock);
         delete pblocktemplate;
     }
 


### PR DESCRIPTION
This forces everyone to use GetBlockSize() and ensures that
the expensive ::GetSerializeSize() is only called once per block.

It also ensures that nBlockSize has been set and is not zero by accident.