### PR TITLE
Fix a clang warning in wallet serialization method

### DIFF
--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -61,7 +61,6 @@ public:
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
         READWRITE(this->nVersion);
-        nVersion = this->nVersion;
         READWRITE(nExternalChainCounter);
         READWRITE(masterKeyID);
     }


### PR DESCRIPTION
The warning was due to a self assignment and this is
how the warning messages looked like:

```
In file included from ../../src/wallet/test/walletdb_tests.cpp:9:
In file included frohttps://travis-ci.org/sickpig/BitcoinUnlimited/jobs/404968549m ../../src/wallet/wallet.h:21:
../../src/wallet/walletdb.h:64:18: warning: assigning field to itself [-Wself-assign-field]
        nVersion = this->nVersion;
                 ^
```