### PR TITLE
Extend CTransactionRef into the Wallet

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -956,7 +956,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
     }
 
     if (!fRejectAbsurdFee)
-        SyncWithWallets(*ptx, nullptr, -1);
+        SyncWithWallets(ptx, nullptr, -1);
 
     int64_t end = GetTimeMicros();
 
@@ -2603,9 +2603,9 @@ bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusPa
     UpdateTip(pindexDelete->pprev);
     // Let wallets know transactions went from 1-confirmed to
     // 0-confirmed or conflicted:
-    for (const auto &tx : block.vtx)
+    for (const auto &ptx : block.vtx)
     {
-        SyncWithWallets(*tx, nullptr, -1);
+        SyncWithWallets(ptx, nullptr, -1);
     }
 
     return true;
@@ -2699,15 +2699,15 @@ bool static ConnectTip(CValidationState &state,
     UpdateTip(pindexNew);
     // Tell wallet about transactions that went from mempool
     // to conflicted:
-    for (const auto &tx : txConflicted)
+    for (const auto &ptx : txConflicted)
     {
-        SyncWithWallets(*tx, nullptr, -1);
+        SyncWithWallets(ptx, nullptr, -1);
     }
     // ... and about transactions that got confirmed:
     int txIdx = 0;
-    for (const auto &tx : pblock->vtx)
+    for (const auto &ptx : pblock->vtx)
     {
-        SyncWithWallets(*tx, pblock, txIdx);
+        SyncWithWallets(ptx, pblock, txIdx);
         txIdx++;
     }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -999,7 +999,7 @@ UniValue sendrawtransaction(const UniValue &params, bool fHelp)
         }
 #ifdef ENABLE_WALLET
         else
-            SyncWithWallets(*ptx, nullptr, -1);
+            SyncWithWallets(ptx, nullptr, -1);
 #endif
     }
     else if (fHaveChain)

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -48,7 +48,7 @@ void UnregisterAllValidationInterfaces()
     g_signals.UpdatedBlockTip.disconnect_all_slots();
 }
 
-void SyncWithWallets(const CTransaction &tx, const CBlock *pblock, int txIdx)
+void SyncWithWallets(const CTransactionRef &ptx, const CBlock *pblock, int txIdx)
 {
-    g_signals.SyncTransaction(tx, pblock, txIdx);
+    g_signals.SyncTransaction(ptx, pblock, txIdx);
 }

--- a/src/validationinterface.h
+++ b/src/validationinterface.h
@@ -7,6 +7,8 @@
 #ifndef BITCOIN_VALIDATIONINTERFACE_H
 #define BITCOIN_VALIDATIONINTERFACE_H
 
+#include "primitives/transaction.h"
+
 #include <boost/shared_ptr.hpp>
 #include <boost/signals2/signal.hpp>
 
@@ -14,7 +16,6 @@ class CBlock;
 struct CBlockLocator;
 class CBlockIndex;
 class CReserveScript;
-class CTransaction;
 class CValidationInterface;
 class CValidationState;
 class uint256;
@@ -28,13 +29,13 @@ void UnregisterValidationInterface(CValidationInterface *pwalletIn);
 /** Unregister all wallets from core */
 void UnregisterAllValidationInterfaces();
 /** Push an updated transaction to all registered wallets, pass NULL if block not known, pass -1 if txIdx not known */
