### PR TITLE
Refactor script interpreter as a virtual machine encapsulated by a class

### DIFF
--- a/qa/rpc-tests/test_framework/cashlib/__init__.py
+++ b/qa/rpc-tests/test_framework/cashlib/__init__.py
@@ -2,4 +2,4 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-from test_framework.cashlib.cashlib import init, bin2hex, signTxInput, randombytes, pubkey, spendscript, addrbin, txid, SIGHASH_ALL, SIGHASH_NONE, SIGHASH_SINGLE, SIGHASH_FORKID, SIGHASH_ANYONECANPAY
+from test_framework.cashlib.cashlib import init, bin2hex, signTxInput, randombytes, pubkey, spendscript, addrbin, txid, SIGHASH_ALL, SIGHASH_NONE, SIGHASH_SINGLE, SIGHASH_FORKID, SIGHASH_ANYONECANPAY, ScriptMachine, Error

--- a/qa/rpc-tests/test_framework/cashlib/cashlib.py
+++ b/qa/rpc-tests/test_framework/cashlib/cashlib.py
@@ -13,6 +13,8 @@ SIGHASH_SINGLE = 3
 SIGHASH_FORKID = 0x40
 SIGHASH_ANYONECANPAY = 0x80
 
+MAX_STACK_ITEM_LENGTH = 520
+
 BCH = 100000000
 
 cashlib = None
@@ -159,6 +161,178 @@ def spendscript(*data):
         else:  # bigger values won't fit on the stack anyway
             assert 0, "cannot push %d bytes" % l
     return b"".join(ret)
