### PR TITLE
main.cpp cleanup

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -70,8 +70,9 @@ int64_t nTimeOffset = 0;
 CCriticalSection cs_rpcWarmup;
 
 CCriticalSection cs_main;
-BlockMap mapBlockIndex;
-CChain chainActive;
+BlockMap mapBlockIndex GUARDED_BY(cs_main);
+CChain chainActive GUARDED_BY(cs_main);
+
 CWaitableCriticalSection csBestBlock;
 CConditionVariable cvBlockChange;
 

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -62,7 +62,6 @@ std::atomic<bool> fRescan{false};
 CStatusString statusStrings;
 // main.cpp CriticalSections:
 CCriticalSection cs_LastBlockFile;
-CCriticalSection cs_nBlockSequenceId;
 
 CCriticalSection cs_nTimeOffset;
 int64_t nTimeOffset = 0;
@@ -286,7 +285,6 @@ public:
         printf("csBestBlock %p\n", &csBestBlock);
         printf("cvBlockChange %p\n", &cvBlockChange);
         printf("cs_LastBlockFile %p\n", &cs_LastBlockFile);
-        printf("cs_nBlockSequenceId %p\n", &cs_nBlockSequenceId);
         printf("cs_nTimeOffset %p\n", &cs_nTimeOffset);
         printf("cs_rpcWarmup %p\n", &cs_rpcWarmup);
         printf("cs_main %p\n", &cs_main);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3340,7 +3340,7 @@ bool ReceivedBlockTransactions(const CBlock &block,
             CBlockIndex *pindex = queue.front();
             queue.pop_front();
             pindex->nChainTx = (pindex->pprev ? pindex->pprev->nChainTx : 0) + pindex->nTx;
-            { 
+            {
                 pindex->nSequenceId = ++nBlockSequenceId;
             }
             if (chainActive.Tip() == NULL || !setBlockIndexCandidates.value_comp()(pindex, chainActive.Tip()))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -220,7 +220,7 @@ std::unique_ptr<CRollingBloomFilter> txn_recently_in_block GUARDED_BY(cs_recentR
 
 
 /** Number of preferable block download peers. */
-int nPreferredDownload = 0;
+int nPreferredDownload = 0 GUARDED_BY(cs_main);
 
 /** Dirty block file entries. */
 std::set<int> setDirtyFileInfo GUARDED_BY(cs_main);
@@ -245,6 +245,7 @@ int GetHeight()
 
 void UpdatePreferredDownload(CNode *node, CNodeState *state)
 {
+    LOCK(cs_main);
     nPreferredDownload -= state->fPreferredDownload;
 
     // Whether this node should be marked as a preferred download node.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -65,11 +65,10 @@
  */
 
 // BU variables moved to globals.cpp
-// BU moved CCriticalSection cs_main;
-
-// BU moved BlockMap mapBlockIndex;
-// BU movedCChain chainActive;
-CBlockIndex *pindexBestHeader = NULL;
+// - moved CCriticalSection cs_main;
+// - moved BlockMap mapBlockIndex;
+// - movedCChain chainActive;
+CBlockIndex *pindexBestHeader = nullptr GUARDED_BY(cs_main);
 
 CCoinsViewDB *pcoinsdbview = nullptr;
 
@@ -89,7 +88,7 @@ int64_t nCoinCacheUsage = 0;
 uint64_t nPruneTarget = 0;
 uint32_t nXthinBloomFilterSize = SMALLEST_MAX_BLOOM_FILTER_SIZE;
 
-CFeeRate minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
+CFeeRate minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE) GUARDED_BY(cs_main);
 
 // BU: Move global objects to a single file
 extern CTxMemPool mempool;
@@ -104,7 +103,7 @@ extern std::map<CNetAddr, ConnectionHistory> mapInboundConnectionTracker;
 extern CCriticalSection cs_mapInboundConnectionTracker;
 
 /** A cache to store headers that have arrived but can not yet be connected **/
-std::map<uint256, std::pair<CBlockHeader, int64_t> > mapUnConnectedHeaders;
+std::map<uint256, std::pair<CBlockHeader, int64_t> > mapUnConnectedHeaders GUARDED_BY(cs_main);
 
 static void CheckBlockIndex(const Consensus::Params &consensusParams);
 
@@ -146,22 +145,22 @@ struct CBlockIndexWorkComparator
     }
 };
 
-CBlockIndex *pindexBestInvalid;
+CBlockIndex *pindexBestInvalid = nullptr GUARDED_BY(cs_main);
 
 /**
  * The set of all CBlockIndex entries with BLOCK_VALID_TRANSACTIONS (for itself and all ancestors) and
  * as good as our current tip or better. Entries may be failed, though, and pruning nodes may be
  * missing the data for the block.
  */
-std::set<CBlockIndex *, CBlockIndexWorkComparator> setBlockIndexCandidates;
+std::set<CBlockIndex *, CBlockIndexWorkComparator> setBlockIndexCandidates GUARDED_BY(cs_main);
 /** Number of nodes with fSyncStarted. */
 int nSyncStarted = 0;
 /** All pairs A->B, where A (or one of its ancestors) misses transactions, but B has transactions.
  * Pruned nodes may have entries where B is missing data.
  */
-std::multimap<CBlockIndex *, CBlockIndex *> mapBlocksUnlinked;
+std::multimap<CBlockIndex *, CBlockIndex *> mapBlocksUnlinked GUARDED_BY(cs_main);
 
-std::vector<CBlockFileInfo> vinfoBlockFile;
+std::vector<CBlockFileInfo> vinfoBlockFile GUARDED_BY(cs_main);
 int nLastBlockFile = 0;
 /** Global flag to indicate we should check to see if there are
  *  block/undo files that should be deleted.  Set on startup
@@ -181,7 +180,7 @@ uint32_t nBlockSequenceId = 1;
  * messages or ban them when processing happens afterwards. Protected by
  * cs_main.
  */
-std::map<uint256, NodeId> mapBlockSource;
+std::map<uint256, NodeId> mapBlockSource GUARDED_BY(cs_main);
 
 CCriticalSection cs_recentRejects;
 /**
@@ -225,12 +224,12 @@ std::unique_ptr<CRollingBloomFilter> txn_recently_in_block GUARDED_BY(cs_recentR
 int nPreferredDownload = 0;
 
 /** Dirty block file entries. */
-std::set<int> setDirtyFileInfo;
+std::set<int> setDirtyFileInfo GUARDED_BY(cs_main);
 
 } // anon namespace
 
 /** Dirty block index entries. */
