### PR TITLE
(port from giga_perf) Implement shared lock semantics for the UTXO

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -323,7 +323,7 @@ def initialize_datadir(dirname, n, bitcoinConfDict=None, wallet=None, bins=None)
     return datadir
 
 def rpc_auth_pair(n):
-    return 'rpcuser' + str(n), 'rpcpass' + str(n)
+    return 'rpcuser💻' + str(n), 'rpcpass🔑' + str(n)
 
 def rpc_url(i, rpchost=None):
     rpc_u, rpc_p = rpc_auth_pair(i)

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -323,7 +323,7 @@ def initialize_datadir(dirname, n, bitcoinConfDict=None, wallet=None, bins=None)
     return datadir
 
 def rpc_auth_pair(n):
-    return 'rpcuser💻' + str(n), 'rpcpass🔑' + str(n)
+    return 'rpcuser' + str(n), 'rpcpass' + str(n)
 
 def rpc_url(i, rpchost=None):
     rpc_u, rpc_p = rpc_auth_pair(i)

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -495,6 +495,7 @@ static void MutateTxSign(CMutableTransaction &tx, const string &flagStr)
             std::vector<unsigned char> pkData(ParseHexUV(prevOut["scriptPubKey"], "scriptPubKey"));
             CScript scriptPubKey(pkData.begin(), pkData.end());
 
+            Coin newcoin;
             {
                 CoinAccessor coin(view, out);
                 if (!coin->IsSpent() && coin->out.scriptPubKey != scriptPubKey)
@@ -503,7 +504,7 @@ static void MutateTxSign(CMutableTransaction &tx, const string &flagStr)
                     err = err + ScriptToAsmStr(coin->out.scriptPubKey) + "\nvs:\n" + ScriptToAsmStr(scriptPubKey);
                     throw runtime_error(err);
                 }
-                Coin newcoin;
+
                 newcoin.out.scriptPubKey = scriptPubKey;
                 newcoin.out.nValue = 0;
                 if (prevOut.exists("amount"))
@@ -511,8 +512,8 @@ static void MutateTxSign(CMutableTransaction &tx, const string &flagStr)
                     newcoin.out.nValue = AmountFromValue(prevOut["amount"]);
                 }
                 newcoin.nHeight = 1;
-                view.AddCoin(out, std::move(newcoin), true);
             }
