### PR TITLE
Display advanced block propagation technology (XThin/Graphene) statistics in the Debug Window UI

### DIFF
--- a/qa/rpc-tests/thinblocks.py
+++ b/qa/rpc-tests/thinblocks.py
@@ -120,7 +120,7 @@ class ThinBlockTest(BitcoinTestFramework):
         gni = self.nodes[0].getnetworkinfo()
         tbs = gni["thinblockstats"]
 
-        assert tbs['summary'] == '0 thin block has saved 0.00B of bandwidth'
+        assert tbs['summary'] == '0 inbound and 0 outbound thin blocks have saved 0.00B of bandwidth'
 
 if __name__ == '__main__':
     ThinBlockTest().main()

--- a/src/graphene.cpp
+++ b/src/graphene.cpp
@@ -914,18 +914,16 @@ std::string CGrapheneBlockData::InBoundPercentToString()
     double nCompressionRate = 0;
     uint64_t nGrapheneSizeTotal = 0;
     uint64_t nOriginalSizeTotal = 0;
-    for (std::map<int64_t, std::pair<uint64_t, uint64_t> >::iterator mi = mapGrapheneBlocksInBound.begin();
-         mi != mapGrapheneBlocksInBound.end(); ++mi)
+    for (const auto &mi : mapGrapheneBlocksInBound)
     {
-        nGrapheneSizeTotal += (*mi).second.first;
-        nOriginalSizeTotal += (*mi).second.second;
+        nGrapheneSizeTotal += mi.second.first;
+        nOriginalSizeTotal += mi.second.second;
     }
     // We count up the outbound CMemPoolInfo sizes. Outbound CMemPoolInfo sizes go with Inbound graphene blocks.
     uint64_t nOutBoundMemPoolInfoSize = 0;
-    for (std::map<int64_t, uint64_t>::iterator mi = mapMemPoolInfoOutBound.begin(); mi != mapMemPoolInfoOutBound.end();
-         ++mi)
+    for (const auto &mi : mapMemPoolInfoOutBound)
     {
-        nOutBoundMemPoolInfoSize += (*mi).second;
+        nOutBoundMemPoolInfoSize += mi.second;
     }
 
     if (nOriginalSizeTotal > 0)
@@ -949,17 +947,15 @@ std::string CGrapheneBlockData::OutBoundPercentToString()
     double nCompressionRate = 0;
     uint64_t nGrapheneSizeTotal = 0;
     uint64_t nOriginalSizeTotal = 0;
-    for (std::map<int64_t, std::pair<uint64_t, uint64_t> >::iterator mi = mapGrapheneBlocksOutBound.begin();
-         mi != mapGrapheneBlocksOutBound.end(); ++mi)
+    for (const auto &mi : mapGrapheneBlocksOutBound)
     {
-        nGrapheneSizeTotal += (*mi).second.first;
-        nOriginalSizeTotal += (*mi).second.second;
+        nGrapheneSizeTotal += mi.second.first;
+        nOriginalSizeTotal += mi.second.second;
     }
     // We count up the inbound CMemPoolInfo sizes. Inbound CMemPoolInfo sizes go with Outbound graphene blocks.
     uint64_t nInBoundMemPoolInfoSize = 0;
-    for (std::map<int64_t, uint64_t>::iterator mi = mapMemPoolInfoInBound.begin(); mi != mapMemPoolInfoInBound.end();
-         ++mi)
-        nInBoundMemPoolInfoSize += (*mi).second;
+    for (const auto &mi : mapMemPoolInfoInBound)
+        nInBoundMemPoolInfoSize += mi.second;
 
     if (nOriginalSizeTotal > 0)
         nCompressionRate = 100 - (100 * (double)(nGrapheneSizeTotal + nInBoundMemPoolInfoSize) / nOriginalSizeTotal);
@@ -1047,12 +1043,11 @@ std::string CGrapheneBlockData::ResponseTimeToString()
     double nPercentile = 0;
     double nTotalResponseTime = 0;
     double nTotalEntries = 0;
-    for (std::map<int64_t, double>::iterator mi = mapGrapheneBlockResponseTime.begin();
-         mi != mapGrapheneBlockResponseTime.end(); ++mi)
+    for (const auto &mi : mapGrapheneBlockResponseTime)
     {
         nTotalEntries += 1;
-        nTotalResponseTime += (*mi).second;
-        vResponseTime.push_back((*mi).second);
+        nTotalResponseTime += mi.second;
+        vResponseTime.push_back(mi.second);
     }
 
     if (nTotalEntries > 0)
