### PR TITLE
Remove MSG_XTHINBLOCK from possible GETDATA types allowed

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5726,7 +5726,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         {
             const CInv &inv = vInv[nInv];
             if (!((inv.type == MSG_TX) || (inv.type == MSG_BLOCK) || (inv.type == MSG_FILTERED_BLOCK) ||
-                    (inv.type == MSG_THINBLOCK) || (inv.type == MSG_XTHINBLOCK)))
+                    (inv.type == MSG_THINBLOCK)))
             {
                 dosMan.Misbehaving(pfrom, 20);
                 return error("message inv invalid type = %u", inv.type);


### PR DESCRIPTION
We can not request an Xthin by using a GETDATA. This was once allowed in
the very first version of Xthins when we send the bloom filter separate
from the getdata request. But we no longer need the backward compatibility
which has already been taken out.