### PR TITLE
Selective pruning using hashmask

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -262,7 +262,8 @@ testScripts = [ RpcTest(t) for t in [
     WhenElectrumFound('electrum_cashaccount'),
     'minimaldata-activation',
     'schnorrmultisig_activation',
-    WhenElectrumFound('electrum_subscriptions')
+    WhenElectrumFound('electrum_subscriptions'),
+    'randompruning'
 
 ] ]
 
@@ -292,8 +293,7 @@ testScriptsExt = [ RpcTest(t) for t in [
     Disabled('maxblocksinflight', "needs a rewrite and is already somewhat tested in sendheaders.py"),
     'p2p-acceptblock',
     'mempool_packages',
-    'maxuploadtarget',
-    'randompruning'
+    'maxuploadtarget'
 ] ]
 
 #Enable ZMQ tests

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -292,7 +292,8 @@ testScriptsExt = [ RpcTest(t) for t in [
     Disabled('maxblocksinflight', "needs a rewrite and is already somewhat tested in sendheaders.py"),
     'p2p-acceptblock',
     'mempool_packages',
-    'maxuploadtarget'
+    'maxuploadtarget',
+    'randompruning'
 ] ]
 
 #Enable ZMQ tests

--- a/qa/rpc-tests/randompruning.py
+++ b/qa/rpc-tests/randompruning.py
@@ -64,7 +64,9 @@ class RandomPruning (BitcoinTestFramework):
         # get the 64 LSB (everything else should just be 0's)
         hashMask64 = GetLow64(fullhashMask)
         # calculate the normalize threshold for the node
-        normalized_threshold = threshold * threshold_percent
+        x = threshold * threshold_percent
+        # this hardcode is a work around for uint being little endian, this is what x is equal to
+        normalized_threshold = int(0x000000000000000000000000000000000000000000000000fffffffffffffff0)
 
         # check the blocks mined prior to determine if we are keeping the blocks we expect to have
         # and pruning the ones we expect to prune
@@ -76,7 +78,8 @@ class RandomPruning (BitcoinTestFramework):
             low64block = GetLow64(block)
             # if the 64LSB of the blockhash is equal to or above our threshold we should have pruned it
             # assert this is the case
-            if ((int(low64block, 16) ^ int(hashMask64, 16)) >= normalized_threshold):
+            valxmask = (int(low64block, 16) ^ int(hashMask64, 16))
+            if valxmask >= normalized_threshold:
                 assert_raises_rpc_error(-32603, "Block not available (pruned data)", self.nodes[1].getblock, block)
             else:
                 kept.append(self.nodes[1].getblock(block)['height'])

--- a/qa/rpc-tests/randompruning.py
+++ b/qa/rpc-tests/randompruning.py
@@ -31,7 +31,7 @@ class RandomPruning (BitcoinTestFramework):
     def setup_network(self, split=False):
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-useblockdb=1"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug=prune", "-useblockdb=1", "-prunewithmask=1"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug=prune", "-useblockdb=1", "-prunewithmask=1", "-prunethreshold=10"]))
 
         # Now interconnect the nodes
         connect_nodes_full(self.nodes)

--- a/qa/rpc-tests/randompruning.py
+++ b/qa/rpc-tests/randompruning.py
@@ -84,6 +84,11 @@ class RandomPruning (BitcoinTestFramework):
             else:
                 kept.append(self.nodes[1].getblock(block)['height'])
 
+        # we should get an error raising the threshold higher than 10% since that was its last value
+        assert_raises_rpc_error(-32603, "Block not available (pruned data)", self.nodes[1].set, "prune.hashMaskThreshold=70")
+        # we should be able to lower it, for example to 5
+        self.nodes[1].set("prune.hashMaskThreshold=70")
+
 
 
 

--- a/qa/rpc-tests/randompruning.py
+++ b/qa/rpc-tests/randompruning.py
@@ -78,7 +78,7 @@ class RandomPruning (BitcoinTestFramework):
             # assert this is the case
             valxmask = int(low64block, 16) ^ hashMask64
             if valxmask >= normalized_threshold:
-                assert_raises_rpc_error(-32603, "Block not available (pruned data)", self.nodes[1].getblock, block)
+                assert_raises_rpc_error(-1, "Block not available (pruned data)", self.nodes[1].getblock, block)
             else:
                 kept.append(self.nodes[1].getblock(block)['height'])
 
@@ -109,12 +109,12 @@ class RandomPruning (BitcoinTestFramework):
 
 
         blocks_mined2 = []
-        for i in range(500):
+        for i in range(200):
             blockhash = self.nodes[0].generate(1)[0]
             # dont add blocks above the min blocks to keep line
-            if (i + 100 < 680):
+            if (i + 100 < 380):
                 blocks_mined.append(blockhash)
-            if (i % 50 == 0):
+            if (i % 100 == 0):
                 self.sync_blocks()
         self.sync_blocks()
 
@@ -131,7 +131,7 @@ class RandomPruning (BitcoinTestFramework):
             # assert this is the case
             valxmask = (int(low64block, 16) ^ int(hashMask64, 16))
             if valxmask >= normalized_threshold:
-                assert_raises_rpc_error(-32603, "Block not available (pruned data)", self.nodes[1].getblock, block)
+                assert_raises_rpc_error(-1, "Block not available (pruned data)", self.nodes[1].getblock, block)
             else:
                 kept2.append(self.nodes[1].getblock(block)['height'])
 

--- a/qa/rpc-tests/randompruning.py
+++ b/qa/rpc-tests/randompruning.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+import test_framework.loginit
+# This is a template to make creating new QA tests easy.
+# You can also use this template to quickly start and connect a few regtest nodes.
+
+import time
+import sys
+if sys.version_info[0] < 3:
+    raise "Use Python 3"
+import logging
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+def GetLow64(strhash):
+    return "0x" + strhash[48:]
+
+class RandomPruning (BitcoinTestFramework):
+
+    def setup_chain(self,bitcoinConfDict=None, wallets=None):
+        print("Initializing test directory "+self.options.tmpdir)
+        # pick this one to start from the cached 4 node 100 blocks mined configuration
+        # initialize_chain(self.options.tmpdir, bitcoinConfDict, wallets)
+        # pick this one to start at 0 mined blocks
+        initialize_chain_clean(self.options.tmpdir, 4, bitcoinConfDict, wallets)
+        # Number of nodes to initialize ----------> ^
+
+    def setup_network(self, split=False):
+        self.nodes = []
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-useblockdb=1"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug=prune", "-useblockdb=1", "-prunewithmask=1"]))
+
+        # Now interconnect the nodes
+        connect_nodes_full(self.nodes)
+        # Let the framework know if the network is fully connected.
+        # If not, the framework assumes this partition: (0,1) and (2,3)
+        # For more complex partitions, you can't use the self.sync* member functions
+        self.is_network_split=False
+        self.sync_blocks()
+
+    def run_test (self):
+        # generate enough blocks so that nodes[0] has a balance
+        # mine some number of blocks higher than the minimum we would be pruning
+        self.sync_blocks()
+        blocks_mined = []
+        for i in range(101):
+            blockhash = self.nodes[0].generate(1)[0]
+            # dont add blocks above the min blocks to keep line
+            if (i < 80):
+                blocks_mined.append(blockhash)
+        self.sync_blocks()
+
+        #get the max possible value of our hashmask
+        uint64_t_max = (2**64) - 1
+        # calculate 1% which
+        threshold_percent = uint64_t_max / 100
+        blockchaininfo = self.nodes[1].getblockchaininfo()
+        fullhashMask = blockchaininfo["pruneHashMask"]
+        threshold = blockchaininfo["hashMaskThreshold"]
+        # the mask is stored as a 256 bit int for easy bitwise operations with block hashes
+        # get the 64 LSB (everything else should just be 0's)
+        hashMask64 = GetLow64(fullhashMask)
+        # calculate the normalize threshold for the node
+        normalized_threshold = threshold * threshold_percent
+
+        # check the blocks mined prior to determine if we are keeping the blocks we expect to have
+        # and pruning the ones we expect to prune
+
+        # kept does nothing in the actual test but it was/is useful for debugging if the test fails
+        kept = []
+        for block in blocks_mined:
+            assert_equal(len(block), 64)
+            low64block = GetLow64(block)
+            # if the 64LSB of the blockhash is equal to or above our threshold we should have pruned it
+            # assert this is the case
+            if ((int(low64block, 16) ^ int(hashMask64, 16)) >= normalized_threshold):
+                assert_raises_rpc_error(-32603, "Block not available (pruned data)", self.nodes[1].getblock, block)
+            else:
+                kept.append(self.nodes[1].getblock(block)['height'])
+
+
+
+
+
+if __name__ == '__main__':
+    RandomPruning ().main ()
+
+# Create a convenient function for an interactive python debugging session
+def Test():
+    t = RandomPruning()
+    bitcoinConf = {
+        "debug": ["net", "blk", "thin", "mempool", "req", "bench", "evict"],
+        "blockprioritysize": 2000000  # we don't want any transactions rejected due to insufficient fees...
+    }
+
+
+    flags = standardFlags()
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/randompruning.py
+++ b/qa/rpc-tests/randompruning.py
@@ -31,7 +31,7 @@ class RandomPruning (BitcoinTestFramework):
     def setup_network(self, split=False):
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, ["-debug=0", "-useblockdb=1"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug=prune", "-useblockdb=1", "-prunewithmask=1", "-prunethreshold=10"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-debug=prune", "-useblockdb=1", "-prunewithmask=1", "-prune.hashMaskThreshold=10"]))
 
         # Now interconnect the nodes
         connect_nodes_full(self.nodes)

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -30,11 +30,13 @@ blockrelay/blockrelay_common.h
 blockrelay/blockrelay_common.cpp
 blockstorage/blockleveldb.cpp
 blockstorage/blockleveldb.h
-blockstorage/dbabstract.h
-blockstorage/sequential_files.cpp
-blockstorage/sequential_files.h
 blockstorage/blockstorage.cpp
 blockstorage/blockstorage.h
+blockstorage/dbabstract.h
+blockstorage/prune.cpp
+blockstorage/prune.h
+blockstorage/sequential_files.cpp
+blockstorage/sequential_files.h
 bloom.cpp
 bloom.h
 cashaddr.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -117,6 +117,7 @@ BITCOIN_CORE_H = \
   blockstorage/blockleveldb.h \
   blockstorage/blockstorage.h \
   blockstorage/dbabstract.h \
+  blockstorage/prune.h \
   blockstorage/sequential_files.h \
   bitnodes.h \
   bloom.h \
@@ -269,8 +270,9 @@ libbitcoin_server_a_SOURCES = \
   blockrelay/mempool_sync.cpp \
   blockrelay/thinblock.cpp \
   blockstorage/blockleveldb.cpp \