+            view.AddCoin(out, std::move(newcoin), true);
 
             // if redeemScript given and private keys given,
             // add redeemScript to the tempKeystore so it can be signed:

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -509,8 +509,8 @@ static const size_t nMaxOutputsPerBlock =
 
 CoinAccessor::CoinAccessor(const CCoinsViewCache &view, const uint256 &txid) : cache(&view), lock(cache->csCacheInsert)
 {
-    cache->cs_utxo.lock_shared();
     EnterCritical("CCoinsViewCache.cs_utxo", __FILE__, __LINE__, (void *)(&cache->cs_utxo));
+    cache->cs_utxo.lock_shared();
     COutPoint iter(txid, 0);
     coin = &emptyCoin;
     while (iter.n < nMaxOutputsPerBlock)
@@ -528,8 +528,8 @@ CoinAccessor::CoinAccessor(const CCoinsViewCache &view, const uint256 &txid) : c
 CoinAccessor::CoinAccessor(const CCoinsViewCache &cacheObj, const COutPoint &output)
     : cache(&cacheObj), lock(cache->csCacheInsert)
 {
-    cache->cs_utxo.lock_shared();
     EnterCritical("CCoinsViewCache.cs_utxo", __FILE__, __LINE__, (void *)(&cache->cs_utxo));
+    cache->cs_utxo.lock_shared();
     it = cache->FetchCoin(output, &lock);
     if (it != cache->cacheCoins.end())
         coin = &it->second.coin;
@@ -540,15 +540,15 @@ CoinAccessor::CoinAccessor(const CCoinsViewCache &cacheObj, const COutPoint &out
 CoinAccessor::~CoinAccessor()
 {
     coin = nullptr;
-    LeaveCritical();
     cache->cs_utxo.unlock_shared();
+    LeaveCritical();
 }
 
 
 CoinModifier::CoinModifier(const CCoinsViewCache &cacheObj, const COutPoint &output) : cache(&cacheObj)
 {
-    cache->cs_utxo.lock();
     EnterCritical("CCoinsViewCache.cs_utxo", __FILE__, __LINE__, (void *)(&cache->cs_utxo));
+    cache->cs_utxo.lock();
     it = cache->FetchCoin(output, nullptr);
     if (it != cache->cacheCoins.end())
         coin = &it->second.coin;
@@ -559,6 +559,6 @@ CoinModifier::CoinModifier(const CCoinsViewCache &cacheObj, const COutPoint &out
 CoinModifier::~CoinModifier()
 {
     coin = nullptr;
-    LeaveCritical();
     cache->cs_utxo.unlock();
+    LeaveCritical();
 }

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -141,8 +141,8 @@ bool AreInputsStandard(const CTransaction &tx, const CCoinsViewCache &mapInputs)
     {
         txnouttype whichType;
         {
-            LOCK(mapInputs.cs_utxo);
-            const CTxOut &prev = mapInputs.AccessCoin(tx.vin[i].prevout).out;
+            CoinAccessor coin(mapInputs, tx.vin[i].prevout);
+            const CTxOut &prev = coin->out;
 
             std::vector<std::vector<unsigned char> > vSolutions;
             // get the scriptPubKey corresponding to this input:

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -164,10 +164,15 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
         {
             uint256 txid = txids[insecure_rand() % txids.size()]; // txid we're going to modify in this iteration.
             Coin &coin = result[COutPoint(txid, 0)];
+            if ((insecure_rand() % 500) == 0)
             {
-                LOCK(stack.back()->cs_utxo);
-                const Coin &entry = (insecure_rand() % 500 == 0) ? AccessByTxid(*stack.back(), txid) :
-                                                                   stack.back()->AccessCoin(COutPoint(txid, 0));
+                CoinAccessor entry(*stack.back(), txid);
+                BOOST_CHECK(coin == *entry);
+            }
+            else
+            {
+                WRITELOCK(stack.back()->cs_utxo);
+                const Coin &entry = stack.back()->_AccessCoin(COutPoint(txid, 0));
                 BOOST_CHECK(coin == entry);
             }
 
@@ -221,20 +226,22 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
             for (auto it = result.begin(); it != result.end(); it++)
             {
                 bool have = stack.back()->HaveCoin(it->first);
+                bool isspent = true;
                 {
-                    LOCK(stack.back()->cs_utxo);
-                    const Coin &coin = stack.back()->AccessCoin(it->first);
-                    BOOST_CHECK(have == !coin.IsSpent());
+                    WRITELOCK(stack.back()->cs_utxo);
+                    const Coin &coin = stack.back()->_AccessCoin(it->first);
+                    isspent = coin.IsSpent();
+                    BOOST_CHECK(have == !isspent);
                     BOOST_CHECK(coin == it->second);
-                    if (coin.IsSpent())
-                    {
-                        missed_an_entry = true;
-                    }
-                    else
-                    {
-                        BOOST_CHECK(stack.back()->HaveCoinInCache(it->first));
-                        found_an_entry = true;
-                    }
+                }
+                if (isspent)
+                {
+                    missed_an_entry = true;
+                }
+                else
+                {
+                    BOOST_CHECK(stack.back()->HaveCoinInCache(it->first));
+                    found_an_entry = true;
                 }
             }
             for (const CCoinsViewCacheTest *test : stack)
@@ -495,8 +502,10 @@ void CheckAccessCoin(CAmount base_value,
 {
     SingleEntryCacheTest test(base_value, cache_value, cache_flags);
 
-    LOCK(test.cache.cs_utxo);
-    test.cache.AccessCoin(OUTPOINT);
+    {
+        WRITELOCK(test.cache.cs_utxo);
+        test.cache._AccessCoin(OUTPOINT);
+    }
     test.cache.SelfTest();
 
     CAmount result_value;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -76,16 +76,16 @@ bool CCoinsViewDB::HaveCoin(const COutPoint &outpoint) const
     return db.Exists(CoinEntry(&outpoint));
 }
 
-uint256 CCoinsViewDB::GetBestBlock() const
+uint256 CCoinsViewDB::_GetBestBlock() const
 {
     uint256 hashBestChain;
     if (BLOCK_DB_MODE == SEQUENTIAL_BLOCK_FILES)
     {
-        hashBestChain = GetBestBlockSeq();
+        hashBestChain = _GetBestBlockSeq();
     }
     else if (BLOCK_DB_MODE == DB_BLOCK_STORAGE)
     {
-        hashBestChain = GetBestBlockDb();
+        hashBestChain = _GetBestBlockDb();
     }
     else
     {
@@ -97,6 +97,11 @@ uint256 CCoinsViewDB::GetBestBlock() const
 uint256 CCoinsViewDB::GetBestBlockSeq() const
 {
     READLOCK(cs_utxo);
+    return _GetBestBlockSeq();
+}
+
+uint256 CCoinsViewDB::_GetBestBlockSeq() const
+{
     uint256 hashBestChain;
     if (!db.Read(DB_BEST_BLOCK, hashBestChain))
         return uint256();
@@ -115,6 +120,11 @@ void CCoinsViewDB::WriteBestBlockSeq(const uint256 &hashBlock)
 uint256 CCoinsViewDB::GetBestBlockDb() const
 {
     READLOCK(cs_utxo);
+
+    return _GetBestBlockDb();
+}
+uint256 CCoinsViewDB::_GetBestBlockDb() const
+{
     uint256 hashBestChain;
     if (!db.Read(DB_BEST_BLOCK_BLOCKDB, hashBestChain))
         return uint256();

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -66,19 +66,18 @@ CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe)
 
 bool CCoinsViewDB::GetCoin(const COutPoint &outpoint, Coin &coin) const
 {
-    LOCK(cs_utxo);
+    READLOCK(cs_utxo);
     return db.Read(CoinEntry(&outpoint), coin);
 }
 
 bool CCoinsViewDB::HaveCoin(const COutPoint &outpoint) const
 {
-    LOCK(cs_utxo);
+    READLOCK(cs_utxo);
     return db.Exists(CoinEntry(&outpoint));
 }
 
 uint256 CCoinsViewDB::GetBestBlock() const
 {
-    LOCK(cs_utxo);
     uint256 hashBestChain;
     if (BLOCK_DB_MODE == SEQUENTIAL_BLOCK_FILES)
     {
@@ -97,7 +96,7 @@ uint256 CCoinsViewDB::GetBestBlock() const
 
 uint256 CCoinsViewDB::GetBestBlockSeq() const
 {
-    LOCK(cs_utxo);
+    READLOCK(cs_utxo);
     uint256 hashBestChain;
     if (!db.Read(DB_BEST_BLOCK, hashBestChain))
         return uint256();
@@ -106,7 +105,7 @@ uint256 CCoinsViewDB::GetBestBlockSeq() const
 
 void CCoinsViewDB::WriteBestBlockSeq(const uint256 &hashBlock)
 {
-    LOCK(cs_utxo);
+    WRITELOCK(cs_utxo);
     if (!hashBlock.IsNull())
     {
         db.Write(DB_BEST_BLOCK, hashBlock);
@@ -115,7 +114,7 @@ void CCoinsViewDB::WriteBestBlockSeq(const uint256 &hashBlock)
 
 uint256 CCoinsViewDB::GetBestBlockDb() const
 {
-    LOCK(cs_utxo);
+    READLOCK(cs_utxo);
     uint256 hashBestChain;
     if (!db.Read(DB_BEST_BLOCK_BLOCKDB, hashBestChain))
         return uint256();
@@ -124,7 +123,7 @@ uint256 CCoinsViewDB::GetBestBlockDb() const
 
 void CCoinsViewDB::WriteBestBlockDb(const uint256 &hashBlock)
 {
-    LOCK(cs_utxo);
+    WRITELOCK(cs_utxo);
     if (!hashBlock.IsNull())
     {
         db.Write(DB_BEST_BLOCK_BLOCKDB, hashBlock);
@@ -136,7 +135,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
     const uint64_t nBestCoinHeight,
     size_t &nChildCachedCoinsUsage)
 {
-    LOCK(cs_utxo);
+    WRITELOCK(cs_utxo);
     CDBBatch batch(db);
     size_t count = 0;
     size_t changed = 0;
@@ -206,13 +205,13 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
 
 size_t CCoinsViewDB::EstimateSize() const
 {
-    LOCK(cs_utxo);
+    READLOCK(cs_utxo);
     return db.EstimateSize(DB_COIN, (char)(DB_COIN + 1));
 }
 
 size_t CCoinsViewDB::TotalWriteBufferSize() const
 {
-    LOCK(cs_utxo);
+    READLOCK(cs_utxo);
     return db.TotalWriteBufferSize();
 }
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -111,10 +111,12 @@ public:
 
     bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
     bool HaveCoin(const COutPoint &outpoint) const override;
-    uint256 GetBestBlock() const override;
+    uint256 _GetBestBlock() const override;
     uint256 GetBestBlockSeq() const;
+    uint256 _GetBestBlockSeq() const;
     void WriteBestBlockSeq(const uint256 &hashBlock);
     uint256 GetBestBlockDb() const;
+    uint256 _GetBestBlockDb() const;
     void WriteBestBlockDb(const uint256 &hashBlock);
     bool BatchWrite(CCoinsMap &mapCoins,
         const uint256 &hashBlock,

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -716,17 +716,16 @@ void CTxMemPool::removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMem
         }
         else if (it->GetSpendsCoinbase())
         {
-            LOCK(pcoins->cs_utxo);
             for (const CTxIn &txin : tx.vin)
             {
                 indexed_transaction_set::const_iterator it2 = mapTx.find(txin.prevout.hash);
                 if (it2 != mapTx.end())
                     continue;
-                const Coin &coin = pcoins->AccessCoin(txin.prevout);
+                CoinAccessor coin(*pcoins, txin.prevout);
                 if (nCheckFrequency != 0)
-                    assert(!coin.IsSpent());
-                if (coin.IsSpent() ||
-                    (coin.IsCoinBase() && ((signed long)nMemPoolHeight) - coin.nHeight < COINBASE_MATURITY))
+                    assert(!coin->IsSpent());
+                if (coin->IsSpent() ||
+                    (coin->IsCoinBase() && ((signed long)nMemPoolHeight) - coin->nHeight < COINBASE_MATURITY))
                 {
                     transactionsToRemove.push_back(tx);
                     break;


### PR DESCRIPTION
Implement shared lock semantics for the UTXO coins database.  The Coins API calls were also returning a Coin object whose life extended beyond the lock so new objects were created that provide access to the Coin and also manage the lock.

Also 2 small unrelated changes to make the QA work which we may revert.