### PR TITLE
Use C++11 initialization for the network array

### DIFF
--- a/src/qt/paymentserver.cpp
+++ b/src/qt/paymentserver.cpp
@@ -233,7 +233,7 @@ static bool ipcCanParseLegacyURI(const QString &arg, const std::string &network)
 void PaymentServer::ipcParseCommandLine(int argc, char *argv[])
 {
     std::array<const std::string *, 3> networks = {
-        &CBaseChainParams::MAIN, &CBaseChainParams::TESTNET, &CBaseChainParams::REGTEST};
+        {&CBaseChainParams::MAIN, &CBaseChainParams::TESTNET, &CBaseChainParams::REGTEST}};
 
     const std::string *chosenNetwork = nullptr;
 


### PR DESCRIPTION
This way we also fix this clang warning:
```
qt/paymentserver.cpp:236:9: warning: suggest braces around initialization of subobject [-Wmissing-braces]
        &CBaseChainParams::MAIN, &CBaseChainParams::TESTNET, &CBaseChainParams::REGTEST};
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        {                                                                              }
```