### PR TITLE
Bump MAX_OP_RETURN_RELAY size default to 223 bytes

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -66,6 +66,20 @@ class NoConfigValue:
     def __init__(self):
         pass
 
+def expectException(fn, ExcType, comparison=None):
+    try:
+        fn()
+    except ExcType as exc:
+        if comparison:
+            if comparison in str(exc):  # exception matchs
+                return
+            else:
+                print("Incorrect error.  Was: " + str(exc) + " Expecting: " + comparison)
+                assert(0)
+        else:
+            return
+    assert(0)  # an exception should have happened
+
 def enable_mocktime():
     # Set the mocktime to be after the Bitcoin Cash fork so
     # in normal tests blockchains the fork is in the past

--- a/qa/rpc-tests/validateblocktemplate.py
+++ b/qa/rpc-tests/validateblocktemplate.py
@@ -35,22 +35,6 @@ def create_broken_transaction(prevtx, n, sig, value):
     tx.calc_sha256()
     return tx
 
-
-def expectException(fn, ExcType, comparison=None):
-    try:
-        fn()
-    except ExcType as exc:
-        if comparison:
-            if comparison in str(exc):  # exception matchs
-                return
-            else:
-                print("Incorrect error.  Was: " + str(exc) + " Expecting: " + comparison)
-                assert(0)
-        else:
-            return
-    assert(0)  # an exception should have happened
-
-
 class ValidateblocktemplateTest(BitcoinTestFramework):
 
     def setup_network(self):

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -171,7 +171,8 @@ CTweakRef<uint64_t> miningBlockSize("mining.blockSize",
     &MiningBlockSizeValidator);
 CTweakRef<unsigned int> maxDataCarrierTweak("mining.dataCarrierSize",
     "Maximum size of OP_RETURN data script in bytes.",
-    &nMaxDatacarrierBytes);
+    &nMaxDatacarrierBytes,
+    &MaxDataCarrierValidator);
 
 CTweak<uint64_t> miningForkTime("mining.forkMay2018Time",
     "Time in seconds since the epoch to initiate a hard fork scheduled on 15th May 2018.",

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -816,6 +816,12 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
     fIsBareMultisigStd = GetBoolArg("-permitbaremultisig", DEFAULT_PERMIT_BAREMULTISIG);
     fAcceptDatacarrier = GetBoolArg("-datacarrier", DEFAULT_ACCEPT_DATACARRIER);
     nMaxDatacarrierBytes = GetArg("-datacarriersize", nMaxDatacarrierBytes);
+    if (nMaxDatacarrierBytes < MAX_OP_RETURN_RELAY)
+    {
+        InitWarning(strprintf(_("Increasing -datacarriersize from %d to %d due to new May 15th OP_RETURN size policy."),
+            nMaxDatacarrierBytes, MAX_OP_RETURN_RELAY));
+        nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
+    }
 
     // Option to startup with mocktime set (used for regression testing):
     SetMockTime(GetArg("-mocktime", 0)); // SetMockTime(0) is a no-op
@@ -1139,9 +1145,6 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
         if (miningForkEB.value > excessiveBlockSize)
             excessiveBlockSize = miningForkEB.value;
         settingsToUserAgentString();
-        // Bump OP_RETURN size:
-        if (nMaxDatacarrierBytes < MAX_OP_RETURN_MAY2018)
-            nMaxDatacarrierBytes = MAX_OP_RETURN_MAY2018;
     }
 
 // ********************************************************* Step 7: load wallet

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2445,16 +2445,13 @@ void static UpdateTip(CBlockIndex *pindexNew)
     }
 
     // Next, check every on every block for EB < 32MB and force this as the minimum because this is a consensus issue
