### PR TITLE
 Disable a debug log category if prefixed with '-' 

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -237,7 +237,7 @@ testScripts = [ RpcTest(t) for t in [
     'checkdatasig_activation',
     'xversion',
     'sighashmatch',
-    'getdebugcategories'
+    'getlogcategories'
 ] ]
 
 testScriptsExt = [ RpcTest(t) for t in [

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -236,7 +236,8 @@ testScripts = [ RpcTest(t) for t in [
     'thinblocks',
     'checkdatasig_activation',
     'xversion',
-    'sighashmatch'
+    'sighashmatch',
+    'getdebugcategories'
 ] ]
 
 testScriptsExt = [ RpcTest(t) for t in [

--- a/qa/rpc-tests/getdebugcategories.py
+++ b/qa/rpc-tests/getdebugcategories.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2019 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+import test_framework.loginit
+# This is a template to make creating new QA tests easy.
+# You can also use this template to quickly start and connect a few regtest nodes.
+
+import time
+import sys
+if sys.version_info[0] < 3:
+    raise "Use Python 3"
+import logging
+import random
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class GetDebugCategories (BitcoinTestFramework):
+
+    def setup_chain(self,bitcoinConfDict=None, wallets=None):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 9, bitcoinConfDict, wallets)
+
+    def setup_network(self, split=False):
+        node_opts0 = ["-debug=all,-thin,-graphene,-mempool,-net"]
+        node_opts1 = ["-debug=all,-thin,-graphene,-mempool,-net,-addrman,-tor,-coindb,-rpc"]
+        node_opts2 = ["-debug=all,-thin,-graphene,-mempool,-net,-addrman,-tor,-coindb,-rpc,-evict,-blk,-lck,-proxy"]
+        node_opts3 = ["-debug=all,-thin,-graphene,-mempool,-net,-addrman,-tor,-coindb,-rpc,-evict,-blk,-lck,-proxy,-zmq,-qt,-ibd,-rand"]
+        node_opts4 = ["-debug=-thin,-graphene,-mempool,-net,-addrman,-tor,-coindb,-rpc,all"]
+
+        #Append rpcauth to bitcoin.conf before initialization¶
+        node_opts5 = ["debug=all","debug=-thin","debug=-graphene","debug=-mempool","debug=-net"]
+        random.shuffle(node_opts5)
+        with open(os.path.join(self.options.tmpdir+"/node5", "bitcoin.conf"), 'a') as f:
+            f.write("\n".join(node_opts5))
+
+        node_opts6 = ["-debug=-1"]
+        node_opts7 = ["-debug=-"]
+        node_opts8 = ["-debug=-all"]
+
+
+        self.nodes = [
+            start_node(0, self.options.tmpdir, node_opts0),
+            start_node(1, self.options.tmpdir, node_opts1),
+            start_node(2, self.options.tmpdir, node_opts2),
+            start_node(3, self.options.tmpdir, node_opts3),
+            start_node(4, self.options.tmpdir, node_opts4),
+            start_node(5, self.options.tmpdir),
+            start_node(6, self.options.tmpdir, node_opts6),
+            start_node(7, self.options.tmpdir, node_opts7),
+            start_node(8, self.options.tmpdir, node_opts8)
+        ]
+
+        interconnect_nodes(self.nodes)
+        self.is_network_split = False
+
+    def run_test (self):
+        cat0 = self.nodes[0].getdebugcategories()
+        cat1 = self.nodes[1].getdebugcategories()
+        cat2 = self.nodes[2].getdebugcategories()
+        cat3 = self.nodes[3].getdebugcategories()
+        cat4 = self.nodes[4].getdebugcategories()
+        cat5 = self.nodes[5].getdebugcategories()
+        cat6 = self.nodes[6].getdebugcategories()
+        cat7 = self.nodes[7].getdebugcategories()
+        cat8 = self.nodes[8].getdebugcategories()
+
+        exp0 = "coindb tor addrman libevent http rpc partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks"
+        exp1 = "libevent http partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks"
+        exp2 = "libevent http partitioncheck bench prune reindex mempoolrej parallel rand req bloom estimatefee dbase selectcoins zmq qt ibd respend weakblocks"
+        exp3 = "libevent http partitioncheck bench prune reindex mempoolrej parallel req bloom estimatefee dbase selectcoins respend weakblocks"
+        exp4 = exp1
+        exp5 = exp0
+        exp6 = ""
+        exp7 = ""
+        exp8 = ""
+
+        assert_equal(cat0,exp0)
+        assert_equal(cat1,exp1)
+        assert_equal(cat2,exp2)
+        assert_equal(cat3,exp3)
+        assert_equal(cat4,exp4)
+        assert_equal(cat5,exp5)
+        assert_equal(cat6,exp6)
+        assert_equal(cat7,exp7)
+        assert_equal(cat8,exp8)
+
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+
+if __name__ == '__main__':
+    GetDebugCategories().main()
+
+# Create a convenient function for an interactive python debugging session
+def Test():
+    t = GetDebugCategories()
+    bitcoinConf = {}
+    flags = standardFlags()
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/getlogcategories.py
+++ b/qa/rpc-tests/getlogcategories.py
@@ -17,7 +17,7 @@ import random
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-class GetDebugCategories (BitcoinTestFramework):
+class GetLogCategories (BitcoinTestFramework):
 
     def setup_chain(self,bitcoinConfDict=None, wallets=None):
         print("Initializing test directory "+self.options.tmpdir)
@@ -57,15 +57,15 @@ class GetDebugCategories (BitcoinTestFramework):
         self.is_network_split = False
 
     def run_test (self):
-        cat0 = self.nodes[0].getdebugcategories()
-        cat1 = self.nodes[1].getdebugcategories()
-        cat2 = self.nodes[2].getdebugcategories()
-        cat3 = self.nodes[3].getdebugcategories()
-        cat4 = self.nodes[4].getdebugcategories()
-        cat5 = self.nodes[5].getdebugcategories()
-        cat6 = self.nodes[6].getdebugcategories()
-        cat7 = self.nodes[7].getdebugcategories()
-        cat8 = self.nodes[8].getdebugcategories()
+        cat0 = self.nodes[0].log()
+        cat1 = self.nodes[1].log()
+        cat2 = self.nodes[2].log()
+        cat3 = self.nodes[3].log()
+        cat4 = self.nodes[4].log()
+        cat5 = self.nodes[5].log()
+        cat6 = self.nodes[6].log()
+        cat7 = self.nodes[7].log()
+        cat8 = self.nodes[8].log()
 
         exp0 = "coindb tor addrman libevent http rpc partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks"
         exp1 = "libevent http partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks"
@@ -91,11 +91,11 @@ class GetDebugCategories (BitcoinTestFramework):
         wait_bitcoinds()
 
 if __name__ == '__main__':
-    GetDebugCategories().main()
+    GetLogCategories().main()
 
 # Create a convenient function for an interactive python debugging session
 def Test():
-    t = GetDebugCategories()
+    t = GetLogCategories()
     bitcoinConf = {}
     flags = standardFlags()
     t.main(flags, bitcoinConf, None)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -811,24 +811,32 @@ BOOST_AUTO_TEST_CASE(splitbycommaandremovespaces)
     const std::vector<std::string> r = splitByCommasAndRemoveSpaces(inp1);
 
     BOOST_CHECK_EQUAL(r.size(), 4);
-    BOOST_CHECK_EQUAL(r[0], "one");
-    BOOST_CHECK_EQUAL(r[1], "two");
-    BOOST_CHECK_EQUAL(r[2], "three");
-    BOOST_CHECK_EQUAL(r[3], "four");
+    BOOST_CHECK_EQUAL(r[3], "one");
+    BOOST_CHECK_EQUAL(r[2], "two");
+    BOOST_CHECK_EQUAL(r[1], "three");
+    BOOST_CHECK_EQUAL(r[0], "four");
 
     const std::vector<std::string> r2 = splitByCommasAndRemoveSpaces(r);
     BOOST_CHECK_EQUAL(r.size(), 4);
-    BOOST_CHECK_EQUAL(r[0], "one");
-    BOOST_CHECK_EQUAL(r[1], "two");
-    BOOST_CHECK_EQUAL(r[2], "three");
-    BOOST_CHECK_EQUAL(r[3], "four");
+    BOOST_CHECK_EQUAL(r[3], "one");
+    BOOST_CHECK_EQUAL(r[2], "two");
+    BOOST_CHECK_EQUAL(r[1], "three");
+    BOOST_CHECK_EQUAL(r[0], "four");
 
     std::vector<std::string> inp2{"one", "two, two  ", "f o u r"};
     const std::vector<std::string> r3 = splitByCommasAndRemoveSpaces(inp2, true);
     BOOST_CHECK_EQUAL(r3.size(), 3);
-    BOOST_CHECK_EQUAL(r3[0], "four");
+    BOOST_CHECK_EQUAL(r3[2], "four");
     BOOST_CHECK_EQUAL(r3[1], "one");
-    BOOST_CHECK_EQUAL(r3[2], "two");
+    BOOST_CHECK_EQUAL(r3[0], "two");
+
+    std::vector<std::string> inp3{"1", "2", "3", "-4"};
+    const std::vector<std::string> r4 = splitByCommasAndRemoveSpaces(inp3, true);
+    BOOST_CHECK_EQUAL(r4.size(), 4);
+    BOOST_CHECK_EQUAL(r4[0], "3");
+    BOOST_CHECK_EQUAL(r4[1], "2");
+    BOOST_CHECK_EQUAL(r4[2], "1");
+    BOOST_CHECK_EQUAL(r4[3], "-4");
 }
 
 BOOST_AUTO_TEST_CASE(enum_toString)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -822,6 +822,13 @@ BOOST_AUTO_TEST_CASE(splitbycommaandremovespaces)
     BOOST_CHECK_EQUAL(r[1], "two");
     BOOST_CHECK_EQUAL(r[2], "three");
     BOOST_CHECK_EQUAL(r[3], "four");
+
+    std::vector<std::string> inp2{"one", "two, two  ", "f o u r"};
+    const std::vector<std::string> r3 = splitByCommasAndRemoveSpaces(inp2, true);
+    BOOST_CHECK_EQUAL(r3.size(), 3);
+    BOOST_CHECK_EQUAL(r3[0], "four");
+    BOOST_CHECK_EQUAL(r3[1], "one");
+    BOOST_CHECK_EQUAL(r3[2], "two");
 }
 
 BOOST_AUTO_TEST_CASE(enum_toString)

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1748,6 +1748,22 @@ UniValue setlog(const UniValue &params, bool fHelp)
     return ret;
 }
 
