### PR TITLE
Reduce the time it take to reach the maximum false positive rate for …

### DIFF
--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -1881,7 +1881,7 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
     static int64_t nStartGrowth = GetTime();
 
     // Tuning knobs for the false positive growth algorithm
-    static uint8_t nHoursToGrow = 72; // number of hours until maximum growth for false positive rate
+    static uint8_t nHoursToGrow = 12; // number of hours until maximum growth for false positive rate
     // use for nMinFalsePositive = 0.0001 and nMaxFalsePositive = 0.01 for
     // static double nGrowthCoefficient = 0.7676;
     // 6 hour growth period


### PR DESCRIPTION
…xthins.

Previously we always had set this to 72 hours because on the Legacy chain
the memory pools are periodically overfull and it can take several days
after startup for the memory pools to get in sync. With Bitcoin Cash
the memory pool is cleared almost every block that is mined, so
reducing the 72 hour ramp in false positive rates,  to 12 seems like good
idea while sill leaving room in the event that we have a sudden
and likely temporary backup in the mempool.