### PR TITLE
Remove nVersion self assignement

### DIFF
--- a/src/qt/recentrequeststablemodel.h
+++ b/src/qt/recentrequeststablemodel.h
@@ -32,7 +32,6 @@ public:
         unsigned int nDate = date.toTime_t();
 
         READWRITE(this->nVersion);
-        nVersion = this->nVersion;
         READWRITE(id);
         READWRITE(nDate);
         READWRITE(recipient);

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -93,7 +93,6 @@ public:
         std::string sAuthenticatedMerchant = authenticatedMerchant.toStdString();
 
         READWRITE(this->nVersion);
-        nVersion = this->nVersion;
         READWRITE(sAddress);
         READWRITE(sLabel);
         READWRITE(amount);


### PR DESCRIPTION
We did the same in 5c89c7b, I missed this changes back then due to the
fact I didn't compile bitcoin-qt. The warning were generated using
clang.

see #1103 for more details.