### PR TITLE
[SYNTAX ONLY] remove boost where c++11 works, move filesystem utilities from util.h…

### DIFF
--- a/src/bandb.cpp
+++ b/src/bandb.cpp
@@ -6,6 +6,7 @@
 
 #include "bandb.h"
 #include "chainparams.h"
+#include "fs.h"
 #include "hash.h"
 #include "random.h"
 #include "streams.h"

--- a/src/bitnodes.cpp
+++ b/src/bitnodes.cpp
@@ -305,10 +305,10 @@ bool GetLeaderboardFromBitnodes(vector<string> &vIPs)
             for (std::vector<UniValue>::iterator it = v.begin(); it != v.end(); ++it)
             {
                 const UniValue &o = *it;
-                const UniValue &result = find_value(o, "node");
-                if (result.isStr())
+                const UniValue &findresult = find_value(o, "node");
+                if (findresult.isStr())
                 {
-                    string s = result.get_str();
+                    string s = findresult.get_str();
                     vIPs.push_back(s);
                     count++;
                 }

--- a/src/chain.h
+++ b/src/chain.h
@@ -375,9 +375,9 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
-        int nVersion = s.GetVersion();
+        int version = s.GetVersion();
         if (!(s.GetType() & SER_GETHASH))
-            READWRITE(VARINT(nVersion, VarIntMode::NONNEGATIVE_SIGNED));
+            READWRITE(VARINT(version, VarIntMode::NONNEGATIVE_SIGNED));
 
         READWRITE(VARINT(nHeight, VarIntMode::NONNEGATIVE_SIGNED));
         READWRITE(VARINT(nStatus));

--- a/src/connmgr.cpp
+++ b/src/connmgr.cpp
@@ -11,9 +11,9 @@ std::unique_ptr<CConnMgr> connmgr(new CConnMgr);
  * Find a node in a vector.  Just calls std::find.  Split out for cleanliness and also because std:find won't be
  * enough if we switch to vectors of noderefs.  Requires any lock for vector traversal to be held.
  */
-static std::vector<CNode *>::iterator FindNode(std::vector<CNode *> &vNodes, CNode *pNode)
+static std::vector<CNode *>::iterator FindNode(std::vector<CNode *> &nodes, CNode *pNode)
 {
-    return std::find(vNodes.begin(), vNodes.end(), pNode);
+    return std::find(nodes.begin(), nodes.end(), pNode);
 }
 
 /**
@@ -22,10 +22,10 @@ static std::vector<CNode *>::iterator FindNode(std::vector<CNode *> &vNodes, CNo
  * @param[in] vNodes      The vector of nodes.
  * @param[in] pNode       The node to add.
  */
-static void AddNode(std::vector<CNode *> &vNodes, CNode *pNode)
+static void AddNode(std::vector<CNode *> &nodes, CNode *pNode)
 {
     pNode->AddRef();
-    vNodes.push_back(pNode);
+    nodes.push_back(pNode);
 }
 
 /**
@@ -35,14 +35,14 @@ static void AddNode(std::vector<CNode *> &vNodes, CNode *pNode)
  * @param[in] pNode       The node to remove.
  * @return  True if the node was originally present, false if not.
  */
-static bool RemoveNode(std::vector<CNode *> &vNodes, CNode *pNode)
+static bool RemoveNode(std::vector<CNode *> &nodes, CNode *pNode)
 {
-    auto Node = FindNode(vNodes, pNode);
+    auto Node = FindNode(nodes, pNode);
 
-    if (Node != vNodes.end())
+    if (Node != nodes.end())
     {
         pNode->Release();
-        vNodes.erase(Node);
+        nodes.erase(Node);
         return true;
     }
 

--- a/src/fs.h
+++ b/src/fs.h
@@ -21,4 +21,19 @@ namespace fsbridge {
     FILE *freopen(const fs::path& p, const char *mode, FILE *stream);
 };
 
+bool RenameOver(fs::path src, fs::path dest);
+bool TryCreateDirectories(const fs::path &p);
+fs::path GetDefaultDataDir();
+const fs::path &GetDataDir(bool fNetSpecific = true);
+void ClearDatadirCache();
+fs::path GetConfigFile(const std::string &confPath);
+#ifndef WIN32
+fs::path GetPidFile();
+void CreatePidFile(const fs::path &path, pid_t pid);
+#endif
+#ifdef WIN32
+fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
+#endif
+
+
 #endif

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -45,8 +45,8 @@ static const size_t MAX_HEADERS_SIZE = 8192;
 class HTTPWorkItem : public HTTPClosure
 {
 public:
-    HTTPWorkItem(std::unique_ptr<HTTPRequest> req, const std::string &path, const HTTPRequestHandler &func)
-        : req(std::move(req)), path(path), func(func)
+    HTTPWorkItem(std::unique_ptr<HTTPRequest> reqp, const std::string &pathp, const HTTPRequestHandler &funcp)
+        : req(std::move(reqp)), path(pathp), func(funcp)
     {
     }
     void operator()() { func(req.get(), path); }
@@ -91,7 +91,7 @@ private:
     };
 
 public:
-    WorkQueue(size_t maxDepth) : running(true), maxDepth(maxDepth), numThreads(0) {}
+    WorkQueue(size_t maxDepthp) : running(true), maxDepth(maxDepthp), numThreads(0) {}
     /** Precondition: worker threads have all stopped
      */
     ~WorkQueue() {}
@@ -138,8 +138,8 @@ public:
 struct HTTPPathHandler
 {
     HTTPPathHandler() {}
-    HTTPPathHandler(std::string prefix, bool exactMatch, HTTPRequestHandler handler)
-        : prefix(prefix), exactMatch(exactMatch), handler(handler)
+    HTTPPathHandler(std::string prefixp, bool exactMatchp, HTTPRequestHandler handlerp)
+        : prefix(prefixp), exactMatch(exactMatchp), handler(handlerp)
     {
     }
     std::string prefix;
@@ -559,8 +559,8 @@ static void httpevent_callback_fn(evutil_socket_t, short, void *data)
         delete self;
 }
 
-HTTPEvent::HTTPEvent(struct event_base *base, bool deleteWhenTriggered, const std::function<void(void)> &handler)
-    : deleteWhenTriggered(deleteWhenTriggered), handler(handler)
+HTTPEvent::HTTPEvent(struct event_base *base, bool delWhenTriggered, const std::function<void(void)> &handlerp)
+    : deleteWhenTriggered(delWhenTriggered), handler(handlerp)
 {
     ev = event_new(base, -1, 0, httpevent_callback_fn, this);
     assert(ev);
@@ -573,7 +573,7 @@ void HTTPEvent::trigger(struct timeval *tv)
     else
         evtimer_add(ev, tv); // trigger after timeval passed
 }
-HTTPRequest::HTTPRequest(struct evhttp_request *req) : req(req), replySent(false) {}
+HTTPRequest::HTTPRequest(struct evhttp_request *reqp) : req(reqp), replySent(false) {}
 HTTPRequest::~HTTPRequest()
 {
     if (!replySent)

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -280,13 +280,13 @@ bool CKey::Derive(CKey &keyChild, ChainCode &ccChild, unsigned int nChild, const
     return ret;
 }
 
-bool CExtKey::Derive(CExtKey &out, unsigned int nChild) const
+bool CExtKey::Derive(CExtKey &out, unsigned int nChildp) const
 {
     out.nDepth = nDepth + 1;
     CKeyID id = key.GetPubKey().GetID();
     memcpy(&out.vchFingerprint[0], &id, 4);
-    out.nChild = nChild;
-    return key.Derive(out.key, out.chaincode, nChild, chaincode);
+    out.nChild = nChildp;
+    return key.Derive(out.key, out.chaincode, nChildp, chaincode);
 }
 
 void CExtKey::SetMaster(const unsigned char *seed, unsigned int nSeedLen)

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -20,8 +20,8 @@ class proxyType
 {
 public:
     proxyType() : randomize_credentials(false) {}
-    proxyType(const CService &proxy, bool randomize_credentials = false)
-        : proxy(proxy), randomize_credentials(randomize_credentials)
+    proxyType(const CService &proxyp, bool randomize_credentialsp = false)
+        : proxy(proxyp), randomize_credentials(randomize_credentialsp)
     {
     }
 

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -321,13 +321,13 @@ void CExtPubKey::Decode(const unsigned char code[BIP32_EXTKEY_SIZE])
     pubkey.Set(code + 41, code + BIP32_EXTKEY_SIZE);
 }
 
-bool CExtPubKey::Derive(CExtPubKey &out, unsigned int nChild) const
+bool CExtPubKey::Derive(CExtPubKey &out, unsigned int child) const
 {
     out.nDepth = nDepth + 1;
     CKeyID id = pubkey.GetID();
     memcpy(&out.vchFingerprint[0], &id, 4);
-    out.nChild = nChild;
-    return pubkey.Derive(out.pubkey, out.chaincode, nChild, chaincode);
+    out.nChild = child;
+    return pubkey.Derive(out.pubkey, out.chaincode, child, chaincode);
 }
 
 /* static */ bool CPubKey::CheckLowS(const std::vector<unsigned char> &vchSig)

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -83,7 +83,7 @@ public:
     }
 
     //! Construct a public key from a byte vector.
-    CPubKey(const std::vector<unsigned char> &vch) { Set(vch.begin(), vch.end()); }
+    CPubKey(const std::vector<unsigned char> &vchp) { Set(vchp.begin(), vchp.end()); }
     //! Simple read-only vector-like interface to the pubkey data.
     unsigned int size() const { return GetLen(vch[0]); }
     const unsigned char *begin() const { return vch; }

--- a/src/qt/askpassphrasedialog.cpp
+++ b/src/qt/askpassphrasedialog.cpp
@@ -19,8 +19,8 @@
 #include <QMessageBox>
 #include <QPushButton>
 
-AskPassphraseDialog::AskPassphraseDialog(Mode mode, QWidget *parent)
-    : QDialog(parent), ui(new Ui::AskPassphraseDialog), mode(mode), model(0), fCapsLock(false)
+AskPassphraseDialog::AskPassphraseDialog(Mode modep, QWidget *parent)
+    : QDialog(parent), ui(new Ui::AskPassphraseDialog), mode(modep), model(0), fCapsLock(false)
 {
     ui->setupUi(this);
 
@@ -82,7 +82,7 @@ AskPassphraseDialog::~AskPassphraseDialog()
     delete ui;
 }
 
-void AskPassphraseDialog::setModel(WalletModel *model) { this->model = model; }
+void AskPassphraseDialog::setModel(WalletModel *modelp) { model = modelp; }
 void AskPassphraseDialog::accept()
 {
     SecureString oldpass, newpass1, newpass2;

--- a/src/qt/openuridialog.cpp
+++ b/src/qt/openuridialog.cpp
@@ -11,7 +11,8 @@
 
 #include <QUrl>
 
-OpenURIDialog::OpenURIDialog(const Config *cfg, QWidget *parent) : QDialog(parent), ui(new Ui::OpenURIDialog), cfg(cfg)
+OpenURIDialog::OpenURIDialog(const Config *cfgp, QWidget *parent)
+    : QDialog(parent), ui(new Ui::OpenURIDialog), cfg(cfgp)
 {
     ui->setupUi(this);
     ui->uriEdit->setPlaceholderText(GUIUtil::bitcoinURIScheme(*cfg) + ":");

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -43,13 +43,13 @@ public:
     {
     }
     explicit SendCoinsRecipient(const QString &addr,
-        const QString &label,
-        const CAmount &amount,
-        const QString &message,
-        const QString &freezeLockTime,
-        const QString &labelPublic)
-        : address(addr), label(label), labelPublic(labelPublic), amount(amount), message(message),
-          freezeLockTime(freezeLockTime), fSubtractFeeFromAmount(false), nVersion(SendCoinsRecipient::CURRENT_VERSION)
+        const QString &labelp,
+        const CAmount &amt,
+        const QString &msg,
+        const QString &freezeLockTimep,
+        const QString &labelPublicp)
+        : address(addr), label(labelp), labelPublic(labelPublicp), amount(amt), message(msg),
+          freezeLockTime(freezeLockTimep), fSubtractFeeFromAmount(false), nVersion(SendCoinsRecipient::CURRENT_VERSION)
     {
     }
 
@@ -169,7 +169,7 @@ public:
     // Return status record for SendCoins, contains error id + information
     struct SendCoinsReturn
     {
-        SendCoinsReturn(StatusCode status = OK) : status(status) {}
+        SendCoinsReturn(StatusCode statusp = OK) : status(statusp) {}
         StatusCode status;
     };
 

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -183,9 +183,9 @@ private:
 public:
     MutableTransactionSignatureChecker(const CMutableTransaction *txToIn,
         unsigned int nInIn,
-        const CAmount &amount,
+        const CAmount &amt,
         unsigned int flags = SCRIPT_ENABLE_SIGHASH_FORKID)
-        : TransactionSignatureChecker(&txTo, nInIn, amount, flags), txTo(*txToIn)
+        : TransactionSignatureChecker(&txTo, nInIn, amt, flags), txTo(*txToIn)
     {
     }
 };

--- a/src/script/sigcache.h
+++ b/src/script/sigcache.h
@@ -25,10 +25,10 @@ private:
 public:
     CachingTransactionSignatureChecker(const CTransaction *txToIn,
         unsigned int nInIn,
-        const CAmount &amount,
+        const CAmount &amt,
         unsigned int flags,
         bool storeIn = true)
-        : TransactionSignatureChecker(txToIn, nInIn, amount, flags), store(storeIn)
+        : TransactionSignatureChecker(txToIn, nInIn, amt, flags), store(storeIn)
     {
     }
 

--- a/src/secp256k1/src/num.h
+++ b/src/secp256k1/src/num.h
@@ -7,11 +7,11 @@
 #ifndef SECP256K1_NUM_H
 #define SECP256K1_NUM_H
 
-#ifndef USE_NUM_NONE
-
 #if defined HAVE_CONFIG_H
 #include "libsecp256k1-config.h"
 #endif
+
+#ifndef USE_NUM_NONE
 
 #if defined(USE_NUM_GMP)
 #include "num_gmp.h"

--- a/src/stat.h
+++ b/src/stat.h
@@ -143,11 +143,11 @@ public:
     RecordType &operator()() { return value; }
     virtual UniValue GetNow() { return UniValue(value); }
     virtual UniValue GetTotal() { return NullUniValue; }
-    virtual UniValue GetSeries(const std::string &name, int count)
+    virtual UniValue GetSeries(const std::string &namep, int count)
     {
         return NullUniValue; // Has no series data
     }
-    virtual UniValue GetSeriesTime(const std::string &name, int count)
+    virtual UniValue GetSeriesTime(const std::string &namep, int count)
     {
         return NullUniValue; // Has no series data
     }
@@ -198,28 +198,28 @@ public:
     {
         Clear(false);
     }
-    CStatHistory(const char *name, unsigned int operation = STAT_OP_SUM)
-        : CStat<DataType, RecordType>(name), op(operation), timer(stat_io_service)
+    CStatHistory(const char *namep, unsigned int operation = STAT_OP_SUM)
+        : CStat<DataType, RecordType>(namep), op(operation), timer(stat_io_service)
     {
         Clear();
     }
 
-    CStatHistory(const std::string &name, unsigned int operation = STAT_OP_SUM)
-        : CStat<DataType, RecordType>(name), op(operation), timer(stat_io_service)
+    CStatHistory(const std::string &namep, unsigned int operation = STAT_OP_SUM)
+        : CStat<DataType, RecordType>(namep), op(operation), timer(stat_io_service)
     {
         Clear();
     }
 
-    void init(const char *name, unsigned int operation = STAT_OP_SUM)
+    void init(const char *namep, unsigned int operation = STAT_OP_SUM)
     {
-        CStat<DataType, RecordType>::init(name);
+        CStat<DataType, RecordType>::init(namep);
         op = operation;
         Clear();
     }
 
-    void init(const std::string &name, unsigned int operation = STAT_OP_SUM)
+    void init(const std::string &namep, unsigned int operation = STAT_OP_SUM)
     {
-        CStat<DataType, RecordType>::init(name);
+        CStat<DataType, RecordType>::init(namep);
         op = operation;
         Clear();
     }
@@ -298,23 +298,23 @@ public:
         }
     }
 
