### PR TITLE
Separate the dust threshold from the minrelaytxfee

### DIFF
--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -42,6 +42,8 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         #            = 2 bytes * minRelayTxFeePerByte
         feeTolerance = 2 * min_relay_tx_fee/1000
+        if feeTolerance < 0.00000001:
+            feeTolerance = 0.00000001
 
         self.nodes[2].generate(1)
         self.sync_all()

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -561,10 +561,10 @@ static void addNodeRelayOptions(AllowedArgs &allowedArgs)
         .addArg("datacarriersize=<n>", requiredInt,
             strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"),
                     MAX_OP_RETURN_RELAY))
-        .addArg("dustrelayfee=<amt>", requiredAmount,
-            strprintf(_("Fee rate (in %s/kB) used to defined dust, the value of an output such that it will cost about "
-                        "1/3 of its value in fees at this fee rate to spend it. (default: %s)"),
-                    CURRENCY_UNIT, FormatMoney(DUST_RELAY_TX_FEE)))
+        .addArg("dustthreshold=<amt>", requiredAmount,
+            strprintf(_("Dust Threshold (in satoshis) defines the minimum quantity an output may contain for the "
+                        "transaction to be considered standard, and therefore relayable. (default: %s)"),
+                    DEFAULT_DUST_THRESHOLD))
         .addArg("excessiveacceptdepth=<n>", requiredInt,
             strprintf(_("Excessive blocks are accepted if this many blocks are mined on top of them (default: %u)"),
                     DEFAULT_EXCESSIVE_ACCEPT_DEPTH))

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -561,6 +561,10 @@ static void addNodeRelayOptions(AllowedArgs &allowedArgs)
         .addArg("datacarriersize=<n>", requiredInt,
             strprintf(_("Maximum size of data in data carrier transactions we relay and mine (default: %u)"),
                     MAX_OP_RETURN_RELAY))
+        .addArg("dustrelayfee=<amt>", requiredAmount,
+            strprintf(_("Fee rate (in %s/kB) used to defined dust, the value of an output such that it will cost about "
+                        "1/3 of its value in fees at this fee rate to spend it. (default: %s)"),
+                    CURRENCY_UNIT, FormatMoney(DUST_RELAY_TX_FEE)))
         .addArg("excessiveacceptdepth=<n>", requiredInt,
             strprintf(_("Excessive blocks are accepted if this many blocks are mined on top of them (default: %u)"),
                     DEFAULT_EXCESSIVE_ACCEPT_DEPTH))

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -263,6 +263,10 @@ CTweak<uint64_t> checkScriptDays("blockchain.checkScriptDays",
     "The number of days in the past we check scripts during initial block download.",
     DEFAULT_CHECKPOINT_DAYS);
 
+/** Dust Threshold (in satoshis) defines the minimum quantity an output may contain for the
+    transaction to be considered standard, and therefore relayable.
+ */
+CTweak<unsigned int> nDustThreshold("net.dustThreshold", "Dust Threshold (in satoshis).", DEFAULT_DUST_THRESHOLD);
 
 CRequestManager requester; // after the maps nodes and tweaks
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -799,15 +799,8 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
         return InitError(
             strprintf("acceptnonstdtxn is not currently supported for %s chain", chainparams.NetworkIDString()));
 
-    // Feerate used to define dust.  Shouldn't be changed lightly as old
-    // implementations may inadvertently create non-standard transactions
-    if (mapArgs.count("-dustrelayfee"))
-    {
-        CAmount nFee = 0;
-        if (!ParseMoney(GetArg("-dustrelayfee", ""), nFee) || nFee == 0)
-            return InitError(strprintf("invalid dustrelayfee: %s", GetArg("-dustrelayfee", "")));
-        dustRelayFee = CFeeRate(nFee);
-    }
+    // Set Dust Threshold for outputs.
+    nDustThreshold.value = GetArg("-dustthreshold", DEFAULT_DUST_THRESHOLD);
 
     nBytesPerSigOp = GetArg("-bytespersigop", nBytesPerSigOp);
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -798,6 +798,17 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
     if (fStandard != Params().RequireStandard())
         return InitError(
             strprintf("acceptnonstdtxn is not currently supported for %s chain", chainparams.NetworkIDString()));
