### PR TITLE
Always enforce SCRIPT_ENABLE_SIGHASH_FORKID flag for txns to be included in the mempool

### DIFF
--- a/qa/rpc-tests/uahf.py
+++ b/qa/rpc-tests/uahf.py
@@ -235,29 +235,34 @@ class BUIP055Test (BitcoinTestFramework):
 
         logging.info("Building > 1MB block...")
 
+        ######
+        # DONT delete, just comment sicne we could use this as a template for
+        # future similar requirements.
+        #######
+
         # TEST that the client refuses to include invalid op return txns in the first block
-        self.generateTx(node, 950000, addrs, data='54686973206973203830206279746573206f6620746573742064617461206372656174656420746f20757365207570207472616e73616374696f6e20737061636520666173746572202e2e2e2e2e2e2e')
-        try:
-            self.generateTx(node,100000, addrs,data=invalidOpReturn)
-            assert(0)  # should have raised exception
-        except JSONRPCException as e:
-            assert("wrong-fork" in e.error["message"])
+        #self.generateTx(node, 950000, addrs, data='54686973206973203830206279746573206f6620746573742064617461206372656174656420746f20757365207570207472616e73616374696f6e20737061636520666173746572202e2e2e2e2e2e2e')
+        #try:
+        #    self.generateTx(node,100000, addrs,data=invalidOpReturn)
+        #    assert(0)  # should have raised exception
+        #except JSONRPCException as e:
+        #    assert("wrong-fork" in e.error["message"])
 
         # temporarily turn off forking so we can inject some bad tx into the mempool
-        node.set("mining.forkTime=0")
-        unspendableTx, unspendableTxSize = self.generateTx(node,100000, addrs,data=invalidOpReturn)
-        node.set("mining.forkTime=%d" % forkTime)
+        #node.set("mining.forkTime=0")
+        #unspendableTx, unspendableTxSize = self.generateTx(node,100000, addrs,data=invalidOpReturn)
+        #node.set("mining.forkTime=%d" % forkTime)
 
-        # node 3 is not forking so these tx are allowed
-        self.generateTx(self.nodes[3],100000,addrs,data=invalidOpReturn)
+        ## node 3 is not forking so these tx are allowed
+        #self.generateTx(self.nodes[3],100000,addrs,data=invalidOpReturn)
 
