### PR TITLE
 Fuzzer update

### DIFF
--- a/doc/fuzzing.md
+++ b/doc/fuzzing.md
@@ -5,6 +5,10 @@ A special test harness `test_bitcoin_fuzzy` is provided to provide an easy
 entry point for fuzzers and the like. In this document we'll describe how to
 use it with AFL.
 
+Compared to Bitcoin Core, this test harness has been updated to both
+remove some redundant code as well as to provide entry points for fuzzing
+single data structures.
+
 Building AFL
 -------------
 
@@ -28,9 +32,13 @@ export AFL_HARDEN=1
 cd src/
 make test/test_bitcoin_fuzzy
 ```
-We disable ccache because we don't want to pollute the ccache with instrumented
-objects, and similarly don't want to use non-instrumented cached objects linked
-in.
+
+Disabling ccache should be optional here, and is added above solely to save some HDD
+space.
+
+The fuzzer is _a lot_ faster now when run in LLVM persistent mode. To enable LLVM persistent mode,
+bitcoin_test_fuzzy has to be built with clang/clang++. For this replace the
+above mentions of `afl-gcc` and `afl-g++` with `afl-clang-fast` and afl-clang-fast++`.
 
 Preparing fuzzing
 ------------------
@@ -46,7 +54,8 @@ mkdir outputs
 AFLOUT=$PWD/outputs
 ```
 
-Example inputs are available from:
+For the old fuzzing code that fuzzes everything at once, example inputs might still
+be available from:
 
 - https://download.visucore.com/bitcoin/bitcoin_fuzzy_in.tar.xz
 - http://strateman.ninja/fuzzing.tar.xz
@@ -56,11 +65,37 @@ Extract these (or other starting inputs) into the `inputs` directory before star
 Fuzzing
 --------
 
-To start the actual fuzzing use:
+To start the actual fuzzing and to fuzz all fuzz cases at once:
 ```