+UniValue getdebugcategories(const UniValue &params, bool fHelp)
+{
+    UniValue ret = UniValue("");
+
+    if (fHelp || (params.size() != 0))
+    {
+        throw runtime_error("getlog"
+                            "\nReturn a list of active debug categories\n"
+                            "\nThis rpc has no arguments a part from the help on\n" +
+                            HelpExampleCli("getdebugcategories", "") + HelpExampleRpc("getdebugcategories", ""));
+    }
+
+    ret = UniValue(Logging::LogGetAllString(true));
+    return ret;
+}
+
 /** Mining-Candidate begin */
 
 /** Oustanding candidates are removed 30 sec after a new block has been found*/
@@ -2024,6 +2040,7 @@ static const CRPCCommand commands[] =
 #endif
     { "util",               "getaddressforms",        &getaddressforms,        true  },
     { "util",               "log",                    &setlog,                 true  },
+    { "util",               "getdebugcategories",     &getdebugcategories,     true  },
     /* Coin generation */
     { "generating",         "getgenerate",            &getgenerate,            true  },
     { "generating",         "setgenerate",            &setgenerate,            true  },

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1683,22 +1683,26 @@ UniValue setlog(const UniValue &params, bool fHelp)
     int nparm = params.size();
     bool action = false;
 
