### PR TITLE
Use log level NET for Invalid Message Start messages.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6885,7 +6885,7 @@ bool ProcessMessages(CNode *pfrom)
         // Scan for message start
         if (memcmp(msg.hdr.pchMessageStart, pfrom->GetMagic(chainparams), MESSAGE_START_SIZE) != 0)
         {
-            LOGA("PROCESSMESSAGE: INVALID MESSAGESTART %s peer=%s\n", SanitizeString(msg.hdr.GetCommand()),
+            LOG(NET, "PROCESSMESSAGE: INVALID MESSAGESTART %s peer=%s\n", SanitizeString(msg.hdr.GetCommand()),
                 pfrom->GetLogName());
             if (!pfrom->fWhitelisted)
             {


### PR DESCRIPTION
These are filling up the log with ever increasing fequency with a variety
of fake nodes out there trying to send us messages.