### PR TITLE
Clarify variable naming for coins cache usage

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -973,11 +973,11 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
     // Return the initial values for the various in memory caches.
     int64_t nBlockTreeDBCache = 0;
     int64_t nCoinDBCache = 0;
-    GetCacheConfiguration(nBlockTreeDBCache, nCoinDBCache, nCoinCacheUsage);
+    GetCacheConfiguration(nBlockTreeDBCache, nCoinDBCache, nCoinCacheMaxSize);
     LOGA("Cache configuration:\n");
     LOGA("* Using %.1fMiB for block index database\n", nBlockTreeDBCache * (1.0 / 1024 / 1024));
     LOGA("* Using %.1fMiB for chain state database\n", nCoinDBCache * (1.0 / 1024 / 1024));
-    LOGA("* Using %.1fMiB for in-memory UTXO set\n", nCoinCacheUsage * (1.0 / 1024 / 1024));
+    LOGA("* Using %.1fMiB for in-memory UTXO set\n", nCoinCacheMaxSize * (1.0 / 1024 / 1024));
 
     bool fLoaded = false;
     while (!fLoaded)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,12 +84,11 @@ bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
 unsigned int nBytesPerSigOp = DEFAULT_BYTES_PER_SIGOP;
 bool fCheckBlockIndex = false;
 bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
-int64_t nCoinCacheMaxSize = 0;
 uint64_t nPruneTarget = 0;
 uint32_t nXthinBloomFilterSize = SMALLEST_MAX_BLOOM_FILTER_SIZE;
 
 // The allowed size of the in memory UTXO cache
-int64_t nCoinCacheUsage GUARDED_BY(cs_main) = 0;
+int64_t nCoinCacheMaxSize GUARDED_BY(cs_main) = 0;
 
 CFeeRate minRelayTxFee GUARDED_BY(cs_main) = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2397,7 +2397,7 @@ bool FlushStateToDisk(CValidationState &state, FlushStateMode mode)
         // As a safeguard, periodically check and correct any drift in the value of cachedCoinsUsage.  While a
         // correction should never be needed, resetting the value allows the node to continue operating, and only
         // an error is reported if the new and old values do not match.
-        if (fPeriodicFlush || nCoinCacheMaxSize < 0)
+        if (fPeriodicFlush || nCurrentCacheUsage < 0)
             pcoinsTip->ResetCachedCoinUsage();
     }
     catch (const std::runtime_error &e)

--- a/src/main.h
+++ b/src/main.h
@@ -172,7 +172,7 @@ extern bool fIsBareMultisigStd;
 extern unsigned int nBytesPerSigOp;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
