### PR TITLE
Simplify RPC command registration

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1141,8 +1141,8 @@ static const CRPCCommand commands[] = {
     {"hidden", "rollbackchain", &rollbackchain, true},
 };
 
-void RegisterBlockchainRPCCommands(CRPCTable &tableRPC)
+void RegisterBlockchainRPCCommands(CRPCTable &table)
 {
-    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
-        tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
+    for (auto cmd : commands)
+        table.appendCommand(cmd);
 }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -1002,8 +1002,8 @@ static const CRPCCommand commands[] = {
     {"util", "estimatesmartpriority", &estimatesmartpriority, true},
 };
 
-void RegisterMiningRPCCommands(CRPCTable &tableRPC)
+void RegisterMiningRPCCommands(CRPCTable &table)
 {
-    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
-        tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
+    for (auto cmd : commands)
+        table.appendCommand(cmd);
 }

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -432,8 +432,8 @@ static const CRPCCommand commands[] = {
     {"hidden", "setmocktime", &setmocktime, true},
 };
 
-void RegisterMiscRPCCommands(CRPCTable &tableRPC)
+void RegisterMiscRPCCommands(CRPCTable &table)
 {
-    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
-        tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
+    for (auto cmd : commands)
+        table.appendCommand(cmd);
 }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -654,8 +654,8 @@ static const CRPCCommand commands[] = {
     {"network", "clearbanned", &clearbanned, true},
 };
 
-void RegisterNetRPCCommands(CRPCTable &tableRPC)
+void RegisterNetRPCCommands(CRPCTable &table)
 {
-    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
-        tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
+    for (auto cmd : commands)
+        table.appendCommand(cmd);
 }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1034,8 +1034,8 @@ static const CRPCCommand commands[] = {
     {"blockchain", "gettxoutproof", &gettxoutproof, true}, {"blockchain", "verifytxoutproof", &verifytxoutproof, true},
 };
 
-void RegisterRawTransactionRPCCommands(CRPCTable &tableRPC)
+void RegisterRawTransactionRPCCommands(CRPCTable &table)
 {
-    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
-        tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
+    for (auto cmd : commands)
+        table.appendCommand(cmd);
 }

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -163,15 +163,16 @@ std::string CRPCTable::help(const std::string &strCommand) const
     string strRet;
     string category;
     set<rpcfn_type> setDone;
-    vector<pair<string, const CRPCCommand *> > vCommands;
+    typedef pair<string, CRPCCommand> rpc_pair;
+    vector<rpc_pair> vCommands;
 
