### PR TITLE
Refactor bloom filter targeting for xthins and make it optional

### DIFF
--- a/qa/rpc-tests/thinblocks.py
+++ b/qa/rpc-tests/thinblocks.py
@@ -16,13 +16,14 @@ class ThinBlockTest(BitcoinTestFramework):
 
     def setup_chain(self):
         print ("Initializing test directory " + self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 3)
+        initialize_chain_clean(self.options.tmpdir, 4)
 
     def setup_network(self, split=False):
         node_opts1 = [
             "-rpcservertimeout=0",
             "-debug=thin",
             "-use-thinblocks=1",
+            "-use-bloom-filter-targeting=0",
             "-excessiveblocksize=6000000",
             "-blockprioritysize=6000000",
             "-blockmaxsize=6000000",
@@ -33,15 +34,28 @@ class ThinBlockTest(BitcoinTestFramework):
             "-rpcservertimeout=0",
             "-debug=thin",
             "-use-thinblocks=1",
+            "-use-bloom-filter-targeting=0",
             "-excessiveblocksize=6000000",
             "-blockprioritysize=6000000",
             "-blockmaxsize=6000000",
             "-peerbloomfilters=0"]
 
+        # This node has bloom filter targeting enabled.
+        node_opts3 = [
+            "-rpcservertimeout=0",
+            "-debug=thin",
+            "-use-thinblocks=1",
+            "-use-bloom-filter-targeting=1",
+            "-excessiveblocksize=6000000",
+            "-blockprioritysize=6000000",
+            "-blockmaxsize=6000000",
+            "-peerbloomfilters=1"]
+
         self.nodes = [
             start_node(0, self.options.tmpdir, node_opts1),
             start_node(1, self.options.tmpdir, node_opts1),
-            start_node(2, self.options.tmpdir, node_opts2)
+            start_node(2, self.options.tmpdir, node_opts2),
+            start_node(3, self.options.tmpdir, node_opts3)
         ]
         interconnect_nodes(self.nodes)
         self.is_network_split = False
@@ -98,7 +112,6 @@ class ThinBlockTest(BitcoinTestFramework):
                             "outbound_bloom_filters",
                             "inbound_bloom_filters",
                             "rerequested"}
