### PR TITLE
 Add a new job to travis matrix to compile source code w/ clang5 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ cache:
   - depends/built
   - depends/sdk-sources
   - $HOME/.ccache
+
 env:
   global:
     - MAKEJOBS=-j3
@@ -18,50 +19,100 @@ env:
     - CCACHE_TEMPDIR=/tmp/.ccache-temp
     - CCACHE_COMPRESS=1
     - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
+    - USE_CLANG=false
     - SDK_URL=https://www.bitcoinunlimited.info/sdks
     - PYTHON_DEBUG=1
     - WINEDEBUG=fixme-all
     - PPA=ppa:bitcoin-unlimited/bu-ppa
-  matrix:
-# bitcoind
-    - HOST=x86_64-unknown-linux-gnu PACKAGES="python3-zmq clang-format-3.8" DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1" RUN_TESTS=true RUN_FORMATTING_CHECK=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER"
-# ARM64
-    - HOST=aarch64-linux-gnu PACKAGES="g++-aarch64-linux-gnu" DEP_OPTS="NO_QT=1" GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
-# ARMHF
-    - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf" DEP_OPTS="NO_QT=1" GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
-# Win32
-    - HOST=i686-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-i686 wine1.6 bc" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
-# 32-bit + dash
-    - HOST=i686-pc-linux-gnu PACKAGES="g++-multilib bc python3-zmq" DEP_OPTS="NO_QT=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++" USE_SHELL="/bin/dash"
-# Win64
-    - HOST=x86_64-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6 bc" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
-# x86_64 Linux, No wallet (uses qt5 dev package instead of depends Qt to speed up build and avoid timeout)
-    - HOST=x86_64-unknown-linux-gnu PACKAGES="python3 qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev" DEP_OPTS="NO_WALLET=1 NO_QT=1 ALLOW_HOST_PACKAGES=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
-# Cross-Mac
-    - HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev" BITCOIN_CONFIG="--enable-reduce-exports" OSX_SDK=10.11 GOAL="deploy"
+    - PPA2=ppa:sickpig/boost
+
+matrix:
+  include:
+    #bitcoind clang
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-5.0
+          packages:
+            - clang-5.0
+      env:
+        - USE_CLANG=true
+        - CXX=clang++-5.0 CC=clang-5.0
+        - CXXFLAGS="-std=c++11"
+        - HOST=x86_64-unknown-linux-gnu
+        - RUN_TESTS=true
+        - PACKAGES="python3-zmq clang-format-3.8 build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils libboost-all-dev  qttools5-dev-tools qttools5-dev"
+        - GOAL="install" BITCOIN_CONFIG="--enable-zmq CC=clang-5.0 CXX=clang++-5.0 CPPFLAGS=-DDEBUG_LOCKORDER"
+    #bitcoind
+    - compiler: gcc
+      env:
+        - CXX=g++ CC=gcc
+        - HOST=x86_64-unknown-linux-gnu PACKAGES="python3-zmq clang-format-3.8" DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1" RUN_TESTS=true RUN_FORMATTING_CHECK=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER"
+    #ARM64
+    - compiler: gcc
+      env:
+        - CXX=g++ CC=gcc
+        - HOST=aarch64-linux-gnu PACKAGES="g++-aarch64-linux-gnu" DEP_OPTS="NO_QT=1" GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
+    #ARM32
+    - compiler: gcc
+      env:
+        - CXX=g++ CC=gcc
+        - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf" DEP_OPTS="NO_QT=1" GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
+    #Win32
+    - compiler: gcc
+      env:
+        - CXX=g++ CC=gcc
+        - HOST=i686-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-i686 wine1.6 bc" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
+    #Linux32-bit + dash
+    - compiler: gcc
+      env:
+        - CXX=g++ CC=gcc
+        - HOST=i686-pc-linux-gnu PACKAGES="g++-multilib bc python3-zmq" DEP_OPTS="NO_QT=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++" USE_SHELL="/bin/dash"
+    #Win64
+    - compiler: gcc
+      env:
+        - CXX=g++ CC=gcc
+        - HOST=x86_64-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6 bc" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
+    #x86_64 Linux, No wallet (uses qt5 dev package instead of depends Qt to speed up build and avoid timeout)
+    - compiler: gcc
+      env:
+        - CXX=g++ CC=gcc
+        - HOST=x86_64-unknown-linux-gnu PACKAGES="python3 qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev" DEP_OPTS="NO_WALLET=1 NO_QT=1 ALLOW_HOST_PACKAGES=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
+    #Cross-Mac
+    - compiler: gcc
+      env:
+        - HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev clang-3.8 libc++-dev" BITCOIN_CONFIG="--enable-reduce-exports" OSX_SDK=10.11 GOAL="deploy"
+
 before_install:
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
     #  temp fix with riak repo, by the way we don't need riak at all
     - sudo rm -vf /etc/apt/sources.list.d/*riak*
     - sudo apt-get update
+
 install:
     - if [ -n "$PPA" ]; then travis_retry sudo add-apt-repository "$PPA" -y; fi
+    - if [ -n "$PPA2" ]; then travis_retry sudo add-apt-repository "$PPA2" -y; fi
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq libdb4.8-dev libdb4.8++-dev $PACKAGES; fi
+    - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install -y -qq libboost1.58-dev ; fi
+    - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install -y -qq libboost1.58-tools-dev libboost-system1.58-dev libboost-filesystem1.58-dev libboost-program-options1.58-dev libboost-thread1.58-dev libboost-test1.58-dev; fi
+
 before_script:
     - unset CC; unset CXX
     - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/check-doc.py; fi
     - mkdir -p depends/SDKs depends/sdk-sources
     - if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
     - if [ -n "$OSX_SDK" -a -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
-    - make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS
+    - echo "USE_CLANG=$USE_CLANG"
+    - if [ "$USE_CLANG" = "false" ]; then make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS; fi
 script:
     - export TRAVIS_COMMIT_LOG=`git log --format=fuller -1`
     - if [ -n "$USE_SHELL" ]; then export CONFIG_SHELL="$USE_SHELL"; fi
     - OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
-    - BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib"
-    - depends/$HOST/native/bin/ccache --max-size=$CCACHE_SIZE
+    - BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib";
+    - if [ "$USE_CLANG" = "false" ]; then depends/$HOST/native/bin/ccache --max-size=$CCACHE_SIZE; fi
     - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh 2>&1 > autogen.out"' || ./autogen.sh 2>&1 > autogen.out || ( cat autogen.out && false)
     - mkdir build && cd build
     - echo "BITCOIN_CONFIG_ALL=$BITCOIN_CONFIG_ALL"
@@ -69,8 +120,12 @@ script:
     - echo "GOAL=$GOAL"
     - ../configure $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG > configure.out || ( cat configure.out && cat config.log && false)
     - if [ "$RUN_FORMATTING_CHECK" = "true" ]; then make $MAKEJOBS check-formatting VERBOSE=1; fi
-    - stdbuf -i0 -o0 -e0 make $MAKEJOBS $GOAL 2>&1 | ../contrib/devtools/buildsilence.py || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false )
-    - export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib
+    - if [ "$USE_CLANG" = "false" ]; then
+        stdbuf -i0 -o0 -e0 make $MAKEJOBS $GOAL 2>&1 | ../contrib/devtools/buildsilence.py || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false ) ;
+      else
+         CXXFLAGS="-std=c++11 -Werror" make $MAKEJOBS $GOAL;
+      fi
+    - if [ "USE_CLANG" = "false" ]; then export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib; fi
     - if [ "$RUN_TESTS" = "true" ] && { [ "$HOST" = "i686-w64-mingw32" ] || [ "$HOST" = "x86_64-w64-mingw32" ]; }; then travis_wait make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$RUN_TESTS" = "true" ] && ! { [ "$HOST" = "i686-w64-mingw32" ] || [ "$HOST" = "x86_64-w64-mingw32" ]; }; then make $MAKEJOBS check VERBOSE=1; fi
     - if [ "$RUN_TESTS" = "true" ]; then qa/pull-tester/rpc-tests.py --coverage; fi

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -71,6 +71,7 @@ CCriticalSection cs_rpcWarmup;
 CCriticalSection cs_main;
 BlockMap mapBlockIndex GUARDED_BY(cs_main);
 CChain chainActive GUARDED_BY(cs_main);
+std::map<NodeId, CNodeState> mapNodeState GUARDED_BY(cs_main); // nodestate.h
 
 CWaitableCriticalSection csBestBlock;
 CConditionVariable cvBlockChange;
@@ -79,8 +80,6 @@ proxyType proxyInfo[NET_MAX];
 proxyType nameProxy;
 CCriticalSection cs_proxyInfos;
 
-// moved from main.cpp (now part of nodestate.h)
-std::map<NodeId, CNodeState> mapNodeState;
 
 set<uint256> setPreVerifiedTxHash;
 set<uint256> setUnVerifiedOrphanTxHash;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,7 +68,7 @@
 // - moved CCriticalSection cs_main;
 // - moved BlockMap mapBlockIndex;
 // - movedCChain chainActive;
-CBlockIndex *pindexBestHeader = nullptr GUARDED_BY(cs_main);
+CBlockIndex *pindexBestHeader GUARDED_BY(cs_main) = nullptr;
 
 // Last time the block tip was updated
 std::atomic<int64_t> nTimeBestReceived{0};
@@ -88,9 +88,9 @@ uint64_t nPruneTarget = 0;
 uint32_t nXthinBloomFilterSize = SMALLEST_MAX_BLOOM_FILTER_SIZE;
 
 // The allowed size of the in memory UTXO cache
-int64_t nCoinCacheUsage = 0 GUARDED_BY(cs_main);
+int64_t nCoinCacheUsage  GUARDED_BY(cs_main) = 0;
 
-CFeeRate minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE) GUARDED_BY(cs_main);
+CFeeRate minRelayTxFee  GUARDED_BY(cs_main) = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
 
 // BU: Move global objects to a single file
 extern CTxMemPool mempool;
@@ -144,7 +144,7 @@ struct CBlockIndexWorkComparator
     }
 };
 
-CBlockIndex *pindexBestInvalid = nullptr GUARDED_BY(cs_main);
+CBlockIndex *pindexBestInvalid  GUARDED_BY(cs_main) = nullptr;
 
 /**
  * The set of all CBlockIndex entries with BLOCK_VALID_TRANSACTIONS (for itself and all ancestors) and
@@ -172,7 +172,7 @@ bool fCheckForPruning = false;
  * know which one to give priority in case of a fork.
  */
 /** Blocks loaded from disk are assigned id 0, so start the counter at 1. */
