### PR TITLE
unittests: Default enable all logging with --log_bitcoin console

### DIFF
--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -172,6 +172,10 @@ struct StartupShutdown
             std::string s = opts["log_bitcoin"].as<std::string>();
             if (s == "console")
             {
+                /* To enable this, add
+                   -- --log_bitcoin console
+                   to the end of the test_bitcoin argument list. */
+                Logging::LogToggleCategory(Logging::ALL, true);
                 fPrintToConsole = true;
                 fPrintToDebugLog = false;
             }


### PR DESCRIPTION
More fine-grained control seems unnecessary and there seems to be no other way to enable logging in unit test since the new logging framework got implemented.