### PR TITLE
Min transaction size

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -593,6 +593,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
     TransactionClass allowedTx,
     std::vector<COutPoint> &vCoinsToUncache)
 {
+    const CTransaction& tx = *ptx;
     unsigned int nSigOps = 0;
     ValidationResourceTracker resourceTracker;
     unsigned int nSize = 0;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -631,6 +631,11 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
         return state.DoS(0, false, REJECT_NONSTANDARD, "premature-version2-tx");
     }
 
+    // Do not work on transactions that are too small.
+    // Transactions smaller than this are not relayed to reduce unnecessary malloc overhead.
+    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION) < MIN_STANDARD_TX_SIZE)
+        return state.DoS(0, false, REJECT_NONSTANDARD, "tx-size-small");
+
     // Only accept nLockTime-using transactions that can be mined in the next
     // block; we don't want our mempool filled up with transactions that can't
     // be mined yet.

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -23,6 +23,8 @@ static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = DEFAULT_BLOCK_MAX_SIZE /
 
 /** The maximum size for transactions we're willing to relay/mine */
 static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
+/** The minimum size for transactions we're willing to relay/mine */
+static const unsigned int MIN_STANDARD_TX_SIZE = 65;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */


### PR DESCRIPTION
Core fixed the leaf node vulnerability in 0.16.1, which makes SPV more secure.

Reference:
https://github.com/bitcoin/bitcoin/pull/11423/commits/7485488e907e236133a016ba7064c89bf9ab6da3