### PR TITLE
Fix leak in getblocktemplate

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -157,9 +157,9 @@ CTransactionRef BlockAssembler::coinbaseTx(const CScript &scriptPubKeyIn, int _n
     return MakeTransactionRef(std::move(tx));
 }
 
-CBlockTemplate *BlockAssembler::CreateNewBlock(const CScript &scriptPubKeyIn)
+std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript &scriptPubKeyIn)
 {
-    CBlockTemplate *tmpl = nullptr;
+    std::unique_ptr<CBlockTemplate> tmpl(new CBlockTemplate());
 
     if (nBlockMaxSize > BLOCKSTREAM_CORE_MAX_BLOCK_SIZE)
         tmpl = CreateNewBlock(scriptPubKeyIn, false);
@@ -170,10 +170,11 @@ CBlockTemplate *BlockAssembler::CreateNewBlock(const CScript &scriptPubKeyIn)
         tmpl = CreateNewBlock(scriptPubKeyIn, true);
     }
 
-    return tmpl;
+    return std::move(tmpl);
 }
 
-CBlockTemplate *BlockAssembler::CreateNewBlock(const CScript &scriptPubKeyIn, bool blockstreamCoreCompatible)
+std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript &scriptPubKeyIn,
+    bool blockstreamCoreCompatible)
 {
     resetBlock(scriptPubKeyIn);
 
@@ -252,7 +253,7 @@ CBlockTemplate *BlockAssembler::CreateNewBlock(const CScript &scriptPubKeyIn, bo
         throw std::runtime_error(strprintf("%s: Excessive block generated: %s", __func__, FormatStateMessage(state)));
     }
 
-    return pblocktemplate.release();
+    return std::move(pblocktemplate);
 }
 
 bool BlockAssembler::isStillDependent(CTxMemPool::txiter iter)

--- a/src/miner.h
+++ b/src/miner.h
@@ -65,7 +65,7 @@ private:
 public:
     BlockAssembler(const CChainParams &chainparams);
     /** Construct a new block template with coinbase to scriptPubKeyIn */
-    CBlockTemplate *CreateNewBlock(const CScript &scriptPubKeyIn);
+    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript &scriptPubKeyIn);
 
 private:
     // utility functions
@@ -89,7 +89,7 @@ private:
     /** Bytes to reserve for coinbase and block header */
     uint64_t reserveBlockSize(const CScript &scriptPubKeyIn);
     /** Internal method to construct a new block template */
-    CBlockTemplate *CreateNewBlock(const CScript &scriptPubKeyIn, bool blockstreamCoreCompatible);
+    std::unique_ptr<CBlockTemplate> CreateNewBlock(const CScript &scriptPubKeyIn, bool blockstreamCoreCompatible);
     /** Constructs a coinbase transaction */
     CTransactionRef coinbaseTx(const CScript &scriptPubKeyIn, int nHeight, CAmount nValue);
 };

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -496,7 +496,7 @@ UniValue mkblocktemplate(const UniValue &params, CBlock *pblockOut)
     // Update block
     static CBlockIndex *pindexPrev = NULL;
     static int64_t nStart = 0;
-    static CBlockTemplate *pblocktemplate = NULL;
+    static std::unique_ptr<CBlockTemplate> pblocktemplate(new CBlockTemplate());
     if (pindexPrev != chainActive.Tip() ||
         (mempool.GetTransactionsUpdated() != nTransactionsUpdatedLast && GetTime() - nStart > 5))
     {
@@ -509,12 +509,6 @@ UniValue mkblocktemplate(const UniValue &params, CBlock *pblockOut)
         nStart = GetTime();
 
         // Create new block
-        if (pblocktemplate)
-        {
-            delete pblocktemplate;
-            pblocktemplate = NULL;
-        }
-
         boost::shared_ptr<CReserveScript> coinbaseScript;
         GetMainSignals().ScriptForMining(coinbaseScript);
 

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f"
                                                  "6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f")
                                      << OP_CHECKSIG;
-    CBlockTemplate *pblocktemplate;
+    std::unique_ptr<CBlockTemplate> pblocktemplate(new CBlockTemplate());
     CMutableTransaction tx, tx2;
     CScript script;
     uint256 hash;
@@ -143,11 +143,9 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         BOOST_CHECK(state.IsValid());
         pblock->hashPrevBlock = pblock->GetHash();
     }
