### PR TITLE
Ensure cs_utxo is locked by the caller when a coin reference is returned

### DIFF
--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -226,6 +226,8 @@ bool Consensus::CheckTxInputs(const CTransaction &tx, CValidationState &state, c
             // If prev is coinbase, check that it's matured
             if (coin.IsCoinBase())
             {
+                // Copy these values here because once we unlock and re-lock cs_utxo we can't count on "coin"
+                // still being valid.
                 CAmount nCoinOutValue = coin.out.nValue;
                 int nCoinHeight = coin.nHeight;
 

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -143,11 +143,14 @@ unsigned int GetP2SHSigOpCount(const CTransaction &tx, const CCoinsViewCache &in
         return 0;
 
     unsigned int nSigOps = 0;
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
     {
-        const CTxOut &prevout = inputs.AccessCoin(tx.vin[i].prevout).out;
-        if (prevout.scriptPubKey.IsPayToScriptHash())
-            nSigOps += prevout.scriptPubKey.GetSigOpCount(tx.vin[i].scriptSig);
+        LOCK(inputs.cs_utxo);
+        for (unsigned int i = 0; i < tx.vin.size(); i++)
+        {
+            const CTxOut &prevout = inputs.AccessCoin(tx.vin[i].prevout).out;
+            if (prevout.scriptPubKey.IsPayToScriptHash())
+                nSigOps += prevout.scriptPubKey.GetSigOpCount(tx.vin[i].scriptSig);
+        }
     }
     return nSigOps;
 }
@@ -212,26 +215,48 @@ bool Consensus::CheckTxInputs(const CTransaction &tx, CValidationState &state, c
     CAmount nValueIn = 0;
     CAmount nFees = 0;
     int nSpendHeight = -1;
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
     {
-        const COutPoint &prevout = tx.vin[i].prevout;
-        const Coin &coin = inputs.AccessCoin(prevout);
-        assert(!coin.IsSpent());
-
-        // If prev is coinbase, check that it's matured
-        if (coin.IsCoinBase())
+        LOCK(inputs.cs_utxo);
+        for (unsigned int i = 0; i < tx.vin.size(); i++)
         {
-            if (nSpendHeight == -1)
-                nSpendHeight = GetSpendHeight(inputs);
-            if (nSpendHeight - coin.nHeight < COINBASE_MATURITY)
-                return state.Invalid(false, REJECT_INVALID, "bad-txns-premature-spend-of-coinbase",
-                    strprintf("tried to spend coinbase at depth %d", nSpendHeight - coin.nHeight));
-        }
+            const COutPoint &prevout = tx.vin[i].prevout;
+            const Coin &coin = inputs.AccessCoin(prevout);
+            assert(!coin.IsSpent());
 
-        // Check for negative or overflow input values
-        nValueIn += coin.out.nValue;
-        if (!MoneyRange(coin.out.nValue) || !MoneyRange(nValueIn))
-            return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputvalues-outofrange");
+            // If prev is coinbase, check that it's matured
+            if (coin.IsCoinBase())
+            {
+                CAmount nCoinOutValue = coin.out.nValue;
+                int nCoinHeight = coin.nHeight;
+
+                // If there are multiple coinbase spends we still only need to get the spend height once.
+                if (nSpendHeight == -1)
+                {
+                    // GetSpendHeight requires cs_main but in order to maintain proper locking order cs_utxo
+                    // must be taken after cs_main.
+                    LEAVE_CRITICAL_SECTION(inputs.cs_utxo);
+                    nSpendHeight = GetSpendHeight(inputs);
+                    ENTER_CRITICAL_SECTION(inputs.cs_utxo);
+                }
+                if (nSpendHeight - nCoinHeight < COINBASE_MATURITY)
+                    return state.Invalid(false, REJECT_INVALID, "bad-txns-premature-spend-of-coinbase",
+                        strprintf("tried to spend coinbase at depth %d", nSpendHeight - nCoinHeight));
+
+                // Check for negative or overflow input values.  We use nCoinOutValue which was copied before
+                // we released cs_utxo, because we can't be certain the value didn't change during the time
+                // cs_utxo was unlocked.
+                nValueIn += nCoinOutValue;
+                if (!MoneyRange(nCoinOutValue) || !MoneyRange(nValueIn))
+                    return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputvalues-outofrange");
+            }
+            else
+            {
+                // Check for negative or overflow input values
+                nValueIn += coin.out.nValue;
+                if (!MoneyRange(coin.out.nValue) || !MoneyRange(nValueIn))
+                    return state.DoS(100, false, REJECT_INVALID, "bad-txns-inputvalues-outofrange");
+            }
+        }
     }
 
     if (nValueIn < tx.GetValueOut())

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1390,19 +1390,23 @@ bool CheckInputs(const CTransaction &tx,
             {
                 const COutPoint &prevout = tx.vin[i].prevout;
 
-                LOCK(inputs.cs_utxo);
-                const Coin &coin = inputs.AccessCoin(prevout);
-                if (coin.IsSpent())
-                    LOGA("ASSERTION: no inputs available\n");
-                assert(!coin.IsSpent());
+                CScript scriptPubKey;
+                CAmount amount;
+                {
+                    LOCK(inputs.cs_utxo);
+                    const Coin &coin = inputs.AccessCoin(prevout);
+                    if (coin.IsSpent())
+                        LOGA("ASSERTION: no inputs available\n");
+                    assert(!coin.IsSpent());
 
-                // We very carefully only pass in things to CScriptCheck which
-                // are clearly committed. This provides
-                // a sanity check that our caching is not introducing consensus
-                // failures through additional data in, eg, the coins being
-                // spent being checked as a part of CScriptCheck.
-                const CScript &scriptPubKey = coin.out.scriptPubKey;
-                const CAmount &amount = coin.out.nValue;
+                    // We very carefully only pass in things to CScriptCheck which
+                    // are clearly committed. This provides
+                    // a sanity check that our caching is not introducing consensus
+                    // failures through additional data in, eg, the coins being
+                    // spent being checked as a part of CScriptCheck.
+                    scriptPubKey = coin.out.scriptPubKey;
+                    amount = coin.out.nValue;
+                }
 
                 // Verify signature
                 CScriptCheck check(resourceTracker, scriptPubKey, amount, tx, i, flags, cacheStore);

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -141,14 +141,17 @@ bool AreInputsStandard(const CTransaction &tx, const CCoinsViewCache &mapInputs)
 
     for (unsigned int i = 0; i < tx.vin.size(); i++)
     {
-        const CTxOut &prev = mapInputs.AccessCoin(tx.vin[i].prevout).out;
-
-        std::vector<std::vector<unsigned char> > vSolutions;
         txnouttype whichType;
-        // get the scriptPubKey corresponding to this input:
-        const CScript &prevScript = prev.scriptPubKey;
-        if (!Solver(prevScript, whichType, vSolutions))
-            return false;
+        {
+            LOCK(mapInputs.cs_utxo);
+            const CTxOut &prev = mapInputs.AccessCoin(tx.vin[i].prevout).out;
+
+            std::vector<std::vector<unsigned char> > vSolutions;
+            // get the scriptPubKey corresponding to this input:
+            const CScript &prevScript = prev.scriptPubKey;
+            if (!Solver(prevScript, whichType, vSolutions))
+                return false;
+        }
 
         if (whichType == TX_SCRIPTHASH)
         {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -716,7 +716,8 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
         }
         else if (it->GetSpendsCoinbase())
         {
-            BOOST_FOREACH (const CTxIn &txin, tx.vin)
+            LOCK(pcoins->cs_utxo);
+            for (const CTxIn &txin : tx.vin)
             {
                 indexed_transaction_set::const_iterator it2 = mapTx.find(txin.prevout.hash);
                 if (it2 != mapTx.end())


### PR DESCRIPTION
Thanks to @dagurval for catching this bug.

AccessCoin() and AccessByTxid() both return references to a coin in the dbcache.  The caller of those functions has to make sure the cs_utxo locked during the time the returned coin reference is being used, so by using AssertLockHeld() at the beginning of both AccessCoin() and AccessByTxid() we force the caller to to take the lock where/when appropriate.