-$AFLPATH/afl-fuzz -i ${AFLIN} -o ${AFLOUT} -m52 -- test/test_bitcoin_fuzzy
+$AFLPATH/afl-fuzz -i ${AFLIN} -o ${AFLOUT} -m 200 -- test/test_bitcoin_fuzzy
+```
+
+And to fuzz using just a single fuzzing entrypoint, specify a corresponding command line
+argument to test_bitcoin_fuzzy on what to fuzz. A list of all possible
+arguments can be printed like this:
+```
+test/test_bitcoin_fuzzy list_tests
+```
+
+So, for example, to fuzz the CBlock de-/serialization, you can use this:
+```
+$AFLPATH/afl-fuzz -i ${AFLIN} -o ${AFLOUT} -m 200 -- test/test_bitcoin_fuzzy cblock_deser
 ```
 
 You may have to change a few kernel parameters to test optimally - `afl-fuzz`
 will print an error and suggestion if so.
+
+The memory limit of 200MB above (`-m 200`) might be generous. If you suspect that code might
+have some memory leaks and you want to test for that specifically, try lowering the limit 
+until about just before fuzzing breaks every time.
+Further information can be found in the AFL documentation.
+
+
+Extending
+---------
+
+The code has been updated to be more easily extensible. In test_bitcoin_fuzzy.cpp, 
+simply derive a class from `FuzzTest` or, alternatively, `FuzzTestNet` (in case you want
+to read from a network-like CDataStream). Override the `run()` method and either use
+the `buffer` object or the `ds` object to retrieve the data for your test.
 

--- a/src/test/cashaddrenc_tests.cpp
+++ b/src/test/cashaddrenc_tests.cpp
@@ -139,8 +139,8 @@ BOOST_AUTO_TEST_CASE(invalid_on_wrong_network)
                 continue;
 
             std::string encoded = EncodeCashAddr(dst, Params(net));
-            CTxDestination decoded = DecodeCashAddr(encoded, Params(otherNet));
-            BOOST_CHECK(decoded != dst);
+            const CTxDestination decoded = DecodeCashAddr(encoded, Params(otherNet));
+            BOOST_CHECK(!(decoded == dst));
             BOOST_CHECK(decoded == invalidDst);
         }
     }
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(check_padding)
     {
         data[data.size() - 1] = i;
         std::string fake = cashaddr::Encode(params.CashAddrPrefix(), data);
-        CTxDestination dst = DecodeCashAddr(fake, params);
+        const CTxDestination dst = DecodeCashAddr(fake, params);
 
         // We have 168 bits of payload encoded as 170 bits in 5 bits nimbles. As
         // a result, we must have 2 zeros.
@@ -209,7 +209,7 @@ BOOST_AUTO_TEST_CASE(check_padding)
         }
         else
         {
-            BOOST_CHECK(dst != nodst);
+            BOOST_CHECK(!(dst == nodst));
         }
     }
 }

--- a/src/test/test_bitcoin_fuzzy.cpp
+++ b/src/test/test_bitcoin_fuzzy.cpp
@@ -7,6 +7,7 @@
 #endif
 
 #include "addrman.h"
+#include "cashaddr.h"
 #include "chain.h"
 #include "coins.h"
 #include "compressor.h"
@@ -15,39 +16,254 @@
 #include "primitives/block.h"
 #include "protocol.h"
 #include "pubkey.h"
+#include "script/interpreter.h"
 #include "script/script.h"
 #include "streams.h"
 #include "undo.h"
+#include "util.h"
+#include "utilmoneystr.h"
+#include "utilstrencodings.h"
 #include "version.h"
 
 #include <stdint.h>
 #include <unistd.h>
 
 #include <algorithm>
+#include <map>
+//#include <iostream>
 #include <vector>
 
-enum TEST_ID
+class FuzzTest;
+
+static std::map<std::string, FuzzTest *> registry;
+static std::vector<FuzzTest *> registry_seq;
+
+class FuzzTest
 {
-    CBLOCK_DESERIALIZE = 0,
-    CTRANSACTION_DESERIALIZE,
-    CBLOCKLOCATOR_DESERIALIZE,
-    CBLOCKMERKLEROOT,
-    CADDRMAN_DESERIALIZE,
-    CBLOCKHEADER_DESERIALIZE,
-    CBANENTRY_DESERIALIZE,
-    CTXUNDO_DESERIALIZE,
-    CBLOCKUNDO_DESERIALIZE,
-    CCOINS_DESERIALIZE,
-    CNETADDR_DESERIALIZE,
-    CSERVICE_DESERIALIZE,
-    CMESSAGEHEADER_DESERIALIZE,
-    CADDRESS_DESERIALIZE,
-    CINV_DESERIALIZE,
-    CBLOOMFILTER_DESERIALIZE,
-    CDISKBLOCKINDEX_DESERIALIZE,
-    CTXOUTCOMPRESSOR_DESERIALIZE,
-    TEST_ID_END
+public:
+    FuzzTest(const std::string &name)
+    {
+        assert(registry.count(name) == 0);
+        registry[name] = this;
+        registry_seq.push_back(this);
+    }
+    ~FuzzTest() {}
+    //! initialize with input data before testing
+    virtual void init(const std::vector<char> &_buffer) { buffer = _buffer; }
+    //! run the fuzz test once - calls internal virtual method run()
+    virtual int operator()()
+    {
+        run();
+        return 0;
+    }
+
+protected:
+    std::vector<char> buffer;
+    //! override this with the actual test
+    virtual void run() = 0;
 };
+
+/*! fuzz test that uses network message decoding
+  and cleanly shuts down for std::ios_base::failures. */
+class FuzzTestNet : public FuzzTest
+{
+public:
+    FuzzTestNet(const std::string &name) : FuzzTest(name), ds(nullptr) {}
+    void init(const std::vector<char> &buffer)
+    {
+        FuzzTest::init(buffer);
+        if (ds != nullptr)
+            delete ds;
+        ds = new CDataStream(buffer, SER_NETWORK, INIT_PROTO_VERSION);
+        int nVersion;
+        *ds >> nVersion;
+        ds->SetVersion(nVersion);
+    }
+    ~FuzzTestNet()
+    {
+        delete ds;
+        ds = nullptr;
+    }
+    virtual int operator()()
+    {
+        try
+        {
+            run();
+            return 0;
+        }
+        catch (const std::ios_base::failure &e)
+        {
+            return 0;
+        }
+    }
+
+protected:
+    CDataStream *ds;
+};
+
+template <class T>
+class FuzzDeserNet : public FuzzTestNet
+{
+public:
+    FuzzDeserNet(std::string classname) : FuzzTestNet(classname + "_deser") {}
+protected:
+    void run()
+    {
+        T value;
+        *ds >> value;
+        // FIXME: trying reserialization here, as well
+    }
+};
+
+class FuzzBlockMerkleRoot : FuzzTestNet
+{
+public:
+    FuzzBlockMerkleRoot() : FuzzTestNet("cblockmerkleroot_deser") {}
+protected:
+    void run()
+    {
+        CBlock block;
+        *ds >> block;
+        bool mutated;
+        BlockMerkleRoot(block, &mutated);
+    }
+};
+
+
+class FuzzCMessageHeader : FuzzTestNet
+{
+public:
+    FuzzCMessageHeader() : FuzzTestNet("cmessageheader_deser") {}
+protected:
+    void run()
+    {
+        CMessageHeader::MessageStartChars pchMessageStart = {0x00, 0x00, 0x00, 0x00};
+        CMessageHeader mh(pchMessageStart);
+        *ds >> mh;
+        mh.IsValid(pchMessageStart);
+    }
+};
+
+class FuzzCTxOutCompressor : FuzzTestNet
+{
+public:
+    FuzzCTxOutCompressor() : FuzzTestNet("ctxoutcompressor_deser") {}
+protected:
+    void run()
+    {
+        CTxOut to;
+        CTxOutCompressor toc(to);
+        *ds >> toc;
+    }
+};
+
+class FuzzWildmatch : FuzzTest
+{
+public:
+    FuzzWildmatch() : FuzzTest("wildmatch") {}
+protected:
+    void run()
+    {
+        std::vector<char>::iterator splitpoint = std::find(buffer.begin(), buffer.end(), '\0');
+        std::string pattern(buffer.begin(), splitpoint);
+        std::string test;
+        if (splitpoint + 1 <= buffer.end())
+            test = std::string(splitpoint + 1, buffer.end());
+        wildmatch(pattern, test);
+    }
+};
+
+class FuzzCashAddrEncDec : FuzzTest
+{
+public:
+    FuzzCashAddrEncDec() : FuzzTest("cashaddr_encdec") {}
+protected:
+    void run()
+    {
+        std::vector<char>::iterator splitpoint = std::find(buffer.begin(), buffer.end(), '\0');
+        std::string prefix(buffer.begin(), splitpoint);
+        std::vector<uint8_t> values;
+        if (splitpoint + 1 <= buffer.end())
+            values = std::vector<uint8_t>(splitpoint + 1, buffer.end());
+        std::string encoded = cashaddr::Encode(prefix, values);
+        // FIXME: this is a quite special test and needs to be made more geneal
+        std::pair<std::string, std::vector<uint8_t> > dec = cashaddr::Decode(encoded, prefix);
+        // assert(dec.first == prefix);
+        // assert(dec.second == values);
+    }
+};
+
+class FuzzCashAddrDecode : FuzzTest
+{
+public:
+    FuzzCashAddrDecode() : FuzzTest("cashaddr_decode") {}
+protected:
+    void run()
+    {
+        std::vector<char>::iterator splitpoint = std::find(buffer.begin(), buffer.end(), '\0');
+        std::string prefix(buffer.begin(), splitpoint);
+        std::string test;
+        if (splitpoint + 1 <= buffer.end())
+            test = std::string(splitpoint + 1, buffer.end());
+        std::pair<std::string, std::vector<uint8_t> > dec = cashaddr::Decode(test, prefix);
+    }
+};
+
+class FuzzParseMoney : FuzzTest
+{
+public:
+    FuzzParseMoney() : FuzzTest("parsemoney") {}
+protected:
+    void run()
+    {
+        std::string test(buffer.begin(), buffer.end());
+        CAmount nRet;
+        ParseMoney(test, nRet);
+    }
+};
+
+
+class FuzzParseFixedPoint : FuzzTest
+{
+public:
+    FuzzParseFixedPoint() : FuzzTest("parsefixedpoint") {}
+protected:
+    void run()
+    {
+        int decimals = buffer[0];
+        std::string test(buffer.begin() + 1, buffer.end());
+        int64_t amount_out;
+        ParseFixedPoint(test, decimals, &amount_out);
+    }
+};
+
+
+class FuzzVerifyScript : FuzzTestNet
+{
+public:
+    FuzzVerifyScript() : FuzzTestNet("verifyscript") {}
+protected:
+    void run()
+    {
+        std::vector<std::vector<unsigned char> > stack;
+        std::vector<unsigned char> scriptsig_raw, scriptpubkey_raw;
+        unsigned int flags;
+
+        *ds >> flags;
+        *ds >> stack;
+        *ds >> scriptsig_raw;
+        *ds >> scriptpubkey_raw;
+
+        if ((flags & SCRIPT_VERIFY_CLEANSTACK) != 0)
+            flags |= SCRIPT_VERIFY_P2SH;
+
+        ScriptError error;
+        unsigned char sighashtype;
+        CScript script_sig(scriptsig_raw), script_pubkey(scriptpubkey_raw);
+        VerifyScript(script_sig, script_pubkey, flags, BaseSignatureChecker(), &error, &sighashtype);
+    }
+};
+
 
 bool read_stdin(std::vector<char> &data)
 {
@@ -63,282 +279,128 @@ bool read_stdin(std::vector<char> &data)
     return length == 0;
 }
 
+class FuzzTester : FuzzTest
+{
+public:
+    FuzzTester() : FuzzTest("tester") {}
+protected:
+    void run()
+    {
+        // Just a very simple test to make sure that the AFL
+        // drill down heuristics works for the given Build
+        std::string test(buffer.begin(), buffer.end());
+
+        if (test[0] == 'a' && test[1] == 'b' && test[2] == 'c')
+            abort();
+
+        if (test[0] == 'd' && test[1] == 'e' && test[2] == 'f')
+            while (1)
+                ;
+    }
+};
+
 int main(int argc, char **argv)
 {
     ECCVerifyHandle globalVerifyHandle;
-    std::vector<char> buffer;
-    if (!read_stdin(buffer))
-        return 0;
 
-    if (buffer.size() < sizeof(uint32_t))
-        return 0;
+    FuzzDeserNet<CBlock> fuzz_cblock("cblock");
+    FuzzDeserNet<CTransaction> fuzz_ctransaction("ctransaction");
+    FuzzDeserNet<CBlockLocator> fuzz_cblocklocator("cblocklocator");
+    FuzzBlockMerkleRoot fuzz_blockmerkleroot;
+    FuzzDeserNet<CAddrMan> fuzz_caddrman("caddrman");
+    FuzzDeserNet<CBlockHeader> fuzz_cblockheader("cblockheader");
+    FuzzDeserNet<CBanEntry> fuzz_cbanentry("cbanentry");
+    FuzzDeserNet<CTxUndo> fuzz_ctxundo("ctxundo");
+    FuzzDeserNet<CBlockUndo> fuzz_cblockundo("cblockundo");
+    FuzzDeserNet<Coin> fuzz_coin("coin");
+    FuzzDeserNet<CNetAddr> fuzz_cnetaddr("cnetaddr");
+    FuzzDeserNet<CService> fuzz_service("cservice");
+    FuzzCMessageHeader fuzz_cmessageheader;
+    FuzzDeserNet<CAddress> fuzz_caddress("caddress");
+    FuzzDeserNet<CInv> fuzz_cinv("cinv");
+    FuzzDeserNet<CBloomFilter> fuzz_cbloomfilter("cbloomfilter");
+    FuzzDeserNet<CDiskBlockIndex> fuzz_diskblockindex("cdiskblockindex");
+    FuzzCTxOutCompressor fuzz_ctxoutcompressor;
+    FuzzWildmatch fuzz_wildmatch;
+    FuzzCashAddrEncDec fuzz_cashaddrencdec;
+    FuzzCashAddrDecode fuzz_cashaddrdecode;
+    FuzzParseMoney fuzz_parsemoney;
+    FuzzParseFixedPoint fuzz_parsefixedpoint;
+    FuzzVerifyScript fuzz_verifyscript;
 
-    uint32_t test_id = 0xffffffff;
-    memcpy(&test_id, &buffer[0], sizeof(uint32_t));
-    buffer.erase(buffer.begin(), buffer.begin() + sizeof(uint32_t));
+    FuzzTester fuzz_tester;
 
-    if (test_id >= TEST_ID_END)
-        return 0;
+    // command line arguments can be used to constrain more and
+    // more specifically to a particular test
+    // (only the test name at the moment)
+    int argn = 1;
+    FuzzTest *ft = nullptr;
 
-    CDataStream ds(buffer, SER_NETWORK, INIT_PROTO_VERSION);
-    try
-    {
-        int nVersion;
-        ds >> nVersion;
-        ds.SetVersion(nVersion);
-    }
-    catch (const std::ios_base::failure &e)
-    {
-        return 0;
-    }
+    bool specific = false;
 
-    switch (test_id)
+    if (argn < argc)
     {
-    case CBLOCK_DESERIALIZE:
-    {
-        try
+        std::string testname = argv[argn];
+        specific = true;
+        if (testname == "list_tests")
         {
-            CBlock block;
-            ds >> block;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CTRANSACTION_DESERIALIZE:
-    {
-        try
-        {
-            CTransaction tx;
-            ds >> tx;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CBLOCKLOCATOR_DESERIALIZE:
-    {
-        try
-        {
-            CBlockLocator bl;
-            ds >> bl;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CBLOCKMERKLEROOT:
-    {
-        try
-        {
-            CBlock block;
-            ds >> block;
-            bool mutated;
-            BlockMerkleRoot(block, &mutated);
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CADDRMAN_DESERIALIZE:
-    {
-        try
-        {
-            CAddrMan am;
-            ds >> am;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CBLOCKHEADER_DESERIALIZE:
-    {
-        try
-        {
-            CBlockHeader bh;
-            ds >> bh;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CBANENTRY_DESERIALIZE:
-    {
-        try
-        {
-            CBanEntry be;
-            ds >> be;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CTXUNDO_DESERIALIZE:
-    {
-        try
-        {
-            CTxUndo tu;
-            ds >> tu;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CBLOCKUNDO_DESERIALIZE:
-    {
-        try
-        {
-            CBlockUndo bu;
-            ds >> bu;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CCOINS_DESERIALIZE:
-    {
-        try
-        {
-            Coin coin;
-            ds >> coin;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CNETADDR_DESERIALIZE:
-    {
-        try
-        {
-            CNetAddr na;
-            ds >> na;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CSERVICE_DESERIALIZE:
-    {
-        try
-        {
-            CService s;
-            ds >> s;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CMESSAGEHEADER_DESERIALIZE:
-    {
-        CMessageHeader::MessageStartChars pchMessageStart = {0x00, 0x00, 0x00, 0x00};
-        try
-        {
-            CMessageHeader mh(pchMessageStart);
-            ds >> mh;
-            if (!mh.IsValid(pchMessageStart))
+            for (const auto &entry : registry)
             {
-                return 0;
+                printf("%s\n", entry.first.c_str());
             }
-        }
-        catch (const std::ios_base::failure &e)
-        {
             return 0;
         }
-        break;
+        if (registry.count(testname) == 0)
+        {
+            printf("Test %s not known.\n", testname.c_str());
+            return 1;
+        }
+        ft = registry[testname];
+        argn++;
     }
-    case CADDRESS_DESERIALIZE:
+
+// use persistent mode if available (when compiled with afl-clang-fast(++))
+#ifdef __AFL_LOOP
+    while (__AFL_LOOP(1000))
     {
-        try
-        {
-            CAddress a;
-            ds >> a;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CINV_DESERIALIZE:
+#else
+#ifdef __AFL_INIT
+    __AFL_INIT();
+#endif
+    bool once = true;
+    while (once)
     {
-        try
+        once = false;
+#endif
+        std::vector<char> buffer;
+
+        if (!read_stdin(buffer))
         {
-            CInv i;
-            ds >> i;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CBLOOMFILTER_DESERIALIZE:
-    {
-        try
-        {
-            CBloomFilter bf;
-            ds >> bf;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CDISKBLOCKINDEX_DESERIALIZE:
-    {
-        try
-        {
-            CDiskBlockIndex dbi;
-            ds >> dbi;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
-        }
-        break;
-    }
-    case CTXOUTCOMPRESSOR_DESERIALIZE:
-    {
-        CTxOut to;
-        CTxOutCompressor toc(to);
-        try
-        {
-            ds >> toc;
-        }
-        catch (const std::ios_base::failure &e)
-        {
-            return 0;
+            continue;
         }
 
-        break;
-    }
-    default:
-        return 0;
+        if (buffer.size() < sizeof(uint32_t))
+        {
+            continue;
+        }
+
+        if (!specific)
+        {
+            // no test id given, get it from the stream
+            uint32_t test_id = 0xffffffff;
+            memcpy(&test_id, &buffer[0], sizeof(uint32_t));
+            buffer.erase(buffer.begin(), buffer.begin() + sizeof(uint32_t));
+
+            if (test_id >= registry_seq.size())
+            {
+                // test not available
+                printf("Test no. %d not available.\n", test_id);
+                continue;
+            }
+            ft = registry_seq[test_id];
+        }
+        ft->init(buffer);
+        (*ft)();
     }
     return 0;
 }


### PR DESCRIPTION
To make it easier to write fuzzing cases and so that fuzzing can potentially be used in later automated "integration-fuzzing" steps, I updated the command line driver for fuzzing.

There's still a lot that can be done on the fuzzing front; IMO code that faces the network should be made "fuzzable" as much as possible as well. That should IMO actually be a requirement for code changes - to go into the direction of modularizing so that network message processing can be fuzzed efficiently as much as possible.