@@ -1082,12 +1077,11 @@ std::string CGrapheneBlockData::ValidationTimeToString()
     double nPercentile = 0;
     double nTotalValidationTime = 0;
     double nTotalEntries = 0;
-    for (std::map<int64_t, double>::iterator mi = mapGrapheneBlockValidationTime.begin();
-         mi != mapGrapheneBlockValidationTime.end(); ++mi)
+    for (const auto &mi : mapGrapheneBlockValidationTime)
     {
         nTotalEntries += 1;
-        nTotalValidationTime += (*mi).second;
-        vValidationTime.push_back((*mi).second);
+        nTotalValidationTime += mi.second;
+        vValidationTime.push_back(mi.second);
     }
 
     if (nTotalEntries > 0)
@@ -1116,11 +1110,10 @@ std::string CGrapheneBlockData::ReRequestedTxToString()
     double nReRequestRate = 0;
     uint64_t nTotalReRequests = 0;
     uint64_t nTotalReRequestedTxs = 0;
-    for (std::map<int64_t, int>::iterator mi = mapGrapheneBlocksInBoundReRequestedTx.begin();
-         mi != mapGrapheneBlocksInBoundReRequestedTx.end(); ++mi)
+    for (const auto &mi : mapGrapheneBlocksInBoundReRequestedTx)
     {
         nTotalReRequests += 1;
-        nTotalReRequestedTxs += (*mi).second;
+        nTotalReRequestedTxs += mi.second;
     }
 
     if (mapGrapheneBlocksInBound.size() > 0)

--- a/src/graphene.cpp
+++ b/src/graphene.cpp
@@ -910,6 +910,7 @@ std::string CGrapheneBlockData::InBoundPercentToString()
     LOCK(cs_graphenestats);
 
     expireStats(mapGrapheneBlocksInBound);
+    expireStats(mapMemPoolInfoOutBound);
 
     double nCompressionRate = 0;
     uint64_t nGrapheneSizeTotal = 0;
@@ -943,6 +944,7 @@ std::string CGrapheneBlockData::OutBoundPercentToString()
     LOCK(cs_graphenestats);
 
     expireStats(mapGrapheneBlocksOutBound);
+    expireStats(mapMemPoolInfoInBound);
 
     double nCompressionRate = 0;
     uint64_t nGrapheneSizeTotal = 0;
@@ -1037,6 +1039,8 @@ std::string CGrapheneBlockData::ResponseTimeToString()
 {
     LOCK(cs_graphenestats);
 
+    expireStats(mapGrapheneBlockResponseTime);
+
     std::vector<double> vResponseTime;
 
     double nResponseTimeAverage = 0;
@@ -1070,6 +1074,8 @@ std::string CGrapheneBlockData::ResponseTimeToString()
 std::string CGrapheneBlockData::ValidationTimeToString()
 {
     LOCK(cs_graphenestats);
+
+    expireStats(mapGrapheneBlockValidationTime);
 
     std::vector<double> vValidationTime;
 
@@ -1106,6 +1112,7 @@ std::string CGrapheneBlockData::ReRequestedTxToString()
     LOCK(cs_graphenestats);
 
     expireStats(mapGrapheneBlocksInBoundReRequestedTx);
+    expireStats(mapGrapheneBlocksInBound);
 
     double nReRequestRate = 0;
     uint64_t nTotalReRequests = 0;

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -112,6 +112,12 @@ void ClientModel::updateTimer2()
     Q_EMIT orphanPoolSizeChanged(getOrphanPoolSize());
     Q_EMIT bytesChanged(getTotalBytesRecv(), getTotalBytesSent());
 
+    thindata.FillThinBlockQuickStats(thinStats);
+    Q_EMIT thinBlockPropagationStatsChanged(thinStats);
+
+    graphenedata.FillGrapheneQuickStats(grapheneStats);
+    Q_EMIT grapheneBlockPropagationStatsChanged(grapheneStats);
+
     uiInterface.BannedListChanged();
 }
 

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -6,6 +6,9 @@
 #ifndef BITCOIN_QT_CLIENTMODEL_H
 #define BITCOIN_QT_CLIENTMODEL_H
 
+#include "graphene.h"
+#include "thinblock.h"
+
 #include <QDateTime>
 #include <QObject>
 
@@ -94,6 +97,9 @@ private:
     PeerTableModel *peerTableModel;
     BanTableModel *banTableModel;
 
+    ThinBlockQuickStats thinStats;
+    GrapheneQuickStats grapheneStats;
+
     QTimer *pollTimer1;
     QTimer *pollTimer2;
 
@@ -108,6 +114,8 @@ Q_SIGNALS:
     void alertsChanged(const QString &warnings);
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);
     void transactionsPerSecondChanged(double tansactionsPerSecond); // BU:
