### PR TITLE
ParseFixedPoint() and ParseMoney(): init result to zero always

### DIFF
--- a/src/utilmoneystr.cpp
+++ b/src/utilmoneystr.cpp
@@ -40,6 +40,7 @@ bool ParseMoney(const char *pszIn, CAmount &nRet)
     string strWhole;
     int64_t nUnits = 0;
     const char *p = pszIn;
+    nRet = 0;
     while (isspace(*p))
         p++;
     for (; *p; p++)

--- a/src/utilstrencodings.cpp
+++ b/src/utilstrencodings.cpp
@@ -556,7 +556,8 @@ bool ParseFixedPoint(const std::string &val, int decimals, int64_t *amount_out)
     int ptr = 0;
     int end = val.size();
     int point_ofs = 0;
-
+    if (amount_out != nullptr)
+        *amount_out = 0;
     if (ptr < end && val[ptr] == '-')
     {
         mantissa_sign = true;
@@ -650,7 +651,7 @@ bool ParseFixedPoint(const std::string &val, int decimals, int64_t *amount_out)
     if (mantissa > UPPER_BOUND || mantissa < -UPPER_BOUND)
         return false; /* overflow */
 
-    if (amount_out)
+    if (amount_out != nullptr)
         *amount_out = mantissa;
 
     return true;


### PR DESCRIPTION
This always initializes the results returned by the above two functions
to zero to reduce the chance of dealing with unitialized memory
when using them.

Also makes a null-ptr check in ParseFixedPoint() explicit.