-    if (fHelp || nparm < 1 || nparm > 2)
+    if (fHelp || nparm > 2)
     {
         throw runtime_error(
             "log \"category|all\" \"on|off\""
             "\nTurn categories on or off\n"
+            "\nWith no arguments it returns a list of currently on log categories\n"
             "\nArguments:\n"
             "1. \"category|all\" (string, required) Category or all categories\n"
             "2. \"on\"           (string, optional) Turn a category, or all categories, on\n"
             "2. \"off\"          (string, optional) Turn a category, or all categories, off\n"
             "2.                (string, optional) No argument. Show a category, or all categories, state: on|off\n" +
             HelpExampleCli("log", "\"NET\" on") + HelpExampleCli("log", "\"all\" off") +
-            HelpExampleCli("log", "\"tor\" ") + HelpExampleCli("log", "\"ALL\" "));
+            HelpExampleCli("log", "\"tor\" ") + HelpExampleCli("log", "\"ALL\" ") + HelpExampleCli("log", " "));
     }
 
     try
     {
+        if (nparm == 0)
+            ret = UniValue(Logging::LogGetAllString(true));
+
         if (nparm > 0)
         {
             std::string category;
@@ -1741,22 +1745,6 @@ UniValue setlog(const UniValue &params, bool fHelp)
         ret = UniValue("Something went wrong. That is all we know.");
     }
 
-    return ret;
-}
-
-UniValue getdebugcategories(const UniValue &params, bool fHelp)
-{
-    UniValue ret = UniValue("");
-
-    if (fHelp || (params.size() != 0))
-    {
-        throw runtime_error("getlog"
-                            "\nReturn a list of active debug categories\n"
-                            "\nThis rpc has no arguments a part from the help on\n" +
-                            HelpExampleCli("getdebugcategories", "") + HelpExampleRpc("getdebugcategories", ""));
-    }
-
-    ret = UniValue(Logging::LogGetAllString(true));
     return ret;
 }
 
