### PR TITLE
Properly check whether a transaction was previously in a block or not

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -204,7 +204,7 @@ CCriticalSection cs_recentRejects;
  *
  * Memory used: 1.7MB
  */
-boost::scoped_ptr<CRollingBloomFilter> recentRejects GUARDED_BY(cs_recentRejects);
+std::unique_ptr<CRollingBloomFilter> recentRejects GUARDED_BY(cs_recentRejects);
 uint256 hashRecentRejectsChainTip;
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4987,7 +4987,7 @@ bool AlreadyHave(const CInv &inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
     case MSG_TX:
     {
         LOCK(cs_recentRejects);
-        // remove assertions from P2P code, but this should hold: assert(recentRejects);
+        DbgAssert(recentRejects, return false);
         if (chainActive.Tip()->GetBlockHash() != hashRecentRejectsChainTip)
         {
             // If the chain tip has changed previously rejected transactions

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5594,8 +5594,6 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         if (pfrom->fWhitelisted && GetBoolArg("-whitelistrelay", DEFAULT_WHITELISTRELAY))
             fBlocksOnly = false;
 
-        LOCK(cs_main);
-
         for (unsigned int nInv = 0; nInv < vInv.size(); nInv++)
         {
             boost::this_thread::interruption_point();
@@ -5603,6 +5601,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             const CInv &inv = vInv[nInv];
             if (inv.type == MSG_BLOCK)
             {
+                LOCK(cs_main);
                 bool fAlreadyHaveBlock = AlreadyHaveBlock(inv);
                 LOG(NET, "got inv: %s  %s peer=%d\n", inv.ToString(), fAlreadyHaveBlock ? "have" : "new", pfrom->id);
 
@@ -5649,7 +5648,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                     requester.AskFor(inv, pfrom);
             }
 
-            // Track requests for our stuff
+            // Track requests for our stuff.
             GetMainSignals().Inventory(inv.hash);
 
             if (pfrom->nSendSize > (SendBufferSize() * 2))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5004,9 +5004,11 @@ bool AlreadyHave(const CInv &inv) EXCLUSIVE_LOCKS_REQUIRED(cs_main)
                 recentRejects.reset(new CRollingBloomFilter(120000, 0.000001));
             }
         }
-        if (txn_recently_in_block->contains(inv.hash)) return true;
-        bool rrc = recentRejects ? recentRejects->contains(inv.hash) : false;
-        return rrc || mempool.exists(inv.hash) || orphanpool.AlreadyHaveOrphan(inv.hash);
+        if (txn_recently_in_block->contains(inv.hash))
+            return true;
+        if (recentRejects->contains(inv.hash))
+            return true;
+        return mempool.exists(inv.hash) || orphanpool.AlreadyHaveOrphan(inv.hash);
     }
     case MSG_BLOCK:
     case MSG_XTHINBLOCK:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4471,7 +4471,13 @@ bool InitBlockIndex(const CChainParams &chainparams)
     {
         LOCK(cs_recentRejects);
         recentRejects.reset(new CRollingBloomFilter(120000, 0.000001));
-        txn_recently_in_block.reset(new CRollingBloomFilter(16000 /* just a few block's worth */, 0.000001));
+
+        // Using an average 500 bytes per transaction to calculate number of bloom filter elements.
+        //
+        // We hold a maximum of two blocks worth of data in the event that two blocks
+        // are mined very close in time. But in general we only need one block of data.
+        uint32_t nElements = 2 * excessiveBlockSize / 500;
+        txn_recently_in_block.reset(new CRollingBloomFilter(nElements, 0.000001));
     }
 
     // Check whether we're already initialized

--- a/src/main.h
+++ b/src/main.h
@@ -270,7 +270,10 @@ bool LoadBlockIndex();
 void UnloadBlockIndex();
 /** Process protocol messages received from a given node */
 bool ProcessMessages(CNode *pfrom);
-bool AlreadyHave(const CInv &);
+/** Do we already have this transaction or has it been seen in a block */
+bool AlreadyHaveTx(const CInv &inv);
+/** Do we already have this block on disk */
+bool AlreadyHaveBlock(const CInv &inv);
 bool AcceptBlockHeader(const CBlockHeader &block,
     CValidationState &state,
     const CChainParams &chainparams,

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -875,7 +875,7 @@ void CRequestManager::RequestNextBlocksToDownload(CNode *pto)
         for (CBlockIndex *pindex : vToDownload)
         {
             CInv inv(MSG_BLOCK, pindex->GetBlockHash());
-            if (!AlreadyHave(inv))
+            if (!AlreadyHaveBlock(inv))
             {
                 vGetBlocks.emplace_back(inv);
                 // LOG(REQ, "AskFor block %s (%d) peer=%s\n", pindex->GetBlockHash().ToString(),

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -109,7 +109,7 @@ bool CThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     bool fAlreadyHave = false;
     {
         LOCK(cs_main);
-        fAlreadyHave = AlreadyHave(inv);
+        fAlreadyHave = AlreadyHaveBlock(inv);
     }
     if (fAlreadyHave)
     {
@@ -322,7 +322,7 @@ bool CXThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     bool fAlreadyHave = false;
     {
         LOCK(cs_main);
-        fAlreadyHave = AlreadyHave(inv);
+        fAlreadyHave = AlreadyHaveBlock(inv);
     }
     if (fAlreadyHave)
     {


### PR DESCRIPTION
The current method is somewhat undesirable in that it requires a lock on cs_utxo (which by the way is missing to begin with). Furthermore it is not accurate in that you can't count on coins actually being in the cache as proof of previous existence of transaction because coins can be uncached when the mempool or orphanpool is full.

We also get the benefit here of reducing the scope of cs_main when receiving transaction inventory.