### PR TITLE
Do not relay double spends to SPV clients.

### DIFF
--- a/src/bloom.h
+++ b/src/bloom.h
@@ -77,8 +77,9 @@ private:
     void UpdateEmptyFull();
 
 public:
+    bool IsEmpty() const { return isEmpty; }
     //! for testing only
-    bool getFull() const { return isFull; }
+    bool IsFull() const { return isFull; }
     //! for testing only
     unsigned int vDataSize() const { return vData.size(); }
     /**

--- a/src/net.h
+++ b/src/net.h
@@ -922,8 +922,8 @@ private:
 typedef std::vector<CNodeRef> VNodeRefs;
 
 class CTransaction;
-void RelayTransaction(const CTransaction &tx, bool fDoubleSpend = false);
-void RelayTransaction(const CTransaction &tx, const CDataStream &ss, bool fDoubleSpend = false);
+void RelayTransaction(const CTransaction &tx, const bool fRespend = false);
+void RelayTransaction(const CTransaction &tx, const CDataStream &ss, const bool fRespend = false);
 
 /** Access to the (IP) address database (peers.dat) */
 class CAddrDB

--- a/src/net.h
+++ b/src/net.h
@@ -922,8 +922,8 @@ private:
 typedef std::vector<CNodeRef> VNodeRefs;
 
 class CTransaction;
-void RelayTransaction(const CTransaction &tx);
-void RelayTransaction(const CTransaction &tx, const CDataStream &ss);
+void RelayTransaction(const CTransaction &tx, bool fDoubleSpend = false);
+void RelayTransaction(const CTransaction &tx, const CDataStream &ss, bool fDoubleSpend = false);
 
 /** Access to the (IP) address database (peers.dat) */
 class CAddrDB

--- a/src/respend/respendrelayer.cpp
+++ b/src/respend/respendrelayer.cpp
@@ -86,7 +86,7 @@ void RespendRelayer::Trigger()
     if (!valid || !interesting)
         return;
 
-    RelayTransaction(respend);
+    RelayTransaction(respend, true);
 }
 
 } // ns respend

--- a/src/respend/test/respendrelayer_tests.cpp
+++ b/src/respend/test/respendrelayer_tests.cpp
@@ -74,6 +74,22 @@ BOOST_AUTO_TEST_CASE(triggers_correctly)
     r.Trigger();
     BOOST_CHECK_EQUAL(size_t(1), node.vInventoryToSend.size());
     BOOST_CHECK(respend.GetHash() == node.vInventoryToSend.at(0).hash);
+
+    // Create an interesting and valid respend to an SPV peer
+    // add bloom filter using the respend hash.
+    CBloomFilter *filter = new CBloomFilter(1, .00001, 5, BLOOM_UPDATE_ALL, 36000);
+    delete node.pfilter;
+    node.pfilter = filter;
+    node.pfilter->insert(respend.GetHash());
+    node.vInventoryToSend.clear();
+    r.SetValid(true);
+    r.Trigger();
+    BOOST_CHECK_EQUAL(size_t(0), node.vInventoryToSend.size());
+    node.pfilter->clear();
+
+    // clean up node
+    delete node.pfilter;
+    node.pfilter = nullptr;
     vNodes.erase(vNodes.end() - 1);
 }
 

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -892,27 +892,27 @@ BOOST_AUTO_TEST_CASE(bloom_full_and_size_tests)
     {
         // FP rate of 1.0 will create an empty, zero-element bloom filter
         CBloomFilter filter(1, 1.0, 0, BLOOM_UPDATE_ALL);
-        BOOST_CHECK(filter.getFull());
+        BOOST_CHECK(filter.IsFull());
         filter.insert(ParseHex("00"));
     }
 
     {
         // a filter with good parameters should be non-full upon construction
         CBloomFilter filter(8, 0.01, 0, BLOOM_UPDATE_ALL);
-        BOOST_CHECK(!filter.getFull());
+        BOOST_CHECK(!filter.IsFull());
     }
 
     {
         // constructing bloom filters without any empty elements should work
         // and yield non-full filters as nElements will be set to 1
         CBloomFilter filter(0, 0.01, 0, BLOOM_UPDATE_ALL);
-        BOOST_CHECK(!filter.getFull());
+        BOOST_CHECK(!filter.IsFull());
     }
 
     {
         // default empty filter is full
         CBloomFilter filter;
-        BOOST_CHECK(filter.getFull());
+        BOOST_CHECK(filter.IsFull());
     }
 
     {
@@ -921,7 +921,7 @@ BOOST_AUTO_TEST_CASE(bloom_full_and_size_tests)
         CBloomFilter filter;
         CDataStream stream(ParseHex("00000000000000000000"), SER_NETWORK, PROTOCOL_VERSION);
         stream >> filter;
-        BOOST_CHECK(filter.getFull());
+        BOOST_CHECK(filter.IsFull());
         BOOST_CHECK(filter.IsWithinSizeConstraints());
     }
 