-extern int64_t nCoinCacheUsage;
+extern int64_t nCoinCacheMaxSize;
 /** A fee rate smaller than this is considered zero fee (for relaying, mining and transaction creation) */
 extern CFeeRate minRelayTxFee;
 /** Absolute maximum transaction fee (in satoshis) used by wallet and mempool (rejects high fee in sendrawtransaction)

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -510,7 +510,7 @@ uint64_t GetTotalSystemMemory()
 
 void GetCacheConfiguration(int64_t &_nBlockTreeDBCache,
     int64_t &_nCoinDBCache,
-    int64_t &_nCoinCacheUsage,
+    int64_t &_nCoinCacheMaxSize,
     bool fDefault)
 {
 #ifdef WIN32
@@ -550,13 +550,13 @@ void GetCacheConfiguration(int64_t &_nBlockTreeDBCache,
     }
 
     // Now that we have the nTotalCache we can calculate all the various cache sizes.
-    CacheSizeCalculations(nTotalCache, _nBlockTreeDBCache, _nCoinDBCache, _nCoinCacheUsage);
+    CacheSizeCalculations(nTotalCache, _nBlockTreeDBCache, _nCoinDBCache, _nCoinCacheMaxSize);
 }
 
 void CacheSizeCalculations(int64_t _nTotalCache,
     int64_t &_nBlockTreeDBCache,
     int64_t &_nCoinDBCache,
-    int64_t &_nCoinCacheUsage)
+    int64_t &_nCoinCacheMaxSize)
 {
     // make sure total cache is within limits
     _nTotalCache = std::max(_nTotalCache, nMinDbCache << 20); // total cache cannot be less than nMinDbCache
@@ -574,7 +574,7 @@ void CacheSizeCalculations(int64_t _nTotalCache,
 
     // the remainder goes to the in-memory utxo coins cache
     _nTotalCache -= _nCoinDBCache;
-    _nCoinCacheUsage = _nTotalCache;
+    _nCoinCacheMaxSize = _nTotalCache;
 }
 
 void AdjustCoinCacheSize()
@@ -585,10 +585,10 @@ void AdjustCoinCacheSize()
     // value for dbcache. This will cause the current coins cache to be immediately trimmed to size.
     if (!IsInitialBlockDownload() && !GetArg("-dbcache", 0) && chainActive.Tip())
     {
-        // Get the default value for nCoinCacheUsage.
+        // Get the default value for nCoinCacheMaxSize.
         int64_t dummyBIDiskCache, dummyUtxoDiskCache, nMaxCoinCache = 0;
         CacheSizeCalculations(nDefaultDbCache, dummyBIDiskCache, dummyUtxoDiskCache, nMaxCoinCache);
-        nCoinCacheUsage = nMaxCoinCache;
+        nCoinCacheMaxSize = nMaxCoinCache;
 
         return;
     }
@@ -602,8 +602,8 @@ void AdjustCoinCacheSize()
         nLastDbAdjustment = nNow;
     }
 
-    // used to determine if we had previously reduced the nCoinCacheUsage and also to tell us what the last
-    // mem available was when we modified the nCoinCacheUsage.
+    // used to determine if we had previously reduced the nCoinCacheMaxSize and also to tell us what the last
+    // mem available was when we modified the nCoinCacheMaxSize.
     static int64_t nLastMemAvailable = 0;
 
     // If there is no dbcache setting specified by the node operator then float the dbache setting down or up
@@ -621,23 +621,23 @@ void AdjustCoinCacheSize()
             nUnusedMem = pcoinsdbview->TotalWriteBufferSize();
         }
 
-        // Reduce nCoinCacheUsage if mem available gets near the threshold. We have to be more strict about flushing
+        // Reduce nCoinCacheMaxSize if mem available gets near the threshold. We have to be more strict about flushing
         // if we're running low on mem because on marginal systems with smaller RAM we have very little wiggle room.
         if (nMemAvailable < nUnusedMem * 1.05)
         {
             // Get the lowest possible default coins cache configuration possible and use this value as a limiter
-            // to prevent the nCoinCacheUsage from falling below this value.
+            // to prevent the nCoinCacheMaxSize from falling below this value.
             int64_t dummyBIDiskCache, dummyUtxoDiskCache, nDefaultCoinCache = 0;
             GetCacheConfiguration(dummyBIDiskCache, dummyUtxoDiskCache, nDefaultCoinCache, true);
 
-            nCoinCacheUsage = std::max(nDefaultCoinCache, nCoinCacheUsage - (nUnusedMem - nMemAvailable));
-            LOG(COINDB, "Current cache size: %ld MB, nCoinCacheUsage was reduced by %u MB\n", nCoinCacheUsage / 1000000,
-                (nUnusedMem - nMemAvailable) / 1000000);
+            nCoinCacheMaxSize = std::max(nDefaultCoinCache, nCoinCacheMaxSize - (nUnusedMem - nMemAvailable));
+            LOG(COINDB, "Current cache size: %ld MB, nCoinCacheMaxSize was reduced by %u MB\n",
+                nCoinCacheMaxSize / 1000000, (nUnusedMem - nMemAvailable) / 1000000);
             nLastDbAdjustment = nNow;
             nLastMemAvailable = nMemAvailable;
         }
 
-        // Increase nCoinCacheUsage if mem available increases. We don't want to constantly be
+        // Increase nCoinCacheMaxSize if mem available increases. We don't want to constantly be
         // triggering an increase whenever the nMemAvailable crosses the threshold by just a
         // few bytes, so we'll dampen the increases by triggering only when the threshold is crossed by 5%.
         else if (nLastMemAvailable > 0 && nMemAvailable * 0.95 >= nLastMemAvailable)
@@ -648,9 +648,9 @@ void AdjustCoinCacheSize()
             CacheSizeCalculations(
                 std::numeric_limits<long long>::max(), dummyBIDiskCache, dummyUtxoDiskCache, nMaxCoinCache);
 
-            nCoinCacheUsage = std::min(nMaxCoinCache, nCoinCacheUsage + (nMemAvailable - nLastMemAvailable));
-            LOG(COINDB, "Current cache size: %ld MB, nCoinCacheUsage was increased by %u MB\n",
-                nCoinCacheUsage / 1000000, (nMemAvailable - nLastMemAvailable) / 1000000);
+            nCoinCacheMaxSize = std::min(nMaxCoinCache, nCoinCacheMaxSize + (nMemAvailable - nLastMemAvailable));
+            LOG(COINDB, "Current cache size: %ld MB, nCoinCacheMaxSize was increased by %u MB\n",
+                nCoinCacheMaxSize / 1000000, (nMemAvailable - nLastMemAvailable) / 1000000);
             nLastDbAdjustment = nNow;
             nLastMemAvailable = nMemAvailable;
         }

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -54,7 +54,7 @@ uint64_t GetTotalSystemMemory();
  */
 void GetCacheConfiguration(int64_t &_nBlockTreeDBCache,
     int64_t &_nCoinDBCache,
-    int64_t &_nCoinCacheUsage,
+    int64_t &_nCoinCacheMaxSize,
     bool fDefault = false);
 /** Calculate the various cache sizes. This is primarily used in GetCacheConfiguration() however during
  *  dynamic sizing of the coins cache we also need to use this function directly.
@@ -62,7 +62,7 @@ void GetCacheConfiguration(int64_t &_nBlockTreeDBCache,
 void CacheSizeCalculations(int64_t _nTotalCache,
     int64_t &_nBlockTreeDBCache,
     int64_t &_nCoinDBCache,
-    int64_t &_nCoinCacheUsage);
+    int64_t &_nCoinCacheMaxSize);
 /** This function is called during FlushStateToDisk.  The coins cache is dynamically sized before any
  *  checking is done for cache flushing and trimming
  */


### PR DESCRIPTION
This then makes a bug in any potential drift correction obvious and which is also fixed in this PR.