### PR TITLE
travis: Dump available debug.logs and bitcoin.confs in case of test f…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,3 +132,9 @@ script:
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG
+
+after_failure:
+    - for i in `find /home/travis/ -name debug.log`; do echo $i; echo "-----"; cat $i; done
+    - for i in `find /tmp/ -name debug.log`; do echo $i; echo "-----"; cat $i; done
+    - for i in `find /home/travis/ -name bitcoin.conf`; do echo $i; echo "-----"; cat $i; done
+    - for i in `find /tmp/ -name bitcoin.conf`; do echo $i; echo "-----"; cat $i; done


### PR DESCRIPTION
This is IMO quite handy to have in case of failure. Also seems to create output in travis that is shown collapsed into a single line that can then be opened when one is curious.