### PR TITLE
Add very simple benchmark for Murmur3 hash function

### DIFF
--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -379,6 +379,7 @@ bench/bench.h
 bench/crypto_hash.cpp
 bench/Examples.cpp
 bench/verify_script.cpp
+bench/murmur_hash.cpp
 compat/byteswap.h
 compat/endian.h
 compat/glibc_compat.cpp

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -13,7 +13,8 @@ bench_bench_bitcoin_SOURCES = \
   bench/bench.h \
   bench/Examples.cpp \
   bench/verify_script.cpp \
-  bench/crypto_hash.cpp  
+  bench/crypto_hash.cpp \
+  bench/murmur_hash.cpp
 
 bench_bench_bitcoin_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_bitcoin_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/bench/murmur_hash.cpp
+++ b/src/bench/murmur_hash.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "bench.h"
+#include "hash.h"
+
+static void Murmur3(benchmark::State &state)
+{
+    std::vector<uint8_t> in(32, 0);
+    unsigned x;
+    while (state.KeepRunning())
+    {
+        for (int i = 0; i < 1000000; i++)
+            x += MurmurHash3(5 * 0xfba4c795, in);
+    }
+}
+
+BENCHMARK(Murmur3);


### PR DESCRIPTION
An older commit I had laying around, I was curious about `murmur3`. 43e6 exec/s as per benchmark on my Laptop. Was wondering whether to put this into `crypto_hash.cpp` though it is not cryptographic...