### PR TITLE
[WIP] [graphene] Version all major data structures

### DIFF
--- a/src/graphene.cpp
+++ b/src/graphene.cpp
@@ -22,9 +22,9 @@
 
 static bool ReconstructBlock(CNode *pfrom, const bool fXVal, int &missingCount, int &unnecessaryCount);
 
-CMemPoolInfo::CMemPoolInfo(uint64_t _nTx) : nTx(_nTx) {}
-CMemPoolInfo::CMemPoolInfo() { this->nTx = 0; }
-CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock, uint64_t nReceiverMemPoolTx)
+CMemPoolInfo::CMemPoolInfo(uint64_t _nTx) : nTx(_nTx), version(0) {}
+CMemPoolInfo::CMemPoolInfo() : nTx(0), version(0) {}
+CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock, uint64_t nReceiverMemPoolTx) : version(0)
 {
     header = pblock->GetBlockHeader();
     nBlockTxs = pblock->vtx.size();
@@ -50,7 +50,7 @@ CGrapheneBlock::~CGrapheneBlock()
     }
 }
 
-CGrapheneBlockTx::CGrapheneBlockTx(uint256 blockHash, std::vector<CTransaction> &vTx)
+CGrapheneBlockTx::CGrapheneBlockTx(uint256 blockHash, std::vector<CTransaction> &vTx) : version(0)
 {
     blockhash = blockHash;
     vMissingTx = vTx;
@@ -201,7 +201,7 @@ bool CGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     return true;
 }
 
-CRequestGrapheneBlockTx::CRequestGrapheneBlockTx(uint256 blockHash, std::set<uint64_t> &setHashesToRequest)
+CRequestGrapheneBlockTx::CRequestGrapheneBlockTx(uint256 blockHash, std::set<uint64_t> &setHashesToRequest) : version(0)
 {
     blockhash = blockHash;
     setCheapHashesToRequest = setHashesToRequest;

--- a/src/graphene_set.h
+++ b/src/graphene_set.h
@@ -103,14 +103,13 @@ public:
     }
 
     // The default constructor is for 2-phase construction via deserialization
-    CGrapheneSet() : version(0), ordered(false), nReceiverUniverseItems(0), pSetFilter(nullptr), pSetIblt(nullptr) {}
+    CGrapheneSet() : version(0), nReceiverUniverseItems(0), pSetFilter(nullptr), pSetIblt(nullptr) {}
     CGrapheneSet(size_t _nReceiverUniverseItems,
         const std::vector<uint256> &_itemHashes,
         bool _ordered = false,
         bool fDeterministic = false)
-        : version(0)
+        : version(uint64_t(_ordered))
     {
-        ordered = _ordered;
         // Below is the parameter "m" from the graphene paper
         nReceiverUniverseItems = _nReceiverUniverseItems;
         // Below is the parameter "n" from the graphene paper
@@ -166,7 +165,7 @@ public:
         }
 
         // Record transaction order
-        if (ordered)
+        if (ordered())
         {
             std::map<uint256, uint64_t> mapItemHashes;
             for (const std::pair<uint64_t, uint256> &kv : mapCheapHashes)
@@ -253,7 +252,7 @@ public:
 
         std::vector<uint64_t> receiverSetItems(receiverSet.begin(), receiverSet.end());
 
-        if (!ordered)
+        if (!ordered())
             return receiverSetItems;
 
         // Place items in order
@@ -345,9 +344,8 @@ public:
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
         READWRITE(COMPACTSIZE(version));
-        if (ser_action.ForRead() && version != 0)
-            throw std::ios_base::failure("Only graphene-set message version zero is supported at the moment.");
-        READWRITE(ordered);
+        if (ser_action.ForRead() && version != 0 && version != 1)
+            throw std::ios_base::failure("Only graphene-set message version zero or one is supported at the moment.");
         READWRITE(nReceiverUniverseItems);
         if (nReceiverUniverseItems > LARGE_MEM_POOL_SIZE)
             throw std::runtime_error("nReceiverUniverseItems exceeds threshold for excessive mempool size");
@@ -361,7 +359,7 @@ public:
     }
 
 private:
-    bool ordered;
+    bool ordered() const { return version & 1; }
     uint64_t nReceiverUniverseItems;
     std::vector<unsigned char> encodedRank;
     CBloomFilter *pSetFilter;

--- a/src/graphene_set.h
+++ b/src/graphene_set.h
@@ -29,6 +29,9 @@ const unsigned char WORD_BITS = 8;
 
 class CGrapheneSet
 {
+public:
+    uint64_t version;
+
 private:
     std::vector<uint64_t> ArgSort(const std::vector<uint64_t> &items)
     {
@@ -100,11 +103,12 @@ public:
     }
 
     // The default constructor is for 2-phase construction via deserialization
-    CGrapheneSet() : ordered(false), nReceiverUniverseItems(0), pSetFilter(nullptr), pSetIblt(nullptr) {}
+    CGrapheneSet() : version(0), ordered(false), nReceiverUniverseItems(0), pSetFilter(nullptr), pSetIblt(nullptr) {}
     CGrapheneSet(size_t _nReceiverUniverseItems,
         const std::vector<uint256> &_itemHashes,
         bool _ordered = false,
         bool fDeterministic = false)
+        : version(0)
     {
         ordered = _ordered;
         // Below is the parameter "m" from the graphene paper
@@ -340,6 +344,9 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
+        READWRITE(COMPACTSIZE(version));
+        if (ser_action.ForRead() && version != 0)
+            throw std::ios_base::failure("Only graphene-set message version zero is supported at the moment.");
         READWRITE(ordered);
         READWRITE(nReceiverUniverseItems);
         if (nReceiverUniverseItems > LARGE_MEM_POOL_SIZE)


### PR DESCRIPTION
As per the commit message.

To do a rough order-of-magnitude-dimensional-analysis calculation of the cost impact of this change for a miner, assuming (number pulled out of thin air :-) that a miner is typically connected with at least a 10Mbps line and that all 6 structures are transmitted once and that all delays pessimistically add up and that 'pessimistically' the total reward adds up to 15 BCH/block:

((6 byte / (1 megabyte s^(-1))) / 600s) * 15 BCH/block * $1000 / BCH ~= 0.015 ct

I think it is safe to say that the expected cost overhead of 0.015 US-ct won't stop any miner from running `graphene`, even when all the fields are expanded to the full 64 bit (~ 0.15ct).

Compared to using or reusing a field in the client version message, this should allow for much better local handling of `graphene` protocol version.

@deadalnix, I hope this would address the major concern you have about merging a still somewhat experimental implementation.