-void SyncWithWallets(const CTransaction &tx, const CBlock *pblock, int txIdx);
+void SyncWithWallets(const CTransactionRef &ptx, const CBlock *pblock, int txIdx);
 
 class CValidationInterface
 {
 protected:
     virtual void UpdatedBlockTip(const CBlockIndex *pindex) {}
-    virtual void SyncTransaction(const CTransaction &tx, const CBlock *pblock, int txIdx) {}
+    virtual void SyncTransaction(const CTransactionRef &ptx, const CBlock *pblock, int txIdx) {}
     virtual void SetBestChain(const CBlockLocator &locator) {}
     virtual void UpdatedTransaction(const uint256 &hash) {}
     virtual void Inventory(const uint256 &hash) {}
@@ -52,7 +53,7 @@ struct CMainSignals
     /** Notifies listeners of updated block chain tip */
     boost::signals2::signal<void(const CBlockIndex *)> UpdatedBlockTip;
     /** Notifies listeners of updated transaction data (transaction, and optionally the block it is found in. */
-    boost::signals2::signal<void(const CTransaction &, const CBlock *, int txIndex)> SyncTransaction;
+    boost::signals2::signal<void(const CTransactionRef &, const CBlock *, int txIndex)> SyncTransaction;
     /** Notifies listeners of an updated transaction without new data (for now: a coinbase potentially becoming
      * visible). */
     boost::signals2::signal<void(const uint256 &)> UpdatedTransaction;

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -11,7 +11,6 @@
 #include "script/standard.h"
 #include "util.h"
 
-#include <boost/foreach.hpp>
 #include <string>
 #include <vector>
 

--- a/src/wallet/crypter.cpp
+++ b/src/wallet/crypter.cpp
@@ -302,7 +302,7 @@ bool CCryptoKeyStore::EncryptKeys(CKeyingMaterial &vMasterKeyIn)
             return false;
 
         fUseCrypto = true;
-        BOOST_FOREACH (KeyMap::value_type &mKey, mapKeys)
+        for (KeyMap::value_type &mKey : mapKeys)
         {
             const CKey &key = mKey.second;
             CPubKey vchPubKey = key.GetPubKey();

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -19,7 +19,6 @@
 #include <sys/stat.h>
 #endif
 
-#include <boost/foreach.hpp>
 #include <boost/thread.hpp>
 #include <boost/version.hpp>
 

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -119,9 +119,9 @@ void CDBEnv::MakeMock()
     dbenv->set_lk_max_objects(10000);
     dbenv->set_flags(DB_AUTO_COMMIT, 1);
     dbenv->log_set_config(DB_LOG_IN_MEMORY, 1);
-    int ret =
-        dbenv->open(nullptr, DB_CREATE | DB_INIT_LOCK | DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN | DB_THREAD | DB_PRIVATE,
-            S_IRUSR | S_IWUSR);
+    int ret = dbenv->open(nullptr,
+        DB_CREATE | DB_INIT_LOCK | DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN | DB_THREAD | DB_PRIVATE,
+        S_IRUSR | S_IWUSR);
     if (ret > 0)
         throw runtime_error(strprintf("CDBEnv::MakeMock: Error %d opening database environment.", ret));
 

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -56,12 +56,12 @@ void CDBEnv::Reset()
     fMockDb = false;
 }
 
-CDBEnv::CDBEnv() : dbenv(NULL) { Reset(); }
+CDBEnv::CDBEnv() : dbenv(nullptr) { Reset(); }
 CDBEnv::~CDBEnv()
 {
     EnvShutdown();
     delete dbenv;
-    dbenv = NULL;
+    dbenv = nullptr;
 }
 
 void CDBEnv::Close() { EnvShutdown(); }
@@ -120,7 +120,7 @@ void CDBEnv::MakeMock()
     dbenv->set_flags(DB_AUTO_COMMIT, 1);
     dbenv->log_set_config(DB_LOG_IN_MEMORY, 1);
     int ret =
-        dbenv->open(NULL, DB_CREATE | DB_INIT_LOCK | DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN | DB_THREAD | DB_PRIVATE,
+        dbenv->open(nullptr, DB_CREATE | DB_INIT_LOCK | DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN | DB_THREAD | DB_PRIVATE,
             S_IRUSR | S_IWUSR);
     if (ret > 0)
         throw runtime_error(strprintf("CDBEnv::MakeMock: Error %d opening database environment.", ret));
@@ -136,10 +136,10 @@ CDBEnv::VerifyResult CDBEnv::Verify(const std::string &strFile,
     assert(mapFileUseCount.count(strFile) == 0);
 
     Db db(dbenv, 0);
-    int result = db.verify(strFile.c_str(), NULL, NULL, 0);
+    int result = db.verify(strFile.c_str(), nullptr, nullptr, 0);
     if (result == 0)
         return VERIFY_OK;
-    else if (recoverFunc == NULL)
+    else if (recoverFunc == nullptr)
         return RECOVER_FAIL;
 
     // Try to recover:
@@ -159,7 +159,7 @@ bool CDBEnv::Salvage(const std::string &strFile, bool fAggressive, std::vector<C
     stringstream strDump;
 
     Db db(dbenv, 0);
-    int result = db.verify(strFile.c_str(), NULL, &strDump, flags);
+    int result = db.verify(strFile.c_str(), nullptr, &strDump, flags);
     if (result == DB_VERIFY_BAD)
     {
         LOGA("CDBEnv::Salvage: Database salvage found errors, all data may not be recoverable.\n");
@@ -211,7 +211,7 @@ void CDBEnv::CheckpointLSN(const std::string &strFile)
 }
 
 
-CDB::CDB(const std::string &strFilename, const char *pszMode, bool fFlushOnCloseIn) : pdb(NULL), activeTxn(NULL)
+CDB::CDB(const std::string &strFilename, const char *pszMode, bool fFlushOnCloseIn) : pdb(nullptr), activeTxn(nullptr)
 {
     int ret;
     fReadOnly = (!strchr(pszMode, '+') && !strchr(pszMode, 'w'));
@@ -219,7 +219,7 @@ CDB::CDB(const std::string &strFilename, const char *pszMode, bool fFlushOnClose
     if (strFilename.empty())
         return;
 
-    bool fCreate = strchr(pszMode, 'c') != NULL;
+    bool fCreate = strchr(pszMode, 'c') != nullptr;
     unsigned int nFlags = DB_THREAD;
     if (fCreate)
         nFlags |= DB_CREATE;
@@ -232,7 +232,7 @@ CDB::CDB(const std::string &strFilename, const char *pszMode, bool fFlushOnClose
         strFile = strFilename;
         ++bitdb.mapFileUseCount[strFile];
         pdb = bitdb.mapDb[strFile];
-        if (pdb == NULL)
+        if (pdb == nullptr)
         {
             pdb = new Db(bitdb.dbenv, 0);
 
@@ -246,8 +246,8 @@ CDB::CDB(const std::string &strFilename, const char *pszMode, bool fFlushOnClose
                         strprintf("CDB: Failed to configure for no temp file backing for database %s", strFile));
             }
 
-            ret = pdb->open(NULL, // Txn pointer
-                fMockDb ? NULL : strFile.c_str(), // Filename
+            ret = pdb->open(nullptr, // Txn pointer
+                fMockDb ? nullptr : strFile.c_str(), // Filename
                 fMockDb ? strFile.c_str() : "main", // Logical db name
                 DB_BTREE, // Database type
                 nFlags, // Flags
@@ -256,7 +256,7 @@ CDB::CDB(const std::string &strFilename, const char *pszMode, bool fFlushOnClose
             if (ret != 0)
             {
                 delete pdb;
-                pdb = NULL;
+                pdb = nullptr;
                 --bitdb.mapFileUseCount[strFile];
                 strFile = "";
                 throw runtime_error(strprintf("CDB: Error %d, can't open database %s", ret, strFile));
@@ -294,8 +294,8 @@ void CDB::Close()
         return;
     if (activeTxn)
         activeTxn->abort();
-    activeTxn = NULL;
-    pdb = NULL;
+    activeTxn = nullptr;
+    pdb = nullptr;
 
     if (fFlushOnClose)
         Flush();
@@ -310,13 +310,13 @@ void CDBEnv::CloseDb(const string &strFile)
 {
     {
         LOCK(cs_db);
-        if (mapDb[strFile] != NULL)
+        if (mapDb[strFile] != nullptr)
         {
             // Close the database handle
             Db *pdb = mapDb[strFile];
             pdb->close(0);
             delete pdb;
-            mapDb[strFile] = NULL;
+            mapDb[strFile] = nullptr;
         }
     }
 }
@@ -326,7 +326,7 @@ bool CDBEnv::RemoveDb(const string &strFile)
     this->CloseDb(strFile);
 
     LOCK(cs_db);
-    int rc = dbenv->dbremove(NULL, strFile.c_str(), NULL, DB_AUTO_COMMIT);
+    int rc = dbenv->dbremove(nullptr, strFile.c_str(), nullptr, DB_AUTO_COMMIT);
     return (rc == 0);
 }
 
@@ -350,7 +350,7 @@ bool CDB::Rewrite(const string &strFile, const char *pszSkip)
                     CDB db(strFile.c_str(), "r");
                     Db *pdbCopy = new Db(bitdb.dbenv, 0);
 
-                    int ret = pdbCopy->open(NULL, // Txn pointer
+                    int ret = pdbCopy->open(nullptr, // Txn pointer
                         strFileRes.c_str(), // Filename
                         "main", // Logical db name
                         DB_BTREE, // Database type
@@ -390,7 +390,7 @@ bool CDB::Rewrite(const string &strFile, const char *pszSkip)
                             }
                             Dbt datKey(ssKey.data(), ssKey.size());
                             Dbt datValue(ssValue.data(), ssValue.size());
-                            int ret2 = pdbCopy->put(NULL, &datKey, &datValue, DB_NOOVERWRITE);
+                            int ret2 = pdbCopy->put(nullptr, &datKey, &datValue, DB_NOOVERWRITE);
                             if (ret2 > 0)
                                 fSuccess = false;
                         }
@@ -406,10 +406,10 @@ bool CDB::Rewrite(const string &strFile, const char *pszSkip)
                 if (fSuccess)
                 {
                     Db dbA(bitdb.dbenv, 0);
-                    if (dbA.remove(strFile.c_str(), NULL, 0))
+                    if (dbA.remove(strFile.c_str(), nullptr, 0))
                         fSuccess = false;
                     Db dbB(bitdb.dbenv, 0);
-                    if (dbB.rename(strFileRes.c_str(), NULL, strFile.c_str(), 0))
+                    if (dbB.rename(strFileRes.c_str(), nullptr, strFile.c_str(), 0))
                         fSuccess = false;
                 }
                 if (!fSuccess)

--- a/src/wallet/db.h
+++ b/src/wallet/db.h
@@ -81,10 +81,10 @@ public:
 
     DbTxn *TxnBegin(int flags = DB_TXN_WRITE_NOSYNC)
     {
-        DbTxn *ptxn = NULL;
-        int ret = dbenv->txn_begin(NULL, &ptxn, flags);
+        DbTxn *ptxn = nullptr;
+        int ret = dbenv->txn_begin(nullptr, &ptxn, flags);
         if (!ptxn || ret != 0)
-            return NULL;
+            return nullptr;
         return ptxn;
     }
 };
@@ -130,7 +130,7 @@ protected:
         datValue.set_flags(DB_DBT_MALLOC);
         int ret = pdb->get(activeTxn, &datKey, &datValue, 0);
         memset(datKey.get_data(), 0, datKey.get_size());
-        if (datValue.get_data() == NULL)
+        if (datValue.get_data() == nullptr)
             return false;
 
         // Unserialize value
@@ -225,11 +225,11 @@ protected:
     Dbc *GetCursor()
     {
         if (!pdb)
-            return NULL;
-        Dbc *pcursor = NULL;
-        int ret = pdb->cursor(NULL, &pcursor, 0);
+            return nullptr;
+        Dbc *pcursor = nullptr;
+        int ret = pdb->cursor(nullptr, &pcursor, 0);
         if (ret != 0)
-            return NULL;
+            return nullptr;
         return pcursor;
     }
 
@@ -253,7 +253,7 @@ protected:
         int ret = pcursor->get(&datKey, &datValue, fFlags);
         if (ret != 0)
             return ret;
-        else if (datKey.get_data() == NULL || datValue.get_data() == NULL)
+        else if (datKey.get_data() == nullptr || datValue.get_data() == nullptr)
             return 99999;
 
         // Convert to streams
@@ -289,7 +289,7 @@ public:
         if (!pdb || !activeTxn)
             return false;
         int ret = activeTxn->commit(0);
-        activeTxn = NULL;
+        activeTxn = nullptr;
         return (ret == 0);
     }
 
@@ -298,7 +298,7 @@ public:
         if (!pdb || !activeTxn)
             return false;
         int ret = activeTxn->abort();
-        activeTxn = NULL;
+        activeTxn = nullptr;
         return (ret == 0);
     }
 
@@ -309,7 +309,7 @@ public:
     }
 
     bool WriteVersion(int nVersion) { return Write(std::string("version"), nVersion); }
-    bool static Rewrite(const std::string &strFile, const char *pszSkip = NULL);
+    bool static Rewrite(const std::string &strFile, const char *pszSkip = nullptr);
 };
 
 #endif // BITCOIN_WALLET_DB_H

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -27,7 +27,6 @@
 
 #include <univalue.h>
 
-#include <boost/foreach.hpp>
 
 using namespace std;
 

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -51,7 +51,7 @@ int64_t static DecodeDumpTime(const std::string &str)
 std::string static EncodeDumpString(const std::string &str)
 {
     std::stringstream ret;
-    BOOST_FOREACH (unsigned char c, str)
+    for (unsigned char c : str)
     {
         if (c <= 32 || c >= 128 || c == '%')
         {

--- a/src/wallet/test/accounting_tests.cpp
+++ b/src/wallet/test/accounting_tests.cpp
@@ -3,6 +3,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "main.h"
 #include "wallet/wallet.h"
 #include "wallet/walletdb.h"
 
@@ -39,7 +40,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
     CAccountingEntry ae;
     std::map<CAmount, CAccountingEntry> results;
 
-    LOCK(pwalletMain->cs_wallet);
+    LOCK2(cs_main, pwalletMain->cs_wallet);
 
     ae.strAccount = "";
     ae.nCreditDebit = 1;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -36,7 +36,7 @@
 
 using namespace std;
 
-CWallet *pwalletMain = NULL;
+CWallet *pwalletMain = nullptr;
 /** Transaction fee set by the user */
 CFeeRate payTxFee(DEFAULT_TRANSACTION_FEE);
 unsigned int nTxConfirmTarget = DEFAULT_TX_CONFIRM_TARGET;
@@ -83,7 +83,7 @@ const CWalletTx *CWallet::GetWalletTx(const uint256 &hash) const
     LOCK(cs_wallet);
     std::map<uint256, CWalletTx>::const_iterator it = mapWallet.find(hash);
     if (it == mapWallet.end())
-        return NULL;
+        return nullptr;
     return &(it->second);
 }
 
@@ -251,7 +251,7 @@ bool CWallet::Unlock(const SecureString &strWalletPassphrase)
 
     {
         LOCK(cs_wallet);
-        BOOST_FOREACH (const MasterKeyMap::value_type &pMasterKey, mapMasterKeys)
+        for (const MasterKeyMap::value_type &pMasterKey : mapMasterKeys)
         {
             if (!crypter.SetKeyFromPassphrase(strWalletPassphrase, pMasterKey.second.vchSalt,
                     pMasterKey.second.nDeriveIterations, pMasterKey.second.nDerivationMethod))
@@ -276,7 +276,7 @@ bool CWallet::ChangeWalletPassphrase(const SecureString &strOldWalletPassphrase,
 
         CCrypter crypter;
         CKeyingMaterial vMasterKey;
-        BOOST_FOREACH (MasterKeyMap::value_type &pMasterKey, mapMasterKeys)
+        for (MasterKeyMap::value_type &pMasterKey : mapMasterKeys)
         {
             if (!crypter.SetKeyFromPassphrase(strOldWalletPassphrase, pMasterKey.second.vchSalt,
                     pMasterKey.second.nDeriveIterations, pMasterKey.second.nDerivationMethod))
@@ -377,7 +377,7 @@ set<uint256> CWallet::GetConflicts(const uint256 &txid) const
 
     std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range;
 
-    BOOST_FOREACH (const CTxIn &txin, wtx.vin)
+    for (const CTxIn &txin : wtx.vin)
     {
         if (mapTxSpends.count(txin.prevout) <= 1)
             continue; // No conflict if zero or one spends
@@ -471,7 +471,7 @@ void CWallet::SyncMetaData(pair<TxSpends::iterator, TxSpends::iterator> range)
     // So: find smallest nOrderPos:
 
     int nMinOrderPos = std::numeric_limits<int>::max();
-    const CWalletTx *copyFrom = NULL;
+    const CWalletTx *copyFrom = nullptr;
     for (TxSpends::iterator it = range.first; it != range.second; ++it)
     {
         const uint256 &hash = it->second;
@@ -544,8 +544,10 @@ void CWallet::AddToSpends(const uint256 &wtxid)
     if (thisTx.IsCoinBase()) // Coinbases don't spend anything!
         return;
 
-    BOOST_FOREACH (const CTxIn &txin, thisTx.vin)
+    for (const CTxIn &txin : thisTx.vin)
+    {
         AddToSpends(txin.prevout, wtxid);
+    }
 }
 
 bool CWallet::EncryptWallet(const SecureString &strWalletPassphrase)
@@ -598,7 +600,7 @@ bool CWallet::EncryptWallet(const SecureString &strWalletPassphrase)
             if (!pwalletdbEncryption->TxnBegin())
             {
                 delete pwalletdbEncryption;
-                pwalletdbEncryption = NULL;
+                pwalletdbEncryption = nullptr;
                 return false;
             }
             pwalletdbEncryption->WriteMasterKey(nMasterKeyMaxID, kMasterKey);
@@ -630,7 +632,7 @@ bool CWallet::EncryptWallet(const SecureString &strWalletPassphrase)
             }
 
             delete pwalletdbEncryption;
-            pwalletdbEncryption = NULL;
+            pwalletdbEncryption = nullptr;
         }
 
         Lock();
@@ -664,10 +666,10 @@ int64_t CWallet::IncOrderPosNext(CWalletDB *pwalletdb)
 
 void CWallet::MarkDirty()
 {
+    LOCK(cs_wallet);
+    for (PAIRTYPE(const uint256, CWalletTx) & item : mapWallet)
     {
-        LOCK(cs_wallet);
-        BOOST_FOREACH (PAIRTYPE(const uint256, CWalletTx) & item, mapWallet)
-            item.second.MarkDirty();
+        item.second.MarkDirty();
     }
 }
 
@@ -683,7 +685,7 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
         wtx.BindWallet(this);
         wtxOrdered.insert(make_pair(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry *)0)));
         AddToSpends(hash);
-        BOOST_FOREACH (const CTxIn &txin, wtx.vin)
+        for (const CTxIn &txin : wtx.vin)
         {
             if (mapWallet.count(txin.prevout.hash))
             {
@@ -820,7 +822,7 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransaction &tx, const CBlock *pbl
 
         if (pblock)
         {
-            BOOST_FOREACH (const CTxIn &txin, tx.vin)
+            for (const CTxIn &txin : tx.vin)
             {
                 std::pair<TxSpends::const_iterator, TxSpends::const_iterator> range =
                     mapTxSpends.equal_range(txin.prevout);
@@ -912,7 +914,7 @@ bool CWallet::AbandonTransaction(const uint256 &hashTx)
             }
             // If a transaction changes 'conflicted' state, that changes the balance
             // available of the outputs it spends. So force those to be recomputed
-            BOOST_FOREACH (const CTxIn &txin, wtx.vin)
+            for (const CTxIn &txin : wtx.vin)
             {
                 if (mapWallet.count(txin.prevout.hash))
                     mapWallet[txin.prevout.hash].MarkDirty();
@@ -979,7 +981,7 @@ void CWallet::MarkConflicted(const uint256 &hashBlock, const uint256 &hashTx)
             }
             // If a transaction changes 'conflicted' state, that changes the balance
             // available of the outputs it spends. So force those to be recomputed
-            BOOST_FOREACH (const CTxIn &txin, wtx.vin)
+            for (const CTxIn &txin : wtx.vin)
             {
                 if (mapWallet.count(txin.prevout.hash))
                     mapWallet[txin.prevout.hash].MarkDirty();
@@ -998,7 +1000,7 @@ void CWallet::SyncTransaction(const CTransaction &tx, const CBlock *pblock, int 
     // If a transaction changes 'conflicted' state, that changes the balance
     // available of the outputs it spends. So force those to be
     // recomputed, also:
-    BOOST_FOREACH (const CTxIn &txin, tx.vin)
+    for (const CTxIn &txin : tx.vin)
     {
         if (mapWallet.count(txin.prevout.hash))
             mapWallet[txin.prevout.hash].MarkDirty();
@@ -1040,7 +1042,7 @@ isminetype CWallet::IsMine(const CTxIn &txin) const
 
 bool CWallet::IsMine(const CTransaction &tx) const
 {
-    BOOST_FOREACH (const CTxOut &txout, tx.vout)
+    for (const CTxOut &txout : tx.vout)
     {
         if (IsMine(txout) != ISMINE_NO)
             return true;
@@ -1088,7 +1090,7 @@ bool CWallet::IsFromMe(const CTransaction &tx) const { return (GetDebit(tx, ISMI
 CAmount CWallet::GetDebit(const CTransaction &tx, const isminefilter &filter) const
 {
     CAmount nDebit = 0;
-    BOOST_FOREACH (const CTxIn &txin, tx.vin)
+    for (const CTxIn &txin : tx.vin)
     {
         nDebit += GetDebit(txin, filter);
         if (!MoneyRange(nDebit))
@@ -1100,7 +1102,7 @@ CAmount CWallet::GetDebit(const CTransaction &tx, const isminefilter &filter) co
 CAmount CWallet::GetCredit(const CTransaction &tx, const isminefilter &filter) const
 {
     CAmount nCredit = 0;
-    BOOST_FOREACH (const CTxOut &txout, tx.vout)
+    for (const CTxOut &txout : tx.vout)
     {
         nCredit += GetCredit(txout, filter);
         if (!MoneyRange(nCredit))
@@ -1112,7 +1114,7 @@ CAmount CWallet::GetCredit(const CTransaction &tx, const isminefilter &filter) c
 CAmount CWallet::GetChange(const CTransaction &tx) const
 {
     CAmount nChange = 0;
-    BOOST_FOREACH (const CTxOut &txout, tx.vout)
+    for (const CTxOut &txout : tx.vout)
     {
         nChange += GetChange(txout);
         if (!MoneyRange(nChange))
@@ -1239,13 +1241,15 @@ void CWalletTx::GetAccountAmounts(const string &strAccount,
 
     if (strAccount == strSentAccount)
     {
-        BOOST_FOREACH (const COutputEntry &s, listSent)
+        for (const COutputEntry &s : listSent)
+        {
             nSent += s.amount;
+        }
         nFee = allFee;
     }
     {
         LOCK(pwallet->cs_wallet);
-        BOOST_FOREACH (const COutputEntry &r, listReceived)
+        for (const COutputEntry &r : listReceived)
         {
             if (pwallet->mapAddressBook.count(r.destination))
             {
@@ -1347,7 +1351,7 @@ void CWallet::ReacceptWalletTransactions()
     std::map<int64_t, CWalletTx *> mapSorted;
 
     // Sort pending wallet transactions based on their initial wallet insertion order
-    BOOST_FOREACH (PAIRTYPE(const uint256, CWalletTx) & item, mapWallet)
+    for (PAIRTYPE(const uint256, CWalletTx) & item : mapWallet)
     {
         const uint256 &wtxid = item.first;
         CWalletTx &wtx = item.second;
@@ -1367,7 +1371,7 @@ void CWallet::ReacceptWalletTransactions()
         CWalletTx &wtx = *(item.second);
 
         wtx.AcceptToMemoryPool(false);
-        SyncWithWallets(wtx, NULL, -1);
+        SyncWithWallets(wtx, nullptr, -1);
     }
 }
 
@@ -1389,7 +1393,7 @@ bool CWalletTx::RelayWalletTransaction()
 set<uint256> CWalletTx::GetConflicts() const
 {
     set<uint256> result;
-    if (pwallet != NULL)
+    if (pwallet != nullptr)
     {
         uint256 myHash = GetHash();
         result = pwallet->GetConflicts(myHash);
@@ -1585,11 +1589,11 @@ bool CWalletTx::IsTrusted() const
         return false;
 
     // Trusted if all inputs are from us and are in the mempool:
-    BOOST_FOREACH (const CTxIn &txin, vin)
+    for (const CTxIn &txin : vin)
     {
         // Transactions not sent by us: not trusted
         const CWalletTx *parent = pwallet->GetWalletTx(txin.prevout.hash);
-        if (parent == NULL)
+        if (parent == nullptr)
             return false;
         const CTxOut &parentOut = parent->vout[txin.prevout.n];
         if (pwallet->IsMine(parentOut) != ISMINE_SPENDABLE)
@@ -1616,7 +1620,7 @@ std::vector<uint256> CWallet::ResendWalletTransactionsBefore(int64_t nTime)
     LOCK(cs_wallet);
     // Sort them in chronological order
     multimap<unsigned int, CWalletTx *> mapSorted;
-    BOOST_FOREACH (PAIRTYPE(const uint256, CWalletTx) & item, mapWallet)
+    for (PAIRTYPE(const uint256, CWalletTx) & item : mapWallet)
     {
         CWalletTx &wtx = item.second;
         // Don't rebroadcast if newer than nTime:
@@ -1624,7 +1628,7 @@ std::vector<uint256> CWallet::ResendWalletTransactionsBefore(int64_t nTime)
             continue;
         mapSorted.insert(make_pair(wtx.nTimeReceived, &wtx));
     }
-    BOOST_FOREACH (PAIRTYPE(const unsigned int, CWalletTx *) & item, mapSorted)
+    for (PAIRTYPE(const unsigned int, CWalletTx *) & item : mapSorted)
     {
         CWalletTx &wtx = *item.second;
         if (wtx.RelayWalletTransaction())
@@ -1881,13 +1885,13 @@ bool CWallet::SelectCoinsMinConf(const CAmount &nTargetValue,
     // List of values less than target
     pair<CAmount, pair<const CWalletTx *, unsigned int> > coinLowestLarger;
     coinLowestLarger.first = std::numeric_limits<CAmount>::max();
-    coinLowestLarger.second.first = NULL;
+    coinLowestLarger.second.first = nullptr;
     vector<pair<CAmount, pair<const CWalletTx *, unsigned int> > > vValue;
     CAmount nTotalLower = 0;
 
     random_shuffle(vCoins.begin(), vCoins.end(), GetRandInt);
 
-    BOOST_FOREACH (const COutput &output, vCoins)
+    for (const COutput &output : vCoins)
     {
         if (!output.fSpendable)
             continue;
@@ -1931,7 +1935,7 @@ bool CWallet::SelectCoinsMinConf(const CAmount &nTargetValue,
 
     if (nTotalLower < nTargetValue)
     {
-        if (coinLowestLarger.second.first == NULL)
+        if (coinLowestLarger.second.first == nullptr)
             return false;
         setCoinsRet.insert(coinLowestLarger.second);
         nValueRet += coinLowestLarger.first;
@@ -1985,7 +1989,7 @@ bool CWallet::SelectCoins(const CAmount &nTargetValue,
     // coin control -> return all selected outputs (we want all selected to go into the transaction for sure)
     if (coinControl && coinControl->HasSelected() && !coinControl->fAllowOtherInputs)
     {
-        BOOST_FOREACH (const COutput &out, vCoins)
+        for (const COutput &out : vCoins)
         {
             if (!out.fSpendable)
                 continue;
@@ -2002,7 +2006,7 @@ bool CWallet::SelectCoins(const CAmount &nTargetValue,
     std::vector<COutPoint> vPresetInputs;
     if (coinControl)
         coinControl->ListSelected(vPresetInputs);
-    BOOST_FOREACH (const COutPoint &outpoint, vPresetInputs)
+    for (const COutPoint &outpoint : vPresetInputs)
     {
         map<uint256, CWalletTx>::const_iterator it = mapWallet.find(outpoint.hash);
         if (it != mapWallet.end())
@@ -2052,7 +2056,7 @@ bool CWallet::FundTransaction(CMutableTransaction &tx,
     vector<CRecipient> vecSend;
 
     // Turn the txout set into a CRecipient vector
-    BOOST_FOREACH (const CTxOut &txOut, tx.vout)
+    for (const CTxOut &txOut : tx.vout)
     {
         CRecipient recipient = {txOut.scriptPubKey, txOut.nValue, false};
         vecSend.push_back(recipient);
@@ -2061,8 +2065,10 @@ bool CWallet::FundTransaction(CMutableTransaction &tx,
     CCoinControl coinControl;
     coinControl.fAllowOtherInputs = true;
     coinControl.fAllowWatchOnly = includeWatching;
-    BOOST_FOREACH (const CTxIn &txin, tx.vin)
+    for (const CTxIn &txin : tx.vin)
+    {
         coinControl.Select(txin.prevout);
+    }
 
     CReserveKey reservekey(this);
     CWalletTx wtx;
@@ -2078,10 +2084,10 @@ bool CWallet::FundTransaction(CMutableTransaction &tx,
     }
 
     // Add new txins (keeping original txin scriptSig/order)
-    BOOST_FOREACH (const CTxIn &txin, wtx.vin)
+    for (const CTxIn &txin : wtx.vin)
     {
         bool found = false;
-        BOOST_FOREACH (const CTxIn &origTxIn, tx.vin)
+        for (const CTxIn &origTxIn : tx.vin)
         {
             if (txin.prevout.hash == origTxIn.prevout.hash && txin.prevout.n == origTxIn.prevout.n)
             {
@@ -2110,7 +2116,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient> &vecSend,
     CAmount nValue = 0;
     unsigned int nSubtractFeeFromAmount = 0;
     bool involvesPublicLabel = false;
-    BOOST_FOREACH (const CRecipient &recipient, vecSend)
+    for (const CRecipient &recipient : vecSend)
     {
         if (getLabelPublic(recipient.scriptPubKey) != "")
             involvesPublicLabel = true;
@@ -2184,7 +2190,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient> &vecSend,
                     nValueToSelect += nFeeRet;
                 double dPriority = 0;
                 // vouts to the payees
-                BOOST_FOREACH (const CRecipient &recipient, vecSend)
+                for (const CRecipient &recipient : vecSend)
                 {
                     CTxOut txout(recipient.nAmount, recipient.scriptPubKey);
 
@@ -2225,7 +2231,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient> &vecSend,
                     strFailReason = _("Insufficient funds");
                     return false;
                 }
-                BOOST_FOREACH (PAIRTYPE(const CWalletTx *, unsigned int) pcoin, setCoins)
+                for (PAIRTYPE(const CWalletTx *, unsigned int) pcoin : setCoins)
                 {
                     CAmount nCredit = pcoin.first->vout[pcoin.second].nValue;
                     // The coin age after the next block (depth+1) is used instead of the current,
@@ -2327,7 +2333,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient> &vecSend,
                 //
                 // Note how the sequence number is set to max()-1 so that the
                 // nLockTime set above actually works.
-                BOOST_FOREACH (const PAIRTYPE(const CWalletTx *, unsigned int) & coin, setCoins)
+                for (const PAIRTYPE(const CWalletTx *, unsigned int) & coin : setCoins)
                 {
                     txNew.vin.push_back(CTxIn(
                         coin.first->GetHash(), coin.second, CScript(), std::numeric_limits<unsigned int>::max() - 1));
@@ -2349,7 +2355,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient> &vecSend,
                 }
                 int nIn = 0;
                 CTransaction txNewConst(txNew);
-                BOOST_FOREACH (const PAIRTYPE(const CWalletTx *, unsigned int) & coin, setCoins)
+                for (const PAIRTYPE(const CWalletTx *, unsigned int) & coin : setCoins)
                 {
                     bool signSuccess;
                     const CScript &scriptPubKey = coin.first->vout[coin.second].scriptPubKey;
@@ -2377,8 +2383,10 @@ bool CWallet::CreateTransaction(const vector<CRecipient> &vecSend,
                 // Remove scriptSigs if we used dummy signatures for fee calculation
                 if (!sign)
                 {
-                    BOOST_FOREACH (CTxIn &vin, txNew.vin)
+                    for (CTxIn &vin : txNew.vin)
+                    {
                         vin.scriptSig = CScript();
+                    }
                 }
 
                 // Embed the constructed transaction data in wtxNew.
@@ -2464,7 +2472,7 @@ bool CWallet::CommitTransaction(CWalletTx &wtxNew, CReserveKey &reservekey)
             // This is only to keep the database open to defeat the auto-flush for the
             // duration of this scope.  This is the only place where this optimization
             // maybe makes sense; please don't do it anywhere else.
-            CWalletDB *pwalletdb = fFileBacked ? new CWalletDB(strWalletFile, "r+") : NULL;
+            CWalletDB *pwalletdb = fFileBacked ? new CWalletDB(strWalletFile, "r+") : nullptr;
 
             // Take key pair from key pool so it won't be used again
             reservekey.KeepKey();
@@ -2475,7 +2483,7 @@ bool CWallet::CommitTransaction(CWalletTx &wtxNew, CReserveKey &reservekey)
 
             // Notify that old coins are spent
             set<CWalletTx *> setCoins;
-            BOOST_FOREACH (const CTxIn &txin, wtxNew.vin)
+            for (const CTxIn &txin : wtxNew.vin)
             {
                 CWalletTx &coin = mapWallet[txin.prevout.hash];
                 coin.BindWallet(this);
@@ -2500,7 +2508,7 @@ bool CWallet::CommitTransaction(CWalletTx &wtxNew, CReserveKey &reservekey)
                 return false;
             }
 #else
-            SyncWithWallets(wtxNew, NULL, -1);
+            SyncWithWallets(wtxNew, nullptr, -1);
 #endif
             wtxNew.RelayWalletTransaction();
         }
@@ -2694,8 +2702,10 @@ bool CWallet::NewKeyPool()
     {
         LOCK(cs_wallet);
         CWalletDB walletdb(strWalletFile);
-        BOOST_FOREACH (int64_t nIndex, setKeyPool)
+        for (int64_t nIndex : setKeyPool)
+        {
             walletdb.ErasePool(nIndex);
+        }
         setKeyPool.clear();
 
         if (IsLocked())
@@ -2829,7 +2839,7 @@ std::map<CTxDestination, CAmount> CWallet::GetAddressBalances()
 
     {
         LOCK(cs_wallet);
-        BOOST_FOREACH (PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+        for (PAIRTYPE(uint256, CWalletTx) walletEntry : mapWallet)
         {
             CWalletTx *pcoin = &walletEntry.second;
 
@@ -2869,7 +2879,7 @@ set<set<CTxDestination> > CWallet::GetAddressGroupings()
     set<set<CTxDestination> > groupings;
     set<CTxDestination> grouping;
 
-    BOOST_FOREACH (PAIRTYPE(uint256, CWalletTx) walletEntry, mapWallet)
+    for (PAIRTYPE(uint256, CWalletTx) walletEntry : mapWallet)
     {
         CWalletTx *pcoin = &walletEntry.second;
 
@@ -2877,7 +2887,7 @@ set<set<CTxDestination> > CWallet::GetAddressGroupings()
         {
             bool any_mine = false;
             // group all input addresses with each other
-            BOOST_FOREACH (CTxIn txin, pcoin->vin)
+            for (CTxIn txin : pcoin->vin)
             {
                 CTxDestination address;
                 if (!IsMine(txin)) /* If this input isn't mine, ignore it */
@@ -2891,7 +2901,8 @@ set<set<CTxDestination> > CWallet::GetAddressGroupings()
             // group change with input addresses
             if (any_mine)
             {
-                BOOST_FOREACH (CTxOut txout, pcoin->vout)
+                for (CTxOut txout : pcoin->vout)
+                {
                     if (IsChange(txout))
                     {
                         CTxDestination txoutAddr;
@@ -2899,6 +2910,7 @@ set<set<CTxDestination> > CWallet::GetAddressGroupings()
                             continue;
                         grouping.insert(txoutAddr);
                     }
+                }
             }
             if (grouping.size() > 0)
             {
@@ -2924,18 +2936,20 @@ set<set<CTxDestination> > CWallet::GetAddressGroupings()
 
     set<set<CTxDestination> *> uniqueGroupings; // a set of pointers to groups of addresses
     map<CTxDestination, set<CTxDestination> *> setmap; // map addresses to the unique group containing it
-    BOOST_FOREACH (set<CTxDestination> grouping, groupings)
+    for (set<CTxDestination> grouping : groupings)
     {
         // make a set of all the groups hit by this new group
         set<set<CTxDestination> *> hits;
         map<CTxDestination, set<CTxDestination> *>::iterator it;
-        BOOST_FOREACH (CTxDestination address, grouping)
+        for (CTxDestination address : grouping)
+        {
             if ((it = setmap.find(address)) != setmap.end())
                 hits.insert((*it).second);
+        }
 
         // merge all hit groups into a new single group and delete old groups
         set<CTxDestination> *merged = new set<CTxDestination>(grouping);
-        BOOST_FOREACH (set<CTxDestination> *hit, hits)
+        for (set<CTxDestination> *hit : hits)
         {
             merged->insert(hit->begin(), hit->end());
             uniqueGroupings.erase(hit);
@@ -2944,12 +2958,14 @@ set<set<CTxDestination> > CWallet::GetAddressGroupings()
         uniqueGroupings.insert(merged);
 
         // update setmap
-        BOOST_FOREACH (CTxDestination element, *merged)
+        for (CTxDestination element : *merged)
+        {
             setmap[element] = merged;
+        }
     }
 
     set<set<CTxDestination> > ret;
-    BOOST_FOREACH (set<CTxDestination> *uniqueGrouping, uniqueGroupings)
+    for (set<CTxDestination> *uniqueGrouping : uniqueGroupings)
     {
         ret.insert(*uniqueGrouping);
         delete uniqueGrouping;
@@ -2962,7 +2978,7 @@ std::set<CTxDestination> CWallet::GetAccountAddresses(const std::string &strAcco
 {
     LOCK(cs_wallet);
     set<CTxDestination> result;
-    BOOST_FOREACH (const PAIRTYPE(CTxDestination, CAddressBookData) & item, mapAddressBook)
+    for (const PAIRTYPE(CTxDestination, CAddressBookData) & item : mapAddressBook)
     {
         const CTxDestination &address = item.first;
         const string &strName = item.second.name;
@@ -3013,7 +3029,7 @@ void CWallet::GetAllReserveKeys(set<CKeyID> &setAddress) const
     CWalletDB walletdb(strWalletFile);
 
     LOCK2(cs_main, cs_wallet);
-    BOOST_FOREACH (const int64_t &id, setKeyPool)
+    for (const int64_t &id : setKeyPool)
     {
         CKeyPool keypool;
         if (!walletdb.ReadPool(id, keypool))
@@ -3028,13 +3044,11 @@ void CWallet::GetAllReserveKeys(set<CKeyID> &setAddress) const
 
 void CWallet::UpdatedTransaction(const uint256 &hashTx)
 {
-    {
-        LOCK(cs_wallet);
-        // Only notify UI if this transaction is in this wallet
-        map<uint256, CWalletTx>::const_iterator mi = mapWallet.find(hashTx);
-        if (mi != mapWallet.end())
-            NotifyTransactionChanged(this, hashTx, CT_UPDATED);
-    }
+    LOCK(cs_wallet);
+    // Only notify UI if this transaction is in this wallet
+    map<uint256, CWalletTx>::const_iterator mi = mapWallet.find(hashTx);
+    if (mi != mapWallet.end())
+        NotifyTransactionChanged(this, hashTx, CT_UPDATED);
 }
 
 void CWallet::GetScriptForMining(boost::shared_ptr<CReserveScript> &script)
@@ -3105,8 +3119,10 @@ public:
         int nRequired;
         if (ExtractDestinations(script, type, vDest, nRequired))
         {
-            BOOST_FOREACH (const CTxDestination &dest, vDest)
+            for (const CTxDestination &dest : vDest)
+            {
                 boost::apply_visitor(*this, dest);
+            }
         }
     }
 
@@ -3142,7 +3158,7 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const
     std::map<CKeyID, CBlockIndex *> mapKeyFirstBlock;
     std::set<CKeyID> setKeys;
     GetKeys(setKeys);
-    BOOST_FOREACH (const CKeyID &keyid, setKeys)
+    for (const CKeyID &keyid : setKeys)
     {
         if (mapKeyBirth.count(keyid) == 0)
             mapKeyFirstBlock[keyid] = pindexMax;
@@ -3164,11 +3180,11 @@ void CWallet::GetKeyBirthTimes(std::map<CKeyID, int64_t> &mapKeyBirth) const
         {
             // ... which are already in a block
             int nHeight = blit->second->nHeight;
-            BOOST_FOREACH (const CTxOut &txout, wtx.vout)
+            for (const CTxOut &txout : wtx.vout)
             {
                 // iterate over all their outputs
                 CAffectedKeysVisitor(*this, vAffected).Process(txout.scriptPubKey);
-                BOOST_FOREACH (const CKeyID &keyid, vAffected)
+                for (const CKeyID &keyid : vAffected)
                 {
                     // ... and all their affected keys
                     std::map<CKeyID, CBlockIndex *>::iterator rit = mapKeyFirstBlock.find(keyid);
@@ -3249,7 +3265,7 @@ bool CWallet::InitLoadWallet()
         }
 
         delete tempWallet;
-        tempWallet = NULL;
+        tempWallet = nullptr;
     }
 
     uiInterface.InitMessage(_("Loading wallet..."));
@@ -3360,7 +3376,7 @@ bool CWallet::InitLoadWallet()
         {
             CWalletDB walletdb(walletFile);
 
-            BOOST_FOREACH (const CWalletTx &wtxOld, vWtx)
+            for (const CWalletTx &wtxOld : vWtx)
             {
                 uint256 hash = wtxOld.GetHash();
                 std::map<uint256, CWalletTx>::iterator mi = walletInstance->mapWallet.find(hash);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -677,7 +677,7 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
 {
     uint256 hash = wtxIn.GetHash();
 
-    LOCK(cs_wallet);
+    LOCK2(cs_main, cs_wallet);
     if (fFromLoadWallet)
     {
         mapWallet[hash] = wtxIn;
@@ -817,6 +817,7 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
  */
 bool CWallet::AddToWalletIfInvolvingMe(const CTransaction &tx, const CBlock *pblock, bool fUpdate, int txIndex)
 {
+    AssertLockHeld(cs_main);
     AssertLockHeld(cs_wallet);
 
     if (pblock)

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -729,12 +729,12 @@ public:
      * Increment the next transaction order id
      * @return next transaction order id
      */
-    int64_t IncOrderPosNext(CWalletDB *pwalletdb = NULL);
+    int64_t IncOrderPosNext(CWalletDB *pwalletdb = nullptr);
 
     void MarkDirty();
     bool AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletDB *pwalletdb);
-    void SyncTransaction(const CTransaction &tx, const CBlock *pblock, int txIndex = -1);
-    bool AddToWalletIfInvolvingMe(const CTransaction &tx, const CBlock *pblock, bool fUpdate, int txIndex = -1);
+    void SyncTransaction(const CTransactionRef &ptx, const CBlock *pblock, int txIndex = -1);
+    bool AddToWalletIfInvolvingMe(const CTransactionRef &ptx, const CBlock *pblock, bool fUpdate, int txIndex = -1);
     int ScanForWalletTransactions(CBlockIndex *pindexStart, bool fUpdate = false);
     void ReacceptWalletTransactions();
     void ResendWalletTransactions(int64_t nBestBlockTime);

--- a/src/wallet/wallet_ismine.cpp
+++ b/src/wallet/wallet_ismine.cpp
@@ -21,7 +21,7 @@ typedef vector<unsigned char> valtype;
 unsigned int HaveKeys(const vector<valtype> &pubkeys, const CKeyStore &keystore)
 {
     unsigned int nResult = 0;
-    BOOST_FOREACH (const valtype &pubkey, pubkeys)
+    for (const valtype &pubkey : pubkeys)
     {
         CKeyID keyID = CPubKey(pubkey).GetID();
         if (keystore.HaveKey(keyID))

--- a/src/wallet/wallet_ismine.cpp
+++ b/src/wallet/wallet_ismine.cpp
@@ -12,7 +12,6 @@
 #include "script/sign.h"
 #include "script/standard.h"
 
-#include <boost/foreach.hpp>
 
 using namespace std;
 

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -421,7 +421,7 @@ bool ReadKeyValue(CWallet *pwallet,
             if (wtx.nOrderPos == -1)
                 wss.fAnyUnordered = true;
 
-            pwallet->AddToWallet(wtx, true, NULL);
+            pwallet->AddToWallet(wtx, true, nullptr);
         }
         else if (strType == "acentry")
         {
@@ -1026,7 +1026,7 @@ bool CWalletDB::Recover(CDBEnv &dbenv, const std::string &filename, bool fOnlyKe
     int64_t now = GetTime();
     std::string newFilename = strprintf("wallet.%d.bak", now);
 
-    int result = dbenv.dbenv->dbrename(NULL, filename.c_str(), NULL, newFilename.c_str(), DB_AUTO_COMMIT);
+    int result = dbenv.dbenv->dbrename(nullptr, filename.c_str(), nullptr, newFilename.c_str(), DB_AUTO_COMMIT);
     if (result == 0)
         LOGA("Renamed %s to %s\n", filename, newFilename);
     else
@@ -1045,7 +1045,7 @@ bool CWalletDB::Recover(CDBEnv &dbenv, const std::string &filename, bool fOnlyKe
     LOGA("Salvage(aggressive) found %u records\n", salvagedData.size());
 
     boost::scoped_ptr<Db> pdbCopy(new Db(dbenv.dbenv, 0));
-    int ret = pdbCopy->open(NULL, // Txn pointer
+    int ret = pdbCopy->open(nullptr, // Txn pointer
         filename.c_str(), // Filename
         "main", // Logical db name
         DB_BTREE, // Database type

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -218,8 +218,10 @@ CAmount CWalletDB::GetAccountCreditDebit(const string &strAccount)
     ListAccountCreditDebit(strAccount, entries);
 
     CAmount nCreditDebit = 0;
-    BOOST_FOREACH (const CAccountingEntry &entry, entries)
+    for (const CAccountingEntry &entry : entries)
+    {
         nCreditDebit += entry.nCreditDebit;
+    }
 
     return nCreditDebit;
 }
@@ -286,7 +288,7 @@ DBErrors CWalletDB::ReorderTransactions(CWallet *pwallet)
     }
     list<CAccountingEntry> acentries;
     ListAccountCreditDebit("", acentries);
-    BOOST_FOREACH (CAccountingEntry &entry, acentries)
+    for (CAccountingEntry &entry : acentries)
     {
         txByTime.insert(make_pair(entry.nTime, TxPair((CWalletTx *)0, &entry)));
     }
@@ -316,7 +318,7 @@ DBErrors CWalletDB::ReorderTransactions(CWallet *pwallet)
         else
         {
             int64_t nOrderPosOff = 0;
-            BOOST_FOREACH (const int64_t &nOffsetStart, nOrderPosOffsets)
+            for (const int64_t &nOffsetStart : nOrderPosOffsets)
             {
                 if (nOrderPos >= nOffsetStart)
                     ++nOrderPosOff;
@@ -725,8 +727,10 @@ DBErrors CWalletDB::LoadWallet(CWallet *pwallet)
     if ((wss.nKeys + wss.nCKeys) != wss.nKeyMeta)
         pwallet->nTimeFirstKey = 1; // 0 would be considered 'no value'
 
-    BOOST_FOREACH (uint256 hash, wss.vWalletUpgrade)
+    for (uint256 &hash : wss.vWalletUpgrade)
+    {
         WriteTx(hash, pwallet->mapWallet[hash]);
+    }
 
     // Rewrite encrypted wallets of versions 0.4.0 and 0.5.0rc:
     if (wss.fIsEncrypted && (wss.nFileVersion == 40000 || wss.nFileVersion == 50000))
@@ -740,7 +744,7 @@ DBErrors CWalletDB::LoadWallet(CWallet *pwallet)
 
     pwallet->laccentries.clear();
     ListAccountCreditDebit("*", pwallet->laccentries);
-    BOOST_FOREACH (CAccountingEntry &entry, pwallet->laccentries)
+    for (CAccountingEntry &entry : pwallet->laccentries)
     {
         pwallet->wtxOrdered.insert(make_pair(entry.nOrderPos, CWallet::TxPair((CWalletTx *)0, &entry)));
     }
@@ -835,7 +839,7 @@ DBErrors CWalletDB::ZapSelectTx(CWallet *pwallet, vector<uint256> &vTxHashIn, ve
     // erase each matching wallet TX
     bool delerror = false;
     vector<uint256>::iterator it = vTxHashIn.begin();
-    BOOST_FOREACH (uint256 hash, vTxHash)
+    for (uint256 hash : vTxHash)
     {
         while (it < vTxHashIn.end() && (*it) < hash)
         {
@@ -873,7 +877,7 @@ DBErrors CWalletDB::ZapWalletTx(CWallet *pwallet, vector<CWalletTx> &vWtx)
         return err;
 
     // erase each wallet TX
-    BOOST_FOREACH (uint256 &hash, vTxHash)
+    for (uint256 &hash : vTxHash)
     {
         if (!EraseTx(hash))
             return DB_CORRUPT;
@@ -1060,7 +1064,7 @@ bool CWalletDB::Recover(CDBEnv &dbenv, const std::string &filename, bool fOnlyKe
     CWalletScanState wss;
 
     DbTxn *ptxn = dbenv.TxnBegin();
-    BOOST_FOREACH (CDBEnv::KeyValPair &row, salvagedData)
+    for (CDBEnv::KeyValPair &row : salvagedData)
     {
         if (fOnlyKeys)
         {

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -644,9 +644,9 @@ DBErrors CWalletDB::LoadWallet(CWallet *pwallet)
     bool fNoncriticalErrors = false;
     DBErrors result = DB_LOAD_OK;
 
+    LOCK2(cs_main, pwallet->cs_wallet);
     try
     {
-        LOCK(pwallet->cs_wallet);
         int nMinVersion = 0;
         if (Read((string) "minversion", nMinVersion))
         {

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -20,7 +20,6 @@
 #include "utiltime.h"
 #include "wallet/wallet.h"
 
-#include <boost/foreach.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/thread.hpp>
 #include <boost/version.hpp>

--- a/src/zmq/zmqabstractnotifier.cpp
+++ b/src/zmq/zmqabstractnotifier.cpp
@@ -9,4 +9,4 @@
 
 CZMQAbstractNotifier::~CZMQAbstractNotifier() { assert(!psocket); }
 bool CZMQAbstractNotifier::NotifyBlock(const CBlockIndex * /*CBlockIndex*/) { return true; }
-bool CZMQAbstractNotifier::NotifyTransaction(const CTransaction & /*transaction*/) { return true; }
+bool CZMQAbstractNotifier::NotifyTransaction(const CTransactionRef & /*transaction*/) { return true; }

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -33,7 +33,7 @@ public:
     virtual void Shutdown() = 0;
 
     virtual bool NotifyBlock(const CBlockIndex *pindex);
-    virtual bool NotifyTransaction(const CTransaction &transaction);
+    virtual bool NotifyTransaction(const CTransactionRef &ptx);
 
 protected:
     void *psocket;

--- a/src/zmq/zmqnotificationinterface.cpp
+++ b/src/zmq/zmqnotificationinterface.cpp
@@ -137,12 +137,12 @@ void CZMQNotificationInterface::UpdatedBlockTip(const CBlockIndex *pindex)
     }
 }
 
-void CZMQNotificationInterface::SyncTransaction(const CTransaction &tx, const CBlock *pblock, int txIndex)
+void CZMQNotificationInterface::SyncTransaction(const CTransactionRef &ptx, const CBlock *pblock, int txIndex)
 {
     for (std::list<CZMQAbstractNotifier *>::iterator i = notifiers.begin(); i != notifiers.end();)
     {
         CZMQAbstractNotifier *notifier = *i;
-        if (notifier->NotifyTransaction(tx))
+        if (notifier->NotifyTransaction(ptx))
         {
             i++;
         }

--- a/src/zmq/zmqnotificationinterface.h
+++ b/src/zmq/zmqnotificationinterface.h
@@ -25,7 +25,7 @@ protected:
     void Shutdown();
 
     // CValidationInterface
-    void SyncTransaction(const CTransaction &tx, const CBlock *pblock, int txIndex = -1);
+    void SyncTransaction(const CTransactionRef &ptx, const CBlock *pblock, int txIndex = -1);
     void UpdatedBlockTip(const CBlockIndex *pindex);
 
 private:

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -129,9 +129,9 @@ bool CZMQPublishHashBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
     return rc == 0;
 }
 
-bool CZMQPublishHashTransactionNotifier::NotifyTransaction(const CTransaction &transaction)
+bool CZMQPublishHashTransactionNotifier::NotifyTransaction(const CTransactionRef &ptx)
 {
-    uint256 hash = transaction.GetHash();
+    uint256 hash = ptx->GetHash();
     LOG(ZMQ, "zmq: Publish hashtx %s\n", hash.GetHex());
     char data[32];
     for (unsigned int i = 0; i < 32; i++)
@@ -162,12 +162,12 @@ bool CZMQPublishRawBlockNotifier::NotifyBlock(const CBlockIndex *pindex)
     return rc == 0;
 }
 
-bool CZMQPublishRawTransactionNotifier::NotifyTransaction(const CTransaction &transaction)
+bool CZMQPublishRawTransactionNotifier::NotifyTransaction(const CTransactionRef &ptx)
 {
-    uint256 hash = transaction.GetHash();
+    uint256 hash = ptx->GetHash();
     LOG(ZMQ, "zmq: Publish rawtx %s\n", hash.GetHex());
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-    ss << transaction;
+    ss << *ptx;
     int rc = zmq_send_multipart(psocket, "rawtx", 5, &(*ss.begin()), ss.size(), 0);
     return rc == 0;
 }

--- a/src/zmq/zmqpublishnotifier.h
+++ b/src/zmq/zmqpublishnotifier.h
@@ -26,7 +26,7 @@ public:
 class CZMQPublishHashTransactionNotifier : public CZMQAbstractPublishNotifier
 {
 public:
-    bool NotifyTransaction(const CTransaction &transaction);
+    bool NotifyTransaction(const CTransactionRef &ptx);
 };
 
 class CZMQPublishRawBlockNotifier : public CZMQAbstractPublishNotifier
@@ -38,7 +38,7 @@ public:
 class CZMQPublishRawTransactionNotifier : public CZMQAbstractPublishNotifier
 {
 public:
-    bool NotifyTransaction(const CTransaction &transaction);
+    bool NotifyTransaction(const CTransactionRef &ptx);
 };
 
 #endif // BITCOIN_ZMQ_ZMQPUBLISHNOTIFIER_H


### PR DESCRIPTION
This PR is mainly about extending CTransationRef into the Wallet which also requires it then in ZMQ.  There is also a bit of cleanup work with the C++11 range loops and also a bug fix for a missing cs_main lock.  Once all this is merged we'll be better prepared for brinGing in the HD wallet.