+
+class ScriptMachine:
+    STACK = 0
+    ALTSTACK = 1
+
+    SCRIPT_VERIFY_P2SH = 1
+    SCRIPT_VERIFY_STRICTENC = 1 << 1
+    SCRIPT_VERIFY_DERSIG = 1 << 2
+    SCRIPT_VERIFY_LOW_S = 1 << 3
+    SCRIPT_VERIFY_NULLDUMMY = (1 << 4)
+    SCRIPT_VERIFY_SIGPUSHONLY = (1 << 5)
+    SCRIPT_VERIFY_MINIMALDATA = (1 << 6)
+    SCRIPT_VERIFY_DISCOURAGE_UPGRADABLE_NOPS = (1 << 7)
+    SCRIPT_VERIFY_CLEANSTACK = (1 << 8)
+    SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY = (1 << 9)
+    SCRIPT_VERIFY_CHECKSEQUENCEVERIFY = (1 << 10)
+    SCRIPT_VERIFY_NULLFAIL = (1 << 14)
+    SCRIPT_ENABLE_SIGHASH_FORKID = (1 << 16)
+    SCRIPT_ENABLE_REPLAY_PROTECTION = (1 << 17)
+    SCRIPT_ENABLE_MAY152018_OPCODES = (1 << 18)
+
+    SCRIPT_ERR_OK = 0 
+    SCRIPT_ERR_UNKNOWN_ERROR = 1
+    SCRIPT_ERR_EVAL_FALSE = 2
+    SCRIPT_ERR_OP_RETURN = 3
+    SCRIPT_ERR_SCRIPT_SIZE =4 
+    SCRIPT_ERR_PUSH_SIZE = 5
+    SCRIPT_ERR_OP_COUNT = 6
+    SCRIPT_ERR_STACK_SIZE =7 
+    SCRIPT_ERR_SIG_COUNT = 8
+    SCRIPT_ERR_PUBKEY_COUNT = 9
+    SCRIPT_ERR_INVALID_OPERAND_SIZE = 10
+    SCRIPT_ERR_INVALID_NUMBER_RANGE = 11
+    SCRIPT_ERR_IMPOSSIBLE_ENCODING = 12
+    SCRIPT_ERR_INVALID_SPLIT_RANGE = 13
+    SCRIPT_ERR_VERIFY = 14
+    SCRIPT_ERR_EQUALVERIFY = 15
+    SCRIPT_ERR_CHECKMULTISIGVERIFY = 16
+    SCRIPT_ERR_CHECKSIGVERIFY = 17
+    SCRIPT_ERR_NUMEQUALVERIFY = 18
+    SCRIPT_ERR_BAD_OPCODE = 19
+    SCRIPT_ERR_DISABLED_OPCODE = 20
+    SCRIPT_ERR_INVALID_STACK_OPERATION = 21
+    SCRIPT_ERR_INVALID_ALTSTACK_OPERATION = 22
+    SCRIPT_ERR_UNBALANCED_CONDITIONAL = 23
+    SCRIPT_ERR_DIV_BY_ZERO = 24
+    SCRIPT_ERR_MOD_BY_ZERO = 25
+    SCRIPT_ERR_NEGATIVE_LOCKTIME = 26
+    SCRIPT_ERR_UNSATISFIED_LOCKTIME = 27
+    SCRIPT_ERR_SIG_HASHTYPE = 28
+    SCRIPT_ERR_SIG_DER = 29
+    SCRIPT_ERR_MINIMALDATA = 30
+    SCRIPT_ERR_SIG_PUSHONLY = 31
+    SCRIPT_ERR_SIG_HIGH_S = 32
+    SCRIPT_ERR_SIG_NULLDUMMY = 33
+    SCRIPT_ERR_PUBKEYTYPE = 34
+    SCRIPT_ERR_CLEANSTACK = 35
+    SCRIPT_ERR_SIG_NULLFAIL = 36
+    SCRIPT_ERR_DISCOURAGE_UPGRADABLE_NOPS = 37
+    
+    def __init__(self, flags=-1, nocreate=False, tx=None, inputIdx=None, inputAmount=None):
+        self.flags = flags
+        if self.flags == -1:
+            self.flags = self.SCRIPT_VERIFY_P2SH | self.SCRIPT_VERIFY_STRICTENC | self.SCRIPT_ENABLE_SIGHASH_FORKID | self.SCRIPT_VERIFY_LOW_S | self.SCRIPT_VERIFY_NULLFAIL | self.SCRIPT_ENABLE_MAY152018_OPCODES | self.SCRIPT_VERIFY_CHECKSEQUENCEVERIFY | self.SCRIPT_VERIFY_CHECKLOCKTIMEVERIFY | self.SCRIPT_VERIFY_DERSIG
+        result = create_string_buffer(100)
+        if nocreate:
+            self.smId = None
+        else:
+            if tx is None:
+                self.smId = cashlib.CreateNoContextScriptMachine(self.flags)
+            else:
+                # If string (assumes hex) or object convert to binary serialization
+                if type(tx) == str:
+                    txbin = unhexlify(txbin)
+                elif type(tx) != bytes:
+                    txbin = tx.serialize()
+                else:
+                    txbin = tx
+                self.smId = cashlib.CreateScriptMachine(self.flags, inputIdx, c_longlong(inputAmount), txbin, len(txbin))
+        self.curPos = 0
+        self.script = None
+
+    def __del__(self):
+        if self.smId: self.cleanup()
+
+    def clone(self):
+        sm = ScriptMachine(self.flags, nocreate=True)
+        sm.smId = cashlib.SmClone(self.smId)
+        sm.curPos = self.curPos
+        sm.script = self.script
+        return sm
+
+    def cleanup(self):
+        """Call to explicitly free the resources used by this script machine"""
+        if self.smId:
+            cashlib.SmRelease(self.smId)
+            self.smId = 0
+        else:
+            raise Error("accessed inactive script machine")
+
+    def reset(self):
+        if self.smId==0: raise Error("accessed inactive script machine")
+        cashlib.SmReset(self.smId)
+        self.curPos = 0
+
+    def eval(self, script):
+        if self.smId==0: raise Error("accessed inactive script machine")
+        if type(script) == str:
+            script = unhexlify(script)
+        ret = cashlib.SmEval(self.smId, script, len(script))
+        return ret
+    
+    def begin(self, script):
+        """Start stepping through the provided script"""
+        if self.smId==0: raise Error("accessed inactive script machine")
+        if type(script) == str:
+            script = unhexlify(script)
+        ret = cashlib.SmBeginStep(self.smId, script, len(script))
+        self.curPos = 0
+        self.script = script
+        return ret
+    
+    def step(self):
+        """Step forward 1 instruction"""
+        if self.smId==0: raise Error("accessed inactive script machine")
+        if self.curPos >= len(self.script):
+            raise Error("stepped beyond end of script")
+        ret = cashlib.SmStep(self.smId)
+        if ret == 0:
+            raise Error("execution error")
+        self.curPos = cashlib.SmPos(self.smId)
+        return self.curPos
+
+    def error(self):
+        if self.smId==0: raise Error("accessed inactive script machine")
+        return (cashlib.SmGetError(self.smId), cashlib.SmPos(self.smId))
+    
+    def pos(self):
+        return self.curPos
+
+    def end(self):
+        """Call when script is complete to do final script checks"""
+        if self.smId==0: raise Error("accessed inactive script machine")
+        ret = cashlib.SmEndStep(self.smId)
+        return ret
+
+    def altstack(self):
+        return self.stack(self.ALTSTACK)
+    
+    def stack(self, which = None):
+        """Returns the machine's stack (main stack by default) as a list of byte arrays, index 0 is the stack top"""
+        if self.smId==0: raise Error("accessed inactive script machine")
+        if which is None: which = self.STACK
+        stk = []
+        idx  = 0
+        item = create_string_buffer(MAX_STACK_ITEM_LENGTH)
+        while 1:
+            result = cashlib.SmGetStackItem(self.smId, which, idx, item)
+            if result == -1: break
+            stk.append(item[0:result])
+            idx+=1
+        return stk
+
+    def setAltStackItem(self, idx, value):
+        """Set an item on the stack to a value, index 0 is the top.  index -1 means push"""
+        self.setStackItem(idx, value, self.ALTSTACK)
+
+    def setStackItem(self, idx, value, which = None):
+        """Set an item on the stack to a value, index 0 is the top.  index -1 means push"""
+        if self.smId==0: raise Error("accessed inactive script machine")
+        if which is None: which = self.STACK
+        cashlib.SmSetStackItem(self.smId, which, idx, value, len(value))
 
 
 def Test():

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -318,6 +318,10 @@ libbitcoincash_a_SOURCES = \
   pubkey.h \
   random.cpp \
   random.h \
