### PR TITLE
Use CTransactionRef in maprelay

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -201,7 +201,7 @@ std::list<CStatBase *> mallocedStats;
 CStatMap statistics;
 CTweakMap tweaks;
 
-map<CInv, CDataStream> mapRelay;
+map<CInv, CTransactionRef> mapRelay;
 deque<pair<int64_t, CInv> > vRelayExpiration;
 CCriticalSection cs_mapRelay;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4881,10 +4881,7 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                         // Only offer a TX to the fork if its signed properly
                         if (!(!IsTxUAHFOnly(txe) && IsUAHFforkActiveOnNextBlock(chainActive.Tip()->nHeight)))
                         {
-                            CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-                            ss.reserve(1000);
-                            ss << txe.GetTx();
-                            pfrom->PushMessage(NetMsgType::TX, ss);
+                            pfrom->PushMessage(NetMsgType::TX, txe.GetTx());
                             fPushed = true;
                             pfrom->txsSent += 1;
                         }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2481,14 +2481,6 @@ void NetCleanup()
 
 void RelayTransaction(const CTransactionRef &ptx, const bool fRespend)
 {
-    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-    ss.reserve(10000);
-    ss << *ptx;
-    RelayTransaction(ptx, ss, fRespend);
-}
-
-void RelayTransaction(const CTransactionRef &ptx, const CDataStream &ss, const bool fRespend)
-{
     uint64_t len = ::GetSerializeSize(*ptx, SER_NETWORK, PROTOCOL_VERSION);
     if (len > maxTxSize.Value())
     {

--- a/src/net.h
+++ b/src/net.h
@@ -936,7 +936,6 @@ typedef std::vector<CNodeRef> VNodeRefs;
 
 class CTransaction;
 void RelayTransaction(const CTransactionRef &ptx, const bool fRespend = false);
-void RelayTransaction(const CTransactionRef &ptx, const CDataStream &ss, const bool fRespend = false);
 
 /** Access to the (IP) address database (peers.dat) */
 class CAddrDB

--- a/src/net.h
+++ b/src/net.h
@@ -190,7 +190,7 @@ extern int nMaxConnections;
 extern int nMinXthinNodes;
 extern std::vector<CNode *> vNodes;
 extern CCriticalSection cs_vNodes;
-extern std::map<CInv, CDataStream> mapRelay;
+extern std::map<CInv, CTransactionRef> mapRelay;
 extern std::deque<std::pair<int64_t, CInv> > vRelayExpiration;
 extern CCriticalSection cs_mapRelay;
 
@@ -935,8 +935,8 @@ private:
 typedef std::vector<CNodeRef> VNodeRefs;
 
 class CTransaction;
-void RelayTransaction(const CTransaction &tx, const bool fRespend = false);
-void RelayTransaction(const CTransaction &tx, const CDataStream &ss, const bool fRespend = false);
+void RelayTransaction(const CTransactionRef &ptx, const bool fRespend = false);
+void RelayTransaction(const CTransactionRef &ptx, const CDataStream &ss, const bool fRespend = false);
 
 /** Access to the (IP) address database (peers.dat) */
 class CAddrDB

--- a/src/respend/respendrelayer.cpp
+++ b/src/respend/respendrelayer.cpp
@@ -86,7 +86,7 @@ void RespendRelayer::Trigger()
     if (!valid || !interesting)
         return;
 
-    RelayTransaction(respend, true);
+    RelayTransaction(MakeTransactionRef(respend), true);
 }
 
 } // ns respend

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1017,7 +1017,7 @@ UniValue sendrawtransaction(const UniValue &params, bool fHelp)
     {
         throw JSONRPCError(RPC_TRANSACTION_ALREADY_IN_CHAIN, "transaction already in block chain");
     }
-    RelayTransaction(*ptx);
+    RelayTransaction(ptx);
 
     return hashTx.GetHex();
 }

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1485,7 +1485,7 @@ bool CWalletTx::RelayWalletTransaction()
         if (GetDepthInMainChain() == 0 && !isAbandoned() && InMempool())
         {
             LOGA("Relaying wtx %s\n", GetHash().ToString());
-            RelayTransaction((CTransaction) * this);
+            RelayTransaction(MakeTransactionRef((CTransaction) * this));
             return true;
         }
     }


### PR DESCRIPTION
This further extends CTransactionRef and prevents the unnecessary copy of the entire transaction, in ProcessGetData, when relaying from maprelay.