### PR TITLE
[WIP] TopoCanonical ordering - and more efficient graphene transmission

### DIFF
--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -18,6 +18,8 @@ bitcoin-miner.cpp
 bitcoin-tx.cpp
 bitnodes.cpp
 bitnodes.h
+blockorder.cpp
+blockorder.h
 blockstorage/blockleveldb.cpp
 blockstorage/blockleveldb.h
 blockstorage/sequential_files.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -98,6 +98,7 @@ BITCOIN_CORE_H = \
   base58.h \
   bandb.h \
   banentry.h \
+  blockorder.h \
   blockstorage/blockleveldb.h \
   blockstorage/sequential_files.h \
   blockstorage/blockstorage.h \
@@ -395,6 +396,7 @@ libbitcoin_common_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_common_a_SOURCES = \
   amount.cpp \
   base58.cpp \
+  blockorder.cpp \
   cashaddr.cpp \
   cashaddrenc.cpp \
   chainparams.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -65,6 +65,7 @@ BITCOIN_TESTS =\
   test/base58_tests.cpp \
   test/base64_tests.cpp \
   test/bip32_tests.cpp \
+  test/blockorder_tests.cpp \
   test/bloom_tests.cpp \
   test/checkblock_tests.cpp \
   test/Checkpoints_tests.cpp \

--- a/src/benchorder.py
+++ b/src/benchorder.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import numpy as np
+import time
+from os import system
+from sys import stdout
+
+ntx_values = np.array(10.**np.linspace(0, 6, 20), int)
+
+for test in range(4):
+    for ntx in ntx_values:
+        a = time.time()
+        system("./bitcoin-tx %d %d < ~/blocks-400000-409999  > /dev/null" % (ntx, test))
+        b = time.time()
+
+        print("%3d %10d %8f" % (test, ntx, (b-a)/100.))
+        stdout.flush()

