### PR TITLE
Make sure that RPC tests work with locale LC_ALL=C

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -234,7 +234,7 @@ def initialize_datadir(dirname, n, bitcoinConfDict=None, wallet=None, bins=None)
             defaults = filterUnsupportedParams(defaults)
             file = BITCOIN_CONF
 
-    with open(os.path.join(datadir, file), 'w') as f:
+    with open(os.path.join(datadir, file), 'w', encoding='utf-8') as f:
         for (key,val) in defaults.items():
           if isinstance(val, NoConfigValue):
             pass


### PR DESCRIPTION
This sets the encoding of the configuration file for `bitcoind` with RPC password and user to be explicitly generated as a UTF-8 file.

To test, set the locale to something like this:
```
LANG=en_US.UTF-8
LANGUAGE=en_US
LC_CTYPE="C"
LC_NUMERIC="C"
LC_TIME="C"
LC_COLLATE="C"
LC_MONETARY="C"
LC_MESSAGES="C"
LC_PAPER="C"
LC_NAME="C"
LC_ADDRESS="C"
LC_TELEPHONE="C"
LC_MEASUREMENT="C"
LC_IDENTIFICATION="C"
LC_ALL=C
```

Without this PR applied, the QA RPC tests should then fail with complaints about invalid characters for `ascii` encoding. With this PR applied, the tests should work.
