### PR TITLE
[PORT] RPC HTTP server fixes

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -132,12 +132,6 @@ public:
         running = false;
         cond.notify_all();
     }
-    /** Return current depth of queue */
-    size_t Depth()
-    {
-        std::unique_lock<std::mutex> lock(cs);
-        return queue.size();
-    }
 };
 
 struct HTTPPathHandler

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -23,6 +23,7 @@
 #include <sys/types.h>
 
 #include <event2/buffer.h>
+#include <event2/bufferevent.h>
 #include <event2/event.h>
 #include <event2/http.h>
 #include <event2/keyvalq_struct.h>
@@ -242,6 +243,19 @@ static std::string RequestMethodString(HTTPRequest::RequestMethod m)
 /** HTTP request callback */
 static void http_request_cb(struct evhttp_request *req, void *arg)
 {
+    // Disable reading to work around a libevent bug, fixed in 2.2.0.
+    if (event_get_version_number() < 0x02020001)
+    {
+        evhttp_connection *conn = evhttp_request_get_connection(req);
+        if (conn)
+        {
+            bufferevent *bev = evhttp_connection_get_bufferevent(conn);
+            if (bev)
+            {
+                bufferevent_disable(bev, EV_READ);
+            }
+        }
+    }
     std::unique_ptr<HTTPRequest> hreq(new HTTPRequest(req));
 
     LOG(HTTP, "Received a %s request for %s from %s\n", RequestMethodString(hreq->GetRequestMethod()), hreq->GetURI(),
@@ -620,9 +634,25 @@ void HTTPRequest::WriteReply(int nStatus, const std::string &strReply)
     struct evbuffer *evb = evhttp_request_get_output_buffer(req);
     assert(evb);
     evbuffer_add(evb, strReply.data(), strReply.size());
-    HTTPEvent *ev = new HTTPEvent(
-        eventBase, true, std::bind(evhttp_send_reply, req, nStatus, (const char *)NULL, (struct evbuffer *)NULL));
-    ev->trigger(0);
+    auto req_copy = req;
+    HTTPEvent *ev = new HTTPEvent(eventBase, true, [req_copy, nStatus] {
+        evhttp_send_reply(req_copy, nStatus, nullptr, nullptr);
+        // Re-enable reading from the socket. This is the second part of the libevent
+        // workaround above.
+        if (event_get_version_number() < 0x02020001)
+        {
+            evhttp_connection *conn = evhttp_request_get_connection(req_copy);
+            if (conn)
+            {
+                bufferevent *bev = evhttp_connection_get_bufferevent(conn);
+                if (bev)
+                {
+                    bufferevent_enable(bev, EV_READ | EV_WRITE);
+                }
+            }
+        }
+    });
+    ev->trigger(nullptr);
     replySent = true;
     req = 0; // transferred back to main thread
 }

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -244,7 +244,7 @@ static std::string RequestMethodString(HTTPRequest::RequestMethod m)
 static void http_request_cb(struct evhttp_request *req, void *arg)
 {
     // Disable reading to work around a libevent bug, fixed in 2.2.0.
-    if (event_get_version_number() < 0x02020001)
+    if (event_get_version_number() >= 0x02010600 && event_get_version_number() < 0x02020001)
     {
         evhttp_connection *conn = evhttp_request_get_connection(req);
         if (conn)
@@ -639,7 +639,7 @@ void HTTPRequest::WriteReply(int nStatus, const std::string &strReply)
         evhttp_send_reply(req_copy, nStatus, nullptr, nullptr);
         // Re-enable reading from the socket. This is the second part of the libevent
         // workaround above.
-        if (event_get_version_number() < 0x02020001)
+        if (event_get_version_number() >= 0x02010600 && event_get_version_number() < 0x02020001)
         {
             evhttp_connection *conn = evhttp_request_get_connection(req_copy);
             if (conn)

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -92,7 +92,6 @@ private:
 public:
     WorkQueue(size_t maxDepth) : running(true), maxDepth(maxDepth), numThreads(0) {}
     /** Precondition: worker threads have all stopped
-     * (call WaitExit)
      */
     ~WorkQueue() {}
     /** Enqueue a work item */
@@ -133,14 +132,6 @@ public:
         running = false;
         cond.notify_all();
     }
-    /** Wait for worker threads to exit */
-    void WaitExit()
-    {
-        std::unique_lock<std::mutex> lock(cs);
-        while (numThreads > 0)
-            cond.wait(lock);
-    }
-
     /** Return current depth of queue */
     size_t Depth()
     {
@@ -510,7 +501,6 @@ void StopHTTPServer()
     if (workQueue)
     {
         LOG(HTTP, "Waiting for HTTP worker threads to exit\n");
-        workQueue->WaitExit();
         for (auto &thread : g_thread_http_workers)
         {
             thread.join();

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1425,5 +1425,5 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
 #endif
 
     uiInterface.InitMessage(_("Done loading"));
-    return !fRequestShutdown;
+    return true;
 }


### PR DESCRIPTION
Bunch of fixes for internal http server, (h/t via bitcoinxt/bitcoinxt/pull/456). This should has beneficial effects on all the functional tests that uses the RPC interface. 

These is the list of Core PRs ported:
 
bitcoin/bitcoin#11831 - Always return true if AppInitMain got to the end
bitcoin/bitcoin#11593 - rpc: work-around an upstream libevent bug
bitcoin/bitcoin#12366 - http: Join worker threads before deleting work queue