--- a/src/blockorder.cpp
+++ b/src/blockorder.cpp
@@ -1,0 +1,159 @@
+// Copyright (c) 2018 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "blockorder.h"
+#include <algorithm>
+#include <list>
+
+class TXIDCompareReverse
+{
+public:
+    inline bool operator()(const CTransaction *b, const CTransaction *a) { return a->GetHash() < b->GetHash(); }
+    inline bool operator()(const CTransactionRef &a, const CTransactionRef &b) { return operator()(a.get(), b.get()); }
+};
+
+
+class MinInputTXIDCompare
+{
+    inline std::pair<uint256, uint32_t> min_input(const CTransaction *r)
+    {
+        uint256 min_hash;
+        uint32_t min_idx = 0xffffffff;
+
+        // note: logic should also work for coinbase as it only has a *single* input of zero
+        for (auto &input : r->vin)
+        {
+            if (min_hash.IsNull() || input.prevout.hash < min_hash)
+            {
+                min_hash = input.prevout.hash;
+                min_idx = input.prevout.n;
+            }
+            else if (input.prevout.hash == min_hash)
+            {
+                min_idx = std::min(input.prevout.n, min_idx);
+            }
+        }
+        return std::pair<uint256, uint32_t>(min_hash, min_idx);
+    }
+
+public:
+    inline bool operator()(const CTransaction *b, const CTransaction *a)
+    {
+        std::pair<uint256, uint32_t> min_a = min_input(a);
+        std::pair<uint256, uint32_t> min_b = min_input(b);
+        return min_a < min_b;
+    }
+};
+
+
+// FIXME: deal with coinbase explictly
+void BlockOrder::Lexical::sort(CTxRefVector &txrfv) { std::sort(txrfv.begin() + 1, txrfv.end(), TXIDCompare()); }
+void BlockOrder::TopoCanonical::prepare(const CTxRefVector &txrfv)
+{
+    ptr2ref.reserve(txrfv.size() * 2);
+    txn_map.reserve(txrfv.size() * 2);
+    // build pointer map
+    for (auto &txr : txrfv)
+    {
+        ptr2ref[txr.get()] = txr;
+        txn_map[txr->GetHash()] = txr.get();
+    }
+}
+
+inline void BlockOrder::TopoCanonical::fillIncoming(CTxRefVector &txrfv,
+    std::unordered_map<const CTransaction *, int> &incoming)
+{
+    for (auto &txr : txrfv)
+    {
+        for (auto &input : txr->vin)
+            if (txn_map.count(input.prevout.hash))
+            {
+                const CTransaction *input_tx = txn_map[input.prevout.hash];
+                incoming[input_tx]++;
+            }
+        if (txr->IsCoinBase())
+            std::swap(txrfv[0], txr);
+    }
+}
+
+inline unsigned BlockOrder::TopoCanonical::fillTodo(const CTxRefVector &txrfv,
+    const std::unordered_map<const CTransaction *, int> &incoming,
+    std::vector<const CTransaction *> &todo)
+{
+    unsigned n_todo = 0;
+
+    for (auto &txr : txrfv)
+    {
+        const CTransaction *tx = txr.get();
+        if (!incoming.count(tx))
+            todo[n_todo++] = tx;
+    }
+    return n_todo;
+}
+
+inline void BlockOrder::TopoCanonical::applyKahns(CTxRefVector &txrfv,
+    std::unordered_map<const CTransaction *, int> incoming,
+    std::vector<const CTransaction *> &todo,
+    unsigned n_todo)
+{
+    const int N = txrfv.size();
+    // and apply Kahn's algorithm to build final sorted vector: O(fn)
+    int i = N - 1;
+    int j = 1;
+    while (j < N)
+    {
+        const CTransaction *tx = todo[j++];
+        txrfv[i--] = ptr2ref[tx];
+        for (auto &input : tx->vin)
+        {
+            if (txn_map.count(input.prevout.hash))
+            {
+                auto &input_tx = txn_map[input.prevout.hash];
+                incoming[input_tx]--;
+                if (!incoming[input_tx])
+                    todo[n_todo++] = input_tx;
+            }
+        }
+    }
+}
+
+void BlockOrder::TopoCanonical::sort(CTxRefVector &txrfv)
+{
+    // build incoming counts
+    std::unordered_map<const CTransaction *, int> incoming(txrfv.size() * 2);
+    fillIncoming(txrfv, incoming);
+
+    std::vector<const CTransaction *> todo(txrfv.size());
+    unsigned n_todo = fillTodo(txrfv, incoming, todo);
+
+    // sort TODO list: O( (1-f)n log ( (1-f) n)
+    // note that a fixed order flows from this fixed initial sorted TODO list (the dependency order does the rest)!
+    // skip coinbase
+    std::sort(todo.begin() + 1, todo.begin() + n_todo, TXIDCompareReverse());
+    // std::sort(todo.begin(), todo.begin() + n_todo, MinInputTXIDCompare());
+    applyKahns(txrfv, incoming, todo, n_todo);
+}
+
+bool BlockOrder::isTopological(const CTxRefVector &txrfv)
+{
+    std::unordered_map<uint256, int, BlockHasher> txn_pos;
+    for (size_t i = 0; i < txrfv.size(); i++)
+    {
+        uint256 hash = txrfv[i]->GetHash();
+        if (txn_pos.count(hash))
+            return false; // return false also on duplicates
+        txn_pos[hash] = i;
+    }
+
+    for (size_t i = 0; i < txrfv.size(); i++)
+    {
+        for (auto input : txrfv[i]->vin)
+        {
+            const uint256 inp_hash = input.prevout.hash;
+            if (txn_pos.count(inp_hash) && txn_pos[inp_hash] >= i)
+                return false;
+        }
+    }
+    return true;
+}