-    int Series(int series, DataType *array, int len)
+    int Series(int series, DataType *array, int lenp)
     {
         assert(series < STATISTICS_NUM_RANGES);
-        if (len > STATISTICS_SAMPLES)
-            len = STATISTICS_SAMPLES;
+        if (lenp > STATISTICS_SAMPLES)
+            lenp = STATISTICS_SAMPLES;
 
         int pos = loc[series] - STATISTICS_SAMPLES;
         if (pos < 0)
             pos += STATISTICS_SAMPLES;
-        for (int i = 0; i < len; i++, pos++) // could be a lot more efficient with 2 memcpy
+        for (int i = 0; i < lenp; i++, pos++) // could be a lot more efficient with 2 memcpy
         {
             if (pos >= STATISTICS_SAMPLES)
                 pos -= STATISTICS_SAMPLES;
             array[i] = history[series][pos];
         }
 
-        return len;
+        return lenp;
     }
 
     virtual UniValue GetTotal()
@@ -325,11 +325,11 @@ public:
         return UniValue(total);
     }
 
-    virtual UniValue GetSeries(const std::string &name, int count)
+    virtual UniValue GetSeries(const std::string &seriesName, int count)
     {
         for (int series = 0; series < STATISTICS_NUM_RANGES; series++)
         {
-            if (name == sampleNames[series])
+            if (seriesName == sampleNames[series])
             {
                 UniValue ret(UniValue::VARR);
                 if (count < 0)
@@ -360,11 +360,11 @@ public:
         return history[series][pos];
     }
 
-    virtual UniValue GetSeriesTime(const std::string &name, int count)
+    virtual UniValue GetSeriesTime(const std::string &seriesName, int count)
     {
         for (int series = 0; series < STATISTICS_NUM_RANGES; series++)
         {
-            if (name == sampleNames[series])
+            if (seriesName == sampleNames[series])
             {
                 UniValue data(UniValue::VARR);
                 UniValue times(UniValue::VARR);

--- a/src/support/pagelocker.cpp
+++ b/src/support/pagelocker.cpp
@@ -30,7 +30,7 @@
 #endif
 
 LockedPageManager* LockedPageManager::_instance = NULL;
-boost::once_flag LockedPageManager::init_flag = BOOST_ONCE_INIT;
+std::once_flag LockedPageManager::init_flag;
 
 /** Determine system page size in bytes */
 static inline size_t GetSystemPageSize()

--- a/src/tweak.h
+++ b/src/tweak.h
@@ -5,11 +5,8 @@
 #ifndef TWEAK_H
 #define TWEAK_H
 
-#include <boost/asio.hpp>
-#include <boost/bind.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
-// c++11 #include <type_traits>
 #include "univalue/include/univalue.h"
+#include <string>
 
 class CTweakBase;
 
@@ -35,21 +32,21 @@ public:
 inline void fill(const UniValue &v, double &output)
 {
     if (v.isStr())
-        output = boost::lexical_cast<double>(v.get_str());
+        output = std::stod(v.get_str());
     else
         output = v.get_real();
 }
 inline void fill(const UniValue &v, float &output)
 {
     if (v.isStr())
-        output = boost::lexical_cast<float>(v.get_str());
+        output = std::stof(v.get_str());
     else
         output = v.get_real();
 }
 inline void fill(const UniValue &v, int &output)
 {
     if (v.isStr())
-        output = boost::lexical_cast<int>(v.get_str());
+        output = std::stoi(v.get_str());
     else
         output = v.get_int();
 }
@@ -57,7 +54,7 @@ inline void fill(const UniValue &v, int &output)
 inline void fill(const UniValue &v, unsigned int &output)
 {
     if (v.isStr())
-        output = boost::lexical_cast<unsigned int>(v.get_str());
+        output = std::stoul(v.get_str());
     else
         output = v.get_int();
 }
@@ -65,7 +62,7 @@ inline void fill(const UniValue &v, unsigned int &output)
 inline void fill(const UniValue &v, uint64_t &output)
 {
     if (v.isStr())
-        output = boost::lexical_cast<uint64_t>(v.get_str());
+        output = std::stoull(v.get_str());
     else
         output = v.get_int64();
 }
@@ -73,7 +70,7 @@ inline void fill(const UniValue &v, uint64_t &output)
 inline void fill(const UniValue &v, int64_t &output)
 {
     if (v.isStr())
-        output = boost::lexical_cast<int64_t>(v.get_str());
+        output = std::stoll(v.get_str());
     else
         output = v.get_int64();
 }

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -2080,7 +2080,6 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
 #endif
 
     LOCK(cs_vNodes);
-    std::vector<CNode *>::iterator n;
     uint64_t totalThinBlockSize = 0;
     int disconnected = 0; // watch # of disconnected nodes to ensure they are being cleaned up
     for (std::vector<CNode *>::iterator it = vNodes.begin(); it != vNodes.end(); ++it)

--- a/src/util.h
+++ b/src/util.h
@@ -17,7 +17,6 @@
 
 #include "allowed_args.h"
 #include "compat.h"
-#include "fs.h"
 #include "tinyformat.h"
 #include "utiltime.h"
 
@@ -357,22 +356,9 @@ void FileCommit(FILE *fileout);
 bool TruncateFile(FILE *file, unsigned int length);
 int RaiseFileDescriptorLimit(int nMinFD);
 void AllocateFileRange(FILE *file, unsigned int offset, unsigned int length);
-bool RenameOver(fs::path src, fs::path dest);
-bool TryCreateDirectories(const fs::path &p);
-fs::path GetDefaultDataDir();
-const fs::path &GetDataDir(bool fNetSpecific = true);
-void ClearDatadirCache();
-fs::path GetConfigFile(const std::string &confPath);
-#ifndef WIN32
-fs::path GetPidFile();
-void CreatePidFile(const fs::path &path, pid_t pid);
-#endif
 void ReadConfigFile(std::map<std::string, std::string> &mapSettingsRet,
     std::map<std::string, std::vector<std::string> > &mapMultiSettingsRet,
     const AllowedArgs::AllowedArgs &allowedArgs);
-#ifdef WIN32
-fs::path GetSpecialFolderPath(int nFolder, bool fCreate = true);
-#endif
 void OpenDebugLog();
 void ShrinkDebugFile();
 void runCommand(const std::string &strCommand);


### PR DESCRIPTION
remove boost where c++11 works, 
move filesystem utilities from util.h into fs.h, 
clean up some shadowed variables

No semantic changes except maybe the boost to c++11 conversion (these libs should have the same semantics in the changed areas)... 