### PR TITLE
Fix clang compile warning

### DIFF
--- a/src/test/opcodes_tests.cpp
+++ b/src/test/opcodes_tests.cpp
@@ -14,8 +14,7 @@
 typedef std::vector<uint8_t> valtype;
 typedef std::vector<valtype> stacktype;
 
-std::array<uint32_t, 3> flagset{0, STANDARD_SCRIPT_VERIFY_FLAGS,
-                                MANDATORY_SCRIPT_VERIFY_FLAGS};
+std::array<uint32_t, 3> flagset{{0, STANDARD_SCRIPT_VERIFY_FLAGS, MANDATORY_SCRIPT_VERIFY_FLAGS}};
 
 BOOST_FIXTURE_TEST_SUITE(may152018_opcodes_tests, BasicTestingSetup)
 


### PR DESCRIPTION
need double braces for initializing array.