+    void thinBlockPropagationStatsChanged(const ThinBlockQuickStats &thin);
+    void grapheneBlockPropagationStatsChanged(const GrapheneQuickStats &graphene);
 
     //! Fired when a message should be reported to the user
     void message(const QString &title, const QString &message, unsigned int style);

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>740</width>
-    <height>430</height>
+    <height>648</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,23 +23,7 @@
       <attribute name="title">
        <string>&amp;Information</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0">
-       <property name="horizontalSpacing">
-        <number>12</number>
-       </property>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_9">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>General</string>
-         </property>
-        </widget>
-       </item>
+      <layout class="QGridLayout" name="gridLayout" columnstretch="0,3,0">
        <item row="1" column="0">
         <widget class="QLabel" name="label_5">
          <property name="text">
@@ -47,42 +31,10 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1" colspan="2">
-        <widget class="QLabel" name="clientName">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
        <item row="2" column="0">
         <widget class="QLabel" name="label_6">
          <property name="text">
           <string>Client version</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1" colspan="2">
-        <widget class="QLabel" name="clientVersion">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -96,22 +48,6 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="1" colspan="2">
-        <widget class="QLabel" name="clientUserAgent">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
        <item row="4" column="0">
         <widget class="QLabel" name="label_berkeleyDBVersion">
          <property name="text">
@@ -122,45 +58,10 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1" colspan="2">
-        <widget class="QLabel" name="berkeleyDBVersion">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
        <item row="5" column="0">
         <widget class="QLabel" name="label_12">
          <property name="text">
           <string>Datadir</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1" colspan="2">
-        <widget class="QLabel" name="dataDir">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -171,55 +72,10 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="1" colspan="2">
-        <widget class="QLabel" name="startupTime">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-           <widget class="QLabel" name="labelNetwork">
-               <property name="font">
-                   <font>
-                       <weight>75</weight>
-                       <bold>true</bold>
-                   </font>
-               </property>
-               <property name="text">
-                   <string>Network</string>
-               </property>
-           </widget>
-       </item>
        <item row="8" column="0">
         <widget class="QLabel" name="label_8">
          <property name="text">
           <string>Name</string>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="1" colspan="2">
-        <widget class="QLabel" name="networkName">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -230,55 +86,10 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="1" colspan="2">
-        <widget class="QLabel" name="numberOfConnections">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="0">
-        <widget class="QLabel" name="label_10">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Block chain</string>
-         </property>
-        </widget>
-       </item>
        <item row="11" column="0">
         <widget class="QLabel" name="label_3">
          <property name="text">
           <string>Current number of blocks</string>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="1" colspan="2">
-        <widget class="QLabel" name="numberOfBlocks">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -289,55 +100,10 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="1" colspan="2">
-        <widget class="QLabel" name="lastBlockTime">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
-       <item row="13" column="0">
-        <widget class="QLabel" name="labelMempoolTitle">
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Memory Pool</string>
-         </property>
-        </widget>
-       </item>
        <item row="14" column="0">
         <widget class="QLabel" name="labelNumberOfTransactions">
          <property name="text">
           <string>Current number of transactions</string>
-         </property>
-        </widget>
-       </item>
-       <item row="14" column="1">
-        <widget class="QLabel" name="mempoolNumberTxs">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -348,42 +114,10 @@
          </property>
         </widget>
        </item>
-       <item row="15" column="1">
-        <widget class="QLabel" name="orphanPoolNumberTxs">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-         </property>
-        </widget>
-       </item>
        <item row="16" column="0">
         <widget class="QLabel" name="labelMemoryUsage">
          <property name="text">
           <string>Memory usage</string>
-         </property>
-        </widget>
-       </item>
-       <item row="16" column="1">
-        <widget class="QLabel" name="mempoolSize">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
-         <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
         </widget>
        </item>
