### PR TITLE
[PORT] unit tests: Add operator<< to print uint256s

### DIFF
--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -186,3 +186,9 @@ struct StartupShutdown
 };
 
 BOOST_GLOBAL_FIXTURE(StartupShutdown);
+
+std::ostream &operator<<(std::ostream &os, const uint256 &num)
+{
+    os << num.ToString();
+    return os;
+}

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -116,4 +116,9 @@ struct TestMemPoolEntryHelper
         return *this;
     }
 };
+
+// define an implicit conversion here so that uint256 may be used directly in BOOST_CHECK_*
+std::ostream &operator<<(std::ostream &os, const uint256 &num);
+
+
 #endif


### PR DESCRIPTION
As per the commit message.

@sickpig: Is this using the right attribution? Note that this is not really a port or cherry pick of a whole commit but rather a small part of it.

I think the rest of the original commit does not apply to us due to too much code divergence but maybe @gandrewstone wants to check that as well.