### PR TITLE
Fix TCP drop

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7016,10 +7016,6 @@ bool SendMessages(CNode *pto)
                 pto->fDisconnect = true;
                 LOG(IBD, "peer %s, disconnect request was set, so disconnected\n", pto->GetLogName());
             }
-            // If we are waiting for blocks, we need to make sure this connection is alive by attempting a send
-            // otherwise we may wait for PING_INTERVAL seconds.
-            else
-                pto->fPingQueued = true;
         }
 
         // Now exit early if disconnecting or the version handshake is not complete.  We must not send PING or other

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7016,6 +7016,10 @@ bool SendMessages(CNode *pto)
                 pto->fDisconnect = true;
                 LOG(IBD, "peer %s, disconnect request was set, so disconnected\n", pto->GetLogName());
             }
+            // If we are waiting for blocks, we need to make sure this connection is alive by attempting a send
+            // otherwise we may wait for PING_INTERVAL seconds.
+            else
+                pto->fPingQueued = true;
         }
 
         // Now exit early if disconnecting or the version handshake is not complete.  We must not send PING or other

--- a/src/net.h
+++ b/src/net.h
@@ -844,6 +844,19 @@ public:
         return idstr;
     }
 
+    //! Disconnects after receiving all the blocks we are waiting for.  Typically this happens if the node is
+    // responding slowly compared to other nodes.
+    void InitiateGracefulDisconnect()
+    {
+        if (!fDisconnectRequest)
+        {
+            fDisconnectRequest = true;
+            // But we need to make sure this connection is actually alive by attempting a send
+            // otherwise there is no reason to wait (up to PING_INTERVAL seconds).
+            // If the other side of a TCP connection goes silent you need to do a send to find out that its dead.
+            fPingQueued = true;
+        }
+    }
 
     void copyStats(CNodeStats &stats);
 

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -450,8 +450,7 @@ bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
                 MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
                 AddGrapheneBlockInFlight(pfrom, inv2.hash);
                 pfrom->PushMessage(NetMsgType::GET_GRAPHENE, ss);
-                LOG(GRAPHENE, "Requesting graphene block %s from peer %s (%d)\n", inv2.hash.ToString(),
-                    pfrom->addrName.c_str(), pfrom->id);
+                LOG(GRAPHENE, "Requesting graphene block %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
                 return true;
             }
         }
@@ -470,14 +469,12 @@ bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
                 MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
                 AddGrapheneBlockInFlight(pfrom, inv2.hash);
                 pfrom->PushMessage(NetMsgType::GET_GRAPHENE, ss);
-                LOG(GRAPHENE, "Requesting graphene block %s from peer %s (%d)\n", inv2.hash.ToString(),
-                    pfrom->addrName.c_str(), pfrom->id);
+                LOG(GRAPHENE, "Requesting graphene block %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
                 return true;
             }
             else if (!IsThinBlocksEnabled())
             {
-                LOG(GRAPHENE, "Requesting regular block %s from peer %s (%d)\n", inv2.hash.ToString(),
-                    pfrom->addrName.c_str(), pfrom->id);
+                LOG(GRAPHENE, "Requesting regular block %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
                 std::vector<CInv> vToFetch;
                 inv2.type = MSG_BLOCK;
                 vToFetch.push_back(inv2);
@@ -1195,7 +1192,7 @@ bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
                 {
                     LOG(IBD, "disconnecting %s because too slow , overall avg %d peer avg %d\n", pnode->GetLogName(),
                         nOverallAverageResponseTime, pnode->nAvgBlkResponseTime);
-                    pnode->fDisconnectRequest = true;
+                    pnode->InitiateGracefulDisconnect();
                     // We must not return here but continue in order
                     // to update the vBlocksInFlight stats.
                 }
@@ -1347,8 +1344,8 @@ void CRequestManager::DisconnectOnDownloadTimeout(CNode *pnode, const Consensus:
             mapRequestManagerNodeState[nodeid].nDownloadingSince +
                 consensusParams.nPowTargetSpacing * (BLOCK_DOWNLOAD_TIMEOUT_BASE + BLOCK_DOWNLOAD_TIMEOUT_PER_PEER))
         {
-            LOGA("Timeout downloading block %s from peer=%d, disconnecting\n",
-                mapRequestManagerNodeState[nodeid].vBlocksInFlight.front().hash.ToString(), nodeid);
+            LOGA("Timeout downloading block %s from peer %s, disconnecting\n",
+                mapRequestManagerNodeState[nodeid].vBlocksInFlight.front().hash.ToString(), pnode->GetLogName());
             pnode->fDisconnect = true;
         }
     }


### PR DESCRIPTION
If a TCP connection goes completely dead (without a close) we need to detect that by attempting a send, rather than waiting for a long time for a receive that will never happen.  A good way to trigger this is to sleep your computer for at least 5 minutes during an IBD, and then wake it back up.

EDIT:
In this new version of my PR, I cleaned things up by creating a function "InitiateGracefulDisconnect()", and I also converted a few logs to use GetLogName().    This new function sets the disconnect flag and (here's the semantic change) also triggers a ping.  (If the ping has a write error the existing logic disconnects right away, rather than waiting for a block that will never arrive).  But this ping only happens once when the graceful disconnect is first initiated, rather than every time we loop waiting for the node.