-        try:
-            ret = node.generate(1)
-            logging.info(ret)
-            assert(0)  # should have raised exception
-        except JSONRPCException as e:
-            assert("bad-blk-too-small" in e.error["message"])
-            logging.info("PASS: Invalid OP return transactions were not used when attempting to make the fork block")
+        #try:
+        #    ret = node.generate(1)
+        #    logging.info(ret)
+        #    assert(0)  # should have raised exception
+        #except JSONRPCException as e:
+        #    assert("bad-blk-too-small" in e.error["message"])
+        #    logging.info("PASS: Invalid OP return transactions were not used when attempting to make the fork block")
 
         # TEST REQ-3: generate a large block
         self.generateTx(node, 100000, addrs)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -595,7 +595,6 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
     TransactionClass allowedTx,
     std::vector<COutPoint> &vCoinsToUncache)
 {
-    unsigned int forkVerifyFlags = 0;
     unsigned int nSigOps = 0;
     ValidationResourceTracker resourceTracker;
     unsigned int nSize = 0;
@@ -612,12 +611,6 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
     // Coinbase is only valid in a block, not as a loose transaction
     if (ptx->IsCoinBase())
         return state.DoS(100, false, REJECT_INVALID, "coinbase");
-
-    // UAHF: accept both sighashtypes because we will need all the tx types during the transition.
-    if (IsUAHFforkActiveOnNextBlock((chainActive.Tip()->nHeight) - 12))
-    {
-        forkVerifyFlags = SCRIPT_ENABLE_SIGHASH_FORKID;
-    }
 
     // Reject nonstandard transactions if so configured.
     // (-testnet/-regtest allow nonstandard, and explicit submission via RPC)
@@ -890,8 +883,8 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
         // Check against previous transactions
         // This is done last to help prevent CPU exhaustion denial-of-service attacks.
         unsigned char sighashType = 0;
-        if (!CheckInputs(*ptx, state, view, true, STANDARD_SCRIPT_VERIFY_FLAGS | forkVerifyFlags | extraFlags, true,
-                &resourceTracker, nullptr, &sighashType))
+        if (!CheckInputs(*ptx, state, view, true, STANDARD_SCRIPT_VERIFY_FLAGS | extraFlags, true, &resourceTracker,
+                nullptr, &sighashType))
         {
             LOG(MEMPOOL, "CheckInputs failed for tx: %s\n", ptx->GetHash().ToString().c_str());
             return false;
@@ -908,8 +901,8 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
         // invalid blocks, however allowing such transactions into the mempool
         // can be exploited as a DoS attack.
         unsigned char sighashType2 = 0;
-        if (!CheckInputs(*ptx, state, view, true, MANDATORY_SCRIPT_VERIFY_FLAGS | forkVerifyFlags | extraFlags, true,
-                nullptr, nullptr, &sighashType2))
+        if (!CheckInputs(*ptx, state, view, true, MANDATORY_SCRIPT_VERIFY_FLAGS | extraFlags, true, nullptr, nullptr,
+                &sighashType2))
         {
             return error(
                 "%s: BUG! PLEASE REPORT THIS! ConnectInputs failed against MANDATORY but not STANDARD flags %s, %s",

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -383,11 +383,6 @@ void BlockAssembler::addScoreTxs(CBlockTemplate *pblocktemplate)
             continue;
         }
 
-        // If tx is not applicable to this (forked) chain, skip it
-        if (uahfChainBlock && IsTxOpReturnInvalid(iter->GetTx()))
-        {
-            continue;
-        }
         // Reject the tx if we are on the fork, but the tx is not fork-signed
         if (uahfChainBlock && !IsTxUAHFOnly(*iter))
         {
@@ -485,11 +480,6 @@ void BlockAssembler::addPriorityTxs(CBlockTemplate *pblocktemplate)
             continue;
         }
 
-        // If tx is not applicable to this (forked) chain, skip it
-        if (uahfChainBlock && IsTxOpReturnInvalid(iter->GetTx()))
-        {
-            continue;
-        }
         // Reject the tx if we are on the fork, but the tx is not fork-signed
         if (uahfChainBlock && !IsTxUAHFOnly(*iter))
         {

--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -42,7 +42,9 @@ extern unsigned nMaxDatacarrierBytes;
  * Failing one of these tests may trigger a DoS ban - see CheckInputs() for
  * details.
  */
-static const unsigned int MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH;
+static const uint32_t MANDATORY_SCRIPT_VERIFY_FLAGS = SCRIPT_VERIFY_P2SH | SCRIPT_VERIFY_STRICTENC |
+                                                      SCRIPT_ENABLE_SIGHASH_FORKID | SCRIPT_VERIFY_LOW_S |
+                                                      SCRIPT_VERIFY_NULLFAIL;
 
 enum txnouttype
 {

--- a/src/test/uahf_test.cpp
+++ b/src/test/uahf_test.cpp
@@ -69,50 +69,6 @@ static std::vector<CMutableTransaction> SetupDummyInputs(CBasicKeyStore &keystor
     return dummyTransactions;
 }
 
-BOOST_AUTO_TEST_CASE(uahf_op_return)
-{
-    // Check that a transaction with the invalid OP_RETURN is seen as invalid
-    CMutableTransaction tx;
-    tx.vout.resize(1);
-    tx.vout[0].nValue = 0;
-    tx.vout[0].scriptPubKey = CScript() << OP_RETURN << invalidOpReturn;
-    BOOST_CHECK(IsTxOpReturnInvalid(tx) == true);
-
-    CKey key;
-    key.MakeNewKey(true);
-
-    // Check that an arbitrary OP_RETURN is not invalid
-    tx.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("010203040506070809");
-    BOOST_CHECK(IsTxOpReturnInvalid(tx) == false);
-
-    // Check that a normal tx (without OP_RETURN) is not invalid
-    tx.vout[0].nValue = 50000;
-    tx.vout[0].scriptPubKey = CScript() << OP_DUP << OP_HASH160 << ToByteVector(key.GetPubKey().GetID())
-                                        << OP_EQUALVERIFY << OP_CHECKSIG;
-    BOOST_CHECK(IsTxOpReturnInvalid(tx) == false);
-
-    // Check that a normal tx with the invalid OP_RETURN is invalid
-    tx.vout.resize(2);
-    tx.vout[1].scriptPubKey = CScript() << OP_RETURN << invalidOpReturn;
-    tx.vout[1].nValue = 0;
-    BOOST_CHECK(IsTxOpReturnInvalid(tx) == true);
-
-    // OP_RETURN must be the first instruction for it to could as an invalid tx on the new fork
-    tx.vout[1].scriptPubKey = CScript() << OP_DUP << OP_HASH160 << ToByteVector(key.GetPubKey().GetID())
-                                        << OP_EQUALVERIFY << OP_RETURN << invalidOpReturn;
-    tx.vout[1].nValue = 0;
-    BOOST_CHECK(IsTxOpReturnInvalid(tx) == false);
-
-    tx.vout[1].scriptPubKey = CScript() << OP_DUP << OP_HASH160 << ToByteVector(key.GetPubKey().GetID())
-                                        << OP_EQUALVERIFY << invalidOpReturn;
-    tx.vout[1].nValue = 0;
-    BOOST_CHECK(IsTxOpReturnInvalid(tx) == false);
-
-    tx.vout[1].scriptPubKey = CScript() << OP_DUP << OP_HASH160 << ToByteVector(key.GetPubKey().GetID())
-                                        << OP_EQUALVERIFY << OP_RETURN << ParseHex("0") << invalidOpReturn;
-    BOOST_CHECK(IsTxOpReturnInvalid(tx) == false);
-}
-
 BOOST_AUTO_TEST_CASE(uahf_sighash)
 {
     LOCK(cs_main);

--- a/src/uahf_fork.cpp
+++ b/src/uahf_fork.cpp
@@ -13,28 +13,6 @@
 #include <inttypes.h>
 #include <vector>
 
-const int REQ_6_1_SUNSET_HEIGHT = 530000;
-const int TESTNET_REQ_6_1_SUNSET_HEIGHT = 1250000;
-
-static const std::string ANTI_REPLAY_MAGIC_VALUE = "Bitcoin: A Peer-to-Peer Electronic Cash System";
-
-std::vector<unsigned char> invalidOpReturn =
-    std::vector<unsigned char>(std::begin(ANTI_REPLAY_MAGIC_VALUE), std::end(ANTI_REPLAY_MAGIC_VALUE));
-
-bool ValidateUAHFBlock(const CBlock &block, CValidationState &state, int nHeight)
-{
-    // Validate transactions are HF compatible
-    for (auto &tx : block.vtx)
-    {
-        int sunsetHeight =
-            (Params().NetworkIDString() == "testnet") ? TESTNET_REQ_6_1_SUNSET_HEIGHT : REQ_6_1_SUNSET_HEIGHT;
-        if ((nHeight <= sunsetHeight) && IsTxOpReturnInvalid(*tx))
-            return state.DoS(
-                100, error("transaction is invalid on UAHF cash chain"), REJECT_INVALID, "bad-txns-wrong-fork");
-    }
-    return true;
-}
-
 bool IsTxProbablyNewSigHash(const CTransaction &tx)
 {
     // bool newsighash = false;
@@ -68,48 +46,6 @@ bool IsTxUAHFOnly(const CTxMemPoolEntry &txentry)
     {
         // LOGA("txn is UAHF-specific\n");
         return true;
-    }
-    return false;
-}
-
-bool IsTxOpReturnInvalid(const CTransaction &tx)
-{
-    for (auto txout : tx.vout)
-    {
-        int idx = txout.scriptPubKey.Find(OP_RETURN);
-        if (idx)
-        {
-            CScript::const_iterator pc(txout.scriptPubKey.begin());
-            opcodetype op;
-#if 0 // Allow OP_RETURN anywhere
-            for (;pc != txout.scriptPubKey.end();)
-            {
-                if (txout.scriptPubKey.GetOp(pc, op))
-                {
-                    if (op == OP_RETURN) break;
-                }
-            }
-#else // OP_RETURN must be the first instruction
-            if (txout.scriptPubKey.GetOp(pc, op))
-            {
-                if (op != OP_RETURN)
-                    return false;
-            }
-#endif
-            if (pc != txout.scriptPubKey.end())
-            {
-                std::vector<unsigned char> data;
-                if (txout.scriptPubKey.GetOp(pc, op, data))
-                {
-                    // Note this code only works if the size <= 75 (or we'd have OP_PUSHDATAn instead)
-                    if (op == invalidOpReturn.size())
-                    {
-                        if (data == invalidOpReturn)
-                            return true;
-                    }
-                }
-            }
-        }
     }
     return false;
 }

--- a/src/uahf_fork.h
+++ b/src/uahf_fork.h
@@ -18,17 +18,6 @@ class CBlockIndex;
 class CScript;
 class CTxMemPoolEntry;
 
-// OP_RETURN magic invalid value:
-extern std::vector<unsigned char> invalidOpReturn;
-
-// Validate that the block's contents adhere to the UAHF hard fork requirements.
-// the requirement that the fork block is >= 1MB is not checked because we do not
-// know whether this is the fork block.
-extern bool ValidateUAHFBlock(const CBlock &block, CValidationState &state, int nHeight);
-
-// Return true if this transaction is invalid on the UAHF fork due to a special OP_RETURN code
-extern bool IsTxOpReturnInvalid(const CTransaction &tx);
-
 // Return true if this transaction can only be committed post-fork
 extern bool IsTxUAHFOnly(const CTxMemPoolEntry &tx);
 


### PR DESCRIPTION
Since almost a year passed since Aug 1st protocol upgrade, always enforce SCRIPT_ENABLE_SIGHASH_FORKID flag to validate txns that have to be included in the mempool rather then check current block height for every txn.

Also updated MANDATORY_SCRIPT_VERIFY_FLAGS, added flags:

- SCRIPT_ENABLE_SIGHASH_FORKID (Aug 1st, 2017 protocol upgrade)
- SCRIPT_VERIFY_STRICTENC  (Aug 1st, 2017 protocol upgrade)
- SCRIPT_VERIFY_LOW_S (Nov 13, 2017 protocol upgrade)
- SCRIPT_VERIFY_NULLFAIL (Nov 13, 2017 protocol upgrade)

MANDATORY_SCRIPT_VERIFY_FLAGS contains flags all new blocks must comply    with, old blocks may not comply with it depending on block height/MTP.