-    for (map<string, const CRPCCommand *>::const_iterator mi = mapCommands.begin(); mi != mapCommands.end(); ++mi)
-        vCommands.push_back(make_pair(mi->second->category + mi->first, mi->second));
-    sort(vCommands.begin(), vCommands.end());
-
-    BOOST_FOREACH (const PAIRTYPE(string, const CRPCCommand *) & command, vCommands)
+    for (rpc_pair p : mapCommands)
+        // sort by command category first, then by command name
+        vCommands.push_back(rpc_pair(p.second.category + p.first, p.second));
+    sort(vCommands.begin(), vCommands.end(), [](rpc_pair a, rpc_pair b) { return a.first < b.first; });
+    for (rpc_pair command : vCommands)
     {
-        const CRPCCommand *pcmd = command.second;
+        const CRPCCommand *pcmd = &(command.second);
         string strMethod = pcmd->name;
         // We already filter duplicates, but these deprecated screw up the sort order
         if (strMethod.find("label") != string::npos)
@@ -255,35 +256,29 @@ static const CRPCCommand vRPCCommands[] = {
 
 CRPCTable::CRPCTable()
 {
-    unsigned int vcidx;
-    for (vcidx = 0; vcidx < (sizeof(vRPCCommands) / sizeof(vRPCCommands[0])); vcidx++)
-    {
-        const CRPCCommand *pcmd;
-
-        pcmd = &vRPCCommands[vcidx];
-        mapCommands[pcmd->name] = pcmd;
-    }
+    for (auto cmd : vRPCCommands)
+        appendCommand(cmd);
 }
 
 const CRPCCommand *CRPCTable::operator[](const std::string &name) const
 {
-    map<string, const CRPCCommand *>::const_iterator it = mapCommands.find(name);
+    map<string, CRPCCommand>::const_iterator it = mapCommands.find(name);
     if (it == mapCommands.end())
-        return NULL;
-    return (*it).second;
+        return nullptr;
+    return &(it->second);
 }
 
-bool CRPCTable::appendCommand(const std::string &name, const CRPCCommand *pcmd)
+bool CRPCTable::appendCommand(const CRPCCommand &cmd)
 {
     if (IsRPCRunning())
         return false;
 
     // don't allow overwriting for now
-    map<string, const CRPCCommand *>::const_iterator it = mapCommands.find(name);
+    map<string, CRPCCommand>::const_iterator it = mapCommands.find(cmd.name);
     if (it != mapCommands.end())
         return false;
 
-    mapCommands[name] = pcmd;
+    mapCommands[cmd.name] = cmd;
     return true;
 }
 
@@ -426,7 +421,7 @@ UniValue CRPCTable::execute(const std::string &strMethod, const UniValue &params
 std::vector<std::string> CRPCTable::listCommands() const
 {
     std::vector<std::string> commandList;
-    typedef std::map<std::string, const CRPCCommand *> commandMap;
+    typedef std::map<std::string, CRPCCommand> commandMap;
 
     std::transform(mapCommands.begin(), mapCommands.end(), std::back_inserter(commandList),
         boost::bind(&commandMap::value_type::first, _1));

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -142,7 +142,7 @@ public:
 class CRPCTable
 {
 private:
-    std::map<std::string, const CRPCCommand *> mapCommands;
+    std::map<std::string, CRPCCommand> mapCommands;
 
 public:
     CRPCTable();
@@ -169,8 +169,9 @@ public:
      * Appends a CRPCCommand to the dispatch table.
      * Returns false if RPC server is already running (dump concurrency protection).
      * Commands cannot be overwritten (returns false).
+     * WARNING: The passed reference must be sufficiently long-lived
      */
-    bool appendCommand(const std::string &name, const CRPCCommand *pcmd);
+    bool appendCommand(const CRPCCommand &ccmd);
 };
 
 extern CRPCTable tableRPC;

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -406,4 +406,12 @@ BOOST_AUTO_TEST_CASE(rpc_convert_values_generatetoaddress)
     BOOST_CHECK_EQUAL(result[2].get_int(), 9);
 }
 
+BOOST_AUTO_TEST_CASE(rpc_help)
+{
+    const string s = tableRPC.help("");
+    // check sorting by category (exactly one entry named 'Mining')
+    size_t p = s.find("== Mining ==");
+    BOOST_CHECK(p != string::npos);
+    BOOST_CHECK(s.substr(p + 1).find("== Mining ==") == string::npos);
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1881,10 +1881,10 @@ static const CRPCCommand commands[] =
 };
 /* clang-format on */
 
-void RegisterUnlimitedRPCCommands(CRPCTable &tableRPC)
+void RegisterUnlimitedRPCCommands(CRPCTable &table)
 {
-    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
-        tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
+    for (auto cmd : commands)
+        table.appendCommand(cmd);
 }
 
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -2831,8 +2831,8 @@ static const CRPCCommand commands[] = {
 };
 /* clang-format on */
 
-void RegisterWalletRPCCommands(CRPCTable &tableRPC)
+void RegisterWalletRPCCommands(CRPCTable &table)
 {
-    for (unsigned int vcidx = 0; vcidx < ARRAYLEN(commands); vcidx++)
-        tableRPC.appendCommand(commands[vcidx].name, &commands[vcidx]);
+    for (auto cmd : commands)
+        table.appendCommand(cmd);
 }


### PR DESCRIPTION
Also get rid of the premature optimization that is avoiding copies
of the CRPCCommand structs when registering the RPCs.