-std::set<CBlockIndex *> setDirtyBlockIndex;
+std::set<CBlockIndex *> setDirtyBlockIndex GUARDED_BY(cs_main);
 
 //////////////////////////////////////////////////////////////////////////////
 //

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -97,8 +97,6 @@ extern CTweak<unsigned int> maxBlocksInTransitPerPeer;
 extern CTweak<unsigned int> blockDownloadWindow;
 extern CTweak<uint64_t> reindexTypicalBlockSize;
 
-extern unsigned int BLOCK_DOWNLOAD_WINDOW;
-
 extern std::map<CNetAddr, ConnectionHistory> mapInboundConnectionTracker;
 extern CCriticalSection cs_mapInboundConnectionTracker;
 
@@ -2904,7 +2902,7 @@ static bool ActivateBestChainStep(CValidationState &state,
     {
         // Don't iterate the entire list of potential improvements toward the best tip, as we likely only need
         // a few blocks along the way.
-        int nTargetHeight = std::min(nHeight + (int)BLOCK_DOWNLOAD_WINDOW, pindexMostWork->nHeight);
+        int nTargetHeight = std::min(nHeight + (int)requester.BLOCK_DOWNLOAD_WINDOW.load(), pindexMostWork->nHeight);
         vpindexToConnect.clear();
         CBlockIndex *pindexIter = pindexMostWork->GetAncestor(nTargetHeight);
         while (pindexIter && pindexIter->nHeight != nHeight)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,8 +70,6 @@
 // - movedCChain chainActive;
 CBlockIndex *pindexBestHeader = nullptr GUARDED_BY(cs_main);
 
-CCoinsViewDB *pcoinsdbview = nullptr;
-
 // Last time the block tip was updated
 std::atomic<int64_t> nTimeBestReceived{0};
 
@@ -86,9 +84,11 @@ bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
 unsigned int nBytesPerSigOp = DEFAULT_BYTES_PER_SIGOP;
 bool fCheckBlockIndex = false;
 bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
-int64_t nCoinCacheUsage = 0;
 uint64_t nPruneTarget = 0;
 uint32_t nXthinBloomFilterSize = SMALLEST_MAX_BLOOM_FILTER_SIZE;
+
+// The allowed size of the in memory UTXO cache
+int64_t nCoinCacheUsage = 0 GUARDED_BY(cs_main);
 
 CFeeRate minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE) GUARDED_BY(cs_main);
 

--- a/src/main.h
+++ b/src/main.h
@@ -50,9 +50,6 @@ class CValidationState;
 struct CNodeStateStats;
 struct LockPoints;
 
-/** Global variable that points to the coins database */
-extern CCoinsViewDB *pcoinsdbview;
-
 enum FlushStateMode
 {
     FLUSH_STATE_NONE,

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -49,7 +49,7 @@ struct CNodeState
 };
 
 /** Map maintaining per-node state. Requires cs_main. */
-extern std::map<NodeId, CNodeState> mapNodeState;
+extern std::map<NodeId, CNodeState> mapNodeState GUARDED_BY(cs_main);
 
 // Requires cs_main.
 extern CNodeState *State(NodeId nId);

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -154,6 +154,12 @@ public:
     // How many outbound nodes are we connected to.
     std::atomic<int32_t> nOutbound;
 
+    /** Size of the "block download window": how far ahead of our current height do we fetch?
+     *  Larger windows tolerate larger download speed differences between peer, but increase the potential
+     *  degree of disordering of blocks on disk (which make reindexing and in the future perhaps pruning
+     *  harder). We'll probably want to make this a per-peer adaptive value at some point. */
+    std::atomic<unsigned int> BLOCK_DOWNLOAD_WINDOW{1024};
+
     // Get this object from somewhere, asynchronously.
     void AskFor(const CInv &obj, CNode *from, unsigned int priority = 0);
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -16,6 +16,8 @@
 
 #include <stdint.h>
 
+CCoinsViewDB *pcoinsdbview = nullptr;
+
 using namespace std;
 
 static const char DB_COIN = 'C';
@@ -577,6 +579,8 @@ void CacheSizeCalculations(int64_t _nTotalCache,
 
 void AdjustCoinCacheSize()
 {
+    AssertLockHeld(cs_main);
+
     // If the operator has not set a dbcache and initial sync is complete then revert back to the default
     // value for dbcache. This will cause the current coins cache to be immediately trimmed to size.
     if (!IsInitialBlockDownload() && !GetArg("-dbcache", 0) && chainActive.Tip())

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -170,4 +170,7 @@ public:
     bool LoadBlockIndexGuts();
 };
 
+/** Global variable that points to the coins database */
+extern CCoinsViewDB *pcoinsdbview;
+
 #endif // BITCOIN_TXDB_H


### PR DESCRIPTION
Mainly this is about clearly defining what data is guarded by cs_main (There are so many pieces of data that it's difficult for the uninitiated to know what is supposed to be locked or not)

Also added a couple of atomics rather than relying on cs_main and moved some items to the request manager and txdb.cpp/h