### PR TITLE
Allow to enter logging flags separated by comma

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -512,8 +512,9 @@ static void addDebuggingOptions(AllowedArgs &allowedArgs, HelpMessageMode mode)
                          DEFAULT_DESCENDANT_SIZE_LIMIT))
         .addArg("debug=<category>", optionalStr,
             strprintf(_("Output debugging information (default: %u, supplying <category> is optional)"), 0) + ". " +
-                _("If <category> is not supplied or if <category> = 1, output all debugging information.") +
-                _("<category> can be:") + " " + debugCategories + ".")
+                _("If <category> is not supplied or if <category> = 1, output all debugging information. ") +
+                _("<category> can be:") + " " + debugCategories + ". " +
+                _("Multiple debug categories can be separated by comma."))
         .addArg("gen", optionalBool, strprintf(_("Generate coins (default: %u)"), DEFAULT_GENERATE))
         .addArg("genproclimit=<n>", requiredInt,
             strprintf(_("Set the number of threads for coin generation if enabled (-1 = all cores, default: %d)"),

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -803,4 +803,24 @@ BOOST_AUTO_TEST_CASE(util_wildmatch)
     BOOST_CHECK(!wildmatch("*", std::string("x", 10000)));
 }
 
+BOOST_AUTO_TEST_CASE(splitbycommaandremovespaces)
+{
+    std::vector<std::string> inp1{"one", "two, three  ", "f o u r"};
+
+    const std::vector<std::string> r = splitByCommasAndRemoveSpaces(inp1);
+
+    BOOST_CHECK_EQUAL(r.size(), 4);
+    BOOST_CHECK_EQUAL(r[0], "one");
+    BOOST_CHECK_EQUAL(r[1], "two");
+    BOOST_CHECK_EQUAL(r[2], "three");
+    BOOST_CHECK_EQUAL(r[3], "four");
+
+    const std::vector<std::string> r2 = splitByCommasAndRemoveSpaces(r);
+    BOOST_CHECK_EQUAL(r.size(), 4);
+    BOOST_CHECK_EQUAL(r[0], "one");
+    BOOST_CHECK_EQUAL(r[1], "two");
+    BOOST_CHECK_EQUAL(r[2], "three");
+    BOOST_CHECK_EQUAL(r[3], "four");
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -91,6 +91,26 @@
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
 
+std::vector<std::string> splitByCommasAndRemoveSpaces(const std::vector<std::string> &args)
+{
+    std::vector<std::string> result;
+    for (std::string arg : args)
+    {
+        size_t pos;
+        while ((pos = arg.find(',')) != std::string::npos)
+        {
+            result.push_back(arg.substr(0, pos));
+            arg = arg.substr(pos + 1);
+        }
+        std::string arg_nospace;
+        for (char c : arg)
+            if (c != ' ')
+                arg_nospace += c;
+        result.push_back(arg_nospace);
+    }
+    return result;
+}
+
 // Work around clang compilation problem in Boost 1.46:
 // /usr/include/boost/program_options/detail/config_file.hpp:163:17: error: call to function 'to_internal' that is
 // neither visible in the template definition nor found by argument-dependent lookup
@@ -159,7 +179,7 @@ void LogInit()
 {
     string category = "";
     uint64_t catg = Logging::NONE;
-    const vector<string> &categories = mapMultiArgs["-debug"];
+    const vector<string> categories = splitByCommasAndRemoveSpaces(mapMultiArgs["-debug"]);
 
     // enable all when given -debug=1 or -debug
     if (categories.size() == 1 && (categories[0] == "" || categories[0] == "1"))

--- a/src/util.h
+++ b/src/util.h
@@ -94,6 +94,11 @@ extern const char *const FORKS_CSV_FILENAME; // bip135 added
 /** Send a string to the log output */
 int LogPrintStr(const std::string &str);
 
+// Takes a std::vector of strings and splits individual arguments further up if
+// they contain commas. Also removes space from the output strings.
+// For example, ["a", "b,c", "d"] becomes ["a", "b", "c", "d"]
+extern std::vector<std::string> splitByCommasAndRemoveSpaces(const std::vector<std::string> &args);
+
 // Logging API:
 // Use the two macros
 // LOG(ctgr,...)


### PR DESCRIPTION
This allows to specify multiple logging categories separated by
comma on the command line, like this:

```./bitcoind -debug=net,rpc,req```