### PR TITLE
[PORT] Add static_assert to prevent VARINT(<signed value>)

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -80,7 +80,7 @@ struct CDiskBlockPos
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
-        READWRITE(VARINT(nFile));
+        READWRITE(VARINT(nFile, VarIntMode::NONNEGATIVE_SIGNED));
         READWRITE(VARINT(nPos));
     }
 
@@ -377,13 +377,13 @@ public:
     {
         int nVersion = s.GetVersion();
         if (!(s.GetType() & SER_GETHASH))
-            READWRITE(VARINT(nVersion));
+            READWRITE(VARINT(nVersion, VarIntMode::NONNEGATIVE_SIGNED));
 
-        READWRITE(VARINT(nHeight));
+        READWRITE(VARINT(nHeight, VarIntMode::NONNEGATIVE_SIGNED));
         READWRITE(VARINT(nStatus));
         READWRITE(VARINT(nTx));
         if (nStatus & (BLOCK_HAVE_DATA | BLOCK_HAVE_UNDO))
-            READWRITE(VARINT(nFile));
+            READWRITE(VARINT(nFile, VarIntMode::NONNEGATIVE_SIGNED));
         if (nStatus & BLOCK_HAVE_DATA)
             READWRITE(VARINT(nDataPos));
         if (nStatus & BLOCK_HAVE_UNDO)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -470,17 +470,18 @@ static void ApplyStats(CCoinsStats &stats,
 {
     assert(!outputs.empty());
     ss << hash;
-    ss << VARINT(outputs.begin()->second.nHeight * 2 + outputs.begin()->second.fCoinBase);
+    ss << VARINT(
+        outputs.begin()->second.nHeight * 2 + outputs.begin()->second.fCoinBase, VarIntMode::NONNEGATIVE_SIGNED);
     stats.nTransactions++;
     for (const auto output : outputs)
     {
         ss << VARINT(output.first + 1);
         ss << *(const CScriptBase *)(&output.second.out.scriptPubKey);
-        ss << VARINT(output.second.out.nValue);
+        ss << VARINT(output.second.out.nValue, VarIntMode::NONNEGATIVE_SIGNED);
         stats.nTransactionOutputs++;
         stats.nTotalAmount += output.second.out.nValue;
     }
-    ss << VARINT(0);
+    ss << VARINT(0u);
 }
 
 //! Calculate statistics about the unspent transaction output set

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -200,8 +200,7 @@ enum
     SER_GETHASH = (1 << 2),
 };
 
-#define READWRITE(obj) (::SerReadWrite(s, (obj), ser_action))
-#define READWRITEMANY(...) (::SerReadWriteMany(s, ser_action, __VA_ARGS__))
+#define READWRITE(...) (::SerReadWriteMany(s, ser_action, __VA_ARGS__))
 
 /**
  * Implement three methods for serializable objects. These are actually wrappers over
@@ -453,9 +452,39 @@ uint64_t ReadCompactSize(Stream &is)
  * 2^32:           [0x8E 0xFE 0xFE 0xFF 0x00]
  */
 
-template <typename I>
+
+/**
+ * Mode for encoding VarInts.
+ *
+ * Currently there is no support for signed encodings. The default mode will not
+ * compile with signed values, and the legacy "nonnegative signed" mode will
+ * accept signed values, but improperly encode and decode them if they are
+ * negative. In the future, the DEFAULT mode could be extended to support
+ * negative numbers in a backwards compatible way, and additional modes could be
+ * added to support different varint formats (e.g. zigzag encoding).
+ */
+enum class VarIntMode
+{
+    DEFAULT,
+    NONNEGATIVE_SIGNED
+};
+
+template <VarIntMode Mode, typename I>
+struct CheckVarIntMode
+{
+    constexpr CheckVarIntMode()
+    {
+        static_assert(
+            Mode != VarIntMode::DEFAULT || std::is_unsigned<I>::value, "Unsigned type required with mode DEFAULT.");
+        static_assert(Mode != VarIntMode::NONNEGATIVE_SIGNED || std::is_signed<I>::value,
+            "Signed type required with mode NONNEGATIVE_SIGNED.");
+    }
+};
+
+template <VarIntMode Mode, typename I>
 inline unsigned int GetSizeOfVarInt(I n)
 {
+    CheckVarIntMode<Mode, I>();
     int nRet = 0;
     while (true)
     {
@@ -470,9 +499,10 @@ inline unsigned int GetSizeOfVarInt(I n)
 template <typename I>
 inline void WriteVarInt(CSizeComputer &os, I n);
 
-template <typename Stream, typename I>
+template <typename Stream, VarIntMode Mode, typename I>
 void WriteVarInt(Stream &os, I n)
 {
+    CheckVarIntMode<Mode, I>();
     unsigned char tmp[(sizeof(n) * 8 + 6) / 7];
     int len = 0;
     while (true)
@@ -489,9 +519,10 @@ void WriteVarInt(Stream &os, I n)
     } while (len--);
 }
 
-template <typename Stream, typename I>
+template <typename Stream, VarIntMode Mode, typename I>
 I ReadVarInt(Stream &is)
 {
+    CheckVarIntMode<Mode, I>();
     I n = 0;
     while (true)
     {
@@ -517,7 +548,7 @@ I ReadVarInt(Stream &is)
 }
 
 #define FLATDATA(obj) REF(CFlatData((char *)&(obj), (char *)&(obj) + sizeof(obj)))
-#define VARINT(obj) REF(WrapVarInt(REF(obj)))
+#define VARINT(obj, ...) REF(WrapVarInt<__VA_ARGS__>(REF(obj)))
 #define COMPACTSIZE(obj) REF(CCompactSize(REF(obj)))
 #define LIMITED_STRING(obj, n) REF(LimitedString<n>(REF(obj)))
 
@@ -561,7 +592,7 @@ public:
     }
 };
 
-template <typename I>
+template <VarIntMode Mode, typename I>
 class CVarInt
 {
 protected:
@@ -572,13 +603,13 @@ public:
     template <typename Stream>
     void Serialize(Stream &s) const
     {
-        WriteVarInt<Stream, I>(s, n);
+        WriteVarInt<Stream, Mode, I>(s, n);
     }
 
     template <typename Stream>
     void Unserialize(Stream &s)
     {
-        n = ReadVarInt<Stream, I>(s);
+        n = ReadVarInt<Stream, Mode, I>(s);
     }
 };
 
@@ -632,10 +663,10 @@ public:
     }
 };
 