@@ -394,24 +128,35 @@
          </property>
         </widget>
        </item>
-       <item row="17" column="1">
-        <widget class="QLabel" name="transactionsPerSecond">
-         <property name="cursor">
-          <cursorShape>IBeamCursor</cursorShape>
-         </property>
+       <item row="19" column="0">
+        <widget class="QLabel" name="labelXThinTotals">
          <property name="text">
-          <string>N/A</string>
-         </property>
-         <property name="textFormat">
-          <enum>Qt::PlainText</enum>
-         </property>
-         <property name="textInteractionFlags">
-          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+          <string>XThin (Totals)</string>
          </property>
         </widget>
        </item>
-
-       <item row="18" column="2" rowspan="3">
+       <item row="20" column="0">
+        <widget class="QLabel" name="labelXThin24hAverages">
+         <property name="text">
+          <string>XThin (24-Hour Averages)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="21" column="0">
+        <widget class="QLabel" name="labelGrapheneTotals">
+         <property name="text">
+          <string>Graphene (Totals)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="0">
+        <widget class="QLabel" name="labelGraphene24hAverages">
+         <property name="text">
+          <string>Graphene (24-Hour Averages)</string>
+         </property>
+        </widget>
+       </item>
+       <item row="23" column="2">
         <layout class="QVBoxLayout" name="verticalLayoutDebugButton">
          <property name="spacing">
           <number>3</number>
@@ -451,7 +196,7 @@
          </item>
         </layout>
        </item>
-       <item row="19" column="0">
+       <item row="23" column="0" colspan="2">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -463,6 +208,362 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="22" column="1" colspan="2">
+        <widget class="QLabel" name="blocksGraphene24hAverages">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="21" column="1" colspan="2">
+        <widget class="QLabel" name="blocksGrapheneTotals">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="20" column="1" colspan="2">
+        <widget class="QLabel" name="blocksXThin24hAverages">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="19" column="1" colspan="2">
+        <widget class="QLabel" name="blocksXThinTotals">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="18" column="0" colspan="3">
+        <widget class="QLabel" name="labelStatsTitle">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Block Propagation</string>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="1" colspan="2">
+        <widget class="QLabel" name="transactionsPerSecond">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="16" column="1" colspan="2">
+        <widget class="QLabel" name="mempoolSize">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="1" colspan="2">
+        <widget class="QLabel" name="orphanPoolNumberTxs">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="1" colspan="2">
+        <widget class="QLabel" name="mempoolNumberTxs">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="0" colspan="3">
+        <widget class="QLabel" name="labelMempoolTitle">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Memory Pool</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="1" colspan="2">
+        <widget class="QLabel" name="lastBlockTime">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1" colspan="2">
+        <widget class="QLabel" name="numberOfBlocks">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0" colspan="3">
+        <widget class="QLabel" name="label_10">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Block chain</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1" colspan="2">
+        <widget class="QLabel" name="numberOfConnections">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="1" colspan="2">
+        <widget class="QLabel" name="networkName">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0" colspan="3">
+        <widget class="QLabel" name="labelNetwork">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Network</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1" colspan="2">
+        <widget class="QLabel" name="startupTime">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1" colspan="2">
+        <widget class="QLabel" name="dataDir">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1" colspan="2">
+        <widget class="QLabel" name="berkeleyDBVersion">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1" colspan="2">
+        <widget class="QLabel" name="clientUserAgent">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1" colspan="2">
+        <widget class="QLabel" name="clientVersion">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1" colspan="2">
+        <widget class="QLabel" name="clientName">
+         <property name="cursor">
+          <cursorShape>IBeamCursor</cursorShape>
+         </property>
+         <property name="text">
+          <string>N/A</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::PlainText</enum>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="3">
+        <widget class="QLabel" name="label_9">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>General</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -503,11 +604,11 @@
              <height>24</height>
             </size>
            </property>
-           <property name="text">
-            <string/>
-           </property>
            <property name="toolTip">
             <string>Decrease font size</string>
+           </property>
+           <property name="text">
+            <string/>
            </property>
            <property name="icon">
             <iconset resource="../bitcoin.qrc">

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -9,7 +9,9 @@
 #include "guiutil.h"
 #include "peertablemodel.h"
 
+#include "graphene.h"
 #include "net.h"
+#include "thinblock.h"
 
 #include <QCompleter>
 #include <QWidget>
