### PR TITLE
Support compilation with libboost version 1.54

### DIFF
--- a/src/test/cashaddrenc_tests.cpp
+++ b/src/test/cashaddrenc_tests.cpp
@@ -139,8 +139,8 @@ BOOST_AUTO_TEST_CASE(invalid_on_wrong_network)
                 continue;
 
             std::string encoded = EncodeCashAddr(dst, Params(net));
-            CTxDestination decoded = DecodeCashAddr(encoded, Params(otherNet));
-            BOOST_CHECK(decoded != dst);
+            const CTxDestination decoded = DecodeCashAddr(encoded, Params(otherNet));
+            BOOST_CHECK(!(decoded == dst));
             BOOST_CHECK(decoded == invalidDst);
         }
     }
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(check_padding)
     {
         data[data.size() - 1] = i;
         std::string fake = cashaddr::Encode(params.CashAddrPrefix(), data);
-        CTxDestination dst = DecodeCashAddr(fake, params);
+        const CTxDestination dst = DecodeCashAddr(fake, params);
 
         // We have 168 bits of payload encoded as 170 bits in 5 bits nimbles. As
         // a result, we must have 2 zeros.
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(check_padding)
         }
         else
         {
-            BOOST_CHECK(dst != nodst);
+            BOOST_CHECK(!(dst == nodst));
         }
     }
 }


### PR DESCRIPTION
The configure.ac script allows even lower versions of boost to be used.
However, in cashaddrenc_tests.cpp, there is the assumption that
boost::variant has an operator!=(..) defined, though it has not.
See e.g.:

https://www.boost.org/doc/libs/1_54_0/doc/html/boost/variant.html

This works around the missing operator by using operator==(..) instead.

It also makes two variables const, as they can be made const.