@@ -2036,7 +2024,6 @@ static const CRPCCommand commands[] =
 #endif
     { "util",               "getaddressforms",        &getaddressforms,        true  },
     { "util",               "log",                    &setlog,                 true  },
-    { "util",               "getdebugcategories",     &getdebugcategories,     true  },
     /* Coin generation */
     { "generating",         "getgenerate",            &getgenerate,            true  },
     { "generating",         "setgenerate",            &setgenerate,            true  },

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1697,8 +1697,6 @@ UniValue setlog(const UniValue &params, bool fHelp)
             HelpExampleCli("log", "\"tor\" ") + HelpExampleCli("log", "\"ALL\" "));
     }
 
-    // LOGA("LOG: Before mask: 0x%llx\n", Logging::categoriesEnabled);
-
     try
     {
         if (nparm > 0)
@@ -1742,8 +1740,6 @@ UniValue setlog(const UniValue &params, bool fHelp)
         LOG(ALL, "LOG: Something went wrong in setlog function \n");
         ret = UniValue("Something went wrong. That is all we know.");
     }
-
-    // LOGA("LOG: After  mask: 0x%llx\n", Logging::categoriesEnabled);
 
     return ret;
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -94,7 +94,8 @@
 #include <openssl/rand.h>
 #include <thread>
 
-std::vector<std::string> splitByCommasAndRemoveSpaces(const std::vector<std::string> &args)
+std::vector<std::string> splitByCommasAndRemoveSpaces(const std::vector<std::string> &args,
+    bool removeDuplicates /* false */)
 {
     std::vector<std::string> result;
     for (std::string arg : args)
@@ -110,6 +111,13 @@ std::vector<std::string> splitByCommasAndRemoveSpaces(const std::vector<std::str
             if (c != ' ')
                 arg_nospace += c;
         result.push_back(arg_nospace);
+    }
+
+    // remove duplicates from the list of debug categories
+    if (removeDuplicates)
+    {
+        std::sort(result.begin(), result.end());
+        result.erase(std::unique(result.begin(), result.end()), result.end());
     }
     return result;
 }