+  script/interpreter.cpp \
+  script/interpreter.h \
+  script/script.cpp \
+  script/script.h \
   support/pagelocker.cpp \
   support/pagelocker.h \
   support/cleanse.cpp \

--- a/src/cashlib/cashlib.cpp
+++ b/src/cashlib/cashlib.cpp
@@ -19,6 +19,8 @@
 
 static bool sigInited = false;
 
+ECCVerifyHandle *verifyContext = nullptr;
+
 // stop the logging
 int LogPrintStr(const std::string &str) { return str.size(); }
 namespace Logging
@@ -106,6 +108,7 @@ extern "C" int GetPubKey(unsigned char *keyData, unsigned char *result, unsigned
     {
         sigInited = true;
         ECC_Start();
+        verifyContext = new ECCVerifyHandle();
     }
 
     CKey key = LoadKey(keyData);
@@ -140,6 +143,7 @@ extern "C" int SignTx(unsigned char *txData,
     {
         sigInited = true;
         ECC_Start();
+        verifyContext = new ECCVerifyHandle();
     }
 
     CTransaction tx;
@@ -174,4 +178,196 @@ extern "C" int SignTx(unsigned char *txData,
         return 0;
     std::copy(sig.begin(), sig.end(), result);
     return sigSize;
+}
+
+
+/*
+Since the ScriptMachine is often going to be initialized, called and destructed within a single stack frame, it
+does not make copies of the data it is using.  But higher-level language and debugging interaction use the
+ScriptMachine across stack frames.  Therefore it is necessary to create a class to hold all of this data on behalf
+of the ScriptMachine.
+ */
+class ScriptMachineData
+{
+public:
+    ScriptMachineData() : sm(nullptr), tx(nullptr), checker(nullptr), script(nullptr) {}
+    ScriptMachine *sm;
+    std::shared_ptr<CTransaction> tx;
+    std::shared_ptr<BaseSignatureChecker> checker;
+    std::shared_ptr<CScript> script;
+
+    ~ScriptMachineData()
+    {
+        if (sm)
+        {
+            delete sm;
+            sm = nullptr;
+        }
+    }
+};
+
+// Create a ScriptMachine with no transaction context -- useful for tests and debugging
+// This ScriptMachine can't CHECKSIG or CHECKSIGVERIFY
+extern "C" void *CreateNoContextScriptMachine(unsigned int flags)
+{
+    ScriptMachineData *smd = new ScriptMachineData();
+    smd->checker = std::make_shared<BaseSignatureChecker>();
+    smd->sm = new ScriptMachine(flags, *smd->checker);
+    return (void *)smd;
+}
+
+// Create a ScriptMachine operating in the context of a particular transaction and input.
+// The transaction, input index, and input amount are used in CHECKSIG and CHECKSIGVERIFY to generate the hash that
+// the signature validates.
+extern "C" void *CreateScriptMachine(unsigned int flags,
+    unsigned int inputIdx,
+    int64_t inputAmount,
+    unsigned char *txData,
+    int txbuflen)
+{
+    if (!sigInited)
+    {
+        sigInited = true;
+        ECC_Start();
+        verifyContext = new ECCVerifyHandle();
+    }
+
+    ScriptMachineData *smd = new ScriptMachineData();
+    smd->tx = std::make_shared<CTransaction>();
+
+    CDataStream ssData((char *)txData, (char *)txData + txbuflen, SER_NETWORK, PROTOCOL_VERSION);
+    try
+    {
+        ssData >> *smd->tx;
+    }
+    catch (const std::exception &)
+    {
+        delete smd;
+        return 0;
+    }
+
+    // Its ok to get the bare tx pointer: the life of the CTransaction is the same as TransactionSignatureChecker
+    smd->checker = std::make_shared<TransactionSignatureChecker>(smd->tx.get(), inputIdx, inputAmount, flags);
+    smd->sm = new ScriptMachine(flags, *smd->checker);
+    return (void *)smd;
+}
+
+// Release a ScriptMachine context
+extern "C" void SmRelease(void *smId)
+{
+    ScriptMachineData *smd = (ScriptMachineData *)smId;
+    if (!smd)
+        return;
+    delete smd;
+}
+
+// Copy the provided ScriptMachine, returning a new ScriptMachine id that exactly matches the current one
+extern "C" void *SmClone(void *smId)
+{
+    ScriptMachineData *from = (ScriptMachineData *)smId;
+    ScriptMachineData *to = new ScriptMachineData();
+    to->script = from->script;
+    to->checker = from->checker;
+    to->tx = from->tx;
+    to->sm = new ScriptMachine(*from->sm);
+    return (void *)to;
+}
+
+
+// Evaluate a script within the context of this script machine
+extern "C" bool SmEval(void *smId, unsigned char *scriptBuf, unsigned int scriptLen)
+{
+    ScriptMachineData *smd = (ScriptMachineData *)smId;
+
+    CScript script(scriptBuf, scriptBuf + scriptLen);
+    bool ret = smd->sm->Eval(script);
+    return ret;
+}
+
+// Step-by-step interface: start evaluating a script within the context of this script machine
+extern "C" bool SmBeginStep(void *smId, unsigned char *scriptBuf, unsigned int scriptLen)
+{
+    ScriptMachineData *smd = (ScriptMachineData *)smId;
+    // shared_ptr will auto-release the old one
+    smd->script = std::make_shared<CScript>(scriptBuf, scriptBuf + scriptLen);
+    bool ret = smd->sm->BeginStep(*smd->script);
+    return ret;
+}
+
+// Step-by-step interface: execute the next instruction in the script
+extern "C" unsigned int SmStep(void *smId)
+{
+    ScriptMachineData *smd = (ScriptMachineData *)smId;
+    unsigned int ret = smd->sm->Step();
+    return ret;
+}
+
+// Step-by-step interface: get the current position in this script, specified in bytes offset from the script start
+extern "C" int SmPos(void *smId)
+{
+    ScriptMachineData *smd = (ScriptMachineData *)smId;
+    return smd->sm->getPos();
+}
+
+
+// Step-by-step interface: End script evaluation
+extern "C" bool SmEndStep(void *smId)
+{
+    ScriptMachineData *smd = (ScriptMachineData *)smId;
+    bool ret = smd->sm->EndStep();
+    return ret;
+}
+
+
+// Revert the script machine to initial conditions
+extern "C" void SmReset(void *smId)
+{
+    ScriptMachineData *smd = (ScriptMachineData *)smId;
+    smd->sm->Reset();
+}
+
+
+// Get a stack item, 0 = stack, 1 = altstack,  pass a buffer at least 520 bytes in size
+// returns length of the item or -1 if no item.  0 is the stack top
+extern "C" void SmSetStackItem(void *smId,
+    unsigned int stack,
+    int index,
+    const unsigned char *value,
+    unsigned int valsize)
+{
+    ScriptMachineData *smd = (ScriptMachineData *)smId;
+
+    const std::vector<StackDataType> &stk = (stack == 0) ? smd->sm->getStack() : smd->sm->getAltStack();
+    if (((int)stk.size()) <= index)
+        return;
+    if (stack == 0)
+    {
+        smd->sm->setStackItem(index, StackDataType(value, value + valsize));
+    }
+    else if (stack == 1)
+    {
+        smd->sm->setAltStackItem(index, StackDataType(value, value + valsize));
+    }
+}
+
+// Get a stack item, 0 = stack, 1 = altstack,  pass a buffer at least 520 bytes in size
+// returns length of the item or -1 if no item.  0 is the stack top
+extern "C" int SmGetStackItem(void *smId, unsigned int stack, unsigned int index, unsigned char *result)
+{
+    ScriptMachineData *smd = (ScriptMachineData *)smId;
+
+    const std::vector<StackDataType> &stk = (stack == 0) ? smd->sm->getStack() : smd->sm->getAltStack();
+    if (stk.size() <= index)
+        return -1;
+    index = stk.size() - index - 1; // reverse it so 0 is stack top
+    int sz = stk[index].size();
+    memcpy(result, stk[index].data(), sz);
+    return sz;
+}
+
+// Returns the last error generated during script evaluation (if any)
+extern "C" unsigned int SmGetError(void *smId)
+{
+    ScriptMachineData *smd = (ScriptMachineData *)smId;
+    return (unsigned int)smd->sm->getError();
 }

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -190,6 +190,122 @@ public:
     }
 };
 
