### PR TITLE
CDataStream::ignore Throw exception instead of assert on negative nSize.

### DIFF
--- a/src/streams.h
+++ b/src/streams.h
@@ -245,7 +245,10 @@ public:
     void ignore(int nSize)
     {
         // Ignore from the beginning of the buffer
-        assert(nSize >= 0);
+        if (nSize < 0)
+        {
+            throw std::ios_base::failure("CDataStream::ignore(): nSize negative");
+        }
         unsigned int nReadPosNext = nReadPos + nSize;
         if (nReadPosNext >= vch.size())
         {


### PR DESCRIPTION
This is a cherry pick of the mentioned commit by Core. I hope I am doing all authorship attributions etc. the correct way. Please check, thank you.