### PR TITLE
[qa] Disable unit and functional tests for clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ matrix:
         - CXX=clang++-5.0 CC=clang-5.0
         - CXXFLAGS="-std=c++11"
         - HOST=x86_64-unknown-linux-gnu
-        - RUN_TESTS=true
+        - RUN_TESTS=false
         - PACKAGES="python3-zmq clang-format-3.8 build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils libboost-all-dev  qttools5-dev-tools qttools5-dev"
         - GOAL="install" BITCOIN_CONFIG="--enable-zmq CC=clang-5.0 CXX=clang++-5.0 CPPFLAGS=-DDEBUG_LOCKORDER"
     #bitcoind


### PR DESCRIPTION
The clang conf is supposed to spot compilation problem while using clang.
Running the tests in this case doesn't bring enough advantages to balance the amount additional time needed and the travis resources used in the process.