### PR TITLE
Remove unnecessary vNodes locks

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6179,11 +6179,8 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                 }
 
                 // release refs
-                {
-                    LOCK(cs_vNodes);
-                    for (CNode *pnode : vNodesCopy)
-                        pnode->Release();
-                }
+                for (CNode *pnode : vNodesCopy)
+                    pnode->Release();
             }
         }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1368,7 +1368,6 @@ void ThreadSocketHandler()
             }
         }
         {
-            LOCK(cs_vNodes);
             for (CNode *pnode : vNodesCopy)
                 pnode->Release();
         }
@@ -2172,7 +2171,6 @@ void ThreadMessageHandler()
         // Release refs as a last step. We need to keep the node refs all the way through so that we don't
         // have to take so many vNodes locks during requester.SendRequests().
         {
-            LOCK(cs_vNodes);
             for (CNode *pnode : vNodesCopy)
                 pnode->Release();
         }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1372,7 +1372,7 @@ void ThreadSocketHandler()
         // that a pnode could be disconnected and no longer exist before the decrement takes place.
         for (CNode *pnode : vNodesCopy)
         {
-                pnode->Release();
+            pnode->Release();
         }
 
         // BU: Nothing happened even though select did not block.  So slow us down.

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2173,9 +2173,6 @@ void ThreadMessageHandler()
         // sleeping in the step below so as to allow requests to return during the sleep time.
         requester.SendRequests();
 
-        // Release refs as a last step. We need to keep the node refs all the way through so that we don't
-        // have to take so many vNodes locks during requester.SendRequests().
-        //
         // A cs_vNodes lock is not required here when releasing refs for two reasons: one, this only decrements
         // an atomic counter, and two, the counter will always be > 0 at this point, so we don't have to worry
         // that a pnode could be disconnected and no longer exist before the decrement takes place.

--- a/src/net.h
+++ b/src/net.h
@@ -517,7 +517,12 @@ public:
         return this;
     }
 
-    void Release() { nRefCount--; }
+    void Release()
+    {
+        DbgAssert(nRefCount > 0, );
+        nRefCount--;
+    }
+
     // BUIP010:
     bool ThinBlockCapable()
     {

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -506,7 +506,8 @@ void CParallelValidation::HandleBlockMessage(CNode *pfrom, const string &strComm
     // we do not want CNode to be deleted if the node should disconnect while we are processing this block.
     // We will clean up this reference when the thread finishes.
     {
-        LOCK(cs_vNodes);
+        // We do not have to take a vNodes lock here as would usually be the case because at this point there
+        // will be at least one ref already and we therefore don't have to worry about getting disconnected.
         pfrom->AddRef();
     }
 
@@ -648,10 +649,7 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, CBlockRef p
     PV->Post();
 
     // Remove the CNode reference we aquired just before we launched this thread.
-    {
-        LOCK(cs_vNodes);
-        pfrom->Release();
-    }
+    pfrom->Release();
 
     // If chain is nearly caught up then flush the state after a block is finished processing and the
     // performance timings have been updated.  This way we don't include the flush time in our time to

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -407,12 +407,13 @@ bool CUnknownObj::AddSource(CNode *from)
     if (std::find_if(availableFrom.begin(), availableFrom.end(), MatchCNodeRequestData(from)) == availableFrom.end())
     {
         LOG(REQ, "AddSource %s is available at %s.\n", obj.ToString(), from->GetLogName());
-        {
-            // We do not have to take a vNodes lock here as would usually be the case because the counter is
-            // atomic, and also at this point there will be at least one ref already and we therefore don't
-            // have to worry about the node getting disconnected and no longer existing.
-            from->AddRef();
-        }
+
+        // We do not have to take a vNodes lock here as would usually be the case because the counter is
+        // atomic, and also at this point there will be at least one ref already and we therefore don't
+        // have to worry about the node getting disconnected and no longer existing.
+        DbgAssert(from->GetRefCount() > 0, );
+        from->AddRef();
+
         CNodeRequestData req(from);
         for (ObjectSourceList::iterator i = availableFrom.begin(); i != availableFrom.end(); ++i)
         {
@@ -613,6 +614,7 @@ void CRequestManager::SendRequests()
                             // counter is atomic, and also at this point there will be at least one ref already and
                             // we therefore don't have to worry about the node getting disconnected and no longer
                             // existing.
+                            DbgAssert(next.node->GetRefCount() > 0, );
                             next.node->AddRef();
                         }
                         mapBatchBlockRequests[next.node].emplace_back(obj);
@@ -774,6 +776,7 @@ void CRequestManager::SendRequests()
                                 // counter is atomic, and also at this point there will be at least one ref already and
                                 // we therefore don't have to worry about the node getting disconnected and no longer
                                 // existing.
+                                DbgAssert(next.node->GetRefCount() > 0, );
                                 next.node->AddRef();
                             }
                             mapBatchTxnRequests[next.node].emplace_back(item.obj);


### PR DESCRIPTION
This PR improves sync performance by about 2 to 3%. 

@gandrewstone While this works I wonder about the fragility of the code if somebody changes something.  I think it's ok but maybe we can improve it a bit....I wonder if we should put an assert(pnode>GetRefCount()) at the beginning of AddSource()?

The changes in the requestManager really center around AddSource(). If we have a source then we know it has to have a ref to it (or I think we can assume it does), and this all stems from AddSource(*pnode).  If we do an AddSource() then we must have added a ref previously and we don't have to worry about disconnection by adding another ref so don't need the additional vNodes lock (when we do an AddSource() , but we still need a vNodes lock outside the requestManager when adding a refs because of the possibility of a disconnect.)