@@ -98,6 +100,10 @@ public Q_SLOTS:
     void setOrphanPoolSize(long numberOfTxs);
     /** Set tx's per second in the UI */
     void setTransactionsPerSecond(double nTxPerSec);
+    /** Set block propagation statistics in the UI */
+    void setThinBlockPropagationStats(const ThinBlockQuickStats &thin);
+    /** Set block propagation statistics in the UI */
+    void setGrapheneBlockPropagationStats(const GrapheneQuickStats &graphene);
     /** Go forward or back in history */
     void browseHistory(int offset);
     /** Scroll console view to end */

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -1087,18 +1087,16 @@ std::string CThinBlockData::InBoundPercentToString()
     double nCompressionRate = 0;
     uint64_t nThinSizeTotal = 0;
     uint64_t nOriginalSizeTotal = 0;
-    for (std::map<int64_t, std::pair<uint64_t, uint64_t> >::iterator mi = mapThinBlocksInBound.begin();
-         mi != mapThinBlocksInBound.end(); ++mi)
+    for (const auto &mi : mapThinBlocksInBound)
     {
-        nThinSizeTotal += (*mi).second.first;
-        nOriginalSizeTotal += (*mi).second.second;
+        nThinSizeTotal += mi.second.first;
+        nOriginalSizeTotal += mi.second.second;
     }
     // We count up the outbound bloom filters. Outbound bloom filters go with Inbound xthins.
     uint64_t nOutBoundBloomFilterSize = 0;
-    for (std::map<int64_t, uint64_t>::iterator mi = mapBloomFiltersOutBound.begin();
-         mi != mapBloomFiltersOutBound.end(); ++mi)
+    for (const auto &mi : mapBloomFiltersOutBound)
     {
-        nOutBoundBloomFilterSize += (*mi).second;
+        nOutBoundBloomFilterSize += mi.second;
     }
 
 
@@ -1122,18 +1120,16 @@ std::string CThinBlockData::OutBoundPercentToString()
     double nCompressionRate = 0;
     uint64_t nThinSizeTotal = 0;
     uint64_t nOriginalSizeTotal = 0;
-    for (std::map<int64_t, std::pair<uint64_t, uint64_t> >::iterator mi = mapThinBlocksOutBound.begin();
-         mi != mapThinBlocksOutBound.end(); ++mi)
+    for (const auto &mi : mapThinBlocksOutBound)
     {
-        nThinSizeTotal += (*mi).second.first;
-        nOriginalSizeTotal += (*mi).second.second;
+        nThinSizeTotal += mi.second.first;
+        nOriginalSizeTotal += mi.second.second;
     }
     // We count up the inbound bloom filters. Inbound bloom filters go with Outbound xthins.
     uint64_t nInBoundBloomFilterSize = 0;
-    for (std::map<int64_t, uint64_t>::iterator mi = mapBloomFiltersInBound.begin(); mi != mapBloomFiltersInBound.end();
-         ++mi)
+    for (const auto &mi : mapBloomFiltersInBound)
     {
-        nInBoundBloomFilterSize += (*mi).second;
+        nInBoundBloomFilterSize += mi.second;
     }
 
     if (nOriginalSizeTotal > 0)
@@ -1176,12 +1172,11 @@ std::string CThinBlockData::ResponseTimeToString()
     double nPercentile = 0;
     double nTotalResponseTime = 0;
     double nTotalEntries = 0;
-    for (std::map<int64_t, double>::iterator mi = mapThinBlockResponseTime.begin();
-         mi != mapThinBlockResponseTime.end(); ++mi)
+    for (const auto &mi : mapThinBlockResponseTime)
     {
         nTotalEntries += 1;
-        nTotalResponseTime += (*mi).second;
-        vResponseTime.push_back((*mi).second);
+        nTotalResponseTime += mi.second;
+        vResponseTime.push_back(mi.second);
     }
 
     if (nTotalEntries > 0)
@@ -1211,12 +1206,11 @@ std::string CThinBlockData::ValidationTimeToString()
     double nPercentile = 0;
     double nTotalValidationTime = 0;
     double nTotalEntries = 0;
-    for (std::map<int64_t, double>::iterator mi = mapThinBlockValidationTime.begin();
-         mi != mapThinBlockValidationTime.end(); ++mi)
+    for (const auto &mi : mapThinBlockValidationTime)
     {
         nTotalEntries += 1;
-        nTotalValidationTime += (*mi).second;
-        vValidationTime.push_back((*mi).second);
+        nTotalValidationTime += mi.second;
+        vValidationTime.push_back(mi.second);
     }
 
     if (nTotalEntries > 0)
