### PR TITLE
Add the size of the orphan pool to the total mempool size

### DIFF
--- a/src/graphene.cpp
+++ b/src/graphene.cpp
@@ -1491,7 +1491,7 @@ bool HandleGrapheneBlockRequest(CDataStream &vRecv, CNode *pfrom, const CChainPa
     return true;
 }
 
-CMemPoolInfo GetGrapheneMempoolInfo() { return CMemPoolInfo(mempool.size()); }
+CMemPoolInfo GetGrapheneMempoolInfo() { return CMemPoolInfo(mempool.size() + orphanpool.GetOrphanPoolSize()); }
 void RequestFailoverBlock(CNode *pfrom, uint256 blockHash)
 {
     if (IsThinBlocksEnabled() && pfrom->ThinBlockCapable())


### PR DESCRIPTION
When we request a graphene block we share our mempool size however
at times there can be a significant number of orphans in the orphan
pool which will shortly be pulled into the mempool. They should be
added to the total mempool size because they will/could be used in the
reconstruction phase of a graphene block.