### PR TITLE
[Fixes #765] Wallet balance was not updating correctly.

### DIFF
--- a/qa/rpc-tests/validateblocktemplate.py
+++ b/qa/rpc-tests/validateblocktemplate.py
@@ -47,6 +47,7 @@ class ValidateblocktemplateTest(BitcoinTestFramework):
     def run_test(self):
         # Generate enough blocks to trigger certain block votes
         self.nodes[0].generate(1150)
+        self.sync_all()
 
         logging.info("not on chain tip")
         badtip = int(self.nodes[0].getblockhash(self.nodes[0].getblockcount() - 1), 16)

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -100,6 +100,13 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
         isminetype fAllToMe = ISMINE_SPENDABLE;
         for (const CTxOut &txout : wtx.vout)
         {
+            // Skip any outputs with public labels as they have no bearing
+            // on wallet balances and will only cause us to set the "mine"
+            // return value incorrectly.
+            std::string labelPublic = getLabelPublic(txout.scriptPubKey);
+            if (labelPublic != "")
+                continue;
+
             isminetype mine = wallet->IsMine(txout);
             if (mine & ISMINE_WATCH_ONLY)
                 involvesWatchAddress = true;


### PR DESCRIPTION
When sending to ourselves using a public label the wallet was not
updating correctly in the UI