### PR TITLE
SignatureHash(): Document buggy but consensus-critical legacy behavior, aid in preventing a similar fate for BCH signature hashing

### DIFF
--- a/src/bench/verify_script.cpp
+++ b/src/bench/verify_script.cpp
@@ -72,6 +72,7 @@ static void VerifyScriptBench(benchmark::State &state)
     CMutableTransaction txSpend = BuildSpendingTransaction(scriptSig, txCredit);
     CScript &ssig = txSpend.vin[0].scriptSig;
     uint256 sighash = SignatureHash(witScriptPubkey, txSpend, 0, SIGHASH_ALL, txCredit.vout[0].nValue);
+    assert(sighash != SIGNATURE_HASH_ERROR);
     std::vector<unsigned char> sig1;
     key.Sign(sighash, sig1);
     sig1.push_back(static_cast<unsigned char>(SIGHASH_ALL));

--- a/src/cashlib/cashlib.cpp
+++ b/src/cashlib/cashlib.cpp
@@ -10,6 +10,7 @@
 #include "base58.h"
 #include "random.h"
 #include "streams.h"
+#include "util.h"
 #include "utilstrencodings.h"
 
 #include <openssl/rand.h>
@@ -128,6 +129,8 @@ extern "C" int SignTx(unsigned char *txData,
     unsigned char *result,
     unsigned int resultLen)
 {
+    DbgAssert(nHashType & SIGHASH_FORKID, return 0);
+
     if (!sigInited)
     {
         sigInited = true;
@@ -154,7 +157,7 @@ extern "C" int SignTx(unsigned char *txData,
     CKey key = LoadKey(keyData);
 
     size_t nHashedOut = 0;
-    uint256 sighash = SignatureHashBitcoinCash(priorScript, tx, inputIdx, nHashType, inputAmount, &nHashedOut);
+    uint256 sighash = SignatureHash(priorScript, tx, inputIdx, nHashType, inputAmount, &nHashedOut);
     std::vector<unsigned char> sig;
     if (!key.Sign(sighash, sig))
     {

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1416,171 +1416,27 @@ bool EvalScript(vector<vector<unsigned char> > &stack,
     return set_success(serror);
 }
 
-namespace
-{
-/**
- * Wrapper that serializes like CTransaction, but with the modifications
- *  required for the signature hash done in-place
- */
-class CTransactionSignatureSerializer
-{
-private:
-    const CTransaction &txTo; //! reference to the spending transaction (the one being serialized)
-    const CScript &scriptCode; //! output script being consumed
-    const unsigned int nIn; //! input index of txTo being signed
-    const bool fAnyoneCanPay; //! whether the hashtype has the SIGHASH_ANYONECANPAY flag set
-    const bool fHashSingle; //! whether the hashtype is SIGHASH_SINGLE
-    const bool fHashNone; //! whether the hashtype is SIGHASH_NONE
-
-public:
-    CTransactionSignatureSerializer(const CTransaction &txToIn,
-        const CScript &scriptCodeIn,
-        unsigned int nInIn,
-        int nHashTypeIn)
-        : txTo(txToIn), scriptCode(scriptCodeIn), nIn(nInIn), fAnyoneCanPay(!!(nHashTypeIn & SIGHASH_ANYONECANPAY)),
-          fHashSingle((nHashTypeIn & 0x1f) == SIGHASH_SINGLE), fHashNone((nHashTypeIn & 0x1f) == SIGHASH_NONE)
-    {
-    }
-
-    /** Serialize the passed scriptCode, skipping OP_CODESEPARATORs */
-    template <typename S>
-    void SerializeScriptCode(S &s) const
-    {
-        CScript::const_iterator it = scriptCode.begin();
-        CScript::const_iterator itBegin = it;
-        opcodetype opcode;
-        unsigned int nCodeSeparators = 0;
-        while (scriptCode.GetOp(it, opcode))
-        {
-            if (opcode == OP_CODESEPARATOR)
-                nCodeSeparators++;
-        }
-        ::WriteCompactSize(s, scriptCode.size() - nCodeSeparators);
-        it = itBegin;
-        while (scriptCode.GetOp(it, opcode))
-        {
-            if (opcode == OP_CODESEPARATOR)
-            {
-                s.write((char *)&itBegin[0], it - itBegin - 1);
-                itBegin = it;
-            }
-        }
-        if (itBegin != scriptCode.end())
-            s.write((char *)&itBegin[0], it - itBegin);
-    }
-
-    /** Serialize an input of txTo */
-    template <typename S>
-    void SerializeInput(S &s, unsigned int nInput) const
-    {
-        // In case of SIGHASH_ANYONECANPAY, only the input being signed is serialized
-        if (fAnyoneCanPay)
-            nInput = nIn;
-        // Serialize the prevout
-        ::Serialize(s, txTo.vin[nInput].prevout);
-        // Serialize the script
-        if (nInput != nIn)
-            // Blank out other inputs' signatures
-            ::Serialize(s, CScriptBase());
-        else
-            SerializeScriptCode(s);
-        // Serialize the nSequence
-        if (nInput != nIn && (fHashSingle || fHashNone))
-            // let the others update at will
-            ::Serialize(s, (int)0);
-        else
-            ::Serialize(s, txTo.vin[nInput].nSequence);
-    }
-
-    /** Serialize an output of txTo */
-    template <typename S>
-    void SerializeOutput(S &s, unsigned int nOutput) const
-    {
-        if (fHashSingle && nOutput != nIn)
-            // Do not lock-in the txout payee at other indices as txin
-            ::Serialize(s, CTxOut());
-        else
-            ::Serialize(s, txTo.vout[nOutput]);
-    }
-
-    /** Serialize txTo */
-    template <typename S>
-    void Serialize(S &s) const
-    {
-        // Serialize nVersion
-        ::Serialize(s, txTo.nVersion);
-        // Serialize vin
-        unsigned int nInputs = fAnyoneCanPay ? 1 : txTo.vin.size();
-        ::WriteCompactSize(s, nInputs);
-        for (unsigned int nInput = 0; nInput < nInputs; nInput++)
-            SerializeInput(s, nInput);
-        // Serialize vout
-        unsigned int nOutputs = fHashNone ? 0 : (fHashSingle ? nIn + 1 : txTo.vout.size());
-        ::WriteCompactSize(s, nOutputs);
-        for (unsigned int nOutput = 0; nOutput < nOutputs; nOutput++)
-            SerializeOutput(s, nOutput);
-        // Serialize nLockTime
-        ::Serialize(s, txTo.nLockTime);
-    }
-};
-
-} // anon namespace
-
-uint256 SignatureHashLegacy(const CScript &scriptCode,
-    const CTransaction &txTo,
-    unsigned int nIn,
-    uint32_t nHashType,
-    const CAmount &amount,
-    size_t *nHashedOut)
-{
-    static const uint256 one(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
-    if (nIn >= txTo.vin.size())
-    {
-        //  nIn out of range
-        return one;
-    }
-
-    // Check for invalid use of SIGHASH_SINGLE
-    if ((nHashType & 0x1f) == SIGHASH_SINGLE)
-    {
-        if (nIn >= txTo.vout.size())
-        {
-            //  nOut out of range
-            return one;
-        }
-    }
-
-    // Wrapper to serialize only the necessary parts of the transaction being signed
-    CTransactionSignatureSerializer txTmp(txTo, scriptCode, nIn, nHashType);
-
-    // Serialize and hash
-    CHashWriter ss(SER_GETHASH, 0);
-    ss << txTmp << nHashType;
-    if (nHashedOut != NULL)
-        *nHashedOut = ss.GetNumBytesHashed();
-    return ss.GetHash();
-}
-
-uint256 SignatureHash(const CScript &scriptCode,
-    const CTransaction &txTo,
-    unsigned int nIn,
-    uint32_t nHashType,
-    const CAmount &amount,
-    size_t *nHashedOut)
-{
-    if (nHashType & SIGHASH_FORKID)
-    {
-        return SignatureHashBitcoinCash(scriptCode, txTo, nIn, nHashType, amount, nHashedOut);
-    }
-    return SignatureHashLegacy(scriptCode, txTo, nIn, nHashType, amount, nHashedOut);
-}
-
 bool TransactionSignatureChecker::VerifySignature(const std::vector<unsigned char> &vchSig,
     const CPubKey &pubkey,
     const uint256 &sighash) const
 {
     return pubkey.Verify(sighash, vchSig);
 }
+
+extern uint256 SignatureHashBitcoinCash(const CScript &scriptCode,
+    const CTransaction &txTo,
+    unsigned int nIn,
+    uint32_t nHashType,
+    const CAmount &amount,
+    size_t *nHashedOut);
+
+extern uint256 SignatureHashLegacy(const CScript &scriptCode,
+    const CTransaction &txTo,
+    unsigned int nIn,
+    uint32_t nHashType,
+    const CAmount &amount,
+    size_t *nHashedOut);
+
 
 bool TransactionSignatureChecker::CheckSig(const vector<unsigned char> &vchSigIn,
     const vector<unsigned char> &vchPubKey,

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1423,13 +1423,6 @@ bool TransactionSignatureChecker::VerifySignature(const std::vector<unsigned cha
     return pubkey.Verify(sighash, vchSig);
 }
 
-extern uint256 SignatureHashBitcoinCash(const CScript &scriptCode,
-    const CTransaction &txTo,
-    unsigned int nIn,
-    uint32_t nHashType,
-    const CAmount &amount,
-    size_t *nHashedOut);
-
 extern uint256 SignatureHashLegacy(const CScript &scriptCode,
     const CTransaction &txTo,
     unsigned int nIn,
@@ -1460,7 +1453,7 @@ bool TransactionSignatureChecker::CheckSig(const vector<unsigned char> &vchSigIn
     if (nFlags & SCRIPT_ENABLE_SIGHASH_FORKID)
     {
         if (nHashType & SIGHASH_FORKID)
-            sighash = SignatureHashBitcoinCash(scriptCode, *txTo, nIn, nHashType, amount, &nHashed);
+            sighash = SignatureHash(scriptCode, *txTo, nIn, nHashType, amount, &nHashed);
         else
             return false;
     }

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -120,21 +120,6 @@ uint256 SignatureHash(const CScript &scriptCode,
     uint32_t nHashType,
     const CAmount &amount,
     size_t *nHashedOut = NULL);
-// If you are validating signatures, you must call the appropriate function based on what fork you are on, because
-// the nHashType SIGHASH_FORKID bit is undefined in Legacy mode -- that is, it is valid to set it to one but still
-// sign using the legacy method
-uint256 SignatureHashBitcoinCash(const CScript &scriptCode,
-    const CTransaction &txTo,
-    unsigned int nIn,
-    uint32_t nHashType,
-    const CAmount &amount,
-    size_t *nHashedOut = NULL);
-uint256 SignatureHashLegacy(const CScript &scriptCode,
-    const CTransaction &txTo,
-    unsigned int nIn,
-    uint32_t nHashType,
-    const CAmount &amount,
-    size_t *nHashedOut);
 
 class BaseSignatureChecker
 {

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -113,6 +113,13 @@ enum
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError *serror);
 
+// WARNING:
+// SIGNATURE_HASH_ERROR represents the special value of uint256(1) that is used by the legacy SignatureHash
+// function to signal errors in calculating the signature hash. This export is ONLY meant to check for the
+// consensus-critical oddities of the legacy signature validation code and SHOULD NOT be used to signal
+// problems during signature hash calculations for any current BCH signature hash functions!
+extern const uint256 SIGNATURE_HASH_ERROR;
+
 // If you are signing you may call this function and the BitcoinCash or Legacy method will be chosen based on nHashType
 uint256 SignatureHash(const CScript &scriptCode,
     const CTransaction &txTo,

--- a/src/script/sigcommon.cpp
+++ b/src/script/sigcommon.cpp
@@ -161,6 +161,9 @@ public:
 
 } // end anon namespace
 
+// WARNING: Never use this to signal errors in a signature hash function. This is here solely for legacy reasons!
+const uint256 SIGNATURE_HASH_ERROR(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
+
 uint256 SignatureHashLegacy(const CScript &scriptCode,
     const CTransaction &txTo,
     unsigned int nIn,
@@ -168,7 +171,6 @@ uint256 SignatureHashLegacy(const CScript &scriptCode,
     const CAmount &amount,
     size_t *nHashedOut)
 {
-    static const uint256 one(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
     if (nIn >= txTo.vin.size())
     {
         //  nIn out of range
@@ -178,7 +180,7 @@ uint256 SignatureHashLegacy(const CScript &scriptCode,
         // returned here is, however, due to further omissions in CheckSig, part of the pre-BCH
         // consensus rule set and needs to be left as-is.
         // See also: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2014-November/006878.html
-        return one;
+        return SIGNATURE_HASH_ERROR;
     }
 
     // Check for invalid use of SIGHASH_SINGLE
@@ -193,7 +195,7 @@ uint256 SignatureHashLegacy(const CScript &scriptCode,
             // returned here is, however, due to further omissions in CheckSig, part of the pre-BCH
             // consensus rule set and needs to be left as-is.
             // See also: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2014-November/006878.html
-            return one;
+            return SIGNATURE_HASH_ERROR;
         }
     }
 

--- a/src/script/sigcommon.cpp
+++ b/src/script/sigcommon.cpp
@@ -53,7 +53,148 @@ uint256 GetOutputsHash(const CTransaction &txTo)
     return ss.GetHash();
 }
 
+/**
+ * Wrapper that serializes like CTransaction, but with the modifications
+ *  required for the signature hash done in-place
+ */
+class CTransactionSignatureSerializer
+{
+private:
+    const CTransaction &txTo; //! reference to the spending transaction (the one being serialized)
+    const CScript &scriptCode; //! output script being consumed
+    const unsigned int nIn; //! input index of txTo being signed
+    const bool fAnyoneCanPay; //! whether the hashtype has the SIGHASH_ANYONECANPAY flag set
+    const bool fHashSingle; //! whether the hashtype is SIGHASH_SINGLE
+    const bool fHashNone; //! whether the hashtype is SIGHASH_NONE
+
+public:
+    CTransactionSignatureSerializer(const CTransaction &txToIn,
+        const CScript &scriptCodeIn,
+        unsigned int nInIn,
+        int nHashTypeIn)
+        : txTo(txToIn), scriptCode(scriptCodeIn), nIn(nInIn), fAnyoneCanPay(!!(nHashTypeIn & SIGHASH_ANYONECANPAY)),
+          fHashSingle((nHashTypeIn & 0x1f) == SIGHASH_SINGLE), fHashNone((nHashTypeIn & 0x1f) == SIGHASH_NONE)
+    {
+    }
+
+    /** Serialize the passed scriptCode, skipping OP_CODESEPARATORs */
+    template <typename S>
+    void SerializeScriptCode(S &s) const
+    {
+        CScript::const_iterator it = scriptCode.begin();
+        CScript::const_iterator itBegin = it;
+        opcodetype opcode;
+        unsigned int nCodeSeparators = 0;
+        while (scriptCode.GetOp(it, opcode))
+        {
+            if (opcode == OP_CODESEPARATOR)
+                nCodeSeparators++;
+        }
+        ::WriteCompactSize(s, scriptCode.size() - nCodeSeparators);
+        it = itBegin;
+        while (scriptCode.GetOp(it, opcode))
+        {
+            if (opcode == OP_CODESEPARATOR)
+            {
+                s.write((char *)&itBegin[0], it - itBegin - 1);
+                itBegin = it;
+            }
+        }
+        if (itBegin != scriptCode.end())
+            s.write((char *)&itBegin[0], it - itBegin);
+    }
+
+    /** Serialize an input of txTo */
+    template <typename S>
+    void SerializeInput(S &s, unsigned int nInput) const
+    {
+        // In case of SIGHASH_ANYONECANPAY, only the input being signed is serialized
+        if (fAnyoneCanPay)
+            nInput = nIn;
+        // Serialize the prevout
+        ::Serialize(s, txTo.vin[nInput].prevout);
+        // Serialize the script
+        if (nInput != nIn)
+            // Blank out other inputs' signatures
+            ::Serialize(s, CScriptBase());
+        else
+            SerializeScriptCode(s);
+        // Serialize the nSequence
+        if (nInput != nIn && (fHashSingle || fHashNone))
+            // let the others update at will
+            ::Serialize(s, (int)0);
+        else
+            ::Serialize(s, txTo.vin[nInput].nSequence);
+    }
+
+    /** Serialize an output of txTo */
+    template <typename S>
+    void SerializeOutput(S &s, unsigned int nOutput) const
+    {
+        if (fHashSingle && nOutput != nIn)
+            // Do not lock-in the txout payee at other indices as txin
+            ::Serialize(s, CTxOut());
+        else
+            ::Serialize(s, txTo.vout[nOutput]);
+    }
+
+    /** Serialize txTo */
+    template <typename S>
+    void Serialize(S &s) const
+    {
+        // Serialize nVersion
+        ::Serialize(s, txTo.nVersion);
+        // Serialize vin
+        unsigned int nInputs = fAnyoneCanPay ? 1 : txTo.vin.size();
+        ::WriteCompactSize(s, nInputs);
+        for (unsigned int nInput = 0; nInput < nInputs; nInput++)
+            SerializeInput(s, nInput);
+        // Serialize vout
+        unsigned int nOutputs = fHashNone ? 0 : (fHashSingle ? nIn + 1 : txTo.vout.size());
+        ::WriteCompactSize(s, nOutputs);
+        for (unsigned int nOutput = 0; nOutput < nOutputs; nOutput++)
+            SerializeOutput(s, nOutput);
+        // Serialize nLockTime
+        ::Serialize(s, txTo.nLockTime);
+    }
+};
+
 } // end anon namespace
+
+uint256 SignatureHashLegacy(const CScript &scriptCode,
+    const CTransaction &txTo,
+    unsigned int nIn,
+    uint32_t nHashType,
+    const CAmount &amount,
+    size_t *nHashedOut)
+{
+    static const uint256 one(uint256S("0000000000000000000000000000000000000000000000000000000000000001"));
+    if (nIn >= txTo.vin.size())
+    {
+        //  nIn out of range
+        return one;
+    }
+
+    // Check for invalid use of SIGHASH_SINGLE
+    if ((nHashType & 0x1f) == SIGHASH_SINGLE)
+    {
+        if (nIn >= txTo.vout.size())
+        {
+            //  nOut out of range
+            return one;
+        }
+    }
+
+    // Wrapper to serialize only the necessary parts of the transaction being signed
+    CTransactionSignatureSerializer txTmp(txTo, scriptCode, nIn, nHashType);
+
+    // Serialize and hash
+    CHashWriter ss(SER_GETHASH, 0);
+    ss << txTmp << nHashType;
+    if (nHashedOut != NULL)
+        *nHashedOut = ss.GetNumBytesHashed();
+    return ss.GetHash();
+}
 
 uint256 SignatureHashBitcoinCash(const CScript &scriptCode,
     const CTransaction &txTo,
@@ -117,4 +258,19 @@ uint256 SignatureHashBitcoinCash(const CScript &scriptCode,
         return sighash;
     }
     return one;
+}
+
+
+uint256 SignatureHash(const CScript &scriptCode,
+    const CTransaction &txTo,
+    unsigned int nIn,
+    uint32_t nHashType,
+    const CAmount &amount,
+    size_t *nHashedOut)
+{
+    if (nHashType & SIGHASH_FORKID)
+    {
+        return SignatureHashBitcoinCash(scriptCode, txTo, nIn, nHashType, amount, nHashedOut);
+    }
+    return SignatureHashLegacy(scriptCode, txTo, nIn, nHashType, amount, nHashedOut);
 }

--- a/src/script/sigcommon.cpp
+++ b/src/script/sigcommon.cpp
@@ -211,7 +211,7 @@ uint256 SignatureHashLegacy(const CScript &scriptCode,
 }
 
 // ONLY to be called with SIGHASH_FORKID set in nHashType!
-uint256 SignatureHashBitcoinCash(const CScript &scriptCode,
+static uint256 SignatureHashBitcoinCash(const CScript &scriptCode,
     const CTransaction &txTo,
     unsigned int nIn,
     uint32_t nHashType,

--- a/src/script/sigcommon.cpp
+++ b/src/script/sigcommon.cpp
@@ -172,6 +172,12 @@ uint256 SignatureHashLegacy(const CScript &scriptCode,
     if (nIn >= txTo.vin.size())
     {
         //  nIn out of range
+        // IMPORTANT NOTICE:
+        // Returning one from SignatureHash..() to signal error conditions is a kludge that
+        // is also breaking the ECDSA assumption that only cryptographic hashes are signed. The special value
+        // returned here is, however, due to further omissions in CheckSig, part of the pre-BCH
+        // consensus rule set and needs to be left as-is.
+        // See also: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2014-November/006878.html
         return one;
     }
 
@@ -181,6 +187,12 @@ uint256 SignatureHashLegacy(const CScript &scriptCode,
         if (nIn >= txTo.vout.size())
         {
             //  nOut out of range
+            // IMPORTANT NOTICE:
+            // Returning one from SignatureHash..() to signal error conditions is a kludge that
+            // is also breaking the ECDSA assumption that only cryptographic hashes are signed. The special value
+            // returned here is, however, due to further omissions in CheckSig, part of the pre-BCH
+            // consensus rule set and needs to be left as-is.
+            // See also: https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2014-November/006878.html
             return one;
         }
     }

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -33,6 +33,7 @@ BOOST_FIXTURE_TEST_SUITE(multisig_tests, BasicTestingSetup)
 CScript sign_multisig(CScript scriptPubKey, vector<CKey> keys, CTransaction transaction, int whichIn)
 {
     uint256 hash = SignatureHash(scriptPubKey, transaction, whichIn, SIGHASH_ALL | SIGHASH_FORKID, 0);
+    BOOST_CHECK(hash != SIGNATURE_HASH_ERROR);
 
     CScript result;
     result << OP_0; // CHECKMULTISIG bug workaround

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -319,6 +319,7 @@ public:
         CAmount amount = 0)
     {
         uint256 hash = SignatureHash(script, spendTx, 0, nHashType, amount);
+        BOOST_CHECK(hash != SIGNATURE_HASH_ERROR);
         std::vector<unsigned char> vchSig, r, s;
         uint32_t iter = 0;
         do
@@ -1010,6 +1011,7 @@ CScript sign_multisig(const CScript &scriptPubKey, std::vector<CKey> keys, const
     unsigned char sighashType = SIGHASH_ALL | SIGHASH_FORKID;
 
     uint256 hash = SignatureHash(scriptPubKey, transaction, 0, sighashType, amt, 0);
+    assert(hash != SIGNATURE_HASH_ERROR);
 
     CScript result;
     //
@@ -1234,14 +1236,17 @@ BOOST_AUTO_TEST_CASE(script_combineSigs)
     // A couple of partially-signed versions:
     vector<unsigned char> sig1;
     uint256 hash1 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_ALL | SIGHASH_FORKID, 0);
+    BOOST_CHECK(hash1 != SIGNATURE_HASH_ERROR);
     BOOST_CHECK(keys[0].Sign(hash1, sig1));
     sig1.push_back(SIGHASH_ALL | SIGHASH_FORKID);
     vector<unsigned char> sig2;
     uint256 hash2 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_NONE | SIGHASH_FORKID, 0);
+    BOOST_CHECK(hash2 != SIGNATURE_HASH_ERROR);
     BOOST_CHECK(keys[1].Sign(hash2, sig2));
     sig2.push_back(SIGHASH_NONE | SIGHASH_FORKID);
     vector<unsigned char> sig3;
     uint256 hash3 = SignatureHash(scriptPubKey, txTo, 0, SIGHASH_SINGLE | SIGHASH_FORKID, 0);
+    BOOST_CHECK(hash3 != SIGNATURE_HASH_ERROR);
     BOOST_CHECK(keys[2].Sign(hash3, sig3));
     sig3.push_back(SIGHASH_SINGLE | SIGHASH_FORKID);
 
@@ -1422,6 +1427,7 @@ CTransaction tx1x1(const COutPoint &utxo,
     unsigned int sighashType = SIGHASH_ALL | SIGHASH_FORKID;
     std::vector<unsigned char> vchSig;
     uint256 hash = SignatureHash(prevOutScript, tx, 0, sighashType, amt, 0);
+    BOOST_CHECK(hash != SIGNATURE_HASH_ERROR);
     if (!key.Sign(hash, vchSig))
     {
         assert(0);

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -228,7 +228,20 @@ BOOST_AUTO_TEST_CASE(sighash_from_data)
         }
 
         sh = SignatureHash(scriptCode, tx, nIn, nHashType, 0, 0);
+        assert(sh != SIGNATURE_HASH_ERROR);
         BOOST_CHECK_MESSAGE(sh.GetHex() == sigHashHex, strTest);
     }
+}
+
+BOOST_AUTO_TEST_CASE(sighash_test_fail)
+{
+    CScript scriptCode = CScript();
+    CTransaction tx;
+    const int nIn = 1;
+    const int nHashType = 0;
+    // should fail because nIn point is invalid
+    // Note that this basically broken behavior of SignatureHashLegacy()
+    uint256 hash = SignatureHash(scriptCode, tx, nIn, nHashType, 0, 0);
+    BOOST_CHECK(hash == SIGNATURE_HASH_ERROR);
 }
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -60,6 +60,7 @@ BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
         // Sign:
         std::vector<unsigned char> vchSig;
         uint256 hash = SignatureHash(scriptPubKey, spends[i], 0, sighashType, coinbaseTxns[0].vout[0].nValue, 0);
+        BOOST_CHECK(hash != SIGNATURE_HASH_ERROR);
         BOOST_CHECK(coinbaseKey.Sign(hash, vchSig));
         vchSig.push_back((unsigned char)sighashType);
         spends[i].vin[0].scriptSig << vchSig;
@@ -127,6 +128,7 @@ BOOST_FIXTURE_TEST_CASE(uncache_coins, TestChain100Setup)
     // Sign:
     std::vector<unsigned char> vchSig1;
     uint256 hash1 = SignatureHash(scriptPubKey, spends[0], 0, sighashType, coinbaseTxns[0].vout[0].nValue, 0);
+    BOOST_CHECK(hash1 != SIGNATURE_HASH_ERROR);
     BOOST_CHECK(coinbaseKey.Sign(hash1, vchSig1));
     vchSig1.push_back((unsigned char)sighashType);
     spends[0].vin[0].scriptSig << vchSig1;
@@ -151,6 +153,7 @@ BOOST_FIXTURE_TEST_CASE(uncache_coins, TestChain100Setup)
     // Sign:
     std::vector<unsigned char> vchSig2;
     uint256 hash2 = SignatureHash(scriptPubKey, spends[1], 0, sighashType, coinbaseTxns[1].vout[0].nValue, 0);
+    BOOST_CHECK(hash2 != SIGNATURE_HASH_ERROR);
     BOOST_CHECK(coinbaseKey.Sign(hash2, vchSig2));
     vchSig2.push_back((unsigned char)sighashType);
     spends[1].vin[0].scriptSig << vchSig2;
@@ -175,6 +178,7 @@ BOOST_FIXTURE_TEST_CASE(uncache_coins, TestChain100Setup)
     // Sign:
     std::vector<unsigned char> vchSig3;
     uint256 hash3 = SignatureHash(scriptPubKey, spends[2], 0, sighashType, coinbaseTxns[2].vout[0].nValue, 0);
+    BOOST_CHECK(hash3 != SIGNATURE_HASH_ERROR);
     BOOST_CHECK(coinbaseKey.Sign(hash3, vchSig3));
     vchSig3.push_back((unsigned char)sighashType);
     spends[2].vin[0].scriptSig << vchSig2;
@@ -236,6 +240,7 @@ BOOST_FIXTURE_TEST_CASE(uncache_coins, TestChain100Setup)
     // Sign:
     std::vector<unsigned char> vchSig4;
     uint256 hash4 = SignatureHash(scriptPubKey, spends[3], 0, sighashType, coinbaseTxns[3].vout[0].nValue, 0);
+    BOOST_CHECK(hash4 != SIGNATURE_HASH_ERROR);
     BOOST_CHECK(coinbaseKey.Sign(hash4, vchSig4));
     vchSig4.push_back((unsigned char)sighashType);
     spends[3].vin[0].scriptSig << vchSig4;
@@ -272,6 +277,7 @@ BOOST_FIXTURE_TEST_CASE(uncache_coins, TestChain100Setup)
     // Sign:
     std::vector<unsigned char> vchSig5;
     uint256 hash5 = SignatureHash(scriptPubKey, spends[2], 0, sighashType, coinbaseTxns[5].vout[0].nValue, 0);
+    BOOST_CHECK(hash5 != SIGNATURE_HASH_ERROR);
     BOOST_CHECK(coinbaseKey.Sign(hash5, vchSig5));
     vchSig5.push_back((unsigned char)sighashType);
     spends[4].vin[0].scriptSig << vchSig5;


### PR DESCRIPTION
As discussed previously, I was unhappy about the implicit failure of the SignatureHash(..) function and returning a simple value of 1 without any further, local handling of that value.

This change makes this failure handling more explicit and adds a notice to the docs of SignatureHash(..) to be careful when using it, in addition to hiding the implementing subroutines that were exposed before.

As per my limited understanding, ECDSA signing assumes in its security model that a cryptographic hash of the message is signed, always. The current implementation allows to call SignatureHash(..) with invalid parameters, resulting in a return value 1 *and does further signing and processing of this resulting error code*.

This needs careful review as this touches some key areas.

As far as I understand, returning false in TransactionSignatureCreator::CreateSig(..) is the right response and indicates failure to the higher layers on top of that method, but I might be wrong here and again like someone else to check.

@gandrewstone : I prepared the PR now to keep track of this but I can of course rebase later on top of your changes. When this is ready to be merged at some point in the future, feel free to squash it all together, of course.
