### PR TITLE
Initialize BIP16Height to 0 for nol net

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -223,6 +223,7 @@ public:
             2301659837, 0x1d00ffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
         consensus.nSubsidyHalvingInterval = 210000;
+        consensus.BIP16Height = 0;
         consensus.BIP34Height = 0;
         consensus.BIP34Hash = consensus.hashGenesisBlock;
         consensus.BIP65Height = 0;


### PR DESCRIPTION
Always consider P2SH rules set as activated on `nol` net.

Previously this value was not initialize in `chainparams.cpp` we only declared it in `consensus/params.h`