### PR TITLE
Fix uninitialize variable warning in murmur bench

### DIFF
--- a/src/bench/murmur_hash.cpp
+++ b/src/bench/murmur_hash.cpp
@@ -8,7 +8,7 @@
 static void Murmur3(benchmark::State &state)
 {
     std::vector<uint8_t> in(32, 0);
-    unsigned x;
+    unsigned int x = 0;
     while (state.KeepRunning())
     {
         for (int i = 0; i < 1000000; i++)


### PR DESCRIPTION
```
bench/murmur_hash.cpp:15:13: warning: variable 'x' is uninitialized when used here [-Wuninitialized]
            x += MurmurHash3(5 * 0xfba4c795, in);
            ^
bench/murmur_hash.cpp:11:15: note: initialize the variable 'x' to silence this warning
    unsigned x;
              ^
               = 0
```