--- a/src/blockorder.h
+++ b/src/blockorder.h
@@ -1,0 +1,82 @@
+// Copyright (c) 2018 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+/**
+ * Ordering of vector<CTransactionRef>s (block contents) with different
+ * algorithms. Checks for orders.
+ */
+#ifndef BITCOIN_BLOCKORDER_H
+#define BITCOIN_BLOCKORDER_H
+
+#include "main.h"
+#include "primitives/transaction.h"
+#include <set>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+typedef std::vector<CTransactionRef> CTxRefVector;
+
+namespace BlockOrder
+{
+class TXIDCompare
+{
+public:
+    inline bool operator()(const CTransaction *a, const CTransaction *b) { return a->GetHash() < b->GetHash(); }
+    inline bool operator()(const CTransactionRef &a, const CTransactionRef &b) { return operator()(a.get(), b.get()); }
+};
+
+class Lexical
+{
+public:
+    inline void prepare(const CTxRefVector &txrfv) {}
+    /*! Given a CTxRefVector, sort it in-place lexicographically by TXID.
+      For blocks of size n, the complexity of this should be O(n log n). */
+    void sort(CTxRefVector &txrfv);
+};
+
+class TopoCanonical
+{
+public:
+    void prepare(const CTxRefVector &txrfv);
+
+    /*! Given a CTxRefVector, sort it partial-canonical "TopoCanonical". This is a variant / adaptation
+      of Gavin Andresen's canonical sorting algorithm, as described here:
+
+      Sorting by this order means that the block order will still be valid in the sense
+      of block ordering rules on the BCH network as of August 2018, that is, following
+      the topological block sorting order.
+
+      It will, however, also be unique and can thus be transmitted in a TBD update of the
+      Graphene protocol in an efficient manner that does not need to transmit the block order
+      (just the ordering algorithm used).
+
+      The complexity of this algorithm, for blocks of size n and a fraction f of transactions that are pointing to each
+      other should be as follows (though this needs to be reviewed in a more detailed analysis. Minor points are easy to
+      get
+      wrong):
+      O( (1-f)n log ((1-f)n ) + fn)
+
+      This assumes that txrf is a poset!
+    */
+    void sort(CTxRefVector &txrfv);
+
+private:
+    std::unordered_map<const CTransaction *, CTransactionRef> ptr2ref;
+    std::unordered_map<uint256, const CTransaction *, BlockHasher> txn_map;
+    void fillIncoming(CTxRefVector &txrfv, std::unordered_map<const CTransaction *, int> &incoming);
+    unsigned fillTodo(const CTxRefVector &txrfv,
+        const std::unordered_map<const CTransaction *, int> &incoming,
+        std::vector<const CTransaction *> &todo);
+    void applyKahns(CTxRefVector &txrfv,
+        std::unordered_map<const CTransaction *, int> incoming,
+        std::vector<const CTransaction *> &todo,
+        unsigned n_todo);
+};
+
+
+//! Returns true if vector txrfv is ordered with dependent transactions coming later
+bool isTopological(const CTxRefVector &txrfv);
+}
+#endif // BITCOIN_BLOCKORDER_H

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -256,6 +256,8 @@ CTweak<uint64_t> miningForkMG("mining.forkBlockSize",
     "Set the maximum block generation size to this value at the time of the fork.",
     8000000);
 
