### PR TITLE
[PORT] Make boost::multi_index comparators const

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -162,7 +162,7 @@ struct update_descendant_state
     {
     }
 
-    void operator()(CTxMemPoolEntry &e) { e.UpdateState(modifySize, modifyFee, modifyCount); }
+    void operator()(CTxMemPoolEntry &e) const { e.UpdateState(modifySize, modifyFee, modifyCount); }
 private:
     int64_t modifySize;
     CAmount modifyFee;
@@ -171,13 +171,13 @@ private:
 
 struct set_dirty
 {
-    void operator()(CTxMemPoolEntry &e) { e.SetDirty(); }
+    void operator()(CTxMemPoolEntry &e) const { e.SetDirty(); }
 };
 
 struct update_fee_delta
 {
     update_fee_delta(int64_t _feeDelta) : feeDelta(_feeDelta) {}
-    void operator()(CTxMemPoolEntry &e) { e.UpdateFeeDelta(feeDelta); }
+    void operator()(CTxMemPoolEntry &e) const { e.UpdateFeeDelta(feeDelta); }
 private:
     int64_t feeDelta;
 };
@@ -185,7 +185,7 @@ private:
 struct update_lock_points
 {
     update_lock_points(const LockPoints &_lp) : lp(_lp) {}
-    void operator()(CTxMemPoolEntry &e) { e.UpdateLockPoints(lp); }
+    void operator()(CTxMemPoolEntry &e) const { e.UpdateLockPoints(lp); }
 private:
     const LockPoints &lp;
 };
@@ -204,7 +204,7 @@ struct mempoolentry_txid
 class CompareTxMemPoolEntryByDescendantScore
 {
 public:
-    bool operator()(const CTxMemPoolEntry &a, const CTxMemPoolEntry &b)
+    bool operator()(const CTxMemPoolEntry &a, const CTxMemPoolEntry &b) const
     {
         bool fUseADescendants = UseDescendantScore(a);
         bool fUseBDescendants = UseDescendantScore(b);
@@ -227,7 +227,7 @@ public:
     }
 
     // Calculate which score to use for an entry (avoiding division).
-    bool UseDescendantScore(const CTxMemPoolEntry &a)
+    bool UseDescendantScore(const CTxMemPoolEntry &a) const
     {
         double f1 = (double)a.GetModifiedFee() * a.GetSizeWithDescendants();
         double f2 = (double)a.GetModFeesWithDescendants() * a.GetTxSize();
@@ -242,7 +242,7 @@ public:
 class CompareTxMemPoolEntryByScore
 {
 public:
-    bool operator()(const CTxMemPoolEntry &a, const CTxMemPoolEntry &b)
+    bool operator()(const CTxMemPoolEntry &a, const CTxMemPoolEntry &b) const
     {
         double f1 = (double)a.GetModifiedFee() * b.GetTxSize();
         double f2 = (double)b.GetModifiedFee() * a.GetTxSize();
@@ -257,7 +257,7 @@ public:
 class CompareTxMemPoolEntryByEntryTime
 {
 public:
-    bool operator()(const CTxMemPoolEntry &a, const CTxMemPoolEntry &b) { return a.GetTime() < b.GetTime(); }
+    bool operator()(const CTxMemPoolEntry &a, const CTxMemPoolEntry &b) const { return a.GetTime() < b.GetTime(); }
 };
 
 // Multi_index tag names


### PR DESCRIPTION
This is a port of: 

github.com/bitcoin/bitcoin/pull/12032

and is going to fix #1115 reported by @jcramer, i.e fixes compatibility with boost 1.66+