### PR TITLE
Added cash denomination per BUIP087

### DIFF
--- a/src/qt/bitcoinunits.cpp
+++ b/src/qt/bitcoinunits.cpp
@@ -14,7 +14,7 @@ QList<BitcoinUnits::Unit> BitcoinUnits::availableUnits()
     QList<BitcoinUnits::Unit> unitlist;
     unitlist.append(BCH);
     unitlist.append(mBCH);
-    unitlist.append(uBCH);
+    unitlist.append(XCH);
     return unitlist;
 }
 
@@ -24,7 +24,7 @@ bool BitcoinUnits::valid(int unit)
     {
     case BCH:
     case mBCH:
-    case uBCH:
+    case XCH:
         return true;
     default:
         return false;
@@ -39,8 +39,8 @@ QString BitcoinUnits::name(int unit)
         return QString("BCH");
     case mBCH:
         return QString("mBCH");
-    case uBCH:
-        return QString::fromUtf8("μBCH");
+    case XCH:
+        return QString("cash");
     default:
         return QString("???");
     }
@@ -54,8 +54,8 @@ QString BitcoinUnits::description(int unit)
         return QString("Bitcoins");
     case mBCH:
         return QString("Milli-Bitcoins (1 / 1" THIN_SP_UTF8 "000)");
-    case uBCH:
-        return QString("Micro-Bitcoins (1 / 1" THIN_SP_UTF8 "000" THIN_SP_UTF8 "000)");
+    case XCH:
+        return QString("Cash (1 / 1" THIN_SP_UTF8 "000" THIN_SP_UTF8 "000)");
     default:
         return QString("???");
     }
@@ -69,7 +69,7 @@ qint64 BitcoinUnits::factor(int unit)
         return 100000000;
     case mBCH:
         return 100000;
-    case uBCH:
+    case XCH:
         return 100;
     default:
         return 100000000;
@@ -84,7 +84,7 @@ int BitcoinUnits::decimals(int unit)
         return 8;
     case mBCH:
         return 5;
-    case uBCH:
+    case XCH:
         return 2;
     default:
         return 0;

--- a/src/qt/bitcoinunits.h
+++ b/src/qt/bitcoinunits.h
@@ -59,7 +59,7 @@ public:
     {
         BCH,
         mBCH,
-        uBCH
+        XCH
     };
 
     enum SeparatorStyle


### PR DESCRIPTION
[BUIP087](https://bitco.in/forum/threads/buip087-utilization-of-%E2%80%9Ccash%E2%80%9D-denomination.10202/) recommends that the unit "µBCH" is changed to "cash" or "XCH"