### PR TITLE
Fix vulnerability in deserialized CIblt objects

### DIFF
--- a/src/iblt.cpp
+++ b/src/iblt.cpp
@@ -30,6 +30,9 @@ SOFTWARE.
 #include <utility>
 
 static const size_t N_HASHCHECK = 11;
+// It's extremely unlikely that an IBLT will decode with fewer
+// than 1 cell for every 10 items.
+static const float MIN_OVERHEAD = 0.1;
 
 // mask that can be reduced to reduce the number of checksum bits in the IBLT
 // -- ANY VALUE OTHER THAN 0xffffffff IS FOR TESTING ONLY! --
@@ -230,6 +233,7 @@ bool CIblt::listEntries(std::set<std::pair<uint64_t, std::vector<uint8_t> > > &p
     CIblt peeled = *this;
 
     size_t nErased = 0;
+    size_t nTotalErased = 0;
     do
     {
         nErased = 0;
@@ -252,7 +256,8 @@ bool CIblt::listEntries(std::set<std::pair<uint64_t, std::vector<uint8_t> > > &p
                 ++nErased;
             }
         }
-    } while (nErased > 0);
+        nTotalErased += nErased;
+    } while (nErased > 0 && nTotalErased < peeled.hashTable.size() / MIN_OVERHEAD);
 
     if (!n_hash)
         return false;


### PR DESCRIPTION
While working on a new IBLT feature, I realized that there exists a CIblt vulnerability in the context of the graphene protocol.

Description of attack:
Suppose a malicious sender delivers an IBLT where only half the hash functions are used when adding a certain item. If there are nominally 6 hash functions total, but the sender only uses 3 for item X, then X will hash to just 3 cells instead of 6. Label these cells A and the ones that did not get hashed to B. Now imagine that the receiver has all items, which she adds to her local IBLT, and then creates the differential IBLT D.  D will contain only item X, which will appear in cells from set B. The count in those cells will be -1. So she will attempt to peel X using all 6 hash functions. This will remove X from B, raising the count to 0, but is will also add X to cells in set A, raising the count there to 1. It will, therefore, appear that there exists another item in A that must be removed, and this process will continue indefinitely.

Note that it seems possible to maintain a set of keys that have been peeled from the IBLT and avoid peeling the same key twice. However, it is not immediately clear to me that only ever peeling an item once is always correct; indeed some unit tests failed when I tried this approach. So I have instead elected to simply exit the loop anytime more entries have been peeled than we could reasonably hope to decode under normal circumstances.