### PR TITLE
[1.4.0.0] Fix Another bunch of warnings

### DIFF
--- a/src/blockstorage/blockleveldb.cpp
+++ b/src/blockstorage/blockleveldb.cpp
@@ -118,7 +118,7 @@ uint64_t FindFilesToPruneLevelDB(uint64_t nLastBlockWeCanPrune)
     CDBBatch undoBatch(*pblockundodb);
     while (nDBUsedSpace >= nPruneTarget && pindexOldest != nullptr)
     {
-        if (pindexOldest->nHeight >= nLastBlockWeCanPrune)
+        if (pindexOldest->nHeight >= (int)nLastBlockWeCanPrune)
         {
             break;
         }

--- a/src/blockstorage/blockstorage.cpp
+++ b/src/blockstorage/blockstorage.cpp
@@ -278,7 +278,7 @@ void SyncStorage(const CChainParams &chainparams)
         pblocktreeother->GetSortedHashIndex(indexByHeight);
         LOGA("indexByHeight size = %u \n", indexByHeight.size());
         int64_t bestHeight = 0;
-        uint64_t lastFinishedFile = 0;
+        int64_t lastFinishedFile = 0;
         CBlockIndex *pindexBest = new CBlockIndex();
         // Load block file info
         int loadedblockfile = 0;
@@ -401,7 +401,7 @@ void SyncStorage(const CChainParams &chainparams)
                 }
             }
             setDirtyBlockIndex.insert(index);
-            if (lastFinishedFile <= loadedblockfile && index->nHeight > blockfiles[lastFinishedFile].nHeightLast)
+            if (lastFinishedFile <= loadedblockfile && index->nHeight > (int)blockfiles[lastFinishedFile].nHeightLast)
             {
                 fs::remove(GetDataDir() / "blocks" / strprintf("blk%05u.dat", lastFinishedFile));
                 fs::remove(GetDataDir() / "blocks" / strprintf("rev%05u.dat", lastFinishedFile));

--- a/src/blockstorage/blockstorage.cpp
+++ b/src/blockstorage/blockstorage.cpp
@@ -124,7 +124,6 @@ void SyncStorage(const CChainParams &chainparams)
                 // Start new block file
                 unsigned int nBlockSize = ::GetSerializeSize(block, SER_DISK, CLIENT_VERSION);
                 CDiskBlockPos blockPos;
-                CValidationState state;
                 if (!FindBlockPos(state, blockPos, nBlockSize + 8, 0, block.GetBlockTime(), false))
                 {
                     LOGA("SyncStorage(): FindBlockPos failed");

--- a/src/blockstorage/sequential_files.cpp
+++ b/src/blockstorage/sequential_files.cpp
@@ -175,11 +175,11 @@ void PruneOneBlockFile(const int fileNumber)
                 range = mapBlocksUnlinked.equal_range(pindex->pprev);
             while (range.first != range.second)
             {
-                std::multimap<CBlockIndex *, CBlockIndex *>::iterator it = range.first;
+                std::multimap<CBlockIndex *, CBlockIndex *>::iterator itr = range.first;
                 range.first++;
-                if (it->second == pindex)
+                if (itr->second == pindex)
                 {
-                    mapBlocksUnlinked.erase(it);
+                    mapBlocksUnlinked.erase(itr);
                 }
             }
         }

--- a/src/respend/test/respenddetector_tests.cpp
+++ b/src/respend/test/respenddetector_tests.cpp
@@ -27,12 +27,12 @@ public:
     bool AddOutpointConflict(const COutPoint &out,
         const CTxMemPool::txiter mempoolEntry,
         const CTransaction &respendTx,
-        bool respentBefore,
-        bool isEquivalent) override
+        bool fRespentBefore,
+        bool fIsEquivalent) override
     {
         addOutpointCalls++;
-        this->respentBefore = respentBefore;
-        this->isEquivalent = isEquivalent;
+        this->respentBefore = fRespentBefore;
+        this->isEquivalent = fIsEquivalent;
         return false;
     }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -30,8 +30,6 @@ static const char DB_FLAG = 'F';
 static const char DB_REINDEX_FLAG = 'R';
 static const char DB_LAST_BLOCK = 'l';
 
-static const char DB_BLOCK_SIZES = 'S';
-
 // to distinguish best block for a specific DB type, values correspond to enum vaue (blockdb_wrapper.h)
 static const char DB_BEST_BLOCK_BLOCKDB = 'D';
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -31,7 +31,7 @@ static const int64_t nMinDbCache = 4;
 //! % of available memory to leave unused by dbcache if/when we dynamically size the dbcache.
 static const int64_t nDefaultPcntMemUnused = 10;
 //! max increase in cache size since the last time we did a full flush
-static const int64_t nMaxCacheIncreaseSinceLastFlush = 512 * 1000 * 1000;
+static const uint64_t nMaxCacheIncreaseSinceLastFlush = 512 * 1000 * 1000;
 //! the minimum system memory we always keep free when doing automatic dbcache sizing
 static const uint64_t nMinMemToKeepAvaialable = 300 * 1000 * 1000;
 //! the max size a batch can get before a write to the utxo is made


### PR DESCRIPTION
Shadowing and unused variable warnings in blocksdb code and double spend relaying code. 