### PR TITLE
Use a very high default for DEFAULT_MAX_ORPHAN_TRANSACTIONS.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -70,8 +70,15 @@ static const CAmount DEFAULT_TRANSACTION_MAXFEE = 0.1 * COIN;
 static const CAmount HIGH_TX_FEE_PER_KB = 0.01 * COIN;
 //! -maxtxfee will warn if called with a higher fee than this amount (in satoshis)
 static const CAmount HIGH_MAX_TX_FEE = 100 * HIGH_TX_FEE_PER_KB;
-/** Default for -maxorphantx, maximum number of orphan transactions kept in memory */
-static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 2500;
+/** Default for -maxorphantx, maximum number of orphan transactions kept in memory.
+ *  A high default is chosen which allows for about 1/10 of the default mempool to
+ *  be kept as orphans, assuming 250 byte transactions.  We are essentially disabling
+ *  the limiting or orphan transactions by number and using orphan pool bytes as
+ *  the limiting factor, while at the same time allowing node operators to
+ *  limit by number if transactions if they wish by modifying -maxorphantx=<n> if
+ *  the have a need to.
+ */
+static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 120000;
 /** Default for -limitancestorcount, max number of in-mempool ancestors */
 static const unsigned int DEFAULT_ANCESTOR_LIMIT = 25;
 /** Default for -limitancestorsize, maximum kilobytes of tx + all in-mempool ancestors */


### PR DESCRIPTION
I debated whether to entirely take out the feature of limiting by orphan tx count  but thought maybe we should keep it in for now but basically disable it by using a very high default.

It was observed during stress testing that a node that is launched
after the test had begun would have a very large number of orphans
until a few blocks were mined. If the maxorphantx was too low then
the orphan pool will overfill and start purging orphans, however,
since the txn were chained together for stress testing then the
next txns to arrive would also be orphans causing more and continuous
flushing.  This then caused the mempools to never be close enough
in sync such that graphene blocks could not get propagated.

Setting the default max orphan tx to a very high number essentially
disabes this flushing mechanism by number of orphans, however, the flushing
will still occur if/when we reached an orphan pool size of 1/10 the mempool
or 120000 txn, whichever comes first.