### PR TITLE
Extend CTransactionRef into mempool lookups

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4875,10 +4875,10 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                 }
                 if (!fPushed && inv.type == MSG_TX)
                 {
-                    CTransaction tx;
-                    if (mempool.lookup(inv.hash, tx))
+                    CTransactionRef ptx;
+                    if (mempool.lookup(inv.hash, ptx))
                     {
-                        pfrom->PushMessage(NetMsgType::TX, tx);
+                        pfrom->PushMessage(NetMsgType::TX, ptx);
                         fPushed = true;
                         pfrom->txsSent += 1;
                     }
@@ -6217,11 +6217,11 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             CInv inv(MSG_TX, hash);
             if (pfrom->pfilter)
             {
-                CTransaction tx;
-                bool fInMemPool = mempool.lookup(hash, tx);
+                CTransactionRef ptx;
+                bool fInMemPool = mempool.lookup(hash, ptx);
                 if (!fInMemPool)
                     continue; // another thread removed since queryHashes, maybe...
-                if (!pfrom->pfilter->IsRelevantAndUpdate(tx))
+                if (!pfrom->pfilter->IsRelevantAndUpdate(*ptx))
                     continue;
             }
             vInv.push_back(inv);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4875,8 +4875,9 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                 }
                 if (!fPushed && inv.type == MSG_TX)
                 {
-                    CTransactionRef ptx;
-                    if (mempool.lookup(inv.hash, ptx))
+                    CTransactionRef ptx = nullptr;
+                    ptx = mempool.get(inv.hash);
+                    if (ptx)
                     {
                         pfrom->PushMessage(NetMsgType::TX, ptx);
                         fPushed = true;
@@ -6217,9 +6218,9 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             CInv inv(MSG_TX, hash);
             if (pfrom->pfilter)
             {
-                CTransactionRef ptx;
-                bool fInMemPool = mempool.lookup(hash, ptx);
-                if (!fInMemPool)
+                CTransactionRef ptx = nullptr;
+                ptx = mempool.get(inv.hash);
+                if (ptx == nullptr)
                     continue; // another thread removed since queryHashes, maybe...
                 if (!pfrom->pfilter->IsRelevantAndUpdate(*ptx))
                     continue;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -960,19 +960,19 @@ void CTxMemPool::_queryHashes(vector<uint256> &vtxid) const
 }
 
 
-bool CTxMemPool::lookup(const uint256 &hash, CTransaction &result) const
+bool CTxMemPool::lookup(const uint256 &hash, CTransactionRef &result) const
 {
     READLOCK(cs);
     return _lookup(hash, result);
 }
 
-bool CTxMemPool::_lookup(const uint256 &hash, CTransaction &result) const
+bool CTxMemPool::_lookup(const uint256 &hash, CTransactionRef &result) const
 {
     AssertLockHeld(cs);
     indexed_transaction_set::const_iterator i = mapTx.find(hash);
     if (i == mapTx.end())
         return false;
-    result = i->GetTx();
+    result = i->GetSharedTx();
     return true;
 }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -960,23 +960,6 @@ void CTxMemPool::_queryHashes(vector<uint256> &vtxid) const
 }
 
 
-bool CTxMemPool::_lookup(const uint256 &hash, CTxMemPoolEntry &result) const
-{
-    AssertLockHeld(cs);
-    indexed_transaction_set::const_iterator i = mapTx.find(hash);
-    if (i == mapTx.end())
-        return false;
-    result = *i;
-    return true;
-}
-
-bool CTxMemPool::lookup(const uint256 &hash, CTxMemPoolEntry &result) const
-{
-    READLOCK(cs);
-    return _lookup(hash, result);
-}
-
-
 bool CTxMemPool::lookup(const uint256 &hash, CTransaction &result) const
 {
     READLOCK(cs);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -959,23 +959,6 @@ void CTxMemPool::_queryHashes(vector<uint256> &vtxid) const
         vtxid.push_back(mi->GetTx().GetHash());
 }
 
-
-bool CTxMemPool::lookup(const uint256 &hash, CTransactionRef &result) const
-{
-    READLOCK(cs);
-    return _lookup(hash, result);
-}
-
-bool CTxMemPool::_lookup(const uint256 &hash, CTransactionRef &result) const
-{
-    AssertLockHeld(cs);
-    indexed_transaction_set::const_iterator i = mapTx.find(hash);
-    if (i == mapTx.end())
-        return false;
-    result = i->GetSharedTx();
-    return true;
-}
-
 CFeeRate CTxMemPool::estimateFee(int nBlocks) const
 {
     READLOCK(cs);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -648,9 +648,6 @@ public:
     TxMempoolInfo info(const uint256 &hash) const;
     std::vector<TxMempoolInfo> infoAll() const;
 
-    bool lookup(const uint256 &hash, CTransactionRef &result) const;
-    bool _lookup(const uint256 &hash, CTransactionRef &result) const;
-
     /** Estimate fee rate needed to get into the next nBlocks
      *  If no answer can be given at nBlocks, return an estimate
      *  at the lowest number of blocks where one can be given

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -648,8 +648,8 @@ public:
     TxMempoolInfo info(const uint256 &hash) const;
     std::vector<TxMempoolInfo> infoAll() const;
 
-    bool lookup(const uint256 &hash, CTransaction &result) const;
-    bool _lookup(const uint256 &hash, CTransaction &result) const;
+    bool lookup(const uint256 &hash, CTransactionRef &result) const;
+    bool _lookup(const uint256 &hash, CTransactionRef &result) const;
 
     /** Estimate fee rate needed to get into the next nBlocks
      *  If no answer can be given at nBlocks, return an estimate

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -648,8 +648,6 @@ public:
     TxMempoolInfo info(const uint256 &hash) const;
     std::vector<TxMempoolInfo> infoAll() const;
 
-    bool lookup(const uint256 &hash, CTxMemPoolEntry &result) const;
-    bool _lookup(const uint256 &hash, CTxMemPoolEntry &result) const;
     bool lookup(const uint256 &hash, CTransaction &result) const;
     bool _lookup(const uint256 &hash, CTransaction &result) const;
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -354,9 +354,9 @@ void UnlimitedPushTxns(CNode *dest)
     for (uint256 &hash : vtxid)
     {
         CInv inv(MSG_TX, hash);
-        CTransactionRef ptx;
-        bool fInMemPool = mempool.lookup(hash, ptx);
-        if (!fInMemPool)
+        CTransactionRef ptx = nullptr;
+        ptx = mempool.get(hash);
+        if (ptx == nullptr)
             continue; // another thread removed since queryHashes, maybe...
         if ((dest->pfilter && dest->pfilter->IsRelevantAndUpdate(*ptx)) || (!dest->pfilter))
             vInv.push_back(inv);

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -347,7 +347,6 @@ UniValue pushtx(const UniValue &params, bool fHelp)
 
 void UnlimitedPushTxns(CNode *dest)
 {
-    // LOCK2(cs_main, pfrom->cs_filter);
     LOCK(dest->cs_filter);
     std::vector<uint256> vtxid;
     mempool.queryHashes(vtxid);
@@ -355,11 +354,11 @@ void UnlimitedPushTxns(CNode *dest)
     for (uint256 &hash : vtxid)
     {
         CInv inv(MSG_TX, hash);
-        CTransaction tx;
-        bool fInMemPool = mempool.lookup(hash, tx);
+        CTransactionRef ptx;
+        bool fInMemPool = mempool.lookup(hash, ptx);
         if (!fInMemPool)
             continue; // another thread removed since queryHashes, maybe...
-        if ((dest->pfilter && dest->pfilter->IsRelevantAndUpdate(tx)) || (!dest->pfilter))
+        if ((dest->pfilter && dest->pfilter->IsRelevantAndUpdate(*ptx)) || (!dest->pfilter))
             vInv.push_back(inv);
         if (vInv.size() == MAX_INV_SZ)
         {


### PR DESCRIPTION
The one thing to take care to look at is I removed mempool lookups by CTxMempoolEntry().  These require expensive copy's and I believe we don't need this funtionality any longer because we are now fully on the cash chain and can expect that all txns have the correct sighashtype.  @gandrewstone can you verify that I'm correct.  I still left the check in AcceptToMemoryPoolWorker() for sighhashtype but I believe even there we can take it out?