### PR TITLE
Weakblocks landgrab 😀

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -335,6 +335,8 @@ enum
     // collisions and other cases where nodes may be advertising a service they
     // do not actually support. Other service bits should be allocated via the
     // BUIP process.
+
+    NODE_WEAKBLOCKS = (1 << 7)
 };
 
 /** A CService with information about it as peer */

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -968,6 +968,9 @@ QString formatServicesStr(quint64 mask)
             case NODE_GRAPHENE:
                 strList.append("GRAPH");
                 break;
+            case NODE_WEAKBLOCKS:
+                strList.append("WB");
+                break;
             default:
                 strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
             }

--- a/src/util.h
+++ b/src/util.h
@@ -158,8 +158,10 @@ enum
     ZMQ = 0x2000000,
     QT = 0x4000000,
     IBD = 0x8000000,
+
     GRAPHENE = 0x10000000,
-    RESPEND = 0x20000000
+    RESPEND = 0x20000000,
+    WB = 0x40000000 // weak blocks
 };
 
 // Add corresponding lower case string for the category:
@@ -171,7 +173,7 @@ enum
             {MEMPOOLREJ, "mempoolrej"}, {BLK, "blk"}, {EVICT, "evict"}, {PARALLEL, "parallel"}, {RAND, "rand"}, \
             {REQ, "req"}, {BLOOM, "bloom"}, {LCK, "lck"}, {PROXY, "proxy"}, {DBASE, "dbase"},                   \
             {SELECTCOINS, "selectcoins"}, {ESTIMATEFEE, "estimatefee"}, {QT, "qt"}, {IBD, "ibd"},               \
-            {GRAPHENE, "graphene"}, {RESPEND, "respend"},                                                       \
+            {GRAPHENE, "graphene"}, {RESPEND, "respend"}, {WB, "weakblocks"},                                   \
         {                                                                                                       \
             ZMQ, "zmq"                                                                                          \
         }                                                                                                       \


### PR DESCRIPTION
Hey folks,

there's some arrays that I have to rework every so often when I rebase my subchains / weakblocks code because I have to shift my "reserved values" as something else got merged that takes up the space I former occupied.

More to the point, this is a bit in the node service flags table as well as, BU specific, a bit for the logging category.

I hereby like to take the value of `0b10000000` (1<<7, 128) in the node service flag as meaning "supports weak blocks" with a further more detailed specification of what that means TBD. (Yes, I will write that!)

The node service flag part is also meant @dgenr8, @deadalnix, @jujumax and others. Please complain immediately if there's any road block that I don't see that would be preventing me from grabbing these values. Thank you.