-  blockstorage/sequential_files.cpp \
   blockstorage/blockstorage.cpp \
+  blockstorage/prune.cpp \
+  blockstorage/sequential_files.cpp \
   bloom.cpp \
   chain.cpp \
   checkpoints.cpp \

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -311,10 +311,15 @@ static void addGeneralOptions(AllowedArgs &allowedArgs, HelpMessageMode mode)
                     DEFAULT_PERSIST_MEMPOOL))
         .addArg("prune=<n>", requiredInt,
             strprintf(_("Reduce storage requirements by pruning (deleting) old blocks. This mode is incompatible with "
-                        "-txindex and -rescan. "
+                        "-txindex, -rescan, and -prunewithmask"
                         "Warning: Reverting this setting requires re-downloading the entire blockchain. "
                         "(default: 0 = disable pruning blocks, >%u = target size in MiB to use for block files)"),
                     MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024))
+        .addArg("prunewithmask={true,false,0,1}", optionalBool,
+            strprintf(_("Reduce storage requirements by pruning (deleting) old blocks. This mode is incompatible with "
+                        "-txindex, -rescan, and -prune "
+                        "Warning: Reverting this setting requires re-downloading the entire blockchain. "
+                        "(default: 0 = disable pruning blocks, 1 = prune blocks using a randomly generated mask)")))
         .addArg("reindex", optionalBool, _("Rebuild block chain index from current blk000??.dat files on startup"))
         .addArg("txindex", optionalBool,
             strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"),

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -7,6 +7,7 @@
 
 #include "allowed_args.h"
 #include "blockstorage/blockstorage.h"
+#include "blockstorage/prune.h"
 #include "chainparams.h"
 #include "dosman.h"
 #include "httpserver.h"
@@ -320,6 +321,8 @@ static void addGeneralOptions(AllowedArgs &allowedArgs, HelpMessageMode mode)
                         "-txindex, -rescan, and -prune "
                         "Warning: Reverting this setting requires re-downloading the entire blockchain. "
                         "(default: 0 = disable pruning blocks, 1 = prune blocks using a randomly generated mask)")))
+        .addArg("prunethreshold=<n>", requiredInt, strprintf(_("A normalized threshold to determine how"
+                        "many blocks to keep when prunning with hashmask (default: %u)"), DEFAULT_THRESHOLD_PERCENT))
         .addArg("reindex", optionalBool, _("Rebuild block chain index from current blk000??.dat files on startup"))
         .addArg("txindex", optionalBool,
             strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"),

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -321,10 +321,6 @@ static void addGeneralOptions(AllowedArgs &allowedArgs, HelpMessageMode mode)
                         "-txindex, -rescan, and -prune "
                         "Warning: Reverting this setting requires re-downloading the entire blockchain. "
                         "(default: 0 = disable pruning blocks, 1 = prune blocks using a randomly generated mask)")))
-        .addArg("prunethreshold=<n>", requiredInt,
-            strprintf(_("A normalized threshold to determine how"
-                        "many blocks to keep when prunning with hashmask (default: %u)"),
-                    DEFAULT_THRESHOLD_PERCENT))
         .addArg("reindex", optionalBool, _("Rebuild block chain index from current blk000??.dat files on startup"))
         .addArg("txindex", optionalBool,
             strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"),

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -321,8 +321,10 @@ static void addGeneralOptions(AllowedArgs &allowedArgs, HelpMessageMode mode)
                         "-txindex, -rescan, and -prune "
                         "Warning: Reverting this setting requires re-downloading the entire blockchain. "
                         "(default: 0 = disable pruning blocks, 1 = prune blocks using a randomly generated mask)")))
-        .addArg("prunethreshold=<n>", requiredInt, strprintf(_("A normalized threshold to determine how"
-                        "many blocks to keep when prunning with hashmask (default: %u)"), DEFAULT_THRESHOLD_PERCENT))
+        .addArg("prunethreshold=<n>", requiredInt,
+            strprintf(_("A normalized threshold to determine how"
+                        "many blocks to keep when prunning with hashmask (default: %u)"),
+                    DEFAULT_THRESHOLD_PERCENT))
         .addArg("reindex", optionalBool, _("Rebuild block chain index from current blk000??.dat files on startup"))
         .addArg("txindex", optionalBool,
             strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"),

--- a/src/blockstorage/blockleveldb.h
+++ b/src/blockstorage/blockleveldb.h
@@ -73,6 +73,9 @@ private:
     CDBWrapper *pwrapperblock;
     CDBWrapper *pwrapperundo;
 
+    CDBBatch *blockBatch;
+    CDBBatch *undoBatch;
+
 public:
     // clean up our internal pointers
     ~CBlockLevelDB()
@@ -81,6 +84,8 @@ public:
         pwrapperblock = nullptr;
         delete pwrapperundo;
         pwrapperundo = nullptr;
+        blockBatch = new CDBBatch(*pwrapperblock);
+        undoBatch = new CDBBatch(*pwrapperundo);
     }
 
     // we need a custom read function to account for the way we want to deserialize undodbvalue
@@ -123,6 +128,7 @@ public:
         pwrapperblock->Sync();
         pwrapperundo->Sync();
     }
+    bool EraseBlock(const std::string &key);
 
     void CondenseBlockData(const std::string &key_begin, const std::string &key_end)
     {
@@ -139,6 +145,7 @@ public:
     bool WriteUndo(const CBlockUndo &blockundo, const CBlockIndex *pindex);
     bool ReadUndo(CBlockUndo &blockundo, const CBlockIndex *pindex);
     bool EraseUndo(const CBlockIndex *pindex);
+    bool EraseUndo(const std::string &key);
 
     void CondenseUndoData(const std::string &key_begin, const std::string &key_end)
     {

--- a/src/blockstorage/blockleveldb.h
+++ b/src/blockstorage/blockleveldb.h
@@ -158,8 +158,6 @@ public:
         leveldb::Slice slKey2(ssKey2.data(), ssKey2.size());
         pwrapperundo->getpdb()->CompactRange(&slKey1, &slKey2);
     }
-
-    uint64_t PruneDB(uint64_t nLastBlockWeCanPrune);
 };
 
 #endif // BLOCKDB_H

--- a/src/blockstorage/blockleveldb.h
+++ b/src/blockstorage/blockleveldb.h
@@ -142,11 +142,7 @@ public:
         pwrapperblock->getpdb()->CompactRange(&slKey1, &slKey2);
     }
 
-    void CondenseBlockData()
-    {
-        pwrapperblock->Compact();
-    }
-
+    void CondenseBlockData() { pwrapperblock->Compact(); }
     bool WriteUndo(const CBlockUndo &blockundo, const CBlockIndex *pindex);
     bool ReadUndo(CBlockUndo &blockundo, const CBlockIndex *pindex);
     bool EraseUndo(const CBlockIndex *pindex);
@@ -164,10 +160,7 @@ public:
         pwrapperundo->getpdb()->CompactRange(&slKey1, &slKey2);
     }
 
-    void CondenseUndoData()
-    {
-        pwrapperundo->Compact();
-    }
+    void CondenseUndoData() { pwrapperundo->Compact(); }
 };
 
 #endif // BLOCKDB_H

--- a/src/blockstorage/blockleveldb.h
+++ b/src/blockstorage/blockleveldb.h
@@ -142,6 +142,11 @@ public:
         pwrapperblock->getpdb()->CompactRange(&slKey1, &slKey2);
     }
 
+    void CondenseBlockData()
+    {
+        pwrapperblock->Compact();
+    }
+
     bool WriteUndo(const CBlockUndo &blockundo, const CBlockIndex *pindex);
     bool ReadUndo(CBlockUndo &blockundo, const CBlockIndex *pindex);
     bool EraseUndo(const CBlockIndex *pindex);
@@ -157,6 +162,11 @@ public:
         leveldb::Slice slKey1(ssKey1.data(), ssKey1.size());
         leveldb::Slice slKey2(ssKey2.data(), ssKey2.size());
         pwrapperundo->getpdb()->CompactRange(&slKey1, &slKey2);
+    }
+
+    void CondenseUndoData()
+    {
+        pwrapperundo->Compact();
     }
 };
 