-template <typename I>
-CVarInt<I> WrapVarInt(I &n)
+template <VarIntMode Mode = VarIntMode::DEFAULT, typename I>
+CVarInt<Mode, I> WrapVarInt(I &n)
 {
-    return CVarInt<I>(n);
+    return CVarInt<Mode, I>{n};
 }
 
 /**
@@ -1009,18 +1040,6 @@ struct CSerActionUnserialize
 {
     constexpr bool ForRead() const { return true; }
 };
-
-template <typename Stream, typename T>
-inline void SerReadWrite(Stream &s, const T &obj, CSerActionSerialize ser_action)
-{
-    ::Serialize(s, obj);
-}
-
-template <typename Stream, typename T>
-inline void SerReadWrite(Stream &s, T &obj, CSerActionUnserialize ser_action)
-{
-    ::Unserialize(s, obj);
-}
 
 
 /* ::GetSerializeSize implementations

--- a/src/test/serialize_tests.cpp
+++ b/src/test/serialize_tests.cpp
@@ -64,7 +64,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
-        READWRITEMANY(intval, boolval, stringval, FLATDATA(charstrval), txval);
+        READWRITE(intval, boolval, stringval, FLATDATA(charstrval), txval);
     }
 };
 
@@ -197,8 +197,8 @@ BOOST_AUTO_TEST_CASE(varints)
     CDataStream::size_type size = 0;
     for (int i = 0; i < 100000; i++)
     {
-        ss << VARINT(i);
-        size += ::GetSerializeSize(VARINT(i), 0, 0);
+        ss << VARINT(i, VarIntMode::NONNEGATIVE_SIGNED);
+        size += ::GetSerializeSize(VARINT(i, VarIntMode::NONNEGATIVE_SIGNED), 0, 0);
         BOOST_CHECK(size == ss.size());
     }
 
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE(varints)
     for (int i = 0; i < 100000; i++)
     {
         int j = -1;
-        ss >> VARINT(j);
+        ss >> VARINT(j, VarIntMode::NONNEGATIVE_SIGNED);
         BOOST_CHECK_MESSAGE(i == j, "decoded:" << j << " expected:" << i);
     }
 
@@ -223,6 +223,59 @@ BOOST_AUTO_TEST_CASE(varints)
         ss >> VARINT(j);
         BOOST_CHECK_MESSAGE(i == j, "decoded:" << j << " expected:" << i);
     }
+}
+
+BOOST_AUTO_TEST_CASE(varints_bitpatterns)
+{
+    CDataStream ss(SER_DISK, 0);
+    ss << VARINT(0, VarIntMode::NONNEGATIVE_SIGNED);
+    BOOST_CHECK_EQUAL(HexStr(ss), "00");
+    ss.clear();
+    ss << VARINT(0x7f, VarIntMode::NONNEGATIVE_SIGNED);
+    BOOST_CHECK_EQUAL(HexStr(ss), "7f");
+    ss.clear();
+    ss << VARINT((int8_t)0x7f, VarIntMode::NONNEGATIVE_SIGNED);
+    BOOST_CHECK_EQUAL(HexStr(ss), "7f");
+    ss.clear();
+    ss << VARINT(0x80, VarIntMode::NONNEGATIVE_SIGNED);
+    BOOST_CHECK_EQUAL(HexStr(ss), "8000");
+    ss.clear();
+    ss << VARINT((uint8_t)0x80);
+    BOOST_CHECK_EQUAL(HexStr(ss), "8000");
+    ss.clear();
+    ss << VARINT(0x1234, VarIntMode::NONNEGATIVE_SIGNED);
+    BOOST_CHECK_EQUAL(HexStr(ss), "a334");
+    ss.clear();
+    ss << VARINT((int16_t)0x1234, VarIntMode::NONNEGATIVE_SIGNED);
+    BOOST_CHECK_EQUAL(HexStr(ss), "a334");
+    ss.clear();
+    ss << VARINT(0xffff, VarIntMode::NONNEGATIVE_SIGNED);
+    BOOST_CHECK_EQUAL(HexStr(ss), "82fe7f");
+    ss.clear();
+    ss << VARINT((uint16_t)0xffff);
+    BOOST_CHECK_EQUAL(HexStr(ss), "82fe7f");
+    ss.clear();
+    ss << VARINT(0x123456, VarIntMode::NONNEGATIVE_SIGNED);
+    BOOST_CHECK_EQUAL(HexStr(ss), "c7e756");
+    ss.clear();
+    ss << VARINT((int32_t)0x123456, VarIntMode::NONNEGATIVE_SIGNED);
+    BOOST_CHECK_EQUAL(HexStr(ss), "c7e756");
+    ss.clear();
+    ss << VARINT(0x80123456U);
+    BOOST_CHECK_EQUAL(HexStr(ss), "86ffc7e756");
+    ss.clear();
+    ss << VARINT((uint32_t)0x80123456U);
+    BOOST_CHECK_EQUAL(HexStr(ss), "86ffc7e756");
+    ss.clear();
+    ss << VARINT(0xffffffff);
+    BOOST_CHECK_EQUAL(HexStr(ss), "8efefefe7f");
+    ss.clear();
+    ss << VARINT(0x7fffffffffffffffLL, VarIntMode::NONNEGATIVE_SIGNED);
+    BOOST_CHECK_EQUAL(HexStr(ss), "fefefefefefefefe7f");
+    ss.clear();
+    ss << VARINT(0xffffffffffffffffULL);
+    BOOST_CHECK_EQUAL(HexStr(ss), "80fefefefefefefefe7f");
+    ss.clear();
 }
 
 BOOST_AUTO_TEST_CASE(compactsize)

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -332,7 +332,7 @@ public:
     {
         unsigned int nCode = 0;
         // version
-        int nVersionDummy;
+        unsigned int nVersionDummy;
         ::Unserialize(s, VARINT(nVersionDummy));
         // header code
         ::Unserialize(s, VARINT(nCode));
@@ -362,7 +362,7 @@ public:
                 ::Unserialize(s, REF(CTxOutCompressor(vout[i])));
         }
         // coinbase height
-        ::Unserialize(s, VARINT(nHeight));
+        ::Unserialize(s, VARINT(nHeight, VarIntMode::NONNEGATIVE_SIGNED));
     }
 };
 }

--- a/src/undo.h
+++ b/src/undo.h
@@ -27,7 +27,7 @@ public:
     template <typename Stream>
     void Serialize(Stream &s) const
     {
-        ::Serialize(s, VARINT(txout->nHeight * 2 + (txout->fCoinBase ? 1 : 0)));
+        ::Serialize(s, VARINT(txout->nHeight * 2 + (txout->fCoinBase ? 1 : 0), VarIntMode::NONNEGATIVE_SIGNED));
         if (txout->nHeight > 0)
         {
             // Required to maintain compatibility with older undo format.
@@ -56,7 +56,7 @@ public:
             // Old versions stored the version number for the last spend of
             // a transaction's outputs. Non-final spends were indicated with
             // height = 0.
-            int nVersionDummy;
+            unsigned int nVersionDummy;
             ::Unserialize(s, VARINT(nVersionDummy));
         }
         ::Unserialize(s, REF(CTxOutCompressor(REF(txout->out))));


### PR DESCRIPTION
This is a port of bitcoin/bitcoin#9753 and should fix issue #1144 

varints_bitpatterns test original commit was originally from bitcoin/bitcoin#7849