### PR TITLE
Make the max default mempool limiter be the same as the default min relay fee

### DIFF
--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -16,7 +16,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         initialize_chain_clean(self.options.tmpdir, 4, bitcoinConfDict, wallets)
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(4, self.options.tmpdir)
+        self.extra_args = [["-minlimitertxfee=1"], ["-minlimitertxfee=1"],["-minlimitertxfee=1"],["-minlimitertxfee=1"]]
+        self.nodes = start_nodes(4, self.options.tmpdir, self.extra_args)
 
         connect_nodes_bi(self.nodes,0,1)
         connect_nodes_bi(self.nodes,1,2)

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -571,13 +571,6 @@ static void addNodeRelayOptions(AllowedArgs &allowedArgs)
             _("The maximum number of nodes this node will forward expedited blocks to"))
         .addArg("maxexpeditedtxrecipients=<n>", requiredInt,
             _("The maximum number of nodes this node will forward expedited transactions to"))
-        .addArg("maxlimitertxfee=<amt>", requiredAmount,
-            strprintf(_("Fees (in satoshi/byte) larger than this are always relayed (default: %s)"),
-                    DEFAULT_MAXLIMITERTXFEE))
-        .addArg("minlimitertxfee=<amt>", requiredAmount,
-            strprintf(_("Fees (in satoshi/byte) smaller than this are considered "
-                        "zero fee and subject to -limitfreerelay (default: %s)"),
-                    DEFAULT_MINLIMITERTXFEE))
         .addArg("minrelaytxfee=<amt>", requiredAmount,
             strprintf(_("Fees (in %s/kB) smaller than this are considered zero fee for relaying, mining and "
                         "transaction creation (default: %s)"),
@@ -684,6 +677,8 @@ static void addTweaks(AllowedArgs &allowedArgs, CTweakMap *pTweaks)
         std::string optName = tweak->GetName();
 
         if (dynamic_cast<CTweak<CAmount> *>(tweak))
+            allowedArgs.addArg(optName + "=<amt>", requiredAmount, tweak->GetHelp());
+        else if (dynamic_cast<CTweak<double> *>(tweak))
             allowedArgs.addArg(optName + "=<amt>", requiredAmount, tweak->GetHelp());
         else if (dynamic_cast<CTweakRef<CAmount> *>(tweak))
             allowedArgs.addArg(optName + "=<amt>", requiredAmount, tweak->GetHelp());

--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -215,8 +215,6 @@ bool AppInit(int argc, char *argv[])
         PrintExceptionContinue(NULL, "AppInit()");
     }
 
-    UnlimitedSetup();
-
     if (!fRet)
     {
         Interrupt(threadGroup);

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -267,6 +267,12 @@ CTweak<uint64_t> checkScriptDays("blockchain.checkScriptDays",
  */
 CTweak<unsigned int> nDustThreshold("net.dustThreshold", "Dust Threshold (in satoshis).", DEFAULT_DUST_THRESHOLD);
 
+/** The maxlimitertxfee (in satoshi's per byte) */
+CTweak<double> dMaxLimiterTxFee("net.maxLimiterTxFee", "The maxlimitertxfee (in satoshi's per byte)", boost::lexical_cast<double>(DEFAULT_MAXLIMITERTXFEE));
+
+/** The minlimitertxfee (in satoshi's per byte) */
+CTweak<double> dMinLimiterTxFee("net.minLimiterTxFee", "The minlimitertxfee (in satoshi's per byte).", boost::lexical_cast<double>(DEFAULT_MINLIMITERTXFEE));
+
 CRequestManager requester; // after the maps nodes and tweaks
 
 CStatHistory<unsigned int> txAdded; //"memPool/txAdded");

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -268,14 +268,16 @@ CTweak<uint64_t> checkScriptDays("blockchain.checkScriptDays",
 CTweak<unsigned int> nDustThreshold("net.dustThreshold", "Dust Threshold (in satoshis).", DEFAULT_DUST_THRESHOLD);
 
 /** The maxlimitertxfee (in satoshi's per byte) */
-CTweak<double> dMaxLimiterTxFee("net.maxLimiterTxFee",
-    "The maxlimitertxfee (in satoshi's per byte)",
-    boost::lexical_cast<double>(DEFAULT_MAXLIMITERTXFEE));
+CTweak<double> dMaxLimiterTxFee("maxlimitertxfee",
+    strprintf("Fees (in satoshi/byte) larger than this are always relayed (default: %.4f)", DEFAULT_MAXLIMITERTXFEE),
+    DEFAULT_MAXLIMITERTXFEE);
 
 /** The minlimitertxfee (in satoshi's per byte) */
-CTweak<double> dMinLimiterTxFee("net.minLimiterTxFee",
-    "The minlimitertxfee (in satoshi's per byte).",
-    boost::lexical_cast<double>(DEFAULT_MINLIMITERTXFEE));
+CTweak<double> dMinLimiterTxFee("minlimitertxfee",
+    strprintf("Fees (in satoshi/byte) smaller than this are considered "
+              "zero fee and subject to -limitfreerelay (default: %.4f)",
+                                    DEFAULT_MINLIMITERTXFEE),
+    DEFAULT_MINLIMITERTXFEE);
 
 CRequestManager requester; // after the maps nodes and tweaks
 

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -268,10 +268,14 @@ CTweak<uint64_t> checkScriptDays("blockchain.checkScriptDays",
 CTweak<unsigned int> nDustThreshold("net.dustThreshold", "Dust Threshold (in satoshis).", DEFAULT_DUST_THRESHOLD);
 
 /** The maxlimitertxfee (in satoshi's per byte) */
-CTweak<double> dMaxLimiterTxFee("net.maxLimiterTxFee", "The maxlimitertxfee (in satoshi's per byte)", boost::lexical_cast<double>(DEFAULT_MAXLIMITERTXFEE));
+CTweak<double> dMaxLimiterTxFee("net.maxLimiterTxFee",
+    "The maxlimitertxfee (in satoshi's per byte)",
+    boost::lexical_cast<double>(DEFAULT_MAXLIMITERTXFEE));
 
 /** The minlimitertxfee (in satoshi's per byte) */
-CTweak<double> dMinLimiterTxFee("net.minLimiterTxFee", "The minlimitertxfee (in satoshi's per byte).", boost::lexical_cast<double>(DEFAULT_MINLIMITERTXFEE));
+CTweak<double> dMinLimiterTxFee("net.minLimiterTxFee",
+    "The minlimitertxfee (in satoshi's per byte).",
+    boost::lexical_cast<double>(DEFAULT_MINLIMITERTXFEE));
 
 CRequestManager requester; // after the maps nodes and tweaks
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -596,6 +596,9 @@ void InitLogging()
 bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &scheduler)
 {
 // ********************************************************* Step 1: setup
+
+UnlimitedSetup();
+
 #ifdef _MSC_VER
     // Turn off Microsoft heap dump noise
     _CrtSetReportMode(_CRT_WARN, _CRTDBG_MODE_FILE);
@@ -758,18 +761,6 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
     // a transaction spammer can cheaply fill blocks using
     // 1-satoshi-fee transactions. It should be set above the real
     // cost to you of processing a transaction.
-    if (mapArgs.count("-minlimitertxfee"))
-    {
-        try
-        {
-            dMinLimiterTxFee.value = boost::lexical_cast<double>(mapArgs["-minlimitertxfee"]);
-        }
-        catch (boost::bad_lexical_cast &)
-        {
-            return InitError(
-                strprintf(_("Invalid amount for -minlimitertxfee=<amount>: '%s'"), mapArgs["-minlimitertxfee"]));
-        }
-    }
     ::minRelayTxFee = CFeeRate(dMinLimiterTxFee.value * 1000);
 
     // -minrelaytxfee is no longer a command line option however it is still used in Bitcon Core so we want to tell

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -752,20 +752,6 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
     if (nConnectTimeout <= 0)
         nConnectTimeout = DEFAULT_CONNECT_TIMEOUT;
 
-    // Set the maxlimitertxfee tweak
-    if (mapArgs.count("-maxlimitertxfee"))
-    {
-        try
-        {
-            dMaxLimiterTxFee.value = boost::lexical_cast<double>(mapArgs["-maxlimitertxfee"]);
-        }
-        catch (boost::bad_lexical_cast &)
-        {
-            return InitError(
-                strprintf(_("Invalid amount for -maxlimitertxfee=<amount>: '%s'"), mapArgs["-maxlimitertxfee"]));
-        }
-    }
-
     // Fee in satoshi per byte amount considered the same as "free"
     // If you are mining, be careful setting this:
     // if you set it to zero then
@@ -774,9 +760,6 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
     // cost to you of processing a transaction.
     if (mapArgs.count("-minlimitertxfee"))
     {
-        CAmount nAmt = 0;
-        double minrelaytxfee = 0;
-
         try
         {
             dMinLimiterTxFee.value = boost::lexical_cast<double>(mapArgs["-minlimitertxfee"]);
@@ -786,19 +769,8 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
             return InitError(
                 strprintf(_("Invalid amount for -minlimitertxfee=<amount>: '%s'"), mapArgs["-minlimitertxfee"]));
         }
-
-        // calculate the starting minrelaytxfee. We get this from the minlimitertxfee tweak
-        minrelaytxfee = dMinLimiterTxFee.value / 100000;
-
-        ostringstream ss;
-        ss << fixed << setprecision(8);
-        ss << minrelaytxfee;
-        if (ParseMoney(ss.str(), nAmt))
-            ::minRelayTxFee = CFeeRate(nAmt);
-        else
-            return InitError(
-                strprintf(_("Invalid amount for -minlimitertxfee=<amount>: '%s'"), mapArgs["-minlimitertxfee"]));
     }
+    ::minRelayTxFee = CFeeRate(dMinLimiterTxFee.value * 1000);
 
     // -minrelaytxfee is no longer a command line option however it is still used in Bitcon Core so we want to tell
     // any users that migrate from Core to BU that this option is not used.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -595,9 +595,9 @@ void InitLogging()
  */
 bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &scheduler)
 {
-// ********************************************************* Step 1: setup
+    // ********************************************************* Step 1: setup
 
-UnlimitedSetup();
+    UnlimitedSetup();
 
 #ifdef _MSC_VER
     // Turn off Microsoft heap dump noise

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -762,7 +762,7 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
         catch (boost::bad_lexical_cast &)
         {
             return InitError(
-                _("ERROR: an incorrect value was specified for -maxlimitertxfee.  Please check value and restart."));
+                strprintf(_("Invalid amount for -maxlimitertxfee=<amount>: '%s'"), mapArgs["-maxlimitertxfee"]));
         }
     }
 
@@ -776,19 +776,18 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
     {
         CAmount nAmt = 0;
         double minrelaytxfee = 0;
+
         try
         {
-            // assign the value to our tweak
             dMinLimiterTxFee.value = boost::lexical_cast<double>(mapArgs["-minlimitertxfee"]);
         }
         catch (boost::bad_lexical_cast &)
         {
             return InitError(
-                _("ERROR: an incorrect value was specified for -minlimitertxfee.  Please check value and restart."));
+                strprintf(_("Invalid amount for -minlimitertxfee=<amount>: '%s'"), mapArgs["-minlimitertxfee"]));
         }
 
-
-        // calculate the starting minrelaytxfee
+        // calculate the starting minrelaytxfee. We get this from the minlimitertxfee tweak
         minrelaytxfee = dMinLimiterTxFee.value / 100000;
 
         ostringstream ss;
@@ -800,6 +799,7 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
             return InitError(
                 strprintf(_("Invalid amount for -minlimitertxfee=<amount>: '%s'"), mapArgs["-minlimitertxfee"]));
     }
+
     // -minrelaytxfee is no longer a command line option however it is still used in Bitcon Core so we want to tell
     // any users that migrate from Core to BU that this option is not used.
     if (mapArgs.count("-minrelaytxfee"))

--- a/src/init.h
+++ b/src/init.h
@@ -7,6 +7,7 @@
 #ifndef BITCOIN_INIT_H
 #define BITCOIN_INIT_H
 
+#include "tweak.h"
 #include <string>
 
 class Config;
@@ -37,6 +38,9 @@ static const bool DEFAULT_REST_ENABLE = false;
 static const bool DEFAULT_DISABLE_SAFEMODE = false;
 static const bool DEFAULT_STOPAFTERBLOCKIMPORT = false;
 static const bool DEFAULT_PV_TESTMODE = false;
+
+extern CTweak<double> dMinLimiterTxFee;
+extern CTweak<double> dMaxLimiterTxFee;
 
 /** Returns licensing information (for -version) */
 std::string LicenseInfo();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -776,8 +776,9 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
          * This mitigates 'penny-flooding' -- sending thousands of free transactions just to
          * be annoying or make others' transactions take longer to confirm. */
         // maximum feeCutoff in satoshi per byte
+        static std::string default_maxlimitertxfee = std::to_string((double)DEFAULT_MAXLIMITERTXFEE / 1000);
         static const double maxFeeCutoff =
-            boost::lexical_cast<double>(GetArg("-maxlimitertxfee", DEFAULT_MAXLIMITERTXFEE));
+            boost::lexical_cast<double>(GetArg("-maxlimitertxfee", default_maxlimitertxfee.c_str()));
         // starting value for feeCutoff in satoshi per byte
         static const double initFeeCutoff =
             boost::lexical_cast<double>(GetArg("-minlimitertxfee", DEFAULT_MINLIMITERTXFEE));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -862,7 +862,6 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
 
                 // Use an exponentially decaying ~10-minute window:
                 dFreeCount *= std::pow(1.0 - 1.0 / 600.0, (double)(nNow - nLastTime));
-                nLastTime = nNow;
 
                 // -limitfreerelay unit is thousand-bytes-per-minute
                 // At default rate it would take over a month to fill 1GB

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -793,6 +793,10 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
         static double _dMinLimiterTxFee = dMinLimiterTxFee.value;
         static double _dMaxLimiterTxFee = dMaxLimiterTxFee.value;
 
+        static CCriticalSection cs_limiter;
+        {
+        LOCK(cs_limiter);
+
         // If the tweak values have changed then use them.
         if (dMinLimiterTxFee.value != _dMinLimiterTxFee)
         {
@@ -873,6 +877,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
             dFreeCount += nSize;
         }
         nLastTime = nNow;
+        }
         // BU - Xtreme Thinblocks Auto Mempool Limiter - end section
 
         // BU: we calculate the recommended fee by looking at what's in the mempool.  This starts at 0 though for an

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -855,8 +855,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool &pool,
             minRelayTxFee = CFeeRate(nMinRelay * 1000);
             LOG(MEMPOOL, "MempoolBytes:%d  LimitFreeRelay:%.5g  nMinRelay:%.4g  FeesSatoshiPerByte:%.4g  TxBytes:%d  "
                          "TxFees:%d\n",
-                poolBytes, nFreeLimit, ((double)::minRelayTxFee.GetFee(nSize)) / nSize, ((double)nFees) / nSize, nSize,
-                nFees);
+                poolBytes, nFreeLimit, nMinRelay, ((double)nFees) / nSize, nSize, nFees);
             if (fLimitFree && nFees < ::minRelayTxFee.GetFee(nSize))
             {
                 static double dFreeCount = 0;

--- a/src/main.h
+++ b/src/main.h
@@ -156,7 +156,7 @@ static const bool DEFAULT_PRINTTOCONSOLE = false;
 /** The default value for -minrelaytxfee */
 static const char DEFAULT_MINLIMITERTXFEE[] = "0.000";
 /** The default value for -maxrelaytxfee */
-static const char DEFAULT_MAXLIMITERTXFEE[] = "3.000";
+static const unsigned int DEFAULT_MAXLIMITERTXFEE = DEFAULT_MIN_RELAY_TX_FEE;
 /** The number of block heights to gradually choke spam transactions over */
 static const unsigned int MAX_BLOCK_SIZE_MULTIPLIER = 3;
 /** The minimum value possible for -limitfreerelay when rate limiting */

--- a/src/main.h
+++ b/src/main.h
@@ -153,10 +153,10 @@ static const bool DEFAULT_DISCOVER = true;
 static const bool DEFAULT_PRINTTOCONSOLE = false;
 
 // BU - Xtreme Thinblocks Auto Mempool Limiter - begin section
-/** The default value for -minrelaytxfee */
-static const char DEFAULT_MINLIMITERTXFEE[] = "0.000";
-/** The default value for -maxrelaytxfee */
-static const unsigned int DEFAULT_MAXLIMITERTXFEE = DEFAULT_MIN_RELAY_TX_FEE;
+/** The default value for -minrelaytxfee in sat/byte */
+static const double DEFAULT_MINLIMITERTXFEE = 0.0;
+/** The default value for -maxrelaytxfee in sat/byte */
+static const double DEFAULT_MAXLIMITERTXFEE = (double)DEFAULT_MIN_RELAY_TX_FEE / 1000;
 /** The number of block heights to gradually choke spam transactions over */
 static const unsigned int MAX_BLOCK_SIZE_MULTIPLIER = 3;
 /** The minimum value possible for -limitfreerelay when rate limiting */

--- a/src/main.h
+++ b/src/main.h
@@ -152,6 +152,17 @@ static const bool DEFAULT_REINDEX = false;
 static const bool DEFAULT_DISCOVER = true;
 static const bool DEFAULT_PRINTTOCONSOLE = false;
 
+// BU - Xtreme Thinblocks Auto Mempool Limiter - begin section
+/** The default value for -minrelaytxfee */
+static const char DEFAULT_MINLIMITERTXFEE[] = "0.000";
+/** The default value for -maxrelaytxfee */
+static const char DEFAULT_MAXLIMITERTXFEE[] = "3.000";
+/** The number of block heights to gradually choke spam transactions over */
+static const unsigned int MAX_BLOCK_SIZE_MULTIPLIER = 3;
+/** The minimum value possible for -limitfreerelay when rate limiting */
+static const unsigned int DEFAULT_MIN_LIMITFREERELAY = 1;
+// BU - Xtreme Thinblocks Auto Mempool Limiter - end section
+
 struct BlockHasher
 {
     size_t operator()(const uint256 &hash) const { return hash.GetCheapHash(); }

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -814,8 +814,6 @@ int main(int argc, char *argv[])
     if (GetBoolArg("-splash", DEFAULT_SPLASHSCREEN) && !GetBoolArg("-min", false))
         app.createSplashScreen(networkStyle.data());
 
-    UnlimitedSetup();
-
     // Get global config
     Config &config = const_cast<Config &>(GetConfig());
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -16,6 +16,7 @@
 #include "sync.h"
 #include "thinblock.h"
 #include "timedata.h"
+#include "tweak.h"
 #include "ui_interface.h"
 #include "unlimited.h"
 #include "util.h"
@@ -25,6 +26,9 @@
 #include <boost/lexical_cast.hpp>
 
 #include <univalue.h>
+
+extern CTweak<double> dMinLimiterTxFee;
+extern CTweak<double> dMaxLimiterTxFee;
 
 using namespace std;
 
@@ -541,6 +545,8 @@ UniValue getnetworkinfo(const UniValue &params, bool fHelp)
     obj.push_back(Pair("connections", (int)vNodes.size()));
     obj.push_back(Pair("networks", GetNetworksInfo()));
     obj.push_back(Pair("relayfee", ValueFromAmount(::minRelayTxFee.GetFeePerK())));
+    obj.push_back(Pair("minlimitertxfee", strprintf("%.4f", dMinLimiterTxFee.value)));
+    obj.push_back(Pair("maxlimitertxfee", strprintf("%.4f", dMaxLimiterTxFee.value)));
     UniValue localAddresses(UniValue::VARR);
     {
         LOCK(cs_mapLocalHost);

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -82,17 +82,6 @@ extern int nMaxOutConnections;
 extern std::vector<std::string> BUComments;
 extern std::string minerComment; // An arbitrary field that miners can change to annotate their blocks
 
-// BU - Xtreme Thinblocks Auto Mempool Limiter - begin section
-/** The default value for -minrelaytxfee */
-static const char DEFAULT_MINLIMITERTXFEE[] = "0.000";
-/** The default value for -maxrelaytxfee */
-static const char DEFAULT_MAXLIMITERTXFEE[] = "3.000";
-/** The number of block heights to gradually choke spam transactions over */
-static const unsigned int MAX_BLOCK_SIZE_MULTIPLIER = 3;
-/** The minimum value possible for -limitfreerelay when rate limiting */
-static const unsigned int DEFAULT_MIN_LIMITFREERELAY = 1;
-// BU - Xtreme Thinblocks Auto Mempool Limiter - end section
-
 // The number of days in the past we check scripts during initial block download
 extern CTweak<uint64_t> checkScriptDays;
 


### PR DESCRIPTION
This will keep us in line , by default, with the rest of the Cash network and will prevent our mempools from getting out of sync, if/when there are large and sudden spikes in txn activity, and help with Graphene as well as 0 conf.  But still an operator can modify these setting if they wish.