### PR TITLE
Fix QT5 depends check for native Windows builds

### DIFF
--- a/build-aux/m4/bitcoin_qt.m4
+++ b/build-aux/m4/bitcoin_qt.m4
@@ -154,17 +154,6 @@ AC_DEFUN([BITCOIN_QT_CONFIGURE],[
     fi
   fi
 
-  if test "x$TARGET_OS" = xwindows; then
-    AC_DEFINE(QT_STATICPLUGIN, 1, [Define this symbol if qt plugins are static])
-    _BITCOIN_QT_CHECK_STATIC_PLUGINS([
-       Q_IMPORT_PLUGIN(qcncodecs)
-       Q_IMPORT_PLUGIN(qjpcodecs)
-       Q_IMPORT_PLUGIN(qtwcodecs)
-       Q_IMPORT_PLUGIN(qkrcodecs)
-       Q_IMPORT_PLUGIN(AccessibleFactory)],
-       [-lqcncodecs -lqjpcodecs -lqtwcodecs -lqkrcodecs -lqtaccessiblewidgets])
-  fi
-
   CPPFLAGS=$TEMP_CPPFLAGS
   CXXFLAGS=$TEMP_CXXFLAGS
   ])


### PR DESCRIPTION
Since QT5 is now required, an if-else check for QT version was removed, however the contents of the else block was left so QT4 checks are always performed now when Windows is the target.  This PR removes the lingering QT4 check that previously was part of the else block.

Issue was introduced in the port for #1162, lines 102 through 168 for reference.

I saw this issue when using the MinGW scripts to build natively on Windows, not sure why this didn't trip up the cross-compilation on Travis.