### PR TITLE
[PORT XT] Ensure http server thread is only stopped if it was started.

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -516,7 +516,10 @@ void StopHTTPServer()
             LOGA("HTTP event loop did not exit within allotted time, sending loopbreak\n");
             event_base_loopbreak(eventBase);
         }
-        threadHTTP.join();
+        if (threadHTTP.joinable())
+        {
+            threadHTTP.join();
+        }
     }
     if (eventHTTP)
     {


### PR DESCRIPTION
This is a port of https://github.com/bitcoinxt/bitcoinxt/pull/427

Thread startup (StartHTTPServer) is separate  from
initalization (InitHTTPServer), so we need to check whether the thread
was started before stopping it.
