### PR TITLE
Fixes shadowing warnings

### DIFF
--- a/src/bitnodes.cpp
+++ b/src/bitnodes.cpp
@@ -305,10 +305,10 @@ bool GetLeaderboardFromBitnodes(vector<string> &vIPs)
             for (std::vector<UniValue>::iterator it = v.begin(); it != v.end(); ++it)
             {
                 const UniValue &o = *it;
-                const UniValue &result = find_value(o, "node");
-                if (result.isStr())
+                const UniValue &_result = find_value(o, "node");
+                if (_result.isStr())
                 {
-                    string s = result.get_str();
+                    string s = _result.get_str();
                     vIPs.push_back(s);
                     count++;
                 }

--- a/src/connmgr.cpp
+++ b/src/connmgr.cpp
@@ -11,9 +11,9 @@ std::unique_ptr<CConnMgr> connmgr(new CConnMgr);
  * Find a node in a vector.  Just calls std::find.  Split out for cleanliness and also because std:find won't be
  * enough if we switch to vectors of noderefs.  Requires any lock for vector traversal to be held.
  */
-static std::vector<CNode *>::iterator FindNode(std::vector<CNode *> &vNodes, CNode *pNode)
+static std::vector<CNode *>::iterator FindNode(std::vector<CNode *> &_vNodes, CNode *pNode)
 {
-    return std::find(vNodes.begin(), vNodes.end(), pNode);
+    return std::find(_vNodes.begin(), _vNodes.end(), pNode);
 }
 
 /**
@@ -22,10 +22,10 @@ static std::vector<CNode *>::iterator FindNode(std::vector<CNode *> &vNodes, CNo
  * @param[in] vNodes      The vector of nodes.
  * @param[in] pNode       The node to add.
  */
-static void AddNode(std::vector<CNode *> &vNodes, CNode *pNode)
+static void AddNode(std::vector<CNode *> &_vNodes, CNode *pNode)
 {
     pNode->AddRef();
-    vNodes.push_back(pNode);
+    _vNodes.push_back(pNode);
 }
 
 /**
@@ -35,14 +35,14 @@ static void AddNode(std::vector<CNode *> &vNodes, CNode *pNode)
  * @param[in] pNode       The node to remove.
  * @return  True if the node was originally present, false if not.
  */
-static bool RemoveNode(std::vector<CNode *> &vNodes, CNode *pNode)
+static bool RemoveNode(std::vector<CNode *> &_vNodes, CNode *pNode)
 {
-    auto Node = FindNode(vNodes, pNode);
+    auto Node = FindNode(_vNodes, pNode);
 
-    if (Node != vNodes.end())
+    if (Node != _vNodes.end())
     {
         pNode->Release();
-        vNodes.erase(Node);
+        _vNodes.erase(Node);
         return true;
     }
 

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -280,13 +280,13 @@ bool CKey::Derive(CKey &keyChild, ChainCode &ccChild, unsigned int nChild, const
     return ret;
 }
 
-bool CExtKey::Derive(CExtKey &out, unsigned int nChild) const
+bool CExtKey::Derive(CExtKey &out, unsigned int _nChild) const
 {
     out.nDepth = nDepth + 1;
     CKeyID id = key.GetPubKey().GetID();
     memcpy(&out.vchFingerprint[0], &id, 4);
-    out.nChild = nChild;
-    return key.Derive(out.key, out.chaincode, nChild, chaincode);
+    out.nChild = _nChild;
+    return key.Derive(out.key, out.chaincode, _nChild, chaincode);
 }
 
 void CExtKey::SetMaster(const unsigned char *seed, unsigned int nSeedLen)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1998,7 +1998,7 @@ bool ConnectBlock(const CBlock &block,
     // Begin Section for Boost Scope Guard
     {
         // Scope guard to make sure cs_main is set and resources released if we encounter an exception.
-        BOOST_SCOPE_EXIT(&PV, &fParallel) { PV->SetLocks(fParallel); }
+        BOOST_SCOPE_EXIT(&fParallel) { PV->SetLocks(fParallel); }
         BOOST_SCOPE_EXIT_END
 
 

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -129,7 +129,7 @@ uint64_t BlockAssembler::reserveBlockSize(const CScript &scriptPubKeyIn)
     return nHeaderSize + std::max(nCoinbaseSize, coinbaseReserve.value);
 }
 
-CTransactionRef BlockAssembler::coinbaseTx(const CScript &scriptPubKeyIn, int nHeight, CAmount nValue)
+CTransactionRef BlockAssembler::coinbaseTx(const CScript &scriptPubKeyIn, int _nHeight, CAmount nValue)
 {
     CMutableTransaction tx;
 
@@ -138,7 +138,7 @@ CTransactionRef BlockAssembler::coinbaseTx(const CScript &scriptPubKeyIn, int nH
     tx.vout.resize(1);
     tx.vout[0].scriptPubKey = scriptPubKeyIn;
     tx.vout[0].nValue = nValue;
-    tx.vin[0].scriptSig = CScript() << nHeight << OP_0;
+    tx.vin[0].scriptSig = CScript() << _nHeight << OP_0;
 
     // BU005 add block size settings to the coinbase
     std::string cbmsg = FormatCoinbaseMessage(BUComments, minerComment);

--- a/src/netaddress.cpp
+++ b/src/netaddress.cpp
@@ -159,8 +159,8 @@ bool CNetAddr::IsValid() const
         return false;
 
     // unspecified IPv6 address (::/128)
-    unsigned char ipNone[16] = {};
-    if (memcmp(ip, ipNone, 16) == 0)
+    unsigned char _ipNone[16] = {};
+    if (memcmp(ip, _ipNone, 16) == 0)
         return false;
 
     // documentation IPv6 address

--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -717,8 +717,8 @@ bool ConnectSocketByName(CService &addr,
 
     SplitHostPort(std::string(pszDest), port, strDest);
 
-    proxyType nameProxy;
-    GetNameProxy(nameProxy);
+    proxyType _nameProxy;
+    GetNameProxy(_nameProxy);
 
     CService addrResolved;
     if (Lookup(strDest.c_str(), addrResolved, port, fNameLookup && !HaveNameProxy()))
@@ -734,7 +734,7 @@ bool ConnectSocketByName(CService &addr,
 
     if (!HaveNameProxy())
         return false;
-    return ConnectThroughProxy(nameProxy, strDest, port, hSocketRet, nTimeout, outProxyConnectionFailed);
+    return ConnectThroughProxy(_nameProxy, strDest, port, hSocketRet, nTimeout, outProxyConnectionFailed);
 }
 
 #ifdef WIN32

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -275,13 +275,13 @@ bool CPubKey::Decompress()
     return true;
 }
 
-bool CPubKey::Derive(CPubKey &pubkeyChild, ChainCode &ccChild, unsigned int nChild, const ChainCode &cc) const
+bool CPubKey::Derive(CPubKey &pubkeyChild, ChainCode &ccChild, unsigned int _nChild, const ChainCode &cc) const
 {
     assert(IsValid());
-    assert((nChild >> 31) == 0);
+    assert((_nChild >> 31) == 0);
     assert(begin() + 33 == end());
     unsigned char out[64];
-    BIP32Hash(cc, nChild, *begin(), begin() + 1, out);
+    BIP32Hash(cc, _nChild, *begin(), begin() + 1, out);
     memcpy(ccChild.begin(), out + 32, 32);
     secp256k1_pubkey pubkey;
     if (!secp256k1_ec_pubkey_parse(secp256k1_context_verify, &pubkey, &(*this)[0], size()))
@@ -321,13 +321,13 @@ void CExtPubKey::Decode(const unsigned char code[BIP32_EXTKEY_SIZE])
     pubkey.Set(code + 41, code + BIP32_EXTKEY_SIZE);
 }
 
-bool CExtPubKey::Derive(CExtPubKey &out, unsigned int nChild) const
+bool CExtPubKey::Derive(CExtPubKey &out, unsigned int _nChild) const
 {
     out.nDepth = nDepth + 1;
     CKeyID id = pubkey.GetID();
     memcpy(&out.vchFingerprint[0], &id, 4);
-    out.nChild = nChild;
-    return pubkey.Derive(out.pubkey, out.chaincode, nChild, chaincode);
+    out.nChild = _nChild;
+    return pubkey.Derive(out.pubkey, out.chaincode, _nChild, chaincode);
 }
 
 /* static */ bool CPubKey::CheckLowS(const std::vector<unsigned char> &vchSig)

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -532,14 +532,14 @@ void CRequestManager::SendRequests()
 
     // Modify retry interval. If we're doing IBD or if Traffic Shaping is ON we want to have a longer interval because
     // those blocks and txns can take much longer to download.
-    unsigned int blkReqRetryInterval = MIN_BLK_REQUEST_RETRY_INTERVAL;
-    unsigned int txReqRetryInterval = MIN_TX_REQUEST_RETRY_INTERVAL;
+    unsigned int _blkReqRetryInterval = MIN_BLK_REQUEST_RETRY_INTERVAL;
+    unsigned int _txReqRetryInterval = MIN_TX_REQUEST_RETRY_INTERVAL;
     if ((!IsChainNearlySyncd() && Params().NetworkIDString() != "regtest") || IsTrafficShapingEnabled())
     {
-        blkReqRetryInterval *= 6;
+        _blkReqRetryInterval *= 6;
         // we want to optimise block DL during IBD (and give lots of time for shaped nodes) so push the TX retry up to 2
         // minutes (default val of MIN_TX is 5 sec)
-        txReqRetryInterval *= (12 * 2);
+        _txReqRetryInterval *= (12 * 2);
     }
 
     // When we are still doing an initial sync we want to batch request the blocks instead of just
@@ -565,7 +565,7 @@ void CRequestManager::SendRequests()
             break;
 
         // if never requested then lastRequestTime==0 so this will always be true
-        if (now - item.lastRequestTime > blkReqRetryInterval)
+        if (now - item.lastRequestTime > _blkReqRetryInterval)
         {
             if (!item.availableFrom.empty())
             {
@@ -715,7 +715,7 @@ void CRequestManager::SendRequests()
             break;
 
         // if never requested then lastRequestTime==0 so this will always be true
-        if (now - item.lastRequestTime > txReqRetryInterval)
+        if (now - item.lastRequestTime > _txReqRetryInterval)
         {
             if (!item.rateLimited)
             {
@@ -1170,12 +1170,12 @@ bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
         if (IsChainNearlySyncd())
         {
             LOCK(cs_vNodes);
-            for (CNode *pnode : vNodes)
+            for (CNode *_pnode : vNodes)
             {
-                if (pnode->mapThinBlocksInFlight.size() > 0)
+                if (_pnode->mapThinBlocksInFlight.size() > 0)
                 {
-                    LOCK(pnode->cs_mapthinblocksinflight);
-                    if (pnode->mapThinBlocksInFlight.count(hash))
+                    LOCK(_pnode->cs_mapthinblocksinflight);
+                    if (_pnode->mapThinBlocksInFlight.count(hash))
                     {
                         // Only update thinstats if this is actually a thinblock and not a regular block.
                         // Sometimes we request a thinblock but then revert to requesting a regular block

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -592,9 +592,9 @@ UniValue mkblocktemplate(const UniValue &params, CBlock *pblockOut)
 
     UniValue aRules(UniValue::VARR);
     UniValue vbavailable(UniValue::VOBJ);
-    for (int i = 0; i < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++i)
+    for (int j = 0; j < (int)Consensus::MAX_VERSION_BITS_DEPLOYMENTS; ++j)
     {
-        Consensus::DeploymentPos pos = Consensus::DeploymentPos(i);
+        Consensus::DeploymentPos pos = Consensus::DeploymentPos(j);
         ThresholdState state = VersionBitsState(pindexPrev, consensusParams, pos, versionbitscache);
         switch (state)
         {

--- a/src/stat.h
+++ b/src/stat.h
@@ -69,9 +69,9 @@ public:
     virtual ~CStatBase(){};
     virtual UniValue GetNow() = 0; // Returns the current value of this statistic
     virtual UniValue GetTotal() = 0; // Returns the cumulative value of this statistic
-    virtual UniValue GetSeries(const std::string &name, int count) = 0; // Returns the historical or series data
+    virtual UniValue GetSeries(const std::string &_name, int count) = 0; // Returns the historical or series data
     // Returns the historical or series data along with timestamp
-    virtual UniValue GetSeriesTime(const std::string &name, int count) = 0;
+    virtual UniValue GetSeriesTime(const std::string &_namep, int count) = 0;
 };
 
 template <class DataType, class RecordType = DataType>
@@ -143,11 +143,11 @@ public:
     RecordType &operator()() { return value; }
     virtual UniValue GetNow() { return UniValue(value); }
     virtual UniValue GetTotal() { return NullUniValue; }
-    virtual UniValue GetSeries(const std::string &name, int count)
+    virtual UniValue GetSeries(const std::string &_name, int count)
     {
         return NullUniValue; // Has no series data
     }
-    virtual UniValue GetSeriesTime(const std::string &name, int count)
+    virtual UniValue GetSeriesTime(const std::string &_name, int count)
     {
         return NullUniValue; // Has no series data
     }
@@ -298,23 +298,23 @@ public:
         }
     }
 
-    int Series(int series, DataType *array, int len)
+    int Series(int series, DataType *array, int _len)
     {
         assert(series < STATISTICS_NUM_RANGES);
-        if (len > STATISTICS_SAMPLES)
-            len = STATISTICS_SAMPLES;
+        if (_len > STATISTICS_SAMPLES)
+            _len = STATISTICS_SAMPLES;
 
         int pos = loc[series] - STATISTICS_SAMPLES;
         if (pos < 0)
             pos += STATISTICS_SAMPLES;
-        for (int i = 0; i < len; i++, pos++) // could be a lot more efficient with 2 memcpy
+        for (int i = 0; i < _len; i++, pos++) // could be a lot more efficient with 2 memcpy
         {
             if (pos >= STATISTICS_SAMPLES)
                 pos -= STATISTICS_SAMPLES;
             array[i] = history[series][pos];
         }
 
-        return len;
+        return _len;
     }
 
     virtual UniValue GetTotal()
@@ -325,11 +325,11 @@ public:
         return UniValue(total);
     }
 
-    virtual UniValue GetSeries(const std::string &name, int count)
+    virtual UniValue GetSeries(const std::string &_name, int count)
     {
         for (int series = 0; series < STATISTICS_NUM_RANGES; series++)
         {
-            if (name == sampleNames[series])
+            if (_name == sampleNames[series])
             {
                 UniValue ret(UniValue::VARR);
                 if (count < 0)
@@ -360,11 +360,11 @@ public:
         return history[series][pos];
     }
 
-    virtual UniValue GetSeriesTime(const std::string &name, int count)
+    virtual UniValue GetSeriesTime(const std::string &_name, int count)
     {
         for (int series = 0; series < STATISTICS_NUM_RANGES; series++)
         {
-            if (name == sampleNames[series])
+            if (_name == sampleNames[series])
             {
                 UniValue data(UniValue::VARR);
                 UniValue times(UniValue::VARR);

--- a/src/test/crypto_tests.cpp
+++ b/src/test/crypto_tests.cpp
@@ -143,13 +143,13 @@ void TestAES128CBC(const std::string &hexkey,
     {
         std::vector<unsigned char> sub(i, in.end());
         std::vector<unsigned char> subout(sub.size() + AES_BLOCKSIZE);
-        int size = enc.Encrypt(&sub[0], sub.size(), &subout[0]);
-        if (size != 0)
+        int size2 = enc.Encrypt(&sub[0], sub.size(), &subout[0]);
+        if (size2 != 0)
         {
-            subout.resize(size);
+            subout.resize(size2);
             std::vector<unsigned char> subdecrypted(subout.size());
-            size = dec.Decrypt(&subout[0], subout.size(), &subdecrypted[0]);
-            subdecrypted.resize(size);
+            size2 = dec.Decrypt(&subout[0], subout.size(), &subdecrypted[0]);
+            subdecrypted.resize(size2);
             BOOST_CHECK(decrypted.size() == in.size());
             BOOST_CHECK_MESSAGE(subdecrypted == sub, HexStr(subdecrypted) + std::string(" != ") + HexStr(sub));
         }
@@ -188,13 +188,13 @@ void TestAES256CBC(const std::string &hexkey,
     {
         std::vector<unsigned char> sub(i, in.end());
         std::vector<unsigned char> subout(sub.size() + AES_BLOCKSIZE);
-        int size = enc.Encrypt(&sub[0], sub.size(), &subout[0]);
-        if (size != 0)
+        int size3 = enc.Encrypt(&sub[0], sub.size(), &subout[0]);
+        if (size3 != 0)
         {
-            subout.resize(size);
+            subout.resize(size3);
             std::vector<unsigned char> subdecrypted(subout.size());
-            size = dec.Decrypt(&subout[0], subout.size(), &subdecrypted[0]);
-            subdecrypted.resize(size);
+            size3 = dec.Decrypt(&subout[0], subout.size(), &subdecrypted[0]);
+            subdecrypted.resize(size3);
             BOOST_CHECK(decrypted.size() == in.size());
             BOOST_CHECK_MESSAGE(subdecrypted == sub, HexStr(subdecrypted) + std::string(" != ") + HexStr(sub));
         }

--- a/src/test/net_tests.cpp
+++ b/src/test/net_tests.cpp
@@ -54,11 +54,11 @@ public:
     }
 };
 
-CDataStream AddrmanToStream(CAddrManSerializationMock &addrman)
+CDataStream AddrmanToStream(CAddrManSerializationMock &_addrman)
 {
     CDataStream ssPeersIn(SER_DISK, CLIENT_VERSION);
     ssPeersIn << FLATDATA(Params().MessageStart());
-    ssPeersIn << addrman;
+    ssPeersIn << _addrman;
     std::string str = ssPeersIn.str();
     std::vector<uint8_t> vchData(str.begin(), str.end());
     return CDataStream(vchData, SER_DISK, CLIENT_VERSION);

--- a/src/test/script_tests.cpp
+++ b/src/test/script_tests.cpp
@@ -292,10 +292,10 @@ public:
         return *this;
     }
 
-    TestBuilder &Add(const CScript &script)
+    TestBuilder &Add(const CScript &scriptLocal)
     {
         DoPush();
-        spendTx.vin[0].scriptSig += script;
+        spendTx.vin[0].scriptSig += scriptLocal;
         return *this;
     }
 
@@ -1553,10 +1553,10 @@ BOOST_AUTO_TEST_CASE(script_datasigverify)
         stack.clear();
         std::vector<unsigned char> vaddr = ToByteVector(dataSigner.addr);
         vaddr.resize(19);
-        CScript condScript = CScript() << vaddr << OP_DATASIGVERIFY;
+        CScript condScript2 = CScript() << vaddr << OP_DATASIGVERIFY;
         proveScript = CScript() << data << sigtype;
         BOOST_CHECK(EvalScript(stack, proveScript, 0, sigChecker, &serror, nullptr));
-        BOOST_CHECK(!EvalScript(stack, condScript, 0, sigChecker, &serror, nullptr));
+        BOOST_CHECK(!EvalScript(stack, condScript2, 0, sigChecker, &serror, nullptr));
         BOOST_CHECK(serror == SCRIPT_ERR_INVALID_STACK_OPERATION);
     }
 
@@ -1565,20 +1565,20 @@ BOOST_AUTO_TEST_CASE(script_datasigverify)
         stack.clear();
         std::vector<unsigned char> vaddr = ToByteVector(dataSigner.addr);
         vaddr.push_back(1);
-        CScript condScript = CScript() << vaddr << OP_DATASIGVERIFY;
+        CScript condScript3 = CScript() << vaddr << OP_DATASIGVERIFY;
         proveScript = CScript() << data << sigtype;
         BOOST_CHECK(EvalScript(stack, proveScript, 0, sigChecker, &serror, nullptr));
-        BOOST_CHECK(!EvalScript(stack, condScript, 0, sigChecker, &serror, nullptr));
+        BOOST_CHECK(!EvalScript(stack, condScript3, 0, sigChecker, &serror, nullptr));
         BOOST_CHECK(serror == SCRIPT_ERR_INVALID_STACK_OPERATION);
     }
 
     // Test wrong stack size
     {
         stack.clear();
-        CScript condScript = CScript() << OP_DATASIGVERIFY;
+        CScript condScript4 = CScript() << OP_DATASIGVERIFY;
         proveScript = CScript() << data << sigtype;
         BOOST_CHECK(EvalScript(stack, proveScript, 0, sigChecker, &serror, nullptr));
-        BOOST_CHECK(!EvalScript(stack, condScript, 0, sigChecker, &serror, nullptr));
+        BOOST_CHECK(!EvalScript(stack, condScript4, 0, sigChecker, &serror, nullptr));
         BOOST_CHECK(serror == SCRIPT_ERR_INVALID_STACK_OPERATION);
     }
 

--- a/src/test/test_bitcoin_fuzzy.cpp
+++ b/src/test/test_bitcoin_fuzzy.cpp
@@ -457,9 +457,9 @@ int main(int argc, char **argv)
             if (testname == "list_tests")
             {
                 int idx = 0;
-                for (const auto &ft : registry_seq)
+                for (const auto &ft2 : registry_seq)
                 {
-                    printf("%4d %s\n", idx, ft->name.c_str());
+                    printf("%4d %s\n", idx, ft2->name.c_str());
                     idx++;
                 }
                 return 0;

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -107,10 +107,10 @@ BOOST_AUTO_TEST_CASE(util_sharedcriticalsection)
 }
 
 
-void ThreadCorralTest(CThreadCorral *c, int region, int *readVal, int setVal)
+void ThreadCorralTest(CThreadCorral *c, int region, int *pReadVal, int setVal)
 {
     CORRAL(*c, region);
-    *readVal = critVal;
+    *pReadVal = critVal;
     if (setVal != 0)
         critVal = setVal;
 }

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -203,8 +203,8 @@ void TorControlConnection::eventcb(struct bufferevent *bev, short what, void *ct
 }
 
 bool TorControlConnection::Connect(const std::string &target,
-    const ConnectionCB &connected,
-    const ConnectionCB &disconnected)
+    const ConnectionCB &_connected,
+    const ConnectionCB &_disconnected)
 {
     if (b_conn)
         Disconnect();
@@ -223,8 +223,8 @@ bool TorControlConnection::Connect(const std::string &target,
         return false;
     bufferevent_setcb(b_conn, TorControlConnection::readcb, NULL, TorControlConnection::eventcb, this);
     bufferevent_enable(b_conn, EV_READ | EV_WRITE);
-    this->connected = connected;
-    this->disconnected = disconnected;
+    this->connected = _connected;
+    this->disconnected = _disconnected;
 
     // Finally, connect to target
     if (bufferevent_socket_connect(b_conn, (struct sockaddr *)&connect_to_addr, connect_to_addrlen) < 0)
@@ -452,7 +452,7 @@ TorController::~TorController()
     }
 }
 
-void TorController::add_onion_cb(TorControlConnection &conn, const TorControlReply &reply)
+void TorController::add_onion_cb(TorControlConnection &_conn, const TorControlReply &reply)
 {
     if (reply.code == 250)
     {
@@ -490,7 +490,7 @@ void TorController::add_onion_cb(TorControlConnection &conn, const TorControlRep
     }
 }
 
-void TorController::auth_cb(TorControlConnection &conn, const TorControlReply &reply)
+void TorController::auth_cb(TorControlConnection &_conn, const TorControlReply &reply)
 {
     if (reply.code == 250)
     {
@@ -511,7 +511,7 @@ void TorController::auth_cb(TorControlConnection &conn, const TorControlReply &r
         // Request hidden service, redirect port.
         // Note that the 'virtual' port doesn't have to be the same as our internal port, but this is just a convenient
         // choice.  TODO; refactor the shutdown sequence some day.
-        conn.Command(strprintf("ADD_ONION %s Port=%i,127.0.0.1:%i", private_key, GetListenPort(), GetListenPort()),
+        _conn.Command(strprintf("ADD_ONION %s Port=%i,127.0.0.1:%i", private_key, GetListenPort(), GetListenPort()),
             boost::bind(&TorController::add_onion_cb, this, _1, _2));
     }
     else
@@ -550,7 +550,7 @@ static std::vector<uint8_t> ComputeResponse(const std::string &key,
     return computedHash;
 }
 
-void TorController::authchallenge_cb(TorControlConnection &conn, const TorControlReply &reply)
+void TorController::authchallenge_cb(TorControlConnection &_conn, const TorControlReply &reply)
 {
     if (reply.code == 250)
     {
@@ -579,7 +579,7 @@ void TorController::authchallenge_cb(TorControlConnection &conn, const TorContro
 
             std::vector<uint8_t> computedClientHash =
                 ComputeResponse(TOR_SAFE_CLIENTKEY, cookie, clientNonce, serverNonce);
-            conn.Command(
+            _conn.Command(
                 "AUTHENTICATE " + HexStr(computedClientHash), boost::bind(&TorController::auth_cb, this, _1, _2));
         }
         else
@@ -593,7 +593,7 @@ void TorController::authchallenge_cb(TorControlConnection &conn, const TorContro
     }
 }
 
-void TorController::protocolinfo_cb(TorControlConnection &conn, const TorControlReply &reply)
+void TorController::protocolinfo_cb(TorControlConnection &_conn, const TorControlReply &reply)
 {
     if (reply.code == 250)
     {
@@ -639,7 +639,7 @@ void TorController::protocolinfo_cb(TorControlConnection &conn, const TorControl
         if (methods.count("NULL"))
         {
             LOG(TOR, "tor: Using NULL authentication\n");
-            conn.Command("AUTHENTICATE", boost::bind(&TorController::auth_cb, this, _1, _2));
+            _conn.Command("AUTHENTICATE", boost::bind(&TorController::auth_cb, this, _1, _2));
         }
         else if (methods.count("SAFECOOKIE"))
         {
@@ -653,7 +653,7 @@ void TorController::protocolinfo_cb(TorControlConnection &conn, const TorControl
                 cookie = std::vector<uint8_t>(status_cookie.second.begin(), status_cookie.second.end());
                 clientNonce = std::vector<uint8_t>(TOR_NONCE_SIZE, 0);
                 GetRandBytes(&clientNonce[0], TOR_NONCE_SIZE);
-                conn.Command("AUTHCHALLENGE SAFECOOKIE " + HexStr(clientNonce),
+                _conn.Command("AUTHCHALLENGE SAFECOOKIE " + HexStr(clientNonce),
                     boost::bind(&TorController::authchallenge_cb, this, _1, _2));
             }
             else
@@ -675,7 +675,7 @@ void TorController::protocolinfo_cb(TorControlConnection &conn, const TorControl
             {
                 LOG(TOR, "tor: Using HASHEDPASSWORD authentication\n");
                 boost::replace_all(torpassword, "\"", "\\\"");
-                conn.Command(
+                _conn.Command(
                     "AUTHENTICATE \"" + torpassword + "\"", boost::bind(&TorController::auth_cb, this, _1, _2));
             }
             else
@@ -694,15 +694,15 @@ void TorController::protocolinfo_cb(TorControlConnection &conn, const TorControl
     }
 }
 
-void TorController::connected_cb(TorControlConnection &conn)
+void TorController::connected_cb(TorControlConnection &_conn)
 {
     reconnect_timeout = RECONNECT_TIMEOUT_START;
     // First send a PROTOCOLINFO command to figure out what authentication is expected
-    if (!conn.Command("PROTOCOLINFO 1", boost::bind(&TorController::protocolinfo_cb, this, _1, _2)))
+    if (!_conn.Command("PROTOCOLINFO 1", boost::bind(&TorController::protocolinfo_cb, this, _1, _2)))
         LOGA("tor: Error sending initial protocolinfo command\n");
 }
 
-void TorController::disconnected_cb(TorControlConnection &conn)
+void TorController::disconnected_cb(TorControlConnection &_conn)
 {
     // Stop advertising service when disconnected
     if (service.IsValid())

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1197,8 +1197,8 @@ int CTxMemPool::Expire(int64_t time, std::vector<COutPoint> &vCoinsToUncache)
     setEntries stage;
     for (txiter removeit : toremove)
         _CalculateDescendants(removeit, stage);
-    for (txiter it : stage)
-        for (const CTxIn &txin : it->GetTx().vin)
+    for (txiter it2 : stage)
+        for (const CTxIn &txin : it2->GetTx().vin)
             vCoinsToUncache.push_back(txin.prevout);
 
     _RemoveStaged(stage);
@@ -1331,8 +1331,8 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint> *pvNoSpends
         if (pvNoSpendsRemaining)
         {
             txn.reserve(stage.size());
-            BOOST_FOREACH (txiter it, stage)
-                txn.push_back(it->GetTx());
+            BOOST_FOREACH (txiter it3, stage)
+                txn.push_back(it3->GetTx());
         }
         _RemoveStaged(stage);
         if (pvNoSpendsRemaining)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -680,19 +680,19 @@ bool TryCreateDirectories(const fs::path &p)
     return false;
 }
 
-void FileCommit(FILE *fileout)
+void FileCommit(FILE *pFileout)
 {
-    fflush(fileout); // harmless if redundantly called
+    fflush(pFileout); // harmless if redundantly called
 #ifdef WIN32
-    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(fileout));
+    HANDLE hFile = (HANDLE)_get_osfhandle(_fileno(pFileout));
     FlushFileBuffers(hFile);
 #else
 #if defined(__linux__) || defined(__NetBSD__)
-    fdatasync(fileno(fileout));
+    fdatasync(fileno(pFileout));
 #elif defined(__APPLE__) && defined(F_FULLFSYNC)
-    fcntl(fileno(fileout), F_FULLFSYNC, 0);
+    fcntl(fileno(pFileout), F_FULLFSYNC, 0);
 #else
-    fsync(fileno(fileout));
+    fsync(fileno(pFileout));
 #endif
 #endif
 }

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -367,13 +367,13 @@ bool CDB::Rewrite(const string &strFile, const char *pszSkip)
                         {
                             CDataStream ssKey(SER_DISK, CLIENT_VERSION);
                             CDataStream ssValue(SER_DISK, CLIENT_VERSION);
-                            int ret = db.ReadAtCursor(pcursor, ssKey, ssValue, DB_NEXT);
-                            if (ret == DB_NOTFOUND)
+                            int ret3 = db.ReadAtCursor(pcursor, ssKey, ssValue, DB_NEXT);
+                            if (ret3 == DB_NOTFOUND)
                             {
                                 pcursor->close();
                                 break;
                             }
-                            else if (ret != 0)
+                            else if (ret3 != 0)
                             {
                                 pcursor->close();
                                 fSuccess = false;

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -114,11 +114,11 @@ UniValue importprivkey(const UniValue &params, bool fHelp)
         strLabel = params[1].get_str();
 
     // Whether to perform rescan after import
-    bool fRescan = true;
+    bool fRescanLocal = true;
     if (params.size() > 2)
         fRescan = params[2].get_bool();
 
-    if (fRescan && fPruneMode)
+    if (fRescanLocal && fPruneMode)
         throw JSONRPCError(RPC_WALLET_ERROR, "Rescan is disabled in pruned mode");
 
     CBitcoinSecret vchSecret;
@@ -150,7 +150,7 @@ UniValue importprivkey(const UniValue &params, bool fHelp)
         // whenever a key is imported, we need to scan the whole chain
         pwalletMain->nTimeFirstKey = 1; // 0 would be considered 'no value'
 
-        if (fRescan)
+        if (fRescanLocal)
         {
             pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), true);
         }
@@ -184,16 +184,16 @@ UniValue importprivatekeys(const UniValue &params, bool fHelp)
     EnsureWalletIsUnlocked();
 
     unsigned int paramNum = 0;
-    bool fRescan = true;
+    bool fRescanLocal = true;
 
     if (params[0].get_str() == "no-rescan")
     {
-        fRescan = false;
+        fRescanLocal = false;
         paramNum++;
     }
     else if (params[0].get_str() == "rescan")
     {
-        fRescan = true;
+        fRescanLocal = true;
         paramNum++;
     }
 
@@ -232,7 +232,7 @@ UniValue importprivatekeys(const UniValue &params, bool fHelp)
         }
     }
 
-    if (fRescan)
+    if (fRescanLocal)
     {
         StartWalletRescanThread();
     }
@@ -308,11 +308,11 @@ UniValue importaddress(const UniValue &params, bool fHelp)
         strLabel = params[1].get_str();
 
     // Whether to perform rescan after import
-    bool fRescan = true;
+    bool fRescanLocal = true;
     if (params.size() > 2)
-        fRescan = params[2].get_bool();
+        fRescanLocal = params[2].get_bool();
 
-    if (fRescan && fPruneMode)
+    if (fRescanLocal && fPruneMode)
         throw JSONRPCError(RPC_WALLET_ERROR, "Rescan is disabled in pruned mode");
 
     // Whether to import a p2sh version, too
@@ -342,7 +342,7 @@ UniValue importaddress(const UniValue &params, bool fHelp)
         throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Invalid Bitcoin address or script");
     }
 
-    if (fRescan)
+    if (fRescanLocal)
     {
         pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), true);
         pwalletMain->ReacceptWalletTransactions();
@@ -379,22 +379,22 @@ UniValue importaddresses(const UniValue &params, bool fHelp)
         strLabel = params[1].get_str();
 
     // Whether to perform rescan after import
-    bool fRescan = true;
+    bool fRescanLocal = true;
 
     unsigned int paramNum = 0;
 
     if (params[0].get_str() == "no-rescan")
     {
-        fRescan = false;
+        fRescanLocal = false;
         paramNum++;
     }
     else if (params[0].get_str() == "rescan")
     {
-        fRescan = true;
+        fRescanLocal = true;
         paramNum++;
     }
 
-    if (fRescan && fPruneMode)
+    if (fRescanLocal && fPruneMode)
         throw JSONRPCError(RPC_WALLET_ERROR, "Rescan is disabled in pruned mode");
 
     LOCK2(cs_main, pwalletMain->cs_wallet);
@@ -419,7 +419,7 @@ UniValue importaddresses(const UniValue &params, bool fHelp)
         }
     }
 
-    if (fRescan)
+    if (fRescanLocal)
     {
         StartWalletRescanThread();
     }
@@ -565,11 +565,11 @@ UniValue importpubkey(const UniValue &params, bool fHelp)
         strLabel = params[1].get_str();
 
     // Whether to perform rescan after import
-    bool fRescan = true;
+    bool fRescanLocal = true;
     if (params.size() > 2)
-        fRescan = params[2].get_bool();
+        fRescanLocal = params[2].get_bool();
 
-    if (fRescan && fPruneMode)
+    if (fRescanLocal && fPruneMode)
         throw JSONRPCError(RPC_WALLET_ERROR, "Rescan is disabled in pruned mode");
 
     if (!IsHex(params[0].get_str()))
@@ -584,7 +584,7 @@ UniValue importpubkey(const UniValue &params, bool fHelp)
     ImportAddress(pubKey.GetID(), strLabel);
     ImportScript(GetScriptForRawPubKey(pubKey), strLabel, false);
 
-    if (fRescan)
+    if (fRescanLocal)
     {
         pwalletMain->ScanForWalletTransactions(chainActive.Genesis(), true);
         pwalletMain->ReacceptWalletTransactions();

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1237,10 +1237,10 @@ UniValue ListReceived(const UniValue &params, bool fByAccounts)
 
         if (fByAccounts)
         {
-            tallyitem &item = mapAccountTally[strAccount];
-            item.nAmount += nAmount;
-            item.nConf = min(item.nConf, nConf);
-            item.fIsWatchonly = fIsWatchonly;
+            tallyitem &item2 = mapAccountTally[strAccount];
+            item2.nAmount += nAmount;
+            item2.nConf = min(item2.nConf, nConf);
+            item2.fIsWatchonly = fIsWatchonly;
         }
         else
         {
@@ -1261,9 +1261,9 @@ UniValue ListReceived(const UniValue &params, bool fByAccounts)
             UniValue transactions(UniValue::VARR);
             if (it != mapTally.end())
             {
-                for (const uint256 &item : (*it).second.txids)
+                for (const uint256 &item3 : (*it).second.txids)
                 {
-                    transactions.push_back(item.GetHex());
+                    transactions.push_back(item3.GetHex());
                 }
             }
             obj.push_back(Pair("txids", transactions));
@@ -2686,10 +2686,10 @@ UniValue listunspent(const UniValue &params, bool fHelp)
         entry.push_back(Pair("scriptPubKey", HexStr(pk.begin(), pk.end())));
         if (pk.IsPayToScriptHash())
         {
-            CTxDestination address;
-            if (ExtractDestination(pk, address))
+            CTxDestination address2;
+            if (ExtractDestination(pk, address2))
             {
-                const CScriptID &hash = boost::get<CScriptID>(address);
+                const CScriptID &hash = boost::get<CScriptID>(address2);
                 CScript redeemScript;
                 if (pwalletMain->GetCScript(hash, redeemScript))
                     entry.push_back(Pair("redeemScript", HexStr(redeemScript.begin(), redeemScript.end())));

--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
         // run the 'mtgox' test (see http://blockexplorer.com/tx/29a3efd3ef04f9153d47a990bd7b048a4b2d213daaa5fb8ed670fb85f13bdbcf)
         // they tried to consolidate 10 50k coins into one 500k coin, and ended up with 50k in change
         empty_wallet();
-        for (int i = 0; i < 20; i++)
+        for (int j = 0; j < 20; j++)
             add_coin(wallet, 50000 * COIN);
 
         BOOST_CHECK( wallet.SelectCoinsMinConf(500000 * COIN, 1, 1, vCoins, setCoinsRet, nValueRet));
@@ -301,7 +301,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
             BOOST_CHECK(!equal_sets(setCoinsRet, setCoinsRet2));
 
             int fails = 0;
-            for (int i = 0; i < RANDOM_REPEATS; i++)
+            for (int k = 0; k < RANDOM_REPEATS; k++)
             {
                 // selecting 1 from 100 identical coins depends on the shuffle; this test will fail 1% of the time
                 // run the test RANDOM_REPEATS times and only complain if all of them fail
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
             add_coin(wallet,  5*CENT); add_coin(wallet, 10*CENT); add_coin(wallet, 15*CENT); add_coin(wallet, 20*CENT); add_coin(wallet, 25*CENT);
 
             fails = 0;
-            for (int i = 0; i < RANDOM_REPEATS; i++)
+            for (int z = 0; z < RANDOM_REPEATS; z++)
             {
                 // selecting 1 from 100 identical coins depends on the shuffle; this test will fail 1% of the time
                 // run the test RANDOM_REPEATS times and only complain if all of them fail

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -436,8 +436,8 @@ set<uint256> CWallet::GetConflicts(const uint256 &txid) const
         if (mapTxSpends.count(txin.prevout) <= 1)
             continue; // No conflict if zero or one spends
         range = mapTxSpends.equal_range(txin.prevout);
-        for (TxSpends::const_iterator it = range.first; it != range.second; ++it)
-            result.insert(it->second);
+        for (TxSpends::const_iterator it2 = range.first; it2 != range.second; ++it2)
+            result.insert(it2->second);
     }
     return result;
 }
@@ -1257,9 +1257,9 @@ int CWalletTx::GetRequestCount() const
                 // How about the block it's in?
                 if (nRequests == 0 && !hashUnset())
                 {
-                    map<uint256, int>::const_iterator mi = pwallet->mapRequestCount.find(hashBlock);
-                    if (mi != pwallet->mapRequestCount.end())
-                        nRequests = (*mi).second;
+                    map<uint256, int>::const_iterator mi2 = pwallet->mapRequestCount.find(hashBlock);
+                    if (mi2 != pwallet->mapRequestCount.end())
+                        nRequests = (*mi2).second;
                     else
                         nRequests = 1; // If it's in someone else's block it must have got out
                 }
@@ -3033,19 +3033,19 @@ set<set<CTxDestination> > CWallet::GetAddressGroupings()
 
     set<set<CTxDestination> *> uniqueGroupings; // a set of pointers to groups of addresses
     map<CTxDestination, set<CTxDestination> *> setmap; // map addresses to the unique group containing it
-    for (set<CTxDestination> grouping : groupings)
+    for (set<CTxDestination> grouping2 : groupings)
     {
         // make a set of all the groups hit by this new group
         set<set<CTxDestination> *> hits;
         map<CTxDestination, set<CTxDestination> *>::iterator it;
-        for (CTxDestination address : grouping)
+        for (CTxDestination address : grouping2)
         {
             if ((it = setmap.find(address)) != setmap.end())
                 hits.insert((*it).second);
         }
 
         // merge all hit groups into a new single group and delete old groups
-        set<CTxDestination> *merged = new set<CTxDestination>(grouping);
+        set<CTxDestination> *merged = new set<CTxDestination>(grouping2);
         for (set<CTxDestination> *hit : hits)
         {
             merged->insert(hit->begin(), hit->end());

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -937,8 +937,8 @@ void ThreadFlushWalletDB(const string &strFile)
                 if (nRefCount == 0)
                 {
                     boost::this_thread::interruption_point();
-                    map<string, int>::iterator mi = bitdb.mapFileUseCount.find(strFile);
-                    if (mi != bitdb.mapFileUseCount.end())
+                    map<string, int>::iterator mi2 = bitdb.mapFileUseCount.find(strFile);
+                    if (mi2 != bitdb.mapFileUseCount.end())
                     {
                         LOG(DBASE, "Flushing wallet.dat\n");
                         nLastFlushed = nWalletDBUpdated;
@@ -948,7 +948,7 @@ void ThreadFlushWalletDB(const string &strFile)
                         bitdb.CloseDb(strFile);
                         bitdb.CheckpointLSN(strFile);
 
-                        bitdb.mapFileUseCount.erase(mi++);
+                        bitdb.mapFileUseCount.erase(mi2++);
                         LOG(DBASE, "Flushed wallet.dat %dms\n", GetTimeMillis() - nStart);
                     }
                 }


### PR DESCRIPTION
Since #1171 and #1172 got merged, if the compiler supports it, a lot of warnings started to be raised during the build process.

This PR is taking care at the most obvious warnings generated by `-Wshadow`flag, e.g. : 

```
     connmgr.cpp:38:46: warning: declaration shadows a variable in the global namespace [-Wshadow]
    static bool RemoveNode(std::vector<CNode *> &vNodes, CNode *pNode)
                                                 ^
    ./net.h:191:29: note: previous declaration is here
    extern std::vector<CNode *> vNodes;
                                ^
```