-    // Although OP_RETURN size is not consensus, enforce the new minimum size on every block so that the expectation
-    // of relay for any tx < 220 bytes is met by this node.
     if (IsMay152018Enabled(chainParams.GetConsensus(), pindexNew))
     {
         if (miningForkEB.value > excessiveBlockSize)
+        {
             excessiveBlockSize = miningForkEB.value;
-        // Bump OP_RETURN size:
-        if (nMaxDatacarrierBytes < MAX_OP_RETURN_MAY2018)
-            nMaxDatacarrierBytes = MAX_OP_RETURN_MAY2018;
-        settingsToUserAgentString();
+            settingsToUserAgentString();
+        }
     }
 
     // New best block

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -28,8 +28,7 @@ public:
     CScriptID(const uint160 &in) : uint160(in) {}
 };
 
-static const unsigned int MAX_OP_RETURN_RELAY = 83; //! bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
-static const unsigned int MAX_OP_RETURN_MAY2018 = 223; //! 220 bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
+static const unsigned int MAX_OP_RETURN_RELAY = 223; //! bytes (+1 for OP_RETURN, +2 for the pushdata opcodes)
 extern bool fAcceptDatacarrier;
 extern unsigned nMaxDatacarrierBytes;
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -364,15 +364,26 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
                                                                 "e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a671"
-                                                                "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38");
+                                                                "e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a671"
+                                                                "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                                "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38ce"
+                                                                "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                                "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38ce"
+                                                                "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef7105"
+                                                                "2312acbd");
     BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY, t.vout[0].scriptPubKey.size());
     BOOST_CHECK(IsStandardTx(t, reason));
 
     // MAX_OP_RETURN_RELAY+1-byte TX_NULL_DATA (non-standard)
-    t.vout[0].scriptPubKey =
-        CScript() << OP_RETURN
-                  << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3804678afd"
-                              "b0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3800");
+    t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                                "e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a671"
+                                                                "e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a671"
+                                                                "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                                "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38ce"
+                                                                "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                                "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38ce"
+                                                                "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef7105"
+                                                                "2312acbdab");
     BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY + 1, t.vout[0].scriptPubKey.size());
     BOOST_CHECK(!IsStandardTx(t, reason));
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -25,6 +25,7 @@
 #include "primitives/block.h"
 #include "requestManager.h"
 #include "rpc/server.h"
+#include "script/standard.h"
 #include "stat.h"
 #include "thinblock.h"
 #include "timedata.h"
@@ -146,6 +147,22 @@ std::string OutboundConnectionValidator(const int &value, int *item, bool valida
                 for (int i = 0; i < diff; i++)
                     semOutboundAddNode->post();
         }
+    }
+    return std::string();
+}
+
+std::string MaxDataCarrierValidator(const unsigned int &value, unsigned int *item, bool validate)
+{
+    if (validate)
+    {
+        if (value < MAX_OP_RETURN_RELAY) // sanity check
+        {
+            return "Invalid Value. Data Carrier minimum size has to be greater of equal to 223 bytes";
+        }
+    }
+    else // Do anything to "take" the new value
+    {
+        // nothing needed
     }
     return std::string();
 }

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -265,6 +265,7 @@ bool MiningAndExcessiveBlockValidatorRule(const uint64_t newExcessiveBlockSize, 
 std::string AcceptDepthValidator(const unsigned int &value, unsigned int *item, bool validate);
 std::string ExcessiveBlockValidator(const uint64_t &value, uint64_t *item, bool validate);
 std::string OutboundConnectionValidator(const int &value, int *item, bool validate);
+std::string MaxDataCarrierValidator(const unsigned int &value, unsigned int *item, bool validate);
 std::string SubverValidator(const std::string &value, std::string *item, bool validate);
 std::string MiningBlockSizeValidator(const uint64_t &value, uint64_t *item, bool validate);
 


### PR DESCRIPTION
In the May 15th 2018 protocol upgrade we introduce an increase OP_RETURN relay size to 223 total bytes. 

This patch use this value as default so that a pristine BU client will use it. 

This is not a consensus related changes but since it is used to determine if a transaction is standard, i.e. relay-able, it helps to keep mempools in sync across Bitcoin Cash p2p network.

This PR also changes things so that an explicit settings as command line flag or as a parameter in the configuration file would not be override on each new accepted block.