--- a/src/blockstorage/blockstorage.cpp
+++ b/src/blockstorage/blockstorage.cpp
@@ -809,9 +809,9 @@ bool FindBlockPos(CValidationState &state,
             FILE *file = OpenBlockFile(pos);
             if (file)
             {
-                LOGA("Pre-allocating up to position 0x%x in blk%05u.dat\n", nNewChunks * BLOCKFILE_CHUNK_SIZE,
+                LOGA("Pre-allocating up to position 0x%x in blk%05u.dat\n", nNewChunks * blockfile_chunk_size,
                     pos.nFile);
-                AllocateFileRange(file, pos.nPos, nNewChunks * BLOCKFILE_CHUNK_SIZE - pos.nPos);
+                AllocateFileRange(file, pos.nPos, nNewChunks * blockfile_chunk_size - pos.nPos);
                 fclose(file);
             }
         }
@@ -858,8 +858,8 @@ bool FindUndoPos(CValidationState &state, int nFile, CDiskBlockPos &pos, unsigne
         FILE *file = OpenUndoFile(pos);
         if (file)
         {
-            LOGA("Pre-allocating up to position 0x%x in rev%05u.dat\n", nNewChunks * UNDOFILE_CHUNK_SIZE, pos.nFile);
-            AllocateFileRange(file, pos.nPos, nNewChunks * UNDOFILE_CHUNK_SIZE - pos.nPos);
+            LOGA("Pre-allocating up to position 0x%x in rev%05u.dat\n", nNewChunks * undofile_chunk_size, pos.nFile);
+            AllocateFileRange(file, pos.nPos, nNewChunks * undofile_chunk_size - pos.nPos);
             fclose(file);
         }
     }

--- a/src/blockstorage/blockstorage.h
+++ b/src/blockstorage/blockstorage.h
@@ -20,7 +20,6 @@ enum FlushStateMode
 static const BlockDBMode DEFAULT_BLOCK_DB_MODE = SEQUENTIAL_BLOCK_FILES;
 extern BlockDBMode BLOCK_DB_MODE;
 extern CDatabaseAbstract *pblockdb;
-extern arith_uint256 pruneHashMask;
 
 /** The pre-allocation chunk size for blk?????.dat files (since 0.8) */
 static const unsigned int DEFAULT_BLOCKFILE_CHUNK_SIZE = 0x1000000; // 16 MiB

--- a/src/blockstorage/blockstorage.h
+++ b/src/blockstorage/blockstorage.h
@@ -20,6 +20,7 @@ enum FlushStateMode
 static const BlockDBMode DEFAULT_BLOCK_DB_MODE = SEQUENTIAL_BLOCK_FILES;
 extern BlockDBMode BLOCK_DB_MODE;
 extern CDatabaseAbstract *pblockdb;
+extern arith_uint256 pruneHashMask;
 
 /** The pre-allocation chunk size for blk?????.dat files (since 0.8) */
 static const unsigned int DEFAULT_BLOCKFILE_CHUNK_SIZE = 0x1000000; // 16 MiB

--- a/src/blockstorage/blockstorage.h
+++ b/src/blockstorage/blockstorage.h
@@ -45,25 +45,6 @@ bool WriteUndoToDisk(const CBlockUndo &blockundo,
     const CMessageHeader::MessageStartChars &messageStart);
 bool ReadUndoFromDisk(CBlockUndo &blockundo, const CDiskBlockPos &pos, const CBlockIndex *pindex);
 
-/**
- * Prune block and undo files (blk???.dat and undo???.dat) so that the disk space used is less than a user-defined
- * target.
- * The user sets the target (in MB) on the command line or in config file.  This will be run on startup and whenever new
- * space is allocated in a block or undo file, staying below the target. Changing back to unpruned requires a reindex
- * (which in this case means the blockchain must be re-downloaded.)
- *
- * Pruning functions are called from FlushStateToDisk when the global fCheckForPruning flag has been set.
- * Block and undo files are deleted in lock-step (when blk00003.dat is deleted, so is rev00003.dat.)
- * Pruning cannot take place until the longest chain is at least a certain length (100000 on mainnet, 1000 on testnet,
- * 1000 on regtest).
- * Pruning will never delete a block within a defined distance (currently 288) from the active chain's tip.
- * The block index is updated by unsetting HAVE_DATA and HAVE_UNDO for any blocks that were stored in the deleted files.
- * A db flag records the fact that at least some block files have been pruned.
- *
- * @param[out]   setFilesToPrune   The set of file indices that can be unlinked will be returned
- */
-void FindFilesToPrune(std::set<int> &setFilesToPrune, uint64_t nPruneAfterHeight);
-
 /** Flush all state, indexes and buffers to disk. */
 bool FlushStateToDiskInternal(CValidationState &state,
     FlushStateMode mode = FLUSH_STATE_ALWAYS,

--- a/src/blockstorage/dbabstract.h
+++ b/src/blockstorage/dbabstract.h
@@ -45,6 +45,7 @@ public:
 
     // clean up the block data if supported by the db
     virtual void CondenseBlockData(const std::string &start, const std::string &end) = 0;
+    virtual void CondenseBlockData() = 0;
 
     //! Write undo data to the database
     virtual bool WriteUndo(const CBlockUndo &blockundo, const CBlockIndex *pindex) = 0;
@@ -63,6 +64,7 @@ public:
 
     // clean up the undo data if supported by the db
     virtual void CondenseUndoData(const std::string &start, const std::string &end) = 0;
+    virtual void CondenseUndoData() = 0;
 
     // prune the database - this is now managed seperately inside prune.cpp
     // we now pass the db to the pruner to determine if pruning is needed

--- a/src/blockstorage/dbabstract.h
+++ b/src/blockstorage/dbabstract.h
@@ -58,7 +58,7 @@ public:
 
     //! Flush database files to disk
     virtual void Flush() = 0;
-    
+
     //! Remove undo data from the database via its key
     virtual bool EraseUndo(const std::string &key) = 0;
 

--- a/src/blockstorage/dbabstract.h
+++ b/src/blockstorage/dbabstract.h
@@ -40,6 +40,9 @@ public:
     //! remove a block from the database using the blockindex
     virtual bool EraseBlock(const CBlockIndex *pindex) = 0;
 
+    //! remove a block from the database using the key
+    virtual bool EraseBlock(const std::string &key) = 0;
+
     // clean up the block data if supported by the db
     virtual void CondenseBlockData(const std::string &start, const std::string &end) = 0;
 
@@ -54,6 +57,9 @@ public:
 
     //! Flush database files to disk
     virtual void Flush() = 0;
+    
+    //! Remove undo data from the database via its key
+    virtual bool EraseUndo(const std::string &key) = 0;
 
     // clean up the undo data if supported by the db
     virtual void CondenseUndoData(const std::string &start, const std::string &end) = 0;

--- a/src/blockstorage/dbabstract.h
+++ b/src/blockstorage/dbabstract.h
@@ -64,8 +64,10 @@ public:
     // clean up the undo data if supported by the db
     virtual void CondenseUndoData(const std::string &start, const std::string &end) = 0;
 
-    // prune the database
-    virtual uint64_t PruneDB(uint64_t nLastBlockWeCanPrune) = 0;
+    // prune the database - this is now managed seperately inside prune.cpp
+    // we now pass the db to the pruner to determine if pruning is needed
+    // we do the pruning itself with erase block and erase undo
+    // virtual uint64_t PruneDB(uint64_t nLastBlockWeCanPrune) = 0;
 
     virtual ~CDatabaseAbstract() {}
 };

--- a/src/blockstorage/prune.cpp
+++ b/src/blockstorage/prune.cpp
@@ -95,7 +95,7 @@ void GenerateRandomPruningHashMask()
 }
 
 /** Get important pruning bits from a block hash and compare their value to our pruning threshold*/
