### PR TITLE
Do not download initial headers from inbound peers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7176,7 +7176,7 @@ bool SendMessages(CNode *pto)
         if (!state.fSyncStarted && !pto->fClient && !fImporting && !fReindex)
         {
             // Only actively request headers from a single peer, unless we're close to today.
-            if ((nSyncStarted < MAX_HEADER_REQS_DURING_IBD && fFetch && !pto->fInbound) ||
+            if ((nSyncStarted < MAX_HEADER_REQS_DURING_IBD && fFetch) ||
                 chainActive.Tip()->GetBlockTime() > GetAdjustedTime() - SINGLE_PEER_REQUEST_MODE_AGE)
             {
                 const CBlockIndex *pindexStart = chainActive.Tip();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7176,7 +7176,7 @@ bool SendMessages(CNode *pto)
         if (!state.fSyncStarted && !pto->fClient && !fImporting && !fReindex)
         {
             // Only actively request headers from a single peer, unless we're close to today.
-            if ((nSyncStarted < MAX_HEADER_REQS_DURING_IBD && fFetch) ||
+            if ((nSyncStarted < MAX_HEADER_REQS_DURING_IBD && fFetch && !pto->fInbound) ||
                 chainActive.Tip()->GetBlockTime() > GetAdjustedTime() - SINGLE_PEER_REQUEST_MODE_AGE)
             {
                 const CBlockIndex *pindexStart = chainActive.Tip();


### PR DESCRIPTION
When we start syncing and we are still in IsInitialBlockdownload()
then do not request the initial batches of headers from inbound peers.
They are the least trustworthy peers, so we should rather only download
the headers from outbound peers, until we've completed initial sync.