@@ -931,7 +931,7 @@ BOOST_AUTO_TEST_CASE(bloom_full_and_size_tests)
         CBloomFilter filter;
         CDataStream stream(ParseHex("0100000000000000000000"), SER_NETWORK, PROTOCOL_VERSION);
         stream >> filter;
-        BOOST_CHECK(!filter.getFull());
+        BOOST_CHECK(!filter.IsFull());
         BOOST_CHECK(filter.IsWithinSizeConstraints());
     }
 
@@ -941,7 +941,7 @@ BOOST_AUTO_TEST_CASE(bloom_full_and_size_tests)
         CBloomFilter filter;
         CDataStream stream(ParseHex("01ff000000000000000000"), SER_NETWORK, PROTOCOL_VERSION);
         stream >> filter;
-        BOOST_CHECK(filter.getFull());
+        BOOST_CHECK(filter.IsFull());
         BOOST_CHECK(filter.IsWithinSizeConstraints());
     }
     {
@@ -957,7 +957,7 @@ BOOST_AUTO_TEST_CASE(bloom_full_and_size_tests)
         stream << (unsigned char)0; // nFlags
 
         stream >> filter;
-        BOOST_CHECK(!filter.getFull());
+        BOOST_CHECK(!filter.IsFull());
         BOOST_CHECK(!filter.IsWithinSizeConstraints());
     }
 
@@ -975,7 +975,7 @@ BOOST_AUTO_TEST_CASE(bloom_full_and_size_tests)
 
 
         stream >> filter;
-        BOOST_CHECK(filter.getFull());
+        BOOST_CHECK(filter.IsFull());
         BOOST_CHECK(!filter.IsWithinSizeConstraints());
     }
 


### PR DESCRIPTION
Relaying double spends to SPV clients can be easily attacked.  An attacker
could intially send tx1 to their own wallet. Then send a double spend (tx2) to
another merchant's  SPV wallet. The merchant will never see tx1 but will
see and receive tx2, however, tx2 will not get mined since the miners node
will see tx2 but not add it to their mempool. Later, tx1 will get mined
leaving the merchant with an invalid/conflicting tx2 and no payment will
be confirmed.

gandrewstone says: Hijacking the top comment to describe the problem:

Any connected entity (generally a SPV wallet) can install a bloom filter telling the full node to only send a subset of transactions of "interest" to the entity.  If the entity is a merchant, it is very likely that it will be given only the "pay" doublespent transaction and not the "fraud" doublespend because the "pay" transaction is going to the merchant's address so will be selected by the bloom filter, but the "fraud" tx will have a bloom filter miss since it pays to someone else.

There are several possible solutions:

1. relay both doublespends even though one misses the bloom filter.  This presupposes that the SPV wallet would know what to do with what will look like an irrelevant tx -- an unmodified SPV wallet would still be vulnerable

2. relay just the filtered doublespend but "break" it (change 1 byte, for example).  Again the SPV wallet would need to be changed to recognize this as a doublespend, but at least an unmodified wallet would just drop the tx.  However, the unmodified wallet might also disconnect (behavior when given a bad tx is undefined).  And we my relay the tx before we know that it is a doublespend.

3. relay a double spend proof (Except they don't exist).

4. don't relay either doublespend.  This approach presupposes that the node knows about the doublespend BEFORE relaying to the SPV wallet.  In other words, the "fraud" tx needs to beat the "pay" tx to the full node.  Otherwise the "pay" tx gets relayed.  But "Mallory" is actively working to create the opposite scenario.  

However, approach 4 causes the same behavior the network exhibits today (without doublespend relay), and allows a option 3 to be added at some later time.  So option 4 is what this PR implements.