+CTweak<bool> miningTopoCanonical("mining.topoCanonical", "Enable mining of topo-canonically ordered blocks.", false);
+
 CTweak<bool> walletSignWithForkSig("wallet.useNewSig",
     "Once the fork occurs, sign transactions using the new signature scheme so that they will only be valid on the "
     "fork.",

--- a/src/graphene.h
+++ b/src/graphene.h
@@ -100,7 +100,6 @@ public:
     /** Public only for unit testing */
     uint256 blockhash;
     std::vector<CTransaction> vMissingTx; // map of missing transactions
-
 public:
     CGrapheneBlockTx(uint256 blockHash, std::vector<CTransaction> &vTx);
     CGrapheneBlockTx() {}

--- a/src/graphene_set.h
+++ b/src/graphene_set.h
@@ -36,6 +36,8 @@ enum GrapheneOrderings
 
 class CGrapheneSet
 {
+    friend class CGrapheneBlock;
+
 private:
     std::vector<uint64_t> ArgSort(const std::vector<uint64_t> &items)
     {

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -73,7 +73,14 @@ private:
     // memory only
     mutable uint64_t nBlockSize; // Serialized block size in bytes
 
+    // this flag can be set and queried but will NOT be checked when set
+    // It is meant to signal a generated or received block that is in topocanonical order,
+    // with signalling from the network layer (e.g. Graphene) or the mining code.
+    bool fTopoCanonical;
+
 public:
+    void setTopoCanonical(bool _f) { fTopoCanonical = _f; }
+    bool isTopoCanonical() { return fTopoCanonical; }
     // network and disk
     std::vector<CTransactionRef> vtx;
 
@@ -162,6 +169,7 @@ public:
         fChecked = false;
         fExcessive = false;
         nBlockSize = 0;
+        fTopoCanonical = false;
     }
 
     CBlockHeader GetBlockHeader() const

--- a/src/test/blockorder_tests.cpp
+++ b/src/test/blockorder_tests.cpp
@@ -1,0 +1,97 @@
+#include <boost/test/unit_test.hpp>
+#include "blockorder.h"
+#include "test/testutil.h"
+#include "test/test_bitcoin.h"
+
+BOOST_FIXTURE_TEST_SUITE(blockorder_tests, BasicTestingSetup)
+
+using namespace BlockOrder;
+
+inline void printTXRFV(const CTxRefVector &v) {
+    for (int i = 0; i < v.size(); i++) {
+        auto&tx = v[i];
+        printf("%d %s %s\n", i, tx->GetHash().GetHex().c_str(), tx->ToString().c_str());
+    }
+}
+
+/*! Check that the second part of transactions that are not being consumed in
+a block (no other transaction *within the block* depending on them) are
+properly sorted according to the TXIDCompare comparator function.
+
+Returns: negative position if the condition is not fulfilled at that position
+other, returns the position of the last matching transaction
+
+*/
+int checkLastAreLexical(const CTxRefVector& txrfv) {
+    std::set<uint256> deps;
+    TXIDCompare compare;
+
+    // > 1 -> skip coinbase
+    for (int i=txrfv.size()-1; i > 1; i--) {
+        for (auto& input : txrfv[i-1]->vin)
+            deps.insert(input.prevout.hash);
+
+        if (!compare(txrfv[i-1], txrfv[i]) &&
+            !deps.count(txrfv[i-1]->GetHash()))
+                return -i;
+    }
+    return 1;
+}
+
+
+void checkForFraction(double f)
+{
+    //  Create random block with some interdependent transactions
+    CBlockRef block0 = RandomBlock(1000, f);
+
+    BOOST_CHECK(block0->vtx[0]->IsCoinBase());
+    BOOST_CHECK(isTopological(block0->vtx));
+
+    TopoCanonical tc;
+    tc.prepare(block0->vtx);
+
+    // Copy out transaction list and sort it once
+    CTxRefVector ref(block0->vtx);
+    CTxRefVector test(block0->vtx);
+
+    tc.sort(ref);
+
+    BOOST_CHECK(isTopological(ref));
+
+    // Now do some random shuffles on test, resort, and test for identity
+    for (size_t i = 0; i < 100; i++) {
+        random_shuffle(test.begin()+1, test.end());
+        tc.sort(test);
+        BOOST_CHECK(test == ref);
+        if (test != ref) {
+            printf("REF:\n");
+            printTXRFV(ref);
+            printf("TEST:\n");
+            printTXRFV(test);
+
+            for (auto& tx : test)
+                printf("%s %s\n", tx->GetHash().GetHex().c_str(), tx->ToString().c_str());
+        }
+        BOOST_CHECK(test[0]->IsCoinBase());
+        for (size_t j=1; j < test.size(); j++)
+            BOOST_CHECK(!test[j]->IsCoinBase());
+        BOOST_CHECK(isTopological(test));
+        int last_are_lexical = checkLastAreLexical(test);
+        BOOST_CHECK(last_are_lexical);
+        if (last_are_lexical < 0) {
+            printf("pos: %d\n", last_are_lexical);
+            printf("REF:\n"); printTXRFV(ref);
+            printf("TEST:\n"); printTXRFV(test);
+        }
+        if (f == 0.0)
+            BOOST_CHECK(last_are_lexical == 1);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(blockorder_topocanonical_stable_and_topological)
+{
+    checkForFraction(0.0);
+    checkForFraction(0.1);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/sighash_tests.cpp
+++ b/src/test/sighash_tests.cpp
@@ -14,6 +14,7 @@
 #include "streams.h"
 #include "test/test_bitcoin.h"
 #include "test/test_random.h"
+#include "test/testutil.h"
 #include "util.h"
 #include "utilstrencodings.h"
 #include "version.h"
@@ -87,42 +88,6 @@ uint256 static SignatureHashOld(CScript scriptCode, const CTransaction &txTo, un
     CHashWriter ss(SER_GETHASH, 0);
     ss << txTmp << nHashType;
     return ss.GetHash();
-}
-
-void static RandomScript(CScript &script)
-{
-    static const opcodetype oplist[] = {
-        OP_FALSE, OP_1, OP_2, OP_3, OP_CHECKSIG, OP_IF, OP_VERIF, OP_RETURN, OP_CODESEPARATOR};
-    script = CScript();
-    int ops = (insecure_rand() % 10);
-    for (int i = 0; i < ops; i++)
-        script << oplist[insecure_rand() % (sizeof(oplist) / sizeof(oplist[0]))];
-}
-
-void static RandomTransaction(CMutableTransaction &tx, bool fSingle)
-{
-    tx.nVersion = insecure_rand();
-    tx.vin.clear();
-    tx.vout.clear();
-    tx.nLockTime = (insecure_rand() % 2) ? insecure_rand() : 0;
-    int ins = (insecure_rand() % 4) + 1;
-    int outs = fSingle ? ins : (insecure_rand() % 4) + 1;
-    for (int in = 0; in < ins; in++)
-    {
-        tx.vin.push_back(CTxIn());
-        CTxIn &txin = tx.vin.back();
-        txin.prevout.hash = GetRandHash();
-        txin.prevout.n = insecure_rand() % 4;
-        RandomScript(txin.scriptSig);
-        txin.nSequence = (insecure_rand() % 2) ? insecure_rand() : (unsigned int)-1;
-    }
-    for (int out = 0; out < outs; out++)
-    {
-        tx.vout.push_back(CTxOut());
-        CTxOut &txout = tx.vout.back();
-        txout.nValue = insecure_rand() % 100000000;
-        RandomScript(txout.scriptPubKey);
-    }
 }
 
 BOOST_FIXTURE_TEST_SUITE(sighash_tests, BasicTestingSetup)

--- a/src/test/testutil.cpp
+++ b/src/test/testutil.cpp
@@ -3,6 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "testutil.h"
+#include "primitives/transaction.h"
+#include "test/test_random.h"
 
 #ifdef WIN32
 #include <shlobj.h>
@@ -11,3 +13,38 @@
 #include "fs.h"
 
 fs::path GetTempPath() { return fs::temp_directory_path(); }
+void RandomScript(CScript &script)
+{
+    static const opcodetype oplist[] = {
+        OP_FALSE, OP_1, OP_2, OP_3, OP_CHECKSIG, OP_IF, OP_VERIF, OP_RETURN, OP_CODESEPARATOR};
+    script = CScript();
+    int ops = (insecure_rand() % 10);
+    for (int i = 0; i < ops; i++)
+        script << oplist[insecure_rand() % (sizeof(oplist) / sizeof(oplist[0]))];
+}
+
+void RandomTransaction(CMutableTransaction &tx, bool fSingle)
+{
+    tx.nVersion = insecure_rand();
+    tx.vin.clear();
+    tx.vout.clear();
+    tx.nLockTime = (insecure_rand() % 2) ? insecure_rand() : 0;
+    int ins = (insecure_rand() % 4) + 1;
+    int outs = fSingle ? ins : (insecure_rand() % 4) + 1;
+    for (int in = 0; in < ins; in++)
+    {
+        tx.vin.push_back(CTxIn());
+        CTxIn &txin = tx.vin.back();
+        txin.prevout.hash = GetRandHash();
+        txin.prevout.n = insecure_rand() % 4;
+        RandomScript(txin.scriptSig);
+        txin.nSequence = (insecure_rand() % 2) ? insecure_rand() : (unsigned int)-1;
+    }
+    for (int out = 0; out < outs; out++)
+    {
+        tx.vout.push_back(CTxOut());
+        CTxOut &txout = tx.vout.back();
+        txout.nValue = insecure_rand() % 100000000;
+        RandomScript(txout.scriptPubKey);
+    }
+}

--- a/src/test/testutil.h
+++ b/src/test/testutil.h
@@ -9,13 +9,28 @@
 #define BITCOIN_TEST_TESTUTIL_H
 
 #include "fs.h"
+#include "primitives/block.h"
 
 fs::path GetTempPath();
 
+class CTransaction;
 class CMutableTransaction;
 class CScript;
 
 void RandomScript(CScript &script);
-void RandomTransaction(CMutableTransaction &tx, bool fSingle);
+
+//! fCoinbase_like: Make the transaction so that it has a single input with
+//  prevout being a null hash and the input number being zero as well.
+//! vInputs: Inputs to select from (or None)
+void RandomTransaction(CMutableTransaction &tx,
+    bool fSingle,
+    bool fCoinbase_like = false,
+    std::vector<std::pair<uint256, uint32_t> > *pvInputs = nullptr);
+
+
+//! Create block of size ntx transaction with a fraction of 'dependent' dependent transactions
+//! The transactions in this block will not full any further validation rules, however
+// they'll be in the block in topological order
+CBlockRef RandomBlock(const size_t ntx, float dependent);
 
 #endif // BITCOIN_TEST_TESTUTIL_H

--- a/src/test/testutil.h
+++ b/src/test/testutil.h
@@ -12,4 +12,10 @@
 
 fs::path GetTempPath();
 
+class CMutableTransaction;
+class CScript;
+
+void RandomScript(CScript &script);
+void RandomTransaction(CMutableTransaction &tx, bool fSingle);
+
 #endif // BITCOIN_TEST_TESTUTIL_H

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -277,6 +277,8 @@ extern CTweak<uint64_t> miningForkTime;
 extern CTweak<uint64_t> miningForkEB;
 /** This specifies the minimum max block size at the fork point */
 extern CTweak<uint64_t> miningForkMG;
+/** This specificies whether the miner uses topo-canonical ordering for the blocks and block templates produced */
+extern CTweak<bool> miningTopoCanonical;
 
 // Mining-Candidate start
 /** Return a Merkle root given a Coinbase hash and Merkle proof */


### PR DESCRIPTION
(WARNING: To save makefile setup time etc., `bitcoin-tx` is being abused for crude benchmarking in this string of commits and doesn't work as expected any more. But you can take out the corresponding commit to make it work again.)

Hey folks,

this implements a variant of canonical ordering that I will hereby call "TopoCanonical" for lack of a better name. It includes:

- a unit test of this ordering
- changes to the mining code to support generating topocanonical blocks
- changes to the Graphene block transmission code (for the next version graphene?) to avoid transmitting the order and instead signal topocanonical ordering to the other end

All the code is at the proof-of-concept stage, but so far has been working in a couple simple manual tests. **It should be fully compatible with the current set of BCH validation rules.**

Some data:

Using `sendtoaddress`, 100 transactions are generated and transmitted with the current Graphene mode:

```
2018-08-20 10:34:51 received: get_grblk (44 bytes) peer=127.0.0.1:50820 (2)
2018-08-20 10:34:51 nGetGrapheneCount is 2.664810
2018-08-20 10:34:51 Constructed graphene block ordering: 1
2018-08-20 10:34:51 fp rate: 0.999000 Num elements in bloom filter: 102
2018-08-20 10:34:51 sending msg: grblk (588 bytes) peer=2
2018-08-20 10:34:51 Sent graphene block - size: 588 vs block size: 22924 => peer: 127.0.0.1:50820 (2)
```

The same is tried with topocanonical ordering (ordering number 2):
```
2018-08-20 10:33:07 ReceiveMsgBytes get_grblk
2018-08-20 10:33:07 Receive Queue: pushed get_grblk to the front of the queue
2018-08-20 10:33:07 received: get_grblk (44 bytes) peer=127.0.0.1:50820 (2)
2018-08-20 10:33:07 nGetGrapheneCount is 1.980182
2018-08-20 10:33:07 Constructed graphene block ordering: 2
2018-08-20 10:33:07 fp rate: 0.999000 Num elements in bloom filter: 102
2018-08-20 10:33:07 sending msg: grblk (498 bytes) peer=2
2018-08-20 10:33:07 Sent graphene block - size: 498 vs block size: 22876 => peer: 127.0.0.1:50820 (2)
```
One can see that it avoids sending the log2(100) == 7 * 100 bits = 88 bytes of ordering information.

**Benchmarking**.  Using the transactions from the blocks in BCH/BTC starting at block number 400000 (which are relatively full), the different sort orders have been bench-marked. Up to a million transactions from block number 400000 have been tested. See also the comment in `bitcoin-tx.cpp`.

As the warning above mentions, the current code uses an ad-hoc modification of `bitcoin-tx` to do some preliminary benchmarks. The results are shown below. A note on the columns:

The first column shows the test type, the second the number of transactions tested and the third the runtime for a single sorting step.
There are four modes: 

- 0 is an "empty" mode meant to subtract the time to read in the blocks from the actual sorting.
- 1 is sorting using lexical order (excluding the coinbase)
- 2 is sorting using topocanonical order, assuming a TXID look-up hashtable has been prepared
- 3 is the same as 2, but includes set up time for the preparation step

I think 2 is about the expected, real performance with proper integration into the rest of `bitcoind`.

I have tried to keep the code as self-contained as possible so that if this becomes more interesting to other implementations, it can be easily integrated. This, however, also meant that I didn't tie into any of the existing indexes and mempool data structures in current `bitcoind` but rather operate **only** on the `std::vector<CTransactionRef>`.

The benchmark has been run on a quite decent machine with an Intel(R) Xeon(R) CPU E5-2630 v4 @ 2.20GHz with 256GB of RAM.

```
  0          1 0.000651
  0          2 0.000646
  0          4 0.000642
  0          8 0.000646
  0         18 0.000638
  0         37 0.000642
  0         78 0.000642
  0        162 0.000649
  0        335 0.000646
  0        695 0.000653
  0       1438 0.000662
  0       2976 0.001975
  0       6158 0.002707
  0      12742 0.004769
  0      26366 0.011167
  0      54555 0.023610
  0     112883 0.043013
  0     233572 0.092927
  0     483293 0.192847
  0    1000000 0.383493
  1          1 0.000667
  1          2 0.000651
  1          4 0.000645
  1          8 0.000649
  1         18 0.000648
  1         37 0.000648
  1         78 0.000651
  1        162 0.000663
  1        335 0.000701
  1        695 0.000780
  1       1438 0.001015
  1       2976 0.002760
  1       6158 0.004468
  1      12742 0.008748
  1      26366 0.021105
  1      54555 0.044384
  1     112883 0.102219
  1     233572 0.235065
  1     483293 0.550351
  1    1000000 1.165535
  2          1 0.000664
  2          2 0.000644
  2          4 0.000648
  2          8 0.000644
  2         18 0.000643
  2         37 0.000646
  2         78 0.000657
  2        162 0.000682
  2        335 0.000731
  2        695 0.000840
  2       1438 0.001174
  2       2976 0.002953
  2       6158 0.005047
  2      12742 0.010208
  2      26366 0.024065
  2      54555 0.056132
  2     112883 0.129408
  2     233572 0.299468
  2     483293 0.670155
  2    1000000 1.447066
  3          1 0.000659
  3          2 0.000648
  3          4 0.000652
  3          8 0.000650
  3         18 0.000656
  3         37 0.000658
  3         78 0.000680
  3        162 0.000706
  3        335 0.000813
  3        695 0.001002
  3       1438 0.001594
  3       2976 0.003961
  3       6158 0.007340
  3      12742 0.015132
  3      26366 0.036709
  3      54555 0.097056
  3     112883 0.237627
  3     233572 0.628460
  3     483293 1.473200
  3    1000000 3.325792
```