### PR TITLE
Fix the extended excessive.py test

### DIFF
--- a/qa/rpc-tests/excessive.py
+++ b/qa/rpc-tests/excessive.py
@@ -53,10 +53,10 @@ class ExcessiveBlockTest (BitcoinTestFramework):
 
     def setup_network(self, split=False):
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-rpcservertimeout=0"], timewait=60 * 10))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-rpcservertimeout=0"], timewait=60 * 10))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-rpcservertimeout=0"], timewait=60 * 10))
-        self.nodes.append(start_node(3, self.options.tmpdir, ["-rpcservertimeout=0"], timewait=60 * 10))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-usecashaddr=0", "-rpcservertimeout=0"], timewait=60 * 10))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-usecashaddr=0", "-rpcservertimeout=0"], timewait=60 * 10))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-usecashaddr=0", "-rpcservertimeout=0"], timewait=60 * 10))
+        self.nodes.append(start_node(3, self.options.tmpdir, ["-usecashaddr=0", "-rpcservertimeout=0"], timewait=60 * 10))
 
         interconnect_nodes(self.nodes)
         self.is_network_split = False


### PR DESCRIPTION
This test was failing because of the generateTx() function using
the cashaddr addressing in trying to create a large tx. We could
do the painful conversion process here or simply not use cashaddr
for excessive testing...the latter option being chosen here.