-bool hashMaskCompare(uint256 _blockHash)
+bool IsBlockHashBelowPruneThreshold(uint256 _blockHash)
 {
     uint64_t value = UintToArith256(_blockHash).GetLow64();
     uint64_t valxmask = value ^ pruneHashMask;
@@ -307,7 +307,7 @@ uint64_t PruneDB(uint64_t nLastBlockWeCanPrune)
         {
             break;
         }
-        if (fPruneWithMask == true && hashMaskCompare(pindexOldest->GetBlockHash()))
+        if (fPruneWithMask && IsBlockHashBelowPruneThreshold(pindexOldest->GetBlockHash()))
         {
             pindexOldest = chainActive.Next(pindexOldest);
             continue;

--- a/src/blockstorage/prune.cpp
+++ b/src/blockstorage/prune.cpp
@@ -1,0 +1,279 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "prune.h"
+
+#include "blockstorage.h"
+#include "sequential_files.h"
+#include "txdb.h"
+#include "ui_interface.h"
+#include "util.h"
+#include "utiltime.h"
+#include "xversionkeys.h"
+
+#include <random>
+
+extern CBlockTreeDB *pblocktree;
+extern CDatabaseAbstract *pblockdb;
+extern CChain chainActive;
+extern CTweak<uint64_t> pruneIntervalTweak;
+extern CCriticalSection cs_LastBlockFile;
+extern std::set<int> setDirtyFileInfo;
+extern std::multimap<CBlockIndex *, CBlockIndex *> mapBlocksUnlinked;
+
+bool fHavePruned = false;
+uint64_t nPruneTarget = 0;
+uint64_t nDBUsedSpace = 0;
+/** Global flag to indicate we should check to see if there are
+ *  block/undo files that should be deleted.  Set on startup
+ *  or if we allocate more file space when we're in prune mode
+ */
+bool fCheckForPruning = false;
+bool fPruneMode = false;
+void UnlinkPrunedFiles(std::set<int> &setFilesToPrune)
+{
+    for (std::set<int>::iterator it = setFilesToPrune.begin(); it != setFilesToPrune.end(); ++it)
+    {
+        CDiskBlockPos pos(*it, 0);
+        fs::remove(GetBlockPosFilename(pos, "blk"));
+        fs::remove(GetBlockPosFilename(pos, "rev"));
+        LOG(PRUNE, "Prune: %s deleted blk/rev (%05u)\n", __func__, *it);
+    }
+}
+
+/* Prune a block file (modify associated database entries)*/
+void PruneOneBlockFile(const int fileNumber)
+{
+    READLOCK(cs_mapBlockIndex);
+    for (BlockMap::iterator it = mapBlockIndex.begin(); it != mapBlockIndex.end(); ++it)
+    {
+        CBlockIndex *pindex = it->second;
+        if (pindex->nFile == fileNumber)
+        {
+            pindex->nStatus &= ~BLOCK_HAVE_DATA;
+            pindex->nStatus &= ~BLOCK_HAVE_UNDO;
+            pindex->nFile = 0;
+            pindex->nDataPos = 0;
+            pindex->nUndoPos = 0;
+            setDirtyBlockIndex.insert(pindex);
+
+            // Prune from mapBlocksUnlinked -- any block we prune would have
+            // to be downloaded again in order to consider its chain, at which
+            // point it would be considered as a candidate for
+            // mapBlocksUnlinked or setBlockIndexCandidates.
+            std::pair<std::multimap<CBlockIndex *, CBlockIndex *>::iterator,
+                std::multimap<CBlockIndex *, CBlockIndex *>::iterator>
+                range = mapBlocksUnlinked.equal_range(pindex->pprev);
+            while (range.first != range.second)
+            {
+                std::multimap<CBlockIndex *, CBlockIndex *>::iterator itr = range.first;
+                range.first++;
+                if (itr->second == pindex)
+                {
+                    mapBlocksUnlinked.erase(itr);
+                }
+            }
+        }
+    }
+    vinfoBlockFile[fileNumber].SetNull();
+    setDirtyFileInfo.insert(fileNumber);
+}
+
+/* Calculate the amount of disk space the block & undo files currently use */
+uint64_t CalculateCurrentUsage()
+{
+    uint64_t retval = 0;
+    for (const CBlockFileInfo &file : vinfoBlockFile)
+    {
+        retval += file.nSize + file.nUndoSize;
+    }
+    return retval;
+}
+
+void PruneFiles(std::set<int> &setFilesToPrune, uint64_t nLastBlockWeCanPrune)
+{
+    uint64_t nCurrentUsage = CalculateCurrentUsage();
+    // We don't check to prune until after we've allocated new space for files
+    // So we should leave a buffer under our target to account for another allocation
+    // before the next pruning.
+    uint64_t nBuffer = BLOCKFILE_CHUNK_SIZE + UNDOFILE_CHUNK_SIZE;
+    uint64_t nBytesToPrune;
+    int count = 0;
+
+    if (nCurrentUsage + nBuffer >= nPruneTarget)
+    {
+        for (int fileNumber = 0; fileNumber < nLastBlockFile; fileNumber++)
+        {
+            nBytesToPrune = vinfoBlockFile[fileNumber].nSize + vinfoBlockFile[fileNumber].nUndoSize;
+
+            if (vinfoBlockFile[fileNumber].nSize == 0)
+            {
+                continue;
+            }
+
+            if (nCurrentUsage + nBuffer < nPruneTarget) // are we below our target?
+            {
+                break;
+            }
+
+            // don't prune files that could have a block within MIN_BLOCKS_TO_KEEP of the main chain's tip but keep
+            // scanning
+            if (vinfoBlockFile[fileNumber].nHeightLast > nLastBlockWeCanPrune)
+            {
+                continue;
+            }
+
+            PruneOneBlockFile(fileNumber);
+            // Queue up the files for removal
+            setFilesToPrune.insert(fileNumber);
+            nCurrentUsage -= nBytesToPrune;
+            count++;
+        }
+    }
+
+    LOG(PRUNE, "Prune: target=%dMiB actual=%dMiB diff=%dMiB max_prune_height=%d removed %d blk/rev pairs\n",
+        nPruneTarget / 1024 / 1024, nCurrentUsage / 1024 / 1024,
+        ((int64_t)nPruneTarget - (int64_t)nCurrentUsage) / 1024 / 1024, nLastBlockWeCanPrune, count);
+}
+
+uint64_t PruneDB(uint64_t nLastBlockWeCanPrune)
+{
+    CBlockIndex *pindexOldest = chainActive.Tip();
+    while (pindexOldest->pprev)
+    {
+        pindexOldest = pindexOldest->pprev;
+    }
+    uint64_t prunedCount = 0;
+    std::vector<std::string> blockBatch;
+    std::vector<std::string> undoBatch;
+    while (pindexOldest != nullptr)
+    {
+        if (pindexOldest->GetBlockHash() == Params().GetConsensus().hashGenesisBlock)
+        {
+            pindexOldest = chainActive.Next(pindexOldest);
+            continue;
+        }
+        if (pindexOldest->nFile == 0)
+        {
+            // already pruned block
+            pindexOldest = chainActive.Next(pindexOldest);
+            continue;
+        }
+        if (!fPruneWithMask && nDBUsedSpace < nPruneTarget)
+        {
+            break;
+        }
+        if (pindexOldest->nHeight >= (int)nLastBlockWeCanPrune)
+        {
+            break;
+        }
+        if (fPruneWithMask == true && hashMaskCompare(pindexOldest->GetBlockHash()))
+        {
+            pindexOldest = chainActive.Next(pindexOldest);
+            continue;
+        }
+        unsigned int blockSize = pindexOldest->nDataPos;
+        std::ostringstream key;
+        key << pindexOldest->GetBlockTime() << ":" << pindexOldest->GetBlockHash().ToString();
+        blockBatch.push_back(key.str());
+        undoBatch.push_back(key.str());
+        nDBUsedSpace = nDBUsedSpace - blockSize;
+        pindexOldest->nStatus &= ~BLOCK_HAVE_DATA;
+        pindexOldest->nStatus &= ~BLOCK_HAVE_UNDO;
+        pindexOldest->nFile = 0;
+        pindexOldest->nDataPos = 0;
+        pindexOldest->nUndoPos = 0;
+        setDirtyBlockIndex.insert(pindexOldest);
+        prunedCount = prunedCount + 1;
+        pindexOldest = chainActive.Next(pindexOldest);
+    }
+    CValidationState state;
+    FlushStateToDiskInternal(state);
+    for (const auto &key : blockBatch)
+    {
+        pblockdb->EraseBlock(key);
+    }
+    for (const auto &key : undoBatch)
+    {
+        pblockdb->EraseUndo(key);
+    }
+    LOG(PRUNE, "Pruned %u blocks, size on disk %u\n", prunedCount, nDBUsedSpace);
+    return prunedCount;
+}
+
+bool CheckDiskSpace(uint64_t nAdditionalBytes)
+{
+    uint64_t nFreeBytesAvailable = fs::space(GetDataDir()).available;
+
+    // Check for nMinDiskSpace bytes (currently 50MB)
+    if (nFreeBytesAvailable < nMinDiskSpace + nAdditionalBytes)
+    {
+        return AbortNode("Disk space is low!", _("Error: Disk space is low!"));
+    }
+
+    // we only use this metric with pblockdb
+    if (pblockdb && fPruneMode)
+    {
+        nDBUsedSpace += nAdditionalBytes;
+        if (nDBUsedSpace >= nPruneTarget)
+        {
+            fCheckForPruning = true;
+        }
+    }
+
+    return true;
+}
+
+/* Calculate the files that should be deleted to remain*/
+void FindFilesToPrune(std::set<int> &setFilesToPrune, uint64_t nPruneAfterHeight, bool &fFlushForPrune)
+{
+    LOCK2(cs_main, cs_LastBlockFile);
+
+    if (chainActive.Tip() == NULL || (nPruneTarget == 0 && !fPruneWithMask))
+    {
+        return;
+    }
+    if ((uint64_t)chainActive.Tip()->nHeight <= nPruneAfterHeight)
+    {
+        return;
+    }
+    uint64_t nLastBlockWeCanPrune = chainActive.Tip()->nHeight - Params().MinBlocksToKeep();
+
+    if (!pblockdb)
+    {
+        PruneFiles(setFilesToPrune, nLastBlockWeCanPrune);
+        if (!setFilesToPrune.empty())
+        {
+            fFlushForPrune = true;
+            if (!fHavePruned)
+            {
+                pblocktree->WriteFlag("prunedblockfiles", true);
+                fHavePruned = true;
+            }
+        }
+    }
+    else // if (pblockdb)
+    {
+        if (!fPruneWithMask)
+        {
+            if (nDBUsedSpace < nPruneTarget + (pruneIntervalTweak.Value() * 1024 * 1024))
+            {
+                return;
+            }
+        }
+        uint64_t amntPruned = PruneDB(nLastBlockWeCanPrune);
+        // because we just prune the DB here and dont have a file set to return, we need to set prune triggers here
+        // otherwise they will check for the fileset and incorrectly never be set
+
+        // if this is the first time we attempt to prune, dont set pruned = true if we didnt prune anything so we must
+        // check amntPruned here
+        if (!fHavePruned && amntPruned != 0)
+        {
+            pblocktree->WriteFlag("prunedblockfiles", true);
+            fHavePruned = true;
+        }
+    }
+}

--- a/src/blockstorage/prune.cpp
+++ b/src/blockstorage/prune.cpp
@@ -236,7 +236,7 @@ void PruneFiles(std::set<int> &setFilesToPrune, uint64_t nLastBlockWeCanPrune)
     // We don't check to prune until after we've allocated new space for files
     // So we should leave a buffer under our target to account for another allocation
     // before the next pruning.
-    uint64_t nBuffer = BLOCKFILE_CHUNK_SIZE + UNDOFILE_CHUNK_SIZE;
+    uint64_t nBuffer = blockfile_chunk_size + undofile_chunk_size;
     uint64_t nBytesToPrune;
     int count = 0;
 

--- a/src/blockstorage/prune.cpp
+++ b/src/blockstorage/prune.cpp
@@ -24,15 +24,54 @@ extern CCriticalSection cs_LastBlockFile;
 extern std::set<int> setDirtyFileInfo;
 extern std::multimap<CBlockIndex *, CBlockIndex *> mapBlocksUnlinked;
 
+bool fPruneWithMask = DEFAULT_PRUNE_WITH_MASK;
 bool fHavePruned = false;
 uint64_t nPruneTarget = 0;
 uint64_t nDBUsedSpace = 0;
+arith_uint256 pruneHashMask = 0;
+const arith_uint256 LSB64_MASK = std::numeric_limits<uint64_t>::max();
+const uint64_t ONE_THRESHOLD_PERCENT = std::numeric_limits<uint64_t>::max() / 100;
+uint8_t hashMaskThreshold = DEFAULT_THRESHOLD_PERCENT;
+uint64_t normalized_threshold = hashMaskThreshold * ONE_THRESHOLD_PERCENT;
+
 /** Global flag to indicate we should check to see if there are
  *  block/undo files that should be deleted.  Set on startup
  *  or if we allocate more file space when we're in prune mode
  */
 bool fCheckForPruning = false;
 bool fPruneMode = false;
+
+/** Generate a random list of 32 ints between 8 and 255 that will be used as important pruning bits*/
+void GenerateRandomPruningHashMask()
+{
+    // only generate new bits if we dont already have some
+    uint256 read_hashMask;
+    if (pblocktree->ReadHashMask(read_hashMask))
+    {
+        return;
+    }
+    pruneHashMask = UintToArith256(read_hashMask);
+    uint64_t seed = GetTime();
+    std::mt19937_64 rand(seed); // Standard mersenne_twister_engine seeded with rd()
+    arith_uint256 hashMask64(rand());
+    pruneHashMask = 0;
+    pruneHashMask = pruneHashMask | hashMask64;
+    uint256 write_hashMask = ArithToUint256(pruneHashMask);
+    pblocktree->WriteHashMask(write_hashMask);
+    pblocktree->WriteFlag("hashmaskexists", true);
+}
+
+/** Get important pruning bits from a block hash and compare their value to our pruning threshold*/
+bool hashMaskCompare(uint256 _blockHash)
+{
+    arith_uint256 value = UintToArith256(_blockHash) & LSB64_MASK;
+    if ((value ^ pruneHashMask) < normalized_threshold) // we keep all blocks below the threshold
+    {
+        return true;
+    }
+    return false;
+}
+
 void UnlinkPrunedFiles(std::set<int> &setFilesToPrune)
 {
     for (std::set<int>::iterator it = setFilesToPrune.begin(); it != setFilesToPrune.end(); ++it)

--- a/src/blockstorage/prune.cpp
+++ b/src/blockstorage/prune.cpp
@@ -65,9 +65,12 @@ std::string hashMaskThresholdValidator(const uint8_t &value, uint8_t *item, bool
     else
     {
         uint8_t newValue = *item;
-        if (!pblocktree->WriteHashMaskThreshold(newValue))
+        if(pblocktree)
         {
-            strReturn = "Error writing new threshold to disk";
+            if (!pblocktree->WriteHashMaskThreshold(newValue))
+            {
+                strReturn = "Error writing new threshold to disk";
+            }
         }
         normalized_threshold = (newValue * ONE_THRESHOLD_PERCENT);
         RelayNewXUpdate(XVer::BU_PRUNE_THRESHOLD, normalized_threshold);

--- a/src/blockstorage/prune.cpp
+++ b/src/blockstorage/prune.cpp
@@ -322,6 +322,8 @@ uint64_t PruneDB(uint64_t nLastBlockWeCanPrune)
     {
         pblockdb->EraseUndo(key);
     }
+    pblockdb->CondenseBlockData();
+    pblockdb->CondenseUndoData();
     LOG(PRUNE, "Pruned %u blocks, size on disk %u\n", prunedCount, nDBUsedSpace);
     return prunedCount;
 }

--- a/src/blockstorage/prune.cpp
+++ b/src/blockstorage/prune.cpp
@@ -312,6 +312,7 @@ uint64_t PruneDB(uint64_t nLastBlockWeCanPrune)
             pindexOldest = chainActive.Next(pindexOldest);
             continue;
         }
+        // We have chosen to prune this block
         unsigned int blockSize = pindexOldest->nDataPos;
         std::ostringstream key;
         key << pindexOldest->GetBlockTime() << ":" << pindexOldest->GetBlockHash().ToString();

--- a/src/blockstorage/prune.cpp
+++ b/src/blockstorage/prune.cpp
@@ -41,6 +41,38 @@ uint64_t normalized_threshold = hashMaskThreshold * ONE_THRESHOLD_PERCENT;
 bool fCheckForPruning = false;
 bool fPruneMode = false;
 
+extern void RelayNewXUpdate(const uint64_t key, const uint64_t val);
+extern bool AbortNode(const std::string &strMessage, const std::string &userMessage = "");
+
+std::string hashMaskThresholdValidator(const uint8_t &value, uint8_t *item, bool validate)
+{
+    if (validate)
+    {
+        if (value > hashMaskThreshold)
+        {
+            std::ostringstream ret;
+            ret << "Sorry, your hashMaskThreshold (" << hashMaskThreshold
+                << ") is smaller than your proposed new threshold (" << value
+                << ").  You can only lower this number, not raise it.";
+            return ret.str();
+        }
+        else if (value == hashMaskThreshold)
+        {
+            // just return in this case, nothing has changed
+            return std::string();
+        }
+        hashMaskThreshold = value;
+        pblocktree->WriteHashMaskThreshold(hashMaskThreshold);
+        normalized_threshold = hashMaskThreshold * ONE_THRESHOLD_PERCENT;
+        RelayNewXUpdate(XVer::BU_PRUNE_THRESHOLD, normalized_threshold);
+    }
+    else
+    {
+        return "Validate was false, no changes were made";
+    }
+    return std::string();
+}
+
 /** Generate a random list of 32 ints between 8 and 255 that will be used as important pruning bits*/
 void GenerateRandomPruningHashMask()
 {

--- a/src/blockstorage/prune.cpp
+++ b/src/blockstorage/prune.cpp
@@ -139,7 +139,7 @@ bool SetupPruning()
         GenerateRandomPruningHashMask();
         hashMaskThreshold = 100;
         pblocktree->ReadHashMaskThreshold(hashMaskThreshold);
-        uint8_t potentialThreshold = GetArg("-prunethreshold", 100);
+        uint8_t potentialThreshold = GetArg("-prunethreshold", DEFAULT_THRESHOLD_PERCENT);
         if (potentialThreshold < hashMaskThreshold)
         {
             hashMaskThreshold = potentialThreshold;

--- a/src/blockstorage/prune.cpp
+++ b/src/blockstorage/prune.cpp
@@ -65,7 +65,7 @@ std::string hashMaskThresholdValidator(const uint8_t &value, uint8_t *item, bool
     else
     {
         uint8_t newValue = *item;
-        if(!pblocktree->WriteHashMaskThreshold(newValue))
+        if (!pblocktree->WriteHashMaskThreshold(newValue))
         {
             strReturn = "Error writing new threshold to disk";
         }
@@ -156,8 +156,9 @@ bool SetupPruning()
         }
         else if (potentialThreshold > hashMaskThresholdTweak.Value())
         {
-            LOGA("cannot raise prunethreshold above %u to %u, keeping it at %u \n", hashMaskThresholdTweak.Value(), potentialThreshold, hashMaskThresholdTweak.Value());
-            if(hashMaskThresholdTweak.Value() == 0)
+            LOGA("cannot raise prunethreshold above %u to %u, keeping it at %u \n", hashMaskThresholdTweak.Value(),
+                potentialThreshold, hashMaskThresholdTweak.Value());
+            if (hashMaskThresholdTweak.Value() == 0)
             {
                 LOGA("CRITICAL ERROR, THRESHOLD == 0, PLEASE REPORT THIS\n");
                 return false;

--- a/src/blockstorage/prune.h
+++ b/src/blockstorage/prune.h
@@ -24,6 +24,7 @@ extern uint64_t normalized_threshold;
 /** Number of MiB the blockdb is using. */
 extern uint64_t nDBUsedSpace;
 
+std::string hashMaskThresholdValidator(const uint8_t &value, uint8_t *item, bool validate);
 bool hashMaskCompare(uint256 _blockHash);
 bool SetupPruning();
 /**

--- a/src/blockstorage/prune.h
+++ b/src/blockstorage/prune.h
@@ -7,6 +7,7 @@
 #include "arith_uint256.h"
 #include "uint256.h"
 
+#include <atomic>
 #include <set>
 #include <string>
 
@@ -17,14 +18,14 @@ static const uint8_t DEFAULT_THRESHOLD_PERCENT = 100;
 // this has been moved to chain params
 // static const unsigned int MIN_BLOCKS_TO_KEEP = 288;
 
-extern arith_uint256 pruneHashMask;
+extern uint64_t pruneHashMask;
 extern uint8_t hashMaskThreshold;
-extern uint64_t normalized_threshold;
+extern std::atomic<uint64_t> normalized_threshold;
 
 /** Number of MiB the blockdb is using. */
 extern uint64_t nDBUsedSpace;
 
-std::string hashMaskThresholdValidator(const uint8_t &value, uint8_t *item, bool validate = true);
+std::string hashMaskThresholdValidator(const uint8_t &value, uint8_t *item, bool validate);
 bool hashMaskCompare(uint256 _blockHash);
 bool SetupPruning();
 /**

--- a/src/blockstorage/prune.h
+++ b/src/blockstorage/prune.h
@@ -26,7 +26,7 @@ extern std::atomic<uint64_t> normalized_threshold;
 extern uint64_t nDBUsedSpace;
 
 std::string hashMaskThresholdValidator(const uint8_t &value, uint8_t *item, bool validate);
-bool SetupPruning();
+bool SetupPruning(std::string &strLoadError);
 /**
  *  Actually unlink the specified files
  */

--- a/src/blockstorage/prune.h
+++ b/src/blockstorage/prune.h
@@ -9,11 +9,23 @@
 
 #include <set>
 #include <string>
+
+static const bool DEFAULT_PRUNE_WITH_MASK = false;
+static const uint8_t DEFAULT_THRESHOLD_PERCENT = 100;
+
 /** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of chainActive.Tip() will not be pruned. */
 // this has been moved to chain params
 // static const unsigned int MIN_BLOCKS_TO_KEEP = 288;
+
+extern arith_uint256 pruneHashMask;
+extern uint8_t hashMaskThreshold;
+extern uint64_t normalized_threshold;
+
 /** Number of MiB the blockdb is using. */
 extern uint64_t nDBUsedSpace;
+
+bool hashMaskCompare(uint256 _blockHash);
+bool SetupPruning();
 /**
  *  Actually unlink the specified files
  */

--- a/src/blockstorage/prune.h
+++ b/src/blockstorage/prune.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2015 The Bitcoin Core developers
+// Copyright (c) 2015-2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "arith_uint256.h"
+#include "uint256.h"
+
+#include <set>
+#include <string>
+/** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of chainActive.Tip() will not be pruned. */
+// this has been moved to chain params
+// static const unsigned int MIN_BLOCKS_TO_KEEP = 288;
+/** Number of MiB the blockdb is using. */
+extern uint64_t nDBUsedSpace;
+/**
+ *  Actually unlink the specified files
+ */
+void UnlinkPrunedFiles(std::set<int> &setFilesToPrune);
+
+/** Check whether enough disk space is available for an incoming block */
+bool CheckDiskSpace(uint64_t nAdditionalBytes = 0);
+
+/**
+ * Prune block and undo files (blk???.dat and undo???.dat) so that the disk space used is less than a user-defined
+ * target.
+ * The user sets the target (in MB) on the command line or in config file.  This will be run on startup and whenever new
+ * space is allocated in a block or undo file, staying below the target. Changing back to unpruned requires a reindex
+ * (which in this case means the blockchain must be re-downloaded.)
+ *
+ * Pruning functions are called from FlushStateToDisk when the global fCheckForPruning flag has been set.
+ * Block and undo files are deleted in lock-step (when blk00003.dat is deleted, so is rev00003.dat.)
+ * Pruning cannot take place until the longest chain is at least a certain length (100000 on mainnet, 1000 on testnet,
+ * 1000 on regtest).
+ * Pruning will never delete a block within a defined distance (currently 288) from the active chain's tip.
+ * The block index is updated by unsetting HAVE_DATA and HAVE_UNDO for any blocks that were stored in the deleted files.
+ * A db flag records the fact that at least some block files have been pruned.
+ *
+ * @param[out]   setFilesToPrune   The set of file indices that can be unlinked will be returned
+ */
+void FindFilesToPrune(std::set<int> &setFilesToPrune, uint64_t nPruneAfterHeight, bool &fFlushForPrune);

--- a/src/blockstorage/prune.h
+++ b/src/blockstorage/prune.h
@@ -26,7 +26,6 @@ extern std::atomic<uint64_t> normalized_threshold;
 extern uint64_t nDBUsedSpace;
 
 std::string hashMaskThresholdValidator(const uint8_t &value, uint8_t *item, bool validate);
-bool hashMaskCompare(uint256 _blockHash);
 bool SetupPruning();
 /**
  *  Actually unlink the specified files

--- a/src/blockstorage/prune.h
+++ b/src/blockstorage/prune.h
@@ -24,7 +24,7 @@ extern uint64_t normalized_threshold;
 /** Number of MiB the blockdb is using. */
 extern uint64_t nDBUsedSpace;
 
-std::string hashMaskThresholdValidator(const uint8_t &value, uint8_t *item, bool validate);
+std::string hashMaskThresholdValidator(const uint8_t &value, uint8_t *item, bool validate = true);
 bool hashMaskCompare(uint256 _blockHash);
 bool SetupPruning();
 /**

--- a/src/blockstorage/sequential_files.cpp
+++ b/src/blockstorage/sequential_files.cpp
@@ -8,7 +8,6 @@
 
 #include "blockstorage.h"
 
-
 extern bool AbortNode(CValidationState &state, const std::string &strMessage, const std::string &userMessage = "");
 extern CCriticalSection cs_LastBlockFile;
 extern std::set<int> setDirtyFileInfo;
@@ -125,102 +124,6 @@ bool ReadBlockFromDiskSequential(CBlock &block, const CDiskBlockPos &pos, const 
         return error("ReadBlockFromDisk: Errors in block header at %s", pos.ToString());
     }
     return true;
-}
-
-/* Calculate the amount of disk space the block & undo files currently use */
-uint64_t CalculateCurrentUsage()
-{
-    uint64_t retval = 0;
-    for (const CBlockFileInfo &file : vinfoBlockFile)
-    {
-        retval += file.nSize + file.nUndoSize;
-    }
-    return retval;
-}
-
-
-/* Prune a block file (modify associated database entries)*/
-void PruneOneBlockFile(const int fileNumber)
-{
-    READLOCK(cs_mapBlockIndex);
-    for (BlockMap::iterator it = mapBlockIndex.begin(); it != mapBlockIndex.end(); ++it)
-    {
-        CBlockIndex *pindex = it->second;
-        if (pindex->nFile == fileNumber)
-        {
-            pindex->nStatus &= ~BLOCK_HAVE_DATA;
-            pindex->nStatus &= ~BLOCK_HAVE_UNDO;
-            pindex->nFile = 0;
-            pindex->nDataPos = 0;
-            pindex->nUndoPos = 0;
-            setDirtyBlockIndex.insert(pindex);
-
-            // Prune from mapBlocksUnlinked -- any block we prune would have
-            // to be downloaded again in order to consider its chain, at which
-            // point it would be considered as a candidate for
-            // mapBlocksUnlinked or setBlockIndexCandidates.
-            std::pair<std::multimap<CBlockIndex *, CBlockIndex *>::iterator,
-                std::multimap<CBlockIndex *, CBlockIndex *>::iterator>
-                range = mapBlocksUnlinked.equal_range(pindex->pprev);
-            while (range.first != range.second)
-            {
-                std::multimap<CBlockIndex *, CBlockIndex *>::iterator itr = range.first;
-                range.first++;
-                if (itr->second == pindex)
-                {
-                    mapBlocksUnlinked.erase(itr);
-                }
-            }
-        }
-    }
-    vinfoBlockFile[fileNumber].SetNull();
-    setDirtyFileInfo.insert(fileNumber);
-}
-
-void FindFilesToPruneSequential(std::set<int> &setFilesToPrune, uint64_t nLastBlockWeCanPrune)
-{
-    uint64_t nCurrentUsage = CalculateCurrentUsage();
-    // We don't check to prune until after we've allocated new space for files
-    // So we should leave a buffer under our target to account for another allocation
-    // before the next pruning.
-    uint64_t nBuffer = blockfile_chunk_size + undofile_chunk_size;
-    uint64_t nBytesToPrune;
-    int count = 0;
-
-    if (nCurrentUsage + nBuffer >= nPruneTarget)
-    {
-        for (int fileNumber = 0; fileNumber < nLastBlockFile; fileNumber++)
-        {
-            nBytesToPrune = vinfoBlockFile[fileNumber].nSize + vinfoBlockFile[fileNumber].nUndoSize;
-
-            if (vinfoBlockFile[fileNumber].nSize == 0)
-            {
-                continue;
-            }
-
-            if (nCurrentUsage + nBuffer < nPruneTarget) // are we below our target?
-            {
-                break;
-            }
-
-            // don't prune files that could have a block within MIN_BLOCKS_TO_KEEP of the main chain's tip but keep
-            // scanning
-            if (vinfoBlockFile[fileNumber].nHeightLast > nLastBlockWeCanPrune)
-            {
-                continue;
-            }
-
-            PruneOneBlockFile(fileNumber);
-            // Queue up the files for removal
-            setFilesToPrune.insert(fileNumber);
-            nCurrentUsage -= nBytesToPrune;
-            count++;
-        }
-    }
-
-    LOG(PRUNE, "Prune: target=%dMiB actual=%dMiB diff=%dMiB max_prune_height=%d removed %d blk/rev pairs\n",
-        nPruneTarget / 1024 / 1024, nCurrentUsage / 1024 / 1024,
-        ((int64_t)nPruneTarget - (int64_t)nCurrentUsage) / 1024 / 1024, nLastBlockWeCanPrune, count);
 }
 
 bool WriteUndoToDiskSequenatial(const CBlockUndo &blockundo,

--- a/src/blockstorage/sequential_files.cpp
+++ b/src/blockstorage/sequential_files.cpp
@@ -10,7 +10,6 @@
 
 
 extern bool AbortNode(CValidationState &state, const std::string &strMessage, const std::string &userMessage = "");
-extern bool fCheckForPruning;
 extern CCriticalSection cs_LastBlockFile;
 extern std::set<int> setDirtyFileInfo;
 extern std::multimap<CBlockIndex *, CBlockIndex *> mapBlocksUnlinked;
@@ -73,18 +72,6 @@ void FlushBlockFile(bool fFinalize)
         fclose(fileOld);
     }
 }
-
-void UnlinkPrunedFiles(std::set<int> &setFilesToPrune)
-{
-    for (std::set<int>::iterator it = setFilesToPrune.begin(); it != setFilesToPrune.end(); ++it)
-    {
-        CDiskBlockPos pos(*it, 0);
-        fs::remove(GetBlockPosFilename(pos, "blk"));
-        fs::remove(GetBlockPosFilename(pos, "rev"));
-        LOG(PRUNE, "Prune: %s deleted blk/rev (%05u)\n", __func__, *it);
-    }
-}
-
 
 bool WriteBlockToDiskSequential(const CBlock &block,
     CDiskBlockPos &pos,

--- a/src/blockstorage/sequential_files.h
+++ b/src/blockstorage/sequential_files.h
@@ -25,16 +25,10 @@ fs::path GetBlockPosFilename(const CDiskBlockPos &pos, const char *prefix);
 
 void FlushBlockFile(bool fFinalize = false);
 
-/**
- *  Actually unlink the specified files
- */
-void UnlinkPrunedFiles(std::set<int> &setFilesToPrune);
-
 bool WriteBlockToDiskSequential(const CBlock &block,
     CDiskBlockPos &pos,
     const CMessageHeader::MessageStartChars &messageStart);
 bool ReadBlockFromDiskSequential(CBlock &block, const CDiskBlockPos &pos, const Consensus::Params &consensusParams);
-void FindFilesToPruneSequential(std::set<int> &setFilesToPrune, uint64_t nPruneAfterHeight);
 bool WriteUndoToDiskSequenatial(const CBlockUndo &blockundo,
     CDiskBlockPos &pos,
     const uint256 &hashBlock,

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -155,6 +155,7 @@ public:
         pchCashMessageStart[3] = 0xe8;
         nDefaultPort = DEFAULT_MAINNET_PORT;
         nPruneAfterHeight = 100000;
+        nPruneMinBlocks = 288;
 
         genesis = CreateGenesisBlock(1231006505, 2083236893, 0x1d00ffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
@@ -269,6 +270,7 @@ public:
         pchMessageStart[3] = 0xe9;
         nDefaultPort = DEFAULT_NOLNET_PORT;
         nPruneAfterHeight = 100000;
+        nPruneMinBlocks = 288;
 
         // Aug, 1 2017 hard fork
         consensus.uahfHeight = 0;
@@ -363,6 +365,7 @@ public:
         pchCashMessageStart[3] = 0xf4;
         nDefaultPort = DEFAULT_TESTNET_PORT;
         nPruneAfterHeight = 1000;
+        nPruneMinBlocks = 20;
 
         genesis = CreateGenesisBlock(1296688602, 414098458, 0x1d00ffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();
@@ -478,7 +481,8 @@ public:
         pchCashMessageStart[2] = 0xbf;
         pchCashMessageStart[3] = 0xfa;
         nDefaultPort = DEFAULT_REGTESTNET_PORT;
-        nPruneAfterHeight = 1000;
+        nPruneAfterHeight = 50;
+        nPruneMinBlocks = 20;
 
         genesis = CreateGenesisBlock(1296688602, 2, 0x207fffff, 1, 50 * COIN);
         consensus.hashGenesisBlock = genesis.GetHash();

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -125,6 +125,7 @@ public:
     /** Policy: Filter transactions that do not match well-defined patterns */
     bool RequireStandard() const;
     uint64_t PruneAfterHeight() const { return nPruneAfterHeight; }
+    uint64_t MinBlocksToKeep() const { return nPruneMinBlocks; }
     /** Make miner stop after a block is found. In RPC, don't return until nGenProcLimit blocks are generated */
     bool MineBlocksOnDemand() const { return fMineBlocksOnDemand; }
     /** In the future use NetworkIDString() for RPC fields */
@@ -143,6 +144,7 @@ protected:
     CMessageHeader::MessageStartChars pchCashMessageStart;
     int nDefaultPort;
     uint64_t nPruneAfterHeight;
+    uint64_t nPruneMinBlocks;
     std::vector<CDNSSeedData> vSeeds;
     std::vector<uint8_t> base58Prefixes[MAX_BASE58_TYPES];
     std::string cashaddrPrefix;

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -14,6 +14,7 @@
 #include "blockrelay/graphene.h"
 #include "blockrelay/mempool_sync.h"
 #include "blockrelay/thinblock.h"
+#include "blockstorage/prune.h"
 #include "chain.h"
 #include "chainparams.h"
 #include "clientversion.h"

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -266,6 +266,11 @@ CTweak<uint64_t> pruneIntervalTweak("prune.pruneInterval",
     "How much block data (in MiB) is written to disk before trying to prune our block storage",
     DEFAULT_PRUNE_INTERVAL);
 
+CTweakRef<uint8_t> hashMaskThresholdTweak("prune.hashMaskThreshold",
+    "What percentage of blocks that fall below our threshold should be kept (integers from 0 to 100)",
+    &hashMaskThreshold,
+    &hashMaskThresholdValidator);
+
 CTweak<uint32_t> netMagic("net.magic", "network prefix override. If 0 use the default", 0);
 
 CTweak<uint32_t> randomlyDontInv("net.randomlyDontInv", "Skip sending an INV for some percent of transactions", 0);
@@ -274,6 +279,7 @@ CTweakRef<uint64_t> ebTweak("net.excessiveBlock",
     "Excessive block size in bytes",
     &excessiveBlockSize,
     &ExcessiveBlockValidator);
+
 CTweak<uint64_t> blockSigopsPerMb("net.excessiveSigopsPerMb",
     "Excessive effort per block, denoted in cost (# inputs * txsize) per MB",
     BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -791,24 +791,6 @@ bool AppInit2(Config &config, thread_group &threadGroup)
 
     fServer = GetBoolArg("-server", false);
 
-    // block pruning; get the amount of disk space (in MiB) to allot for block & undo files
-    int64_t nSignedPruneTarget = GetArg("-prune", 0) * 1024 * 1024;
-    if (nSignedPruneTarget < 0)
-    {
-        return InitError(_("Prune cannot be configured with a negative value."));
-    }
-    nPruneTarget = (uint64_t)nSignedPruneTarget;
-    if (nPruneTarget)
-    {
-        if (nPruneTarget < MIN_DISK_SPACE_FOR_BLOCK_FILES)
-        {
-            return InitError(strprintf(_("Prune configured below the minimum of %d MiB.  Please use a higher number."),
-                MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024));
-        }
-        LOGA("Prune configured to target %uMiB on disk for block and undo files.\n", nPruneTarget / 1024 / 1024);
-        fPruneMode = true;
-    }
-
     RegisterAllCoreRPCCommands(tableRPC);
 #ifdef ENABLE_WALLET
     bool fDisableWallet = GetBoolArg("-disablewallet", false);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -13,6 +13,7 @@
 #include "addrman.h"
 #include "amount.h"
 #include "blockstorage/blockstorage.h"
+#include "blockstorage/prune.h"
 #include "blockstorage/sequential_files.h"
 #include "chain.h"
 #include "chainparams.h"

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1196,10 +1196,10 @@ bool AppInit2(Config &config, thread_group &threadGroup)
                 }
 
                 uiInterface.InitMessage(_("Verifying blocks..."));
-                if (fHavePruned && GetArg("-checkblocks", DEFAULT_CHECKBLOCKS) > MIN_BLOCKS_TO_KEEP)
+                if (fHavePruned && GetArg("-checkblocks", DEFAULT_CHECKBLOCKS) > chainparams.MinBlocksToKeep())
                 {
                     LOGA("Prune: pruned datadir may not have more than %d blocks; only checking available blocks",
-                        MIN_BLOCKS_TO_KEEP);
+                        chainparams.MinBlocksToKeep());
                 }
 
                 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -79,14 +79,10 @@ std::atomic<bool> fImporting{false};
 std::atomic<bool> fReindex{false};
 bool fBlocksOnly = false;
 bool fTxIndex = false;
-bool fHavePruned = false;
-bool fPruneMode = false;
 bool fIsBareMultisigStd = DEFAULT_PERMIT_BAREMULTISIG;
 unsigned int nBytesPerSigOp = DEFAULT_BYTES_PER_SIGOP;
 bool fCheckBlockIndex = false;
 bool fCheckpointsEnabled = DEFAULT_CHECKPOINTS_ENABLED;
-uint64_t nPruneTarget = 0;
-uint64_t nDBUsedSpace = 0;
 uint32_t nXthinBloomFilterSize = SMALLEST_MAX_BLOOM_FILTER_SIZE;
 
 // BU: Move global objects to a single file
@@ -115,12 +111,6 @@ std::atomic<int> nPreferredDownload{0};
  * Pruned nodes may have entries where B is missing data.
  */
 std::multimap<CBlockIndex *, CBlockIndex *> mapBlocksUnlinked;
-
-/** Global flag to indicate we should check to see if there are
- *  block/undo files that should be deleted.  Set on startup
- *  or if we allocate more file space when we're in prune mode
- */
-bool fCheckForPruning = false;
 
 std::vector<CBlockFileInfo> vinfoBlockFile;
 int nLastBlockFile = 0;
@@ -456,17 +446,6 @@ bool CheckAgainstCheckpoint(unsigned int height, const uint256 &hash, const CCha
         if (hash != lkup->second) // This block does not match the checkpoint
             return false;
     }
-    return true;
-}
-
-bool CheckDiskSpace(uint64_t nAdditionalBytes)
-{
-    uint64_t nFreeBytesAvailable = fs::space(GetDataDir()).available;
-
-    // Check for nMinDiskSpace bytes (currently 50MB)
-    if (nFreeBytesAvailable < nMinDiskSpace + nAdditionalBytes)
-        return AbortNode("Disk space is low!", _("Error: Disk space is low!"));
-
     return true;
 }
 

--- a/src/main.h
+++ b/src/main.h
@@ -168,16 +168,11 @@ extern bool fHavePruned;
 extern bool fPruneMode;
 /** Number of MiB of block files that we're trying to stay below. */
 extern uint64_t nPruneTarget;
-/** Number of MiB the blockdb is using. */
-extern uint64_t nDBUsedSpace;
+
 /** The maximum bloom filter size that we will support for an xthin request. This value is communicated to
  *  our peer at the time we first make the connection.
  */
 extern uint32_t nXthinBloomFilterSize;
-/** Block files containing a block-height within MIN_BLOCKS_TO_KEEP of chainActive.Tip() will not be pruned. */
-static const unsigned int MIN_BLOCKS_TO_KEEP = 288;
-/** Minimum blocks required to signal NODE_NETWORK_LIMITED */
-static const unsigned int NODE_NETWORK_LIMITED_MIN_BLOCKS = 288;
 
 static const signed int DEFAULT_CHECKBLOCKS = 6;
 static const unsigned int DEFAULT_CHECKLEVEL = 3;
@@ -198,8 +193,6 @@ void RegisterNodeSignals(CNodeSignals &nodeSignals);
 void UnregisterNodeSignals(CNodeSignals &nodeSignals);
 
 
-/** Check whether enough disk space is available for an incoming block */
-bool CheckDiskSpace(uint64_t nAdditionalBytes = 0);
 /** Import blocks from an external file */
 bool LoadExternalBlockFile(const CChainParams &chainparams, FILE *fileIn, CDiskBlockPos *dbp = nullptr);
 /** Do we already have this transaction or has it been seen in a block */

--- a/src/main.h
+++ b/src/main.h
@@ -172,6 +172,8 @@ extern uint64_t nPruneTarget;
 /** The maximum bloom filter size that we will support for an xthin request. This value is communicated to
  *  our peer at the time we first make the connection.
  */
+extern bool fPruneWithMask;
+
 extern uint32_t nXthinBloomFilterSize;
 
 static const signed int DEFAULT_CHECKBLOCKS = 6;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3016,6 +3016,8 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
     nStopwatchConnected = GetStopwatchMicros();
     nTimeOffset = 0;
     addr = addrIn;
+    peerPruneHashMask = 0;
+    peerPruneThreshold = 0;
     addrName = addrNameIn == "" ? addr.ToStringIPPort() : addrNameIn;
     nVersion = 0;
     state_incoming = ConnectionStateIncoming::CONNECTED_WAIT_VERSION;
@@ -3294,6 +3296,9 @@ void CNode::ReadConfigFromXVersion()
     canSyncMempoolWithPeers = (xVersion.as_u64c(XVer::BU_MEMPOOL_SYNC) == 1);
     nMempoolSyncMinVersionSupported = xVersion.as_u64c(XVer::BU_MEMPOOL_SYNC_MIN_VERSION_SUPPORTED);
     nMempoolSyncMaxVersionSupported = xVersion.as_u64c(XVer::BU_MEMPOOL_SYNC_MAX_VERSION_SUPPORTED);
+
+    peerPruneHashMask = arith_uint256(xVersion.as_u64c(XVer::BU_PRUNE_HASHMASK));
+    peerPruneThreshold = xVersion.as_u64c(XVer::BU_PRUNE_THRESHOLD);
 }
 
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3297,7 +3297,7 @@ void CNode::ReadConfigFromXVersion()
     nMempoolSyncMinVersionSupported = xVersion.as_u64c(XVer::BU_MEMPOOL_SYNC_MIN_VERSION_SUPPORTED);
     nMempoolSyncMaxVersionSupported = xVersion.as_u64c(XVer::BU_MEMPOOL_SYNC_MAX_VERSION_SUPPORTED);
 
-    peerPruneHashMask = arith_uint256(xVersion.as_u64c(XVer::BU_PRUNE_HASHMASK));
+    peerPruneHashMask = xVersion.as_u64c(XVer::BU_PRUNE_HASHMASK);
     peerPruneThreshold = xVersion.as_u64c(XVer::BU_PRUNE_THRESHOLD);
 }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2694,6 +2694,21 @@ void NetCleanup()
     }
 }
 
+void RelayNewXUpdate(const CXVersionMessage &msg)
+{
+    LOCK(cs_vNodes);
+    for (CNode *pnode : vNodes)
+    {
+        pnode->PushMessage(NetMsgType::XUPDATE, msg);
+    }
+}
+
+void RelayNewXUpdate(const uint64_t key, const uint64_t val)
+{
+    CXVersionMessage msg;
+    msg.set_u64c(key, val);
+    RelayNewXUpdate(msg);
+}
 
 void RelayTransaction(const CTransactionRef ptx, const bool fRespend, const CTxProperties *txProperties)
 {

--- a/src/net.h
+++ b/src/net.h
@@ -1050,6 +1050,9 @@ private:
     CNode *_pnode;
 };
 
+void RelayNewXUpdate(const CXVersionMessage &msg);
+void RelayNewXUpdate(const uint64_t key, const uint64_t val);
+
 typedef std::vector<CNodeRef> VNodeRefs;
 
 class CTransaction;

--- a/src/net.h
+++ b/src/net.h
@@ -413,6 +413,10 @@ public:
     /** set to true if this node is ok with no message checksum */
     bool skipChecksum;
 
+    //! hash mask of the peer, if hash 64 LSB is less than this hashmask peer should have the block
+    arith_uint256 peerPruneHashMask;
+    uint64_t peerPruneThreshold;
+
     /** The address the remote peer advertised in its version message */
     CAddress addrFrom_advertised;
 

--- a/src/net.h
+++ b/src/net.h
@@ -414,7 +414,7 @@ public:
     bool skipChecksum;
 
     //! hash mask of the peer, if hash 64 LSB is less than this hashmask peer should have the block
-    arith_uint256 peerPruneHashMask;
+    uint64_t peerPruneHashMask;
     uint64_t peerPruneThreshold;
 
     /** The address the remote peer advertised in its version message */

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -171,7 +171,7 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                     {
                         LOG(NET, "Ignore block request below NODE_NETWORK_LIMITED threshold from peer=%d\n",
                             pfrom->GetId());
-                            // disconnect node and prevent it from stalling (would
+                        // disconnect node and prevent it from stalling (would
                         // otherwise wait for the missing block)
                         pfrom->fDisconnect = true;
                         fSend = false;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -13,6 +13,7 @@
 #include "blockrelay/mempool_sync.h"
 #include "blockrelay/thinblock.h"
 #include "blockstorage/blockstorage.h"
+#include "blockstorage/prune.h"
 #include "chain.h"
 #include "dosman.h"
 #include "electrum/electrs.h"

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -600,6 +600,9 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         xver.set_u64c(XVer::BU_MEMPOOL_DESCENDANT_COUNT_LIMIT, nLimitDescendants);
         xver.set_u64c(XVer::BU_MEMPOOL_DESCENDANT_SIZE_LIMIT, nLimitDescendantSize);
 
+        xver.set_u64c(XVer::BU_PRUNE_HASHMASK, pruneHashMask.GetLow64());
+        xver.set_u64c(XVer::BU_PRUNE_THRESHOLD, normalized_threshold);
+
         electrum::set_xversion_flags(xver, chainparams.NetworkIDString());
 
         pfrom->PushMessage(NetMsgType::XVERSION, xver);
@@ -677,10 +680,11 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
     {
         if (!ensureConnectionState(strCommand, ConnectionStateIncoming::SENT_VERACK_READY_FOR_POTENTIAL_XVERSION,
                 ConnectionStateOutgoing::ANY, pfrom))
+        {
             return false;
+        }
         vRecv >> pfrom->xVersion;
-
-        if (pfrom->addrFromPort != 0)
+        if (pfrom->addrFromPort == 0)
         {
             LOG(NET, "Encountered odd node that sent BUVERSION before XVERSION. Ignoring duplicate addrFromPort "
                      "setting. peer=%s version=%s\n",

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -600,7 +600,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         xver.set_u64c(XVer::BU_MEMPOOL_DESCENDANT_COUNT_LIMIT, nLimitDescendants);
         xver.set_u64c(XVer::BU_MEMPOOL_DESCENDANT_SIZE_LIMIT, nLimitDescendantSize);
 
-        xver.set_u64c(XVer::BU_PRUNE_HASHMASK, pruneHashMask.GetLow64());
+        xver.set_u64c(XVer::BU_PRUNE_HASHMASK, pruneHashMask);
         xver.set_u64c(XVer::BU_PRUNE_THRESHOLD, normalized_threshold);
 
         electrum::set_xversion_flags(xver, chainparams.NetworkIDString());

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -7,6 +7,7 @@
 #include "rpc/blockchain.h"
 #include "amount.h"
 #include "blockstorage/blockstorage.h"
+#include "blockstorage/prune.h"
 #include "chain.h"
 #include "chainparams.h"
 #include "checkpoints.h"
@@ -1183,7 +1184,7 @@ UniValue getblockchaininfo(const UniValue &params, bool fHelp)
         }
         else
         {
-            obj.pushKV("pruneHashMask", pruneHashMask.ToString());
+            obj.pushKV("pruneHashMask", pruneHashMask);
             obj.pushKV("hashMaskThreshold", hashMaskThresholdTweak.Value());
         }
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1171,15 +1171,20 @@ UniValue getblockchaininfo(const UniValue &params, bool fHelp)
 
     if (fPruneMode)
     {
-        CBlockIndex *block = chainActive.Tip();
+        if (!fPruneWithMask)
         {
-            READLOCK(cs_mapBlockIndex);
+            CBlockIndex *block = chainActive.Tip();
             while (block && block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA))
                 block = block->pprev;
-        }
 
-        if (block != nullptr)
-            obj.pushKV("pruneheight", block->nHeight);
+            if (block != nullptr)
+                obj.pushKV("pruneheight", block->nHeight);
+        }
+        else
+        {
+            obj.pushKV("pruneHashMask", pruneHashMask.ToString());
+            obj.pushKV("hashMaskThreshold", hashMaskThresholdTweak.Value());
+        }
     }
     return obj;
 }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1173,6 +1173,7 @@ UniValue getblockchaininfo(const UniValue &params, bool fHelp)
     {
         if (!fPruneWithMask)
         {
+            READLOCK(cs_mapBlockIndex);
             CBlockIndex *block = chainActive.Tip();
             while (block && block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA))
                 block = block->pprev;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -41,6 +41,8 @@
 // In case of operator error, limit the rollback of a chain to 100 blocks
 static uint32_t nDefaultRollbackLimit = 100;
 
+extern CTweakRef<uint8_t> hashMaskThresholdTweak;
+
 using namespace std;
 
 extern void TxToJSON(const CTransaction &tx, const uint256 hashBlock, UniValue &entry);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -30,6 +30,8 @@ static const char DB_BEST_BLOCK = 'B';
 static const char DB_FLAG = 'F';
 static const char DB_REINDEX_FLAG = 'R';
 static const char DB_LAST_BLOCK = 'l';
+static const char DB_HASH_MASK = 'H';
+static const char DB_HASH_MASK_THRESHOLD = 'h';
 
 
 namespace
@@ -365,6 +367,18 @@ bool CBlockTreeDB::ReadFlag(const std::string &name, bool &fValue)
         return false;
     fValue = ch == '1';
     return true;
+}
+
+bool CBlockTreeDB::WriteHashMask(const uint256 &_hashMask) { return Write(DB_HASH_MASK, _hashMask); }
+bool CBlockTreeDB::ReadHashMask(uint256 &_hashMask) { return Read(DB_HASH_MASK, _hashMask); }
+bool CBlockTreeDB::WriteHashMaskThreshold(const uint8_t &_hashMaskThreshold)
+{
+    return Write(DB_HASH_MASK_THRESHOLD, _hashMaskThreshold);
+}
+
+bool CBlockTreeDB::ReadHashMaskThreshold(uint8_t &_hashMaskThreshold)
+{
+    return Read(DB_HASH_MASK_THRESHOLD, _hashMaskThreshold);
 }
 
 bool CBlockTreeDB::FindBlockIndex(uint256 blockhash, CDiskBlockIndex *pindex)

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -369,8 +369,8 @@ bool CBlockTreeDB::ReadFlag(const std::string &name, bool &fValue)
     return true;
 }
 
-bool CBlockTreeDB::WriteHashMask(const uint256 &_hashMask) { return Write(DB_HASH_MASK, _hashMask); }
-bool CBlockTreeDB::ReadHashMask(uint256 &_hashMask) { return Read(DB_HASH_MASK, _hashMask); }
+bool CBlockTreeDB::WriteHashMask(const uint64_t &_hashMask) { return Write(DB_HASH_MASK, _hashMask); }
+bool CBlockTreeDB::ReadHashMask(uint64_t &_hashMask) { return Read(DB_HASH_MASK, _hashMask); }
 bool CBlockTreeDB::WriteHashMaskThreshold(const uint8_t &_hashMaskThreshold)
 {
     return Write(DB_HASH_MASK_THRESHOLD, _hashMaskThreshold);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -194,8 +194,8 @@ public:
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &list);
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
-    bool WriteHashMask(const uint256 &_hashMask);
-    bool ReadHashMask(uint256 &_hashMask);
+    bool WriteHashMask(const uint64_t &_hashMask);
+    bool ReadHashMask(uint64_t &_hashMask);
     bool WriteHashMaskThreshold(const uint8_t &_hashMaskThreshold);
     bool ReadHashMaskThreshold(uint8_t &_hashMaskThreshold);
     bool FindBlockIndex(uint256 blockhash, CDiskBlockIndex *index);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -194,6 +194,10 @@ public:
     bool WriteTxIndex(const std::vector<std::pair<uint256, CDiskTxPos> > &list);
     bool WriteFlag(const std::string &name, bool fValue);
     bool ReadFlag(const std::string &name, bool &fValue);
+    bool WriteHashMask(const uint256 &_hashMask);
+    bool ReadHashMask(uint256 &_hashMask);
+    bool WriteHashMaskThreshold(const uint8_t &_hashMaskThreshold);
+    bool ReadHashMaskThreshold(uint8_t &_hashMaskThreshold);
     bool FindBlockIndex(uint256 blockhash, CDiskBlockIndex *index);
     bool LoadBlockIndexGuts();
     bool GetSortedHashIndex(std::vector<std::pair<int, CDiskBlockIndex> > &hashesByHeight);

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -8,6 +8,7 @@
 
 #include "blockrelay/blockrelay_common.h"
 #include "blockstorage/blockstorage.h"
+#include "blockstorage/prune.h"
 #include "blockstorage/sequential_files.h"
 #include "checkpoints.h"
 #include "connmgr.h"
@@ -88,7 +89,6 @@ CBlockIndex *pindexBestForkTip = nullptr;
 CBlockIndex *pindexBestForkBase = nullptr;
 
 extern uint64_t nBlockSequenceId;
-extern bool fCheckForPruning;
 extern std::map<uint256, NodeId> mapBlockSource;
 extern std::multimap<CBlockIndex *, CBlockIndex *> mapBlocksUnlinked;
 extern bool AbortNode(CValidationState &state, const std::string &strMessage, const std::string &userMessage = "");
@@ -100,6 +100,7 @@ extern std::atomic<int> nPreferredDownload;
 extern int nSyncStarted;
 extern bool fLargeWorkForkFound;
 extern bool fLargeWorkInvalidChainFound;
+extern bool fCheckForPruning;
 
 static int64_t nTimeCheck = 0;
 static int64_t nTimeForks = 0;

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -1710,7 +1710,7 @@ bool AcceptBlock(const CBlock &block,
     // blocks which are too close in height to the tip.  Apply this test
     // regardless of whether pruning is enabled; it should generally be safe to
     // not process unrequested blocks.
-    bool fTooFarAhead = (pindex->nHeight > int(chainActive.Height() + MIN_BLOCKS_TO_KEEP));
+    bool fTooFarAhead = (pindex->nHeight > int(chainActive.Height() + chainparams.MinBlocksToKeep()));
 
     // TODO: deal better with return value and error conditions for duplicate
     // and unrequested blocks.

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -339,7 +339,6 @@ bool LoadBlockIndexDB()
     LOCK(cs_main);
     /** This sync method will break on pruned nodes so we cant use if pruned*/
     // Check whether we have ever pruned block & undo files
-    pblocktree->ReadFlag("prunedblockfiles", fHavePruned);
     if (!fHavePruned)
     {
         // by default we want to sync from disk instead of network if possible

--- a/src/xversionkeys.dat
+++ b/src/xversionkeys.dat
@@ -43,10 +43,16 @@ KEY i BU_MEMPOOL_ANCESTOR_SIZE_LIMIT            0x0002                   0x000A 
 KEY i BU_MEMPOOL_DESCENDANT_COUNT_LIMIT         0x0002                   0x000B         u64c
 KEY i BU_MEMPOOL_DESCENDANT_SIZE_LIMIT          0x0002                   0x000C         u64c
 
+# Hashmask for random block pruning
+KEY i BU_PRUNE_HASHMASK                         0x0002                   0x000D         u64c
+# normalized threshold for random block pruning
+KEY i BU_PRUNE_THRESHOLD                        0x0002                   0x000E         u64c
+
 # Port number for unencrypted electrum server RPC, if node is running one.
 KEY i BU_ELECTRUM_SERVER_PORT_TCP               0x0002                   0xF00D         u64c
 # Electrum protocol version, if node is running one.
 KEY i BU_ELECTRUM_SERVER_PROTOCOL_VERSION       0x0002                   0xF00E         u64c
+
 
 # KEY i ABC_...                                0x0000                   ...
 # KEY i XT_DOUBLESPEND_FORWARDING_SCHEME       0x0003                   ...            vector


### PR DESCRIPTION
This PR adds random block pruning. 
This PR adds a new configurable param which when enabled, will set the node to prune based on a randomly generated 64bit number (henceforth hashmask). A second configurable param called threshold (integer between 1 and 100, 100 by default) can be set to lower threshold by which blocks get prune. 
formula is as follows:
given 
normalized_threshold = threshold * MAX_UINT64/100
then
if (blockhash_64LSB XOR hashmask) < normalized_threshold
keep block
else 
prune block


__TODO__
- if both prune and prunewithmask are set, return an error with an explaination
- if previously had prune or prune with mask, return an error when switching to the other