-    delete pblocktemplate;
 
     // Just to make sure we can still make simple blocks
     BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
-    delete pblocktemplate;
 
     mempool.clear();
     // block sigops > limit: 1000 CHECKMULTISIG + 1
@@ -185,7 +183,6 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         tx.vin[0].prevout.hash = hash;
     }
     BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
-    delete pblocktemplate;
 
     // Now generate lots of full size blocks and verify that none exceed the maxGeneratedBlock value, the mempool has
     // 65k bytes of tx in it so this code will test both saturated and unsaturated blocks.
@@ -201,7 +198,6 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         BOOST_CHECK(blockSize <= maxGeneratedBlock);
         // printf("%lu %lu <= %lu\n", (long unsigned int) blockSize, (long unsigned int)
         // pblocktemplate->block.GetBlockSize(), (long unsigned int) maxGeneratedBlock);
-        delete pblocktemplate;
     }
 
     BOOST_CHECK(chainActive.Tip()->nHeight == 110);
@@ -225,7 +221,6 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         minRoom = std::min(minRoom, maxGeneratedBlock - blockSize);
         // printf("%lu %lu <= %lu\n", (long unsigned int) blockSize, (long unsigned int)
         // pblocktemplate->block.GetBlockSize(), (long unsigned int) maxGeneratedBlock);
-        delete pblocktemplate;
     }
 
     // Assert we went right up to the limit.  We reserved 4 bytes for height but only use 2 as height is 110.
@@ -254,7 +249,6 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         minRoom = std::min(minRoom, maxGeneratedBlock - blockSize);
         // printf("%lu %lu (miner comment is %d) <= %lu\n", (long unsigned int) blockSize, (long unsigned int)
         // pblocktemplate->block.GetBlockSize(), i%100, (long unsigned int) maxGeneratedBlock);
-        delete pblocktemplate;
     }
 
     // Assert we went right up to the limit.  We reserved 4 bytes for height but only use 2 as height is 110.
@@ -282,7 +276,6 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         tx.vin[0].prevout.hash = hash;
     }
     BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
-    delete pblocktemplate;
     mempool.clear();
 
     // orphan in mempool, template creation fails
@@ -307,7 +300,6 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(400000000LL).Time(GetTime()).SpendsCoinbase(true).FromTx(tx));
     BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
-    delete pblocktemplate;
     mempool.clear();
 
     // coinbase in mempool, template creation fails
@@ -370,7 +362,6 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         chainActive.SetTip(next);
     }
     BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
-    delete pblocktemplate;
 
     // Extend to a 210000-long block chain.
     while (chainActive.Tip()->nHeight < 210000)
@@ -487,7 +478,6 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     // but relative locked txs will if inconsistently added to mempool.
     // For now these will still generate a valid template until BIP68 soft fork
     BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 3);
-    delete pblocktemplate;
     // However if we advance height by 1 and time by 512, all of them should be mined
     for (int i = 0; i < CBlockIndex::nMedianTimeSpan; i++)
         chainActive.Tip()->GetAncestor(chainActive.Tip()->nHeight - i)->nTime += 512; // Trick the MedianTimePast
@@ -496,7 +486,6 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
 
     BOOST_CHECK(pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey));
     BOOST_CHECK_EQUAL(pblocktemplate->block.vtx.size(), 5);
-    delete pblocktemplate;
 
     chainActive.Tip()->nHeight--;
     SetMockTime(0);

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -101,7 +101,8 @@ CBlock TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransa
     const CScript &scriptPubKey)
 {
     const CChainParams &chainparams = Params();
-    CBlockTemplate *pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
+    std::unique_ptr<CBlockTemplate> pblocktemplate(new CBlockTemplate());
+    pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
     CBlock &block = pblocktemplate->block;
 
     // Replace mempool-selected txns with just coinbase plus passed-in txns:
@@ -120,7 +121,6 @@ CBlock TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransa
     ProcessNewBlock(state, chainparams, NULL, &block, true, NULL, false);
 
     CBlock result = block;
-    delete pblocktemplate;
     return result;
 }
 


### PR DESCRIPTION
Return an std::move( std::unique_ptr<CBlockTemplate>) from CreateNewBlock instead of just
a regular pointer to a CBlockTmplate
