### PR TITLE
Resurrect old log-all command line functionality

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -161,6 +161,12 @@ void LogInit()
     uint64_t catg = Logging::NONE;
     const vector<string> &categories = mapMultiArgs["-debug"];
 
+    // enable all when given -debug=1 or -debug
+    if (categories.size() == 1 && (categories[0] == "" || categories[0] == "1"))
+    {
+        Logging::LogToggleCategory(Logging::ALL, true);
+        return;
+    }
     for (string const &cat : categories)
     {
         category = boost::algorithm::to_lower_copy(cat);


### PR DESCRIPTION
Note that this behavior is also in the documentation for the -debug option still but wasn't available, likely since the rework of the logging system.