-
 
 if __name__ == '__main__':
     ThinBlockTest().main()

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -590,7 +590,10 @@ static void addNodeRelayOptions(AllowedArgs &allowedArgs)
         .addArg("use-thinblocks", optionalBool, _("Enable thin blocks to speed up the relay of blocks (default: 1)"))
         .addArg("xthinbloomfiltersize=<n>", requiredInt,
             strprintf(_("The maximum xthin bloom filter size that our node will accept in Bytes (default: %u)"),
-                    SMALLEST_MAX_BLOOM_FILTER_SIZE));
+                    SMALLEST_MAX_BLOOM_FILTER_SIZE))
+        .addArg("use-bloom-filter-targeting", optionalBool,
+            _("Enable thin block bloom filter targeting which helps to keep the size of bloom filters to a minumum "
+              "although it can impact performance. (default: 0)"));
 }
 
 static void addBlockCreationOptions(AllowedArgs &allowedArgs)

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -1695,11 +1695,12 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
             uint64_t nBlockSize = 0;
             while (mi != mempool.mapTx.get<3>().end())
             {
-                CTransaction tx = mi->GetTx();
+                const CTransaction &tx = mi->GetTx();
+                const uint256 &txHash = tx.GetHash();
 
                 if (!IsFinalTx(tx, nHeight, nLockTimeCutoff))
                 {
-                    LOG(BLOOM, "tx %s is not final\n", tx.GetHash().ToString());
+                    LOG(BLOOM, "tx %s is not final\n", txHash.ToString());
                     mi++;
                     continue;
                 }
@@ -1708,7 +1709,7 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
                 // it to the high score set if it can be and also add any parents or children.  Also add
                 // children and parents to the priority set tx's if they have any.
                 iter = mempool.mapTx.project<0>(mi);
-                if (!setHighScoreMemPoolHashes.count(tx.GetHash()))
+                if (!setHighScoreMemPoolHashes.count(txHash))
                 {
                     LOG(BLOOM,
                         "next tx is %s blocksize %d fee %d modified fee %d size %d clearatentry %d priority %f\n",
@@ -1716,14 +1717,14 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
                         mi->GetTxSize(), mi->WasClearAtEntry(), mi->GetPriority(nHeight));
 
                     // add tx to the set: we don't know if this is a parent or child yet.
-                    setHighScoreMemPoolHashes.insert(tx.GetHash());
+                    setHighScoreMemPoolHashes.insert(txHash);
 
                     // Add any parent tx's
                     bool fChild = false;
                     for (CTxMemPool::txiter parent : mempool.GetMemPoolParents(iter))
                     {
                         fChild = true;
-                        uint256 parentHash = parent->GetTx().GetHash();
+                        const uint256 &parentHash = parent->GetTx().GetHash();
                         if (!setHighScoreMemPoolHashes.count(parentHash))
                         {
                             setHighScoreMemPoolHashes.insert(parentHash);
@@ -1740,7 +1741,7 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
                     for (CTxMemPool::txiter child : mempool.GetMemPoolChildren(iter))
                     {
                         fHasChildren = true;
-                        uint256 childHash = child->GetTx().GetHash();
+                        const uint256 &childHash = child->GetTx().GetHash();
                         if (!setHighScoreMemPoolHashes.count(childHash))
                         {
                             setHighScoreMemPoolHashes.insert(childHash);

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -1622,22 +1622,23 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
     std::set<uint256> setHighScoreMemPoolHashes;
     std::set<uint256> setPriorityMemPoolHashes;
 
-    // How much of the block should be dedicated to high-priority transactions.
-    // Logically this should be the same size as the DEFAULT_BLOCK_PRIORITY_SIZE however,
-    // we can't be sure that a miner won't decide to mine more high priority txs and therefore
-    // by including a full blocks worth of high priority tx's we cover every scenario.  And when we
-    // go on to add the high fee tx's there will be an intersection between the two which then makes
-    // the total number of tx's that go into the bloom filter smaller than just the sum of the two.
-    uint64_t nBlockPrioritySize = LargestBlockSeen() * 1.5;
-
-    // Largest projected block size used to add the high fee transactions.  We multiply it by an
-    // additional factor to take into account that miners may have slighty different policies when selecting
-    // high fee tx's from the pool.
-    uint64_t nBlockMaxProjectedSize = LargestBlockSeen() * 1.5;
-
-    std::vector<TxCoinAgePriority> vPriority;
-    TxCoinAgePriorityCompare pricomparer;
     {
+        // How much of the block should be dedicated to high-priority transactions.
+        // Logically this should be the same size as the DEFAULT_BLOCK_PRIORITY_SIZE however,
+        // we can't be sure that a miner won't decide to mine more high priority txs and therefore
+        // by including a full blocks worth of high priority tx's we cover every scenario.  And when we
+        // go on to add the high fee tx's there will be an intersection between the two which then makes
+        // the total number of tx's that go into the bloom filter smaller than just the sum of the two.
+        uint64_t nBlockPrioritySize = LargestBlockSeen() * 1.5;
+
+        // Largest projected block size used to add the high fee transactions.  We multiply it by an
+        // additional factor to take into account that miners may have slighty different policies when selecting
+        // high fee tx's from the pool.
+        uint64_t nBlockMaxProjectedSize = LargestBlockSeen() * 1.5;
+
+        std::vector<TxCoinAgePriority> vPriority;
+        TxCoinAgePriorityCompare pricomparer;
+
         uint64_t nMapTxSize = 0;
         {
             READLOCK(mempool.cs);

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -1629,12 +1629,12 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
         // by including a full blocks worth of high priority tx's we cover every scenario.  And when we
         // go on to add the high fee tx's there will be an intersection between the two which then makes
         // the total number of tx's that go into the bloom filter smaller than just the sum of the two.
-        uint64_t nBlockPrioritySize = LargestBlockSeen() * 1.5;
+        uint64_t nBlockPrioritySize = excessiveBlockSize * 1.5;
 
         // Largest projected block size used to add the high fee transactions.  We multiply it by an
         // additional factor to take into account that miners may have slighty different policies when selecting
         // high fee tx's from the pool.
-        uint64_t nBlockMaxProjectedSize = LargestBlockSeen() * 1.5;
+        uint64_t nBlockMaxProjectedSize = excessiveBlockSize * 1.5;
 
         std::vector<TxCoinAgePriority> vPriority;
         TxCoinAgePriorityCompare pricomparer;


### PR DESCRIPTION
A few performance improvements for the bloom filter targeting process as well as making it an optional feature defaulting to OFF.  In the past when we were still on the Bitcoin Core chain this and the mempools were constantly full we needed this feature to keep the bloom filters from getting too big, however it does incur significant overhead in generating the filter, particularly during giga net testing.  But now that the mempools are no longer full, we can make it optional.