@@ -1245,11 +1239,10 @@ std::string CThinBlockData::ReRequestedTxToString()
     double nReRequestRate = 0;
     uint64_t nTotalReRequests = 0;
     uint64_t nTotalReRequestedTxs = 0;
-    for (std::map<int64_t, int>::iterator mi = mapThinBlocksInBoundReRequestedTx.begin();
-         mi != mapThinBlocksInBoundReRequestedTx.end(); ++mi)
+    for (const auto &mi : mapThinBlocksInBoundReRequestedTx)
     {
         nTotalReRequests += 1;
-        nTotalReRequestedTxs += (*mi).second;
+        nTotalReRequestedTxs += mi.second;
     }
 
     if (mapThinBlocksInBound.size() > 0)

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -1083,6 +1083,7 @@ std::string CThinBlockData::InBoundPercentToString()
     LOCK(cs_thinblockstats);
 
     expireStats(mapThinBlocksInBound);
+    expireStats(mapBloomFiltersOutBound);
 
     double nCompressionRate = 0;
     uint64_t nThinSizeTotal = 0;
@@ -1116,6 +1117,7 @@ std::string CThinBlockData::OutBoundPercentToString()
     LOCK(cs_thinblockstats);
 
     expireStats(mapThinBlocksOutBound);
+    expireStats(mapBloomFiltersInBound);
 
     double nCompressionRate = 0;
     uint64_t nThinSizeTotal = 0;
@@ -1166,6 +1168,8 @@ std::string CThinBlockData::ResponseTimeToString()
 {
     LOCK(cs_thinblockstats);
 
+    expireStats(mapThinBlockResponseTime);
+
     std::vector<double> vResponseTime;
 
     double nResponseTimeAverage = 0;
@@ -1199,6 +1203,8 @@ std::string CThinBlockData::ResponseTimeToString()
 std::string CThinBlockData::ValidationTimeToString()
 {
     LOCK(cs_thinblockstats);
+
+    expireStats(mapThinBlockValidationTime);
 
     std::vector<double> vValidationTime;
 
@@ -1235,6 +1241,7 @@ std::string CThinBlockData::ReRequestedTxToString()
     LOCK(cs_thinblockstats);
 
     expireStats(mapThinBlocksInBoundReRequestedTx);
+    expireStats(mapThinBlocksInBound);
 
     double nReRequestRate = 0;
     uint64_t nTotalReRequests = 0;

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -990,7 +990,7 @@ void CThinBlockData::UpdateInBound(uint64_t nThinBlockSize, uint64_t nOriginalBl
     // Update InBound thinblock tracking information
     nOriginalSize += nOriginalBlockSize;
     nThinSize += nThinBlockSize;
-    nBlocks += 1;
+    nInBoundBlocks += 1;
     updateStats(mapThinBlocksInBound, std::pair<uint64_t, uint64_t>(nThinBlockSize, nOriginalBlockSize));
 }
 
@@ -999,7 +999,7 @@ void CThinBlockData::UpdateOutBound(uint64_t nThinBlockSize, uint64_t nOriginalB
     LOCK(cs_thinblockstats);
     nOriginalSize += nOriginalBlockSize;
     nThinSize += nThinBlockSize;
-    nBlocks += 1;
+    nOutBoundBlocks += 1;
     updateStats(mapThinBlocksOutBound, std::pair<uint64_t, uint64_t>(nThinBlockSize, nOriginalBlockSize));
 }
 
@@ -1072,8 +1072,8 @@ std::string CThinBlockData::ToString()
     LOCK(cs_thinblockstats);
     double size = double(nOriginalSize() - nThinSize() - nTotalBloomFilterBytes());
     std::ostringstream ss;
-    ss << nBlocks() << " thin " << ((nBlocks() > 1) ? "blocks have" : "block has") << " saved " << formatInfoUnit(size)
-       << " of bandwidth";
+    ss << nInBoundBlocks() << " inbound and " << nOutBoundBlocks() << " outbound thin blocks have saved "
+       << formatInfoUnit(size) << " of bandwidth";
     return ss.str();
 }
 
@@ -1376,7 +1376,8 @@ void CThinBlockData::ClearThinBlockStats()
 
     nOriginalSize.Clear();
     nThinSize.Clear();
-    nBlocks.Clear();
+    nInBoundBlocks.Clear();
+    nOutBoundBlocks.Clear();
     nMempoolLimiterBytesSaved.Clear();
     nTotalBloomFilterBytes.Clear();
     nTotalThinBlockBytes.Clear();

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -151,6 +151,24 @@ public:
     }
 };
 