-uint64_t nBlockSequenceId = 1 GUARDED_BY(cs_main);
+uint64_t nBlockSequenceId  GUARDED_BY(cs_main) = 1;
 
 /**
  * Sources of received blocks, saved to be able to send them reject

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,9 +88,9 @@ uint64_t nPruneTarget = 0;
 uint32_t nXthinBloomFilterSize = SMALLEST_MAX_BLOOM_FILTER_SIZE;
 
 // The allowed size of the in memory UTXO cache
-int64_t nCoinCacheUsage  GUARDED_BY(cs_main) = 0;
+int64_t nCoinCacheUsage GUARDED_BY(cs_main) = 0;
 
-CFeeRate minRelayTxFee  GUARDED_BY(cs_main) = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
+CFeeRate minRelayTxFee GUARDED_BY(cs_main) = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
 
 // BU: Move global objects to a single file
 extern CTxMemPool mempool;
@@ -144,7 +144,7 @@ struct CBlockIndexWorkComparator
     }
 };
 
-CBlockIndex *pindexBestInvalid  GUARDED_BY(cs_main) = nullptr;
+CBlockIndex *pindexBestInvalid GUARDED_BY(cs_main) = nullptr;
 
 /**
  * The set of all CBlockIndex entries with BLOCK_VALID_TRANSACTIONS (for itself and all ancestors) and
@@ -172,7 +172,7 @@ bool fCheckForPruning = false;
  * know which one to give priority in case of a fork.
  */
 /** Blocks loaded from disk are assigned id 0, so start the counter at 1. */
-uint64_t nBlockSequenceId  GUARDED_BY(cs_main) = 1;
+uint64_t nBlockSequenceId GUARDED_BY(cs_main) = 1;
 
 /**
  * Sources of received blocks, saved to be able to send them reject

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -49,7 +49,7 @@ struct CNodeState
 };
 
 /** Map maintaining per-node state. Requires cs_main. */
-extern std::map<NodeId, CNodeState> mapNodeState GUARDED_BY(cs_main);
+extern std::map<NodeId, CNodeState> mapNodeState;
 
 // Requires cs_main.
 extern CNodeState *State(NodeId nId);


### PR DESCRIPTION
This new job will just compile the BU code base and not alse the dependencies. This is done to keep travis load low and because the main purpose is to catch build warnings/errors that otherwise could go unnoticed while using gcc.

This PR is built on top of #1125.