### PR TITLE
Always set the fIsInitialBlockDownload to true before startup

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -56,13 +56,6 @@ std::map<std::pair<void *, void *>, LockStack> lockorders;
 boost::thread_specific_ptr<LockStack> lockstack;
 #endif
 
-
-// We always start with true so that when ActivateBestChain is called during the startup (init.cpp)
-// and we havn't finished initial sync then we don't accidentally trigger the auto-dbcache
-// resize. After ActivateBestChain the fIsInitialBlockDownload flag is set to true or false depending
-// on whether we really have finished sync or not.
-std::atomic<bool> fIsInitialBlockDownload{true};
-
 // this flag is set to true when a wallet rescan has been invoked.
 std::atomic<bool> fRescan{false};
 

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -57,8 +57,14 @@ boost::thread_specific_ptr<LockStack> lockstack;
 #endif
 
 
-std::atomic<bool> fIsInitialBlockDownload{false};
-std::atomic<bool> fRescan{false}; // this flag is set to true when a wallet rescan has been invoked.
+// We always start with true so that when ActivateBestChain is called during the startup (init.cpp)
+// and we havn't finished initial sync then we don't accidentally trigger the auto-dbcache
+// resize. After ActivateBestChain the fIsInitialBlockDownload flag is set to true or false depending
+// on whether we really have finished sync or not.
+std::atomic<bool> fIsInitialBlockDownload{true};
+
+// this flag is set to true when a wallet rescan has been invoked.
+std::atomic<bool> fRescan{false};
 
 CStatusString statusStrings;
 // main.cpp CriticalSections:

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -43,8 +43,6 @@
 //    dummyNode1.nVersion = MIN_PEER_PROTO_VERSION;
 //    dummyNode1.fSuccessfullyConnected = true;
 
-extern std::atomic<bool> fIsInitialBlockDownload;
-
 CBlock TestBlock1() // Thanks dagurval :)
 {
     // Block taken from bloom_tests.cpp merkle_block_1
@@ -486,7 +484,8 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     {
         fImporting = false;
         fReindex = false;
-        fIsInitialBlockDownload.store(false);
+        bool fInit = false;
+        IsInitialBlockDownloadInit(&fInit);
 
         CBloomFilter filter;
         std::vector<uint256> vOrphanHashes;

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -53,7 +53,13 @@ using namespace std;
 extern CTxMemPool mempool; // from main.cpp
 static atomic<uint64_t> nLargestBlockSeen{BLOCKSTREAM_CORE_MAX_BLOCK_SIZE}; // track the largest block we've seen
 static atomic<bool> fIsChainNearlySyncd{false};
-extern atomic<bool> fIsInitialBlockDownload;
+
+// We always start with true so that when ActivateBestChain is called during the startup (init.cpp)
+// and we havn't finished initial sync then we don't accidentally trigger the auto-dbcache
+// resize. After ActivateBestChain the fIsInitialBlockDownload flag is set to true or false depending
+// on whether we really have finished sync or not.
+static std::atomic<bool> fIsInitialBlockDownload{true};
+
 extern CTweakRef<uint64_t> miningBlockSize;
 extern CTweakRef<uint64_t> ebTweak;
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1222,8 +1222,15 @@ UniValue settrafficshaping(const UniValue &params, bool fHelp)
 
 // fIsInitialBlockDownload is updated only during startup and whenever we receive a header.
 // This way we avoid having to lock cs_main so often which tends to be a bottleneck.
-void IsInitialBlockDownloadInit()
+void IsInitialBlockDownloadInit(bool *fInit)
 {
+    // For unit testing purposes, this step allows us to explicitly set the state of block sync.
+    if (fInit)
+    {
+        fIsInitialBlockDownload.store(*fInit);
+        return;
+    }
+
     const CChainParams &chainParams = Params();
     LOCK(cs_main);
     if (!pindexBestHeader)

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -209,7 +209,7 @@ extern bool IsTrafficShapingEnabled();
 
 // Check whether we are doing an initial block download (synchronizing from disk or network)
 extern bool IsInitialBlockDownload();
-extern void IsInitialBlockDownloadInit();
+extern void IsInitialBlockDownloadInit(bool *fInit = nullptr);
 
 // Check whether we are nearly sync'd.  Used primarily to determine whether an xthin can be retrieved.
 extern bool IsChainNearlySyncd();


### PR DESCRIPTION
Otherwise we may accidentally trigger the auto dbcache resize
before initial sync is acually complete. This could happen for instance
when an operator has stopped their node and restarted before initial
sync was completed or perhaps re-started their node after many months
of downtime.