### PR TITLE
Fix clang warnings

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -23,7 +23,7 @@ class GlobalConfig final : public Config
 {
 public:
     GlobalConfig();
-    const CChainParams &GetChainParams() const;
+    const CChainParams &GetChainParams() const override;
     void SetCashAddrEncoding(bool) override;
     bool UseCashAddrEncoding() const override;
 

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -43,7 +43,6 @@ public:
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
         READWRITE(this->nVersion);
-        nVersion = this->nVersion;
         READWRITE(hashPrevBlock);
         READWRITE(hashMerkleRoot);
         READWRITE(nTime);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -266,7 +266,6 @@ struct CMutableTransaction
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
         READWRITE(this->nVersion);
-        nVersion = this->nVersion;
         READWRITE(vin);
         READWRITE(vout);
         READWRITE(nLockTime);

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -1445,7 +1445,7 @@ class SigPubkeyHashChecker : public BaseSignatureChecker
 public:
     virtual bool CheckSig(const std::vector<unsigned char> &scriptSig,
         const std::vector<unsigned char> &vchPubKey,
-        const CScript &scriptCode) const
+        const CScript &scriptCode) const override
     {
         CPubKey pub = CPubKey(vchPubKey);
         uint256 hash = pub.GetHash();

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -65,7 +65,6 @@ public:
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
         READWRITE(this->nVersion);
-        nVersion = this->nVersion;
         READWRITE(nCreateTime);
     }
 


### PR DESCRIPTION
This PR will fix a bunch of warnings generated during the compilation of the source code using clang.

The warning was due to a self assignment and missing override attribute. 

What's strange about the former kind is that in PR #785 commit c8df859 removed the line of code that generated the warning, whereas commit 1751e1f contained in the same PR put it back.