@@ -184,7 +192,7 @@ void LogInit()
 {
     string category = "";
     uint64_t catg = NONE;
-    const vector<string> categories = splitByCommasAndRemoveSpaces(mapMultiArgs["-debug"]);
+    const vector<string> categories = splitByCommasAndRemoveSpaces(mapMultiArgs["-debug"], true);
 
     // enable all when given -debug=1 or -debug
     if (categories.size() == 1 && (categories[0] == "" || categories[0] == "1"))

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -178,9 +178,11 @@ std::string LogGetAllString(bool fEnabled)
             continue;
 
         if (LogAcceptCategory(x.first))
+        {
             allCategories += "on ";
-        if (fEnabled)
-            enabledCategories += (std::string)x.second + " ";
+            if (fEnabled)
+                enabledCategories += (std::string)x.second + " ";
+        }
         else
             allCategories += "   ";
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -183,13 +183,13 @@ std::string LogGetAllString(bool fEnabled)
 void LogInit()
 {
     string category = "";
-    uint64_t catg = Logging::NONE;
+    uint64_t catg = NONE;
     const vector<string> categories = splitByCommasAndRemoveSpaces(mapMultiArgs["-debug"]);
 
     // enable all when given -debug=1 or -debug
     if (categories.size() == 1 && (categories[0] == "" || categories[0] == "1"))
     {
-        Logging::LogToggleCategory(Logging::ALL, true);
+        LogToggleCategory(ALL, true);
     }
     else
     {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -189,15 +189,32 @@ void LogInit()
         Logging::LogToggleCategory(Logging::ALL, true);
         return;
     }
+
     for (string const &cat : categories)
     {
         category = boost::algorithm::to_lower_copy(cat);
+
+        // remove the category from the list of enables one
+        // if label is suffixed with a dash
+        bool toggle_flag = true;
+
+        if (category.length() > 0 && category.at(0) == '-')
+        {
+            toggle_flag = false;
+            category.erase(0, 1);
+        }
+
+        if (category == "" || category == "1")
+        {
+            category == "all";
+        }
+
         catg = LogFindCategory(category);
 
         if (catg == NONE) // Not a valid category
             continue;
 
-        LogToggleCategory(catg, true);
+        LogToggleCategory(catg, toggle_flag);
     }
 }
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -119,6 +119,7 @@ std::vector<std::string> splitByCommasAndRemoveSpaces(const std::vector<std::str
         std::sort(result.begin(), result.end());
         result.erase(std::unique(result.begin(), result.end()), result.end());
     }
+    std::reverse(result.begin(), result.end());
     return result;
 }
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -165,7 +165,6 @@ std::string LogGetAllString()
         if (x.first == ALL || x.first == NONE)
             continue;
 
-        // ret += (std::string)x.second;
         if (LogAcceptCategory(x.first))
             ret += "on ";
         else

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -188,6 +188,10 @@ std::string LogGetAllString(bool fEnabled)
 
         allCategories += (std::string)x.second + "\n";
     }
+    // strip last char from enabledCategories if it is eqaul to a blank space
+    if (enabledCategories.length() > 0)
+        enabledCategories.pop_back();
+
     return fEnabled ? enabledCategories : allCategories;
 }
 

--- a/src/util.h
+++ b/src/util.h
@@ -231,7 +231,7 @@ std::string LogGetLabel(uint64_t category);
  * Formatted for display.
  * returns all categories and states
  */
-std::string LogGetAllString();
+std::string LogGetAllString(bool fEnabled = false);
 
 /**
  * Initialize

--- a/src/util.h
+++ b/src/util.h
@@ -111,7 +111,8 @@ int LogPrintStr(const std::string &str);
 // Takes a std::vector of strings and splits individual arguments further up if
 // they contain commas. Also removes space from the output strings.
 // For example, ["a", "b,c", "d"] becomes ["a", "b", "c", "d"]
-extern std::vector<std::string> splitByCommasAndRemoveSpaces(const std::vector<std::string> &args);
+extern std::vector<std::string> splitByCommasAndRemoveSpaces(const std::vector<std::string> &args,
+    bool removeDuplicates = false);
 
 // Logging API:
 // Use the two macros


### PR DESCRIPTION
This would be particular useful when you want to have all categories enabled but one, e.g. now you can use debug=all,-selectcoins, especially when `bitcoind` is executed automatically, e.g. via the python functional tests suite.  