+
+    // Feerate used to define dust.  Shouldn't be changed lightly as old
+    // implementations may inadvertently create non-standard transactions
+    if (mapArgs.count("-dustrelayfee"))
+    {
+        CAmount nFee = 0;
+        if (!ParseMoney(GetArg("-dustrelayfee", ""), nFee) || nFee == 0)
+            return InitError(strprintf("invalid dustrelayfee: %s", GetArg("-dustrelayfee", "")));
+        dustRelayFee = CFeeRate(nFee);
+    }
+
     nBytesPerSigOp = GetArg("-bytespersigop", nBytesPerSigOp);
 
 #ifdef ENABLE_WALLET

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -34,8 +34,6 @@
  *   DUP CHECKSIG DROP ... repeated 100 times... OP_1
  */
 
-CFeeRate dustRelayFee = CFeeRate(DUST_RELAY_TX_FEE);
-
 bool IsStandard(const CScript &scriptPubKey, txnouttype &whichType)
 {
     std::vector<std::vector<unsigned char> > vSolutions;
@@ -119,7 +117,7 @@ bool IsStandardTx(const CTransaction &tx, std::string &reason)
             reason = "bare-multisig";
             return false;
         }
-        else if (txout.IsDust(dustRelayFee))
+        else if (txout.IsDust())
         {
             reason = "dust";
             return false;

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -34,6 +34,8 @@
  *   DUP CHECKSIG DROP ... repeated 100 times... OP_1
  */
 
+CFeeRate dustRelayFee = CFeeRate(DUST_RELAY_TX_FEE);
+
 bool IsStandard(const CScript &scriptPubKey, txnouttype &whichType)
 {
     std::vector<std::vector<unsigned char> > vSolutions;
@@ -117,7 +119,7 @@ bool IsStandardTx(const CTransaction &tx, std::string &reason)
             reason = "bare-multisig";
             return false;
         }
-        else if (txout.IsDust(::minRelayTxFee))
+        else if (txout.IsDust(dustRelayFee))
         {
             reason = "dust";
             return false;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -30,13 +30,11 @@ static const unsigned int MAX_STANDARD_TX_SIGOPS = BLOCKSTREAM_CORE_MAX_BLOCK_SI
 // BU TODO: we chose: static const unsigned int MAX_STANDARD_TX_SIGOPS = 100*MAX_BLOCK_SIGOPS/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
-/** Min feerate for defining dust. Historically this has been the same as the
- * minRelayTxFee, however changing the dust limit changes which transactions are
- * standard and should be done with care and ideally rarely. It makes sense to
- * only increase the dust limit after prior releases were already not creating
- * outputs below the new threshold */
-static const unsigned int DUST_RELAY_TX_FEE = 1000;
-extern CFeeRate dustRelayFee;
+/** Dust threshold in satoshis. Historically this value was calculated as
+ *  minRelayTxFee/1000 * 546. However now we just allow the operator to set
+ *  a simple dust threshold independant of any other value or relay fee.
+ */
+static const unsigned int DEFAULT_DUST_THRESHOLD = 546;
 
 /**
  * Standard script verification flags that standard transactions will comply

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -30,6 +30,14 @@ static const unsigned int MAX_STANDARD_TX_SIGOPS = BLOCKSTREAM_CORE_MAX_BLOCK_SI
 // BU TODO: we chose: static const unsigned int MAX_STANDARD_TX_SIGOPS = 100*MAX_BLOCK_SIGOPS/5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
+/** Min feerate for defining dust. Historically this has been the same as the
+ * minRelayTxFee, however changing the dust limit changes which transactions are
+ * standard and should be done with care and ideally rarely. It makes sense to
+ * only increase the dust limit after prior releases were already not creating
+ * outputs below the new threshold */
+static const unsigned int DUST_RELAY_TX_FEE = 1000;
+extern CFeeRate dustRelayFee;
+
 /**
  * Standard script verification flags that standard transactions will comply
  * with. However scripts violating these flags may still be present in valid

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -7,8 +7,10 @@
 #include "primitives/transaction.h"
 
 #include "hash.h"
+#include "policy/policy.h"
 #include "tinyformat.h"
 #include "utilstrencodings.h"
+
 
 std::string COutPoint::ToString() const { return strprintf("COutPoint(%s, %u)", hash.ToString().substr(0, 10), n); }
 CTxIn::CTxIn(COutPoint prevoutIn, CScript scriptSigIn, uint32_t nSequenceIn)

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -144,24 +144,24 @@ public:
     bool IsNull() const { return (nValue == -1); }
     uint256 GetHash() const;
 
-    CAmount GetDustThreshold(const CFeeRate &minRelayTxFee) const
+    CAmount GetDustThreshold(const CFeeRate &relayFee) const
     {
-        // "Dust" is defined in terms of CTransaction::minRelayTxFee,
+        // "Dust" is defined in terms of the dustRelayFee,
         // which has units satoshis-per-kilobyte.
         // If you'd pay more than 1/3 in fees
         // to spend something, then we consider it dust.
         // A typical spendable txout is 34 bytes big, and will
         // need a CTxIn of at least 148 bytes to spend:
         // so dust is a spendable txout less than
-        // 546*minRelayTxFee/1000 (in satoshis)
+        // 546*dustRelayFee/1000 (in satoshis)
         if (scriptPubKey.IsUnspendable())
             return 0;
 
         size_t nSize = GetSerializeSize(*this, SER_DISK, 0) + 148u;
-        return 3 * minRelayTxFee.GetFee(nSize);
+        return 3 * relayFee.GetFee(nSize);
     }
 
-    bool IsDust(const CFeeRate &minRelayTxFee) const { return (nValue < GetDustThreshold(minRelayTxFee)); }
+    bool IsDust(const CFeeRate &_dustRelayFee) const { return (nValue < GetDustThreshold(_dustRelayFee)); }
     friend bool operator==(const CTxOut &a, const CTxOut &b)
     {
         return (a.nValue == b.nValue && a.scriptPubKey == b.scriptPubKey);

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -481,7 +481,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog *dialog)
         {
             CTxOut txout(amount, (CScript)std::vector<unsigned char>(24, 0));
             txDummy.vout.push_back(txout);
-            if (txout.IsDust(dustRelayTxFee))
+            if (txout.IsDust())
                 fDust = true;
         }
     }
@@ -589,10 +589,10 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog *dialog)
             if (nChange > 0 && nChange < MIN_CHANGE)
             {
                 CTxOut txout(nChange, (CScript)std::vector<unsigned char>(24, 0));
-                if (txout.IsDust(dustRelayFee))
+                if (txout.IsDust())
                 {
                     if (CoinControlDialog::fSubtractFeeFromAmount) // dust-change will be raised until no dust
-                        nChange = txout.GetDustThreshold(dustRelayFee);
+                        nChange = txout.GetDustThreshold();
                     else
                     {
                         nPayFee += nChange;

--- a/src/qt/coincontroldialog.cpp
+++ b/src/qt/coincontroldialog.cpp
@@ -18,6 +18,7 @@
 #include "dstencode.h"
 #include "init.h"
 #include "main.h" // For minRelayTxFee
+#include "policy/policy.h"
 #include "wallet/wallet.h"
 
 #include <boost/assign/list_of.hpp> // for 'map_list_of()'
@@ -480,7 +481,7 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog *dialog)
         {
             CTxOut txout(amount, (CScript)std::vector<unsigned char>(24, 0));
             txDummy.vout.push_back(txout);
-            if (txout.IsDust(::minRelayTxFee))
+            if (txout.IsDust(dustRelayTxFee))
                 fDust = true;
         }
     }
@@ -588,10 +589,10 @@ void CoinControlDialog::updateLabels(WalletModel *model, QDialog *dialog)
             if (nChange > 0 && nChange < MIN_CHANGE)
             {
                 CTxOut txout(nChange, (CScript)std::vector<unsigned char>(24, 0));
-                if (txout.IsDust(::minRelayTxFee))
+                if (txout.IsDust(dustRelayFee))
                 {
                     if (CoinControlDialog::fSubtractFeeFromAmount) // dust-change will be raised until no dust
-                        nChange = txout.GetDustThreshold(::minRelayTxFee);
+                        nChange = txout.GetDustThreshold(dustRelayFee);
                     else
                     {
                         nPayFee += nChange;

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -288,7 +288,7 @@ bool isDust(const QString &address, const CAmount &amount)
     CTxDestination dest = DecodeDestination(address.toStdString());
     CScript script = GetScriptForDestination(dest);
     CTxOut txOut(amount, script);
-    return txOut.IsDust(dustRelayFee);
+    return txOut.IsDust();
 }
 
 QString HtmlEscape(const QString &str, bool fMultiLine)

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -16,6 +16,7 @@
 #include "fs.h"
 #include "init.h"
 #include "main.h" // For minRelayTxFee
+#include "policy/policy.h"
 #include "primitives/transaction.h"
 #include "protocol.h"
 #include "script/script.h"
@@ -287,7 +288,7 @@ bool isDust(const QString &address, const CAmount &amount)
     CTxDestination dest = DecodeDestination(address.toStdString());
     CScript script = GetScriptForDestination(dest);
     CTxOut txOut(amount, script);
-    return txOut.IsDust(::minRelayTxFee);
+    return txOut.IsDust(dustRelayFee);
 }
 
 QString HtmlEscape(const QString &str, bool fMultiLine)

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -13,6 +13,7 @@
 #include "config.h"
 #include "dstencode.h"
 #include "main.h" // For minRelayTxFee
+#include "policy/policy.h"
 #include "ui_interface.h"
 #include "util.h"
 #include "wallet/wallet.h"
@@ -655,7 +656,7 @@ bool PaymentServer::processPaymentRequest(const PaymentRequestPlus &request, Sen
 
         // Extract and check amounts
         CTxOut txOut(sendingTo.second, sendingTo.first);
-        if (txOut.IsDust(::minRelayTxFee))
+        if (txOut.IsDust(dustRelayFee))
         {
             Q_EMIT message(tr("Payment request error"),
                 tr("Requested payment amount of %1 is too small (considered dust).")

--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -656,7 +656,7 @@ bool PaymentServer::processPaymentRequest(const PaymentRequestPlus &request, Sen
 
         // Extract and check amounts
         CTxOut txOut(sendingTo.second, sendingTo.first);
-        if (txOut.IsDust(dustRelayFee))
+        if (txOut.IsDust())
         {
             Q_EMIT message(tr("Payment request error"),
                 tr("Requested payment amount of %1 is too small (considered dust).")

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -337,7 +337,7 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
 
     // Check dust with default relay fee:
     dustRelayFee = CFeeRate(DUST_RELAY_TX_FEE);
-    CAmount nDustThreshold = 182 * dustRelayFee.GetFeePerK()/1000 * 3;
+    CAmount nDustThreshold = 182 * dustRelayFee.GetFeePerK() / 1000 * 3;
 
     BOOST_CHECK_EQUAL(nDustThreshold, 546);
     // dust:

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -336,8 +336,9 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     BOOST_CHECK(IsStandardTx(t, reason));
 
     // Check dust with default relay fee:
-    minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
-    CAmount nDustThreshold = 182 * minRelayTxFee.GetFeePerK() / 1000 * 3;
+    dustRelayFee = CFeeRate(DUST_RELAY_TX_FEE);
+    CAmount nDustThreshold = 182 * dustRelayFee.GetFeePerK()/1000 * 3;
+
     BOOST_CHECK_EQUAL(nDustThreshold, 546);
     // dust:
     t.vout[0].nValue = nDustThreshold - 1;
@@ -348,14 +349,14 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
 
     // Check dust with odd relay fee to verify rounding:
     // nDustThreshold = 182 * 1234 / 1000 * 3
-    minRelayTxFee = CFeeRate(1234);
+    dustRelayFee = CFeeRate(1234);
     // dust:
     t.vout[0].nValue = 672 - 1;
     BOOST_CHECK(!IsStandardTx(t, reason));
     // not dust:
     t.vout[0].nValue = 672;
     BOOST_CHECK(IsStandardTx(t, reason));
-    minRelayTxFee = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
+    dustRelayFee = CFeeRate(DUST_RELAY_TX_FEE);
 
     t.vout[0].scriptPubKey = CScript() << OP_1;
     BOOST_CHECK(!IsStandardTx(t, reason));

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -36,7 +36,6 @@ using namespace std;
 // In script_tests.cpp
 extern UniValue read_json(const std::string &jsondata);
 
-
 BOOST_FIXTURE_TEST_SUITE(transaction_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(tx_valid)
@@ -335,28 +334,24 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     string reason;
     BOOST_CHECK(IsStandardTx(t, reason));
 
-    // Check dust with default relay fee:
-    dustRelayFee = CFeeRate(DUST_RELAY_TX_FEE);
-    CAmount nDustThreshold = 182 * dustRelayFee.GetFeePerK() / 1000 * 3;
-
-    BOOST_CHECK_EQUAL(nDustThreshold, 546);
+    // Check dust with default threshold:
+    nDustThreshold.value = DEFAULT_DUST_THRESHOLD;
     // dust:
-    t.vout[0].nValue = nDustThreshold - 1;
+    t.vout[0].nValue = nDustThreshold.value - 1;
     BOOST_CHECK(!IsStandardTx(t, reason));
     // not dust:
-    t.vout[0].nValue = nDustThreshold;
+    t.vout[0].nValue = nDustThreshold.value;
     BOOST_CHECK(IsStandardTx(t, reason));
 
-    // Check dust with odd relay fee to verify rounding:
-    // nDustThreshold = 182 * 1234 / 1000 * 3
-    dustRelayFee = CFeeRate(1234);
+    // Check dust with odd threshold
+    nDustThreshold.value = 1234;
     // dust:
-    t.vout[0].nValue = 672 - 1;
+    t.vout[0].nValue = 1234 - 1;
     BOOST_CHECK(!IsStandardTx(t, reason));
     // not dust:
-    t.vout[0].nValue = 672;
+    t.vout[0].nValue = 1234;
     BOOST_CHECK(IsStandardTx(t, reason));
-    dustRelayFee = CFeeRate(DUST_RELAY_TX_FEE);
+    nDustThreshold.value = DEFAULT_DUST_THRESHOLD;
 
     t.vout[0].scriptPubKey = CScript() << OP_1;
     BOOST_CHECK(!IsStandardTx(t, reason));

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2307,7 +2307,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient> &vecSend,
                         }
                     }
 
-                    if (txout.IsDust(::minRelayTxFee))
+                    if (txout.IsDust(dustRelayFee))
                     {
                         if (recipient.fSubtractFeeFromAmount && nFeeRet > 0)
                         {
@@ -2386,16 +2386,16 @@ bool CWallet::CreateTransaction(const vector<CRecipient> &vecSend,
                     // We do not move dust-change to fees, because the sender would end up paying more than requested.
                     // This would be against the purpose of the all-inclusive feature.
                     // So instead we raise the change and deduct from the recipient.
-                    if (nSubtractFeeFromAmount > 0 && newTxOut.IsDust(::minRelayTxFee))
+                    if (nSubtractFeeFromAmount > 0 && newTxOut.IsDust(dustRelayFee))
                     {
-                        CAmount nDust = newTxOut.GetDustThreshold(::minRelayTxFee) - newTxOut.nValue;
+                        CAmount nDust = newTxOut.GetDustThreshold(dustRelayFee) - newTxOut.nValue;
                         newTxOut.nValue += nDust; // raise change until no more dust
                         for (unsigned int i = 0; i < vecSend.size(); i++) // subtract from first recipient
                         {
                             if (vecSend[i].fSubtractFeeFromAmount)
                             {
                                 txNew.vout[i].nValue -= nDust;
-                                if (txNew.vout[i].IsDust(::minRelayTxFee))
+                                if (txNew.vout[i].IsDust(dustRelayFee))
                                 {
                                     strFailReason = _(
                                         "The transaction amount is too small to send after the fee has been deducted");
@@ -2408,7 +2408,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient> &vecSend,
 
                     // Never create dust outputs; if we would, just
                     // add the dust to the fee.
-                    if (newTxOut.IsDust(::minRelayTxFee))
+                    if (newTxOut.IsDust(dustRelayFee))
                     {
                         nFeeRet += nChange;
                         reservekey.ReturnKey();

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2307,7 +2307,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient> &vecSend,
                         }
                     }
 
-                    if (txout.IsDust(dustRelayFee))
+                    if (txout.IsDust())
                     {
                         if (recipient.fSubtractFeeFromAmount && nFeeRet > 0)
                         {
@@ -2386,16 +2386,16 @@ bool CWallet::CreateTransaction(const vector<CRecipient> &vecSend,
                     // We do not move dust-change to fees, because the sender would end up paying more than requested.
                     // This would be against the purpose of the all-inclusive feature.
                     // So instead we raise the change and deduct from the recipient.
-                    if (nSubtractFeeFromAmount > 0 && newTxOut.IsDust(dustRelayFee))
+                    if (nSubtractFeeFromAmount > 0 && newTxOut.IsDust())
                     {
-                        CAmount nDust = newTxOut.GetDustThreshold(dustRelayFee) - newTxOut.nValue;
+                        CAmount nDust = newTxOut.GetDustThreshold() - newTxOut.nValue;
                         newTxOut.nValue += nDust; // raise change until no more dust
                         for (unsigned int i = 0; i < vecSend.size(); i++) // subtract from first recipient
                         {
                             if (vecSend[i].fSubtractFeeFromAmount)
                             {
                                 txNew.vout[i].nValue -= nDust;
-                                if (txNew.vout[i].IsDust(dustRelayFee))
+                                if (txNew.vout[i].IsDust())
                                 {
                                     strFailReason = _(
                                         "The transaction amount is too small to send after the fee has been deducted");
@@ -2408,7 +2408,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient> &vecSend,
 
                     // Never create dust outputs; if we would, just
                     // add the dust to the fee.
-                    if (newTxOut.IsDust(dustRelayFee))
+                    if (newTxOut.IsDust())
                     {
                         nFeeRet += nChange;
                         reservekey.ReturnKey();


### PR DESCRIPTION
ABC has changed their default minRelayTxFee to 250 sat/byte and while changing it in BU doesn't really change much because the mempool limiter will adjust this value on the fly anyway, but I thought it would be a good idea to align ourselves with ABC.  Then we should probably review how we want the mempool limiting defaults to work in the future so we don't end up trampling on zero-conf.

So do make the change we first need to separate out the dustrelayfee from the minrelaytxfee or we end up having issues with the tests but also it's a good idea that users can change the dustrelayfee on the fly if needed in the future.  This was mostly a port from Core with some minor changes so we don't shadow any variables.  After this one done it was a simple one liner to change the minrelaytxfee default.

