### PR TITLE
Fix clang compiler warning for messageTextLabel

### DIFF
--- a/src/qt/forms/sendcoinsentry.ui
+++ b/src/qt/forms/sendcoinsentry.ui
@@ -232,7 +232,7 @@
      </widget>
     </item>
     <item row="3" column="1">
-     <widget class="QLabel" name="messageTextLabel">
+     <widget class="QLabel" name="messageTextLabel1">
       <property name="toolTip">
        <string/>
       </property>


### PR DESCRIPTION
There is a conflict between two messageTextLabels which the compiler
automatically was adjusting for.