### PR TITLE
[PORT] Default to virtual cores and set appropriate thread scheduler

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -400,6 +400,8 @@ void ThreadImport(std::vector<fs::path> vImportFiles)
 {
     const CChainParams &chainparams = Params();
     RenameThread("bitcoin-loadblk");
+    ScheduleBatchPriority();
+
     // -reindex
     if (fReindex)
     {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -91,6 +91,7 @@
 #include <openssl/conf.h>
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
+#include <thread>
 
 // Work around clang compilation problem in Boost 1.46:
 // /usr/include/boost/program_options/detail/config_file.hpp:163:17: error: call to function 'to_internal' that is
@@ -893,15 +894,7 @@ void SetThreadPriority(int nPriority)
 #endif // WIN32
 }
 
-int GetNumCores()
-{
-#if BOOST_VERSION >= 105600
-    return boost::thread::physical_concurrency();
-#else // Must fall back to hardware_concurrency, which unfortunately counts virtual cores
-    return boost::thread::hardware_concurrency();
-#endif
-}
-
+int GetNumCores() { return std::thread::hardware_concurrency(); }
 std::string CopyrightHolders(const std::string &strPrefix)
 {
     std::string strCopyrightHolders = strPrefix + _(COPYRIGHT_HOLDERS);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1000,7 +1000,7 @@ int ScheduleBatchPriority(void)
 {
 #ifdef SCHED_BATCH
     const static sched_param param{.sched_priority = 0};
-    if (int ret = pthread_setschedparam(0, SCHED_BATCH, &param))
+    if (int ret = pthread_setschedparam(pthread_self(), SCHED_BATCH, &param))
     {
         LOGA("Failed to pthread_setschedparam: %s\n", strerror(errno));
         return ret;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -999,7 +999,7 @@ bool wildmatch(string pattern, string test)
 int ScheduleBatchPriority(void)
 {
 #ifdef SCHED_BATCH
-    const static sched_param param{.sched_priority = 0};
+    const static sched_param param{0};
     if (int ret = pthread_setschedparam(pthread_self(), SCHED_BATCH, &param))
     {
         LOGA("Failed to pthread_setschedparam: %s\n", strerror(errno));

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -42,6 +42,7 @@
 
 #include <algorithm>
 #include <fcntl.h>
+#include <sched.h>
 #include <sys/resource.h>
 #include <sys/stat.h>
 
@@ -1000,4 +1001,19 @@ bool wildmatch(string pattern, string test)
         pattern = pattern.substr(1);
         test = test.substr(1);
     }
+}
+
+int ScheduleBatchPriority(void)
+{
+#ifdef SCHED_BATCH
+    const static sched_param param{.sched_priority = 0};
+    if (int ret = pthread_setschedparam(0, SCHED_BATCH, &param))
+    {
+        LOGA("Failed to pthread_setschedparam: %s\n", strerror(errno));
+        return ret;
+    }
+    return 0;
+#else
+    return 1;
+#endif
 }

--- a/src/util.h
+++ b/src/util.h
@@ -480,4 +480,13 @@ the second argument will be matched to this pattern. Returns true iff the string
 matches pattern. */
 bool wildmatch(std::string pattern, std::string test);
 
+/**
+ * On platforms that support it, tell the kernel the calling thread is
+ * CPU-intensive and non-interactive. See SCHED_BATCH in sched(7) for details.
+ *
+ * @return The return value of sched_setschedule(), or 1 on systems without
+ * sched_setchedule().
+ */
+int ScheduleBatchPriority(void);
+
 #endif // BITCOIN_UTIL_H

--- a/src/util.h
+++ b/src/util.h
@@ -432,9 +432,8 @@ bool SoftSetArg(const std::string &strArg, const std::string &strValue);
 bool SoftSetBoolArg(const std::string &strArg, bool fValue);
 
 /**
- * Return the number of physical cores available on the current system.
- * @note This does not count virtual cores, such as those provided by HyperThreading
- * when boost is newer than 1.56.
+ * Return the number of cores available on the current system.
+ * @note This does count virtual cores, such as those provided by HyperThreading.
  */
 int GetNumCores();
 


### PR DESCRIPTION
This bumps number of scriptcheck threads to # virtual cores, without re-introducing the issue that using physical core count fixed (see bitcoin/bitcoin#6361).


bitcoin/bitcoin#10271 - Use std::thread::hardware_concurrency, instead of Boost, to determine available cores
bitcoin/bitcoin#12618 - Set SCHED_BATCH priority on the loadblk thread.
bitcoin/bitcoin#12923 - util: Pass pthread_self() to pthread_setschedparam instead of 0

H/T https://github.com/bitcoinxt/bitcoinxt/pull/446