+typedef std::vector<unsigned char> StackDataType;
+
+class ScriptMachine
+{
+protected:
+    unsigned int flags;
+    std::vector<StackDataType> stack;
+    std::vector<StackDataType> altstack;
+    const CScript *script;
+    const BaseSignatureChecker &checker;
+    ScriptError error;
+
+    unsigned char sighashtype;
+
+    CScript::const_iterator pc;
+    CScript::const_iterator pbegin;
+    CScript::const_iterator pend;
+    CScript::const_iterator pbegincodehash;
+
+    unsigned int nOpCount;
+
+    std::vector<bool> vfExec;
+
+public:
+    ScriptMachine(const ScriptMachine &from)
+        : checker(from.checker), pc(from.pc), pbegin(from.pbegin), pend(from.pend), pbegincodehash(from.pbegincodehash)
+    {
+        flags = from.flags;
+        stack = from.stack;
+        altstack = from.altstack;
+        script = from.script;
+        error = from.error;
+        sighashtype = from.sighashtype;
+        nOpCount = from.nOpCount;
+        vfExec = from.vfExec;
+        nOpCount = 0;
+    }
+
+    ScriptMachine(unsigned int _flags, const BaseSignatureChecker &_checker)
+        : flags(_flags), script(nullptr), checker(_checker), pc(CScript().end()), pbegin(CScript().end()),
+          pend(CScript().end()), pbegincodehash(CScript().end()), nOpCount(0)
+    {
+    }
+
+    // Execute the passed script starting at the current machine state (stack and altstack are not cleared).
+    bool Eval(const CScript &_script);
+
+    // Start a stepwise execution of a script, starting at the current machine state
+    // If BeginStep succeeds, you must keep script alive until EndStep() returns
+    bool BeginStep(const CScript &_script);
+    // Execute the next instruction of a script (you must have previously BeginStep()ed).
+    bool Step();
+    // Do final checks once the script is complete.
+    bool EndStep();
+    // Return true if there are more steps in this script
+    bool isMoreSteps() { return (pc < pend); }
+    // Return the current offset from the beginning of the script. -1 if ended
+    int getPos();
+
+    // Returns info about the next instruction to be run:
+    // first bool is true if the instruction will be executed (false if this is passing across a not-taken branch)
+    std::tuple<bool, opcodetype, StackDataType, ScriptError> Peek();
+
+    // Remove all items from the altstack
+    void ClearAltStack() { altstack.clear(); }
+    // Remove all items from the stack
+    void ClearStack() { stack.clear(); }
+    // clear all state
+    void Reset()
+    {
+        altstack.clear();
+        stack.clear();
+        vfExec.clear();
+        nOpCount = 0;
+    }
+
+    // Set the main stack to the passed data
+    void setStack(std::vector<StackDataType> &stk) { stack = stk; }
+    // Overwrite a stack entry with the passed data.  0 is the stack top, -1 is a special number indicating to push
+    // an item onto the stack top.
+    void setStackItem(int idx, const StackDataType &item)
+    {
+        if (idx == -1)
+            stack.push_back(item);
+        else
+        {
+            stack[stack.size() - idx - 1] = item;
+        }
+    }
+
+    // Overwrite an altstack entry with the passed data.  0 is the stack top, -1 is a special number indicating to push
+    // the item onto the top.
+    void setAltStackItem(int idx, const StackDataType &item)
+    {
+        if (idx == -1)
+            altstack.push_back(item);
+        else
+        {
+            altstack[altstack.size() - idx - 1] = item;
+        }
+    }
+
+    // Set the alt stack to the passed data
+    void setAltStack(std::vector<StackDataType> &stk) { altstack = stk; }
+    // Get the main stack
+    const std::vector<StackDataType> &getStack() { return stack; }
+    // Get the alt stack
+    const std::vector<StackDataType> &getAltStack() { return altstack; }
+    // Get any error that may have occurred
+    const ScriptError &getError() { return error; }
+    // Get the bitwise OR of all sighashtype bytes that occurred in the script
+    unsigned char getSigHashType() { return sighashtype; }
+    // Return the number of instructions executed since the last Reset()
+    unsigned int getOpCount() { return nOpCount; }
+};
+
 bool EvalScript(std::vector<std::vector<unsigned char> > &stack,
     const CScript &script,
     unsigned int flags,


### PR DESCRIPTION
Add access via cashlib and an example of how the script interpreter can be stepped.  This provides the base functionality needed to make a script debugger.