+// This struct is so we can obtain a quick summar of stats for UI display purposes
+// without needing to take the lock more than once
+struct ThinBlockQuickStats
+{
+    // Totals for the lifetime of the node (or since last clear of stats)
+    uint64_t nTotalInbound;
+    uint64_t nTotalOutbound;
+    uint64_t nTotalBandwidthSavings;
+
+    // Last 24-hour averages (or since last clear of stats)
+    uint64_t nLast24hInbound;
+    double fLast24hInboundCompression;
+    uint64_t nLast24hOutbound;
+    double fLast24hOutboundCompression;
+    uint64_t nLast24hRerequestTx;
+    double fLast24hRerequestTxPercent;
+};
+
 // This class stores statistics for thin block derived protocols.
 class CThinBlockData
 {
@@ -201,6 +219,33 @@ private:
       Expires values before calculation. */
     double average(std::map<int64_t, uint64_t> &map);
 
+    /**
+      Calculate total bandwidth savings for using XThin.
+      Requires lock on cs_thinblockstats be held external to this call. */
+    double computeTotalBandwidthSavingsInternal() EXCLUSIVE_LOCKS_REQUIRED(cs_thinblockstats);
+
+    /**
+      Calculate last 24-hour "compression" percent for XThin
+      Requires lock on cs_thinblockstats be held external to this call.
+
+      NOTE: The thinblock and bloom filter maps should be from opposite directions
+            For example inbound block map paired wtih outbound bloom filter map
+
+      Side-effect: This method calls expireStats() on mapThinBlocks and mapBloomFilters
+
+      @param [mapThinBlocks] a statistics array of inbound/outbound XThin blocks
+      @param [mapBloomFilters] a statistics array of outbound/inbound XThin bloom filters
+     */
+    double compute24hAverageCompressionInternal(std::map<int64_t, std::pair<uint64_t, uint64_t> > &mapThinBlocks,
+        std::map<int64_t, uint64_t> &mapBloomFilters) EXCLUSIVE_LOCKS_REQUIRED(cs_thinblockstats);
+
+    /**
+      Calculate last 24-hour transaction re-request percent for inbound XThin
+      Requires lock on cs_thinblockstats be held external to this call.
+
+      Side-effect: This method calls expireStats() on mapThinBlocksInBoundReRequestedTx */
+    double compute24hInboundRerequestTxPercentInternal() EXCLUSIVE_LOCKS_REQUIRED(cs_thinblockstats);
+
 protected:
     //! Virtual method so it can be overridden for better unit testing
     virtual int64_t getTimeForStats() { return GetTimeMillis(); }
@@ -238,6 +283,8 @@ public:
     void DeleteThinBlockBytes(uint64_t, CNode *pfrom);
     void ResetThinBlockBytes();
     uint64_t GetThinBlockBytes();
+
+    void FillThinBlockQuickStats(ThinBlockQuickStats &stats);
 };
 extern CThinBlockData thindata; // Singleton class
 

--- a/src/thinblock.h
+++ b/src/thinblock.h
@@ -165,7 +165,8 @@ private:
 
     CStatHistory<uint64_t> nOriginalSize;
     CStatHistory<uint64_t> nThinSize;
-    CStatHistory<uint64_t> nBlocks;
+    CStatHistory<uint64_t> nInBoundBlocks;
+    CStatHistory<uint64_t> nOutBoundBlocks;
     CStatHistory<uint64_t> nMempoolLimiterBytesSaved;
     CStatHistory<uint64_t> nTotalBloomFilterBytes;
     CStatHistory<uint64_t> nTotalThinBlockBytes;


### PR DESCRIPTION
Now that graphene is merged into `dev`, I wanted a quick way to monitor which block propagation technologies are being actively used directly in the QT UI.  This is just displaying the number of blocks sent/received by XThin/Graphene. Does not currently include any of the other more detailed information available via `getnetworkinfo`.  Stats are automatically updated in the UI using one of the pre-existing timers for the debug window.