### PR TITLE
If we receive a thinblock or graphene block but we already have the b…

### DIFF
--- a/src/graphene.cpp
+++ b/src/graphene.cpp
@@ -101,7 +101,7 @@ bool CGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     }
     if (fAlreadyHave)
     {
-        requester.AlreadyReceived(inv);
+        requester.AlreadyReceived(pfrom, inv);
         graphenedata.ClearGrapheneBlockData(pfrom, inv.hash);
 
         LOG(GRAPHENE, "Received grblocktx but returning because we already have this block %s on disk, peer=%s\n",
@@ -376,7 +376,7 @@ bool CGrapheneBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string
         if (pIndex->nStatus & BLOCK_HAVE_DATA)
         {
             // Tell the Request Manager we received this block
-            requester.AlreadyReceived(inv);
+            requester.AlreadyReceived(pfrom, inv);
 
             graphenedata.ClearGrapheneBlockData(pfrom, grapheneBlock.header.GetHash());
             LOG(GRAPHENE, "Received grapheneblock but returning because we already have block data %s from peer %s hop"

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -176,7 +176,7 @@ public:
     void Received(const CInv &obj, CNode *from, int bytes = 0);
 
     // Indicate that we previously got this object
-    void AlreadyReceived(const CInv &obj);
+    void AlreadyReceived(CNode *pnode, const CInv &obj);
 
     // Indicate that getting this object was rejected
     void Rejected(const CInv &obj, CNode *from, unsigned char reason = 0);

--- a/src/thinblock.cpp
+++ b/src/thinblock.cpp
@@ -115,7 +115,7 @@ bool CThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     }
     if (fAlreadyHave)
     {
-        requester.AlreadyReceived(inv);
+        requester.AlreadyReceived(pfrom, inv);
         thindata.ClearThinBlockData(pfrom, inv.hash);
 
         LOG(THIN, "Received thinblock but returning because we already have this block %s on disk, peer=%s\n",
@@ -328,7 +328,7 @@ bool CXThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     }
     if (fAlreadyHave)
     {
-        requester.AlreadyReceived(inv);
+        requester.AlreadyReceived(pfrom, inv);
         thindata.ClearThinBlockData(pfrom, inv.hash);
 
         LOG(THIN, "Received xblocktx but returning because we already have this block %s on disk, peer=%s\n",
@@ -603,7 +603,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
         if (pIndex->nStatus & BLOCK_HAVE_DATA)
         {
             // Tell the Request Manager we received this block
-            requester.AlreadyReceived(inv);
+            requester.AlreadyReceived(pfrom, inv);
 
             thindata.ClearThinBlockData(pfrom, thinBlock.header.GetHash());
             LOG(THIN, "Received xthinblock but returning because we already have block data %s from peer %s hop"


### PR DESCRIPTION
…lock

Then make sure to MarkBlockAsReceived() when we call AlreadyReceived()
because we'll still think the block is in flight and end up
disconnecting the peer later thinking the block download has timed
out.