### PR TITLE
Travis: Repeat apt-add-repository without relying on return value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,8 +91,8 @@ before_install:
     - sudo apt-get update
 
 install:
-    - if [ -n "$PPA" ]; then travis_retry sudo add-apt-repository "$PPA" -y; fi
-    - if [ -n "$PPA2" ]; then travis_retry sudo add-apt-repository "$PPA2" -y; fi
+    - if [ -n "$PPA" ]; then for i in `seq 0 4`; do sudo add-apt-repository "$PPA" -y 2>&1|tee /dev/stderr|grep -q "imported" && break; sleep 30; done; fi
+    - if [ -n "$PPA2" ]; then for i in `seq 0 4`; do sudo add-apt-repository "$PPA2" -y 2>&1|tee /dev/stderr|grep -q "imported" && break; sleep 30; done; fi
     - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi
     - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq libdb4.8-dev libdb4.8++-dev $PACKAGES; fi


### PR DESCRIPTION
Recent failures on travis seem to point towards `apt-add-repository`
not returning a non-null result when it fails. So this is basically
an attempt at a workaround for a potential bug in `apt-add-repository`,
by calling `apt-add-repository` five times in a row.

Travis log:
Successful, no keyserver trouble: https://travis-ci.org/BitcoinUnlimited/BitcoinUnlimited/builds/401863213