### PR TITLE
Add rpc feature: reconsidermostworkchain

### DIFF
--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -11,6 +11,7 @@ import test_framework.loginit
 
 from decimal import Decimal
 
+import test_framework.loginit
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.authproxy import JSONRPCException
 from test_framework.util import *
@@ -30,7 +31,7 @@ class BlockchainTest(BitcoinTestFramework):
     """
 
     def setup_chain(self):
-        print("Initializing test directory " + self.options.tmpdir)
+        logging.info ("Initializing test directory " + self.options.tmpdir)
         initialize_chain(self.options.tmpdir)
 
     def setup_network(self, split=False):
@@ -63,7 +64,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(len(res['bestblock']), 64)
         assert_equal(len(res['hash_serialized_2']), 64)
 
-        print ("Test that gettxoutsetinfo() works for blockchain with just the genesis block")
+        logging.info ("Test that gettxoutsetinfo() works for blockchain with just the genesis block")
         b1hash = node.getblockhash(1)
         node.invalidateblock(b1hash)
 
@@ -75,7 +76,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(res2['bestblock'], node.getblockhash(0))
         assert_equal(len(res2['hash_serialized_2']), 64)
 
-        print ("Test that gettxoutsetinfo() returns the same result after invalidate/reconsider block")
+        logging.info ("Test that gettxoutsetinfo() returns the same result after invalidate/reconsider block")
         node.reconsiderblock(b1hash)
 
         res3 = node.gettxoutsetinfo()
@@ -122,7 +123,7 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(blockcount + 10, self.nodes[1].getblockcount())
 
         # Now Rollback the chain on Node 0 by 5 blocks
-        print ("Test that rollbackchain() works")
+        logging.info ("Test that rollbackchain() works")
         blockcount = self.nodes[0].getblockcount()
         self.nodes[0].rollbackchain(self.nodes[0].getblockcount() - 5)
         assert_equal(blockcount - 5, self.nodes[0].getblockcount())
@@ -156,7 +157,7 @@ class BlockchainTest(BitcoinTestFramework):
         try:
             self.nodes[0].rollbackchain(self.nodes[0].getblockcount() - 101)
         except JSONRPCException as e:
-            print (e.error['message'])
+            logging.info (e.error['message'])
             assert("You are attempting to rollback the chain by 101 blocks, however the limit is 100 blocks." in e.error['message'])
         assert_equal(blockcount, self.nodes[0].getblockcount())
         assert_equal(blockcount, self.nodes[1].getblockcount())
@@ -229,7 +230,7 @@ class BlockchainTest(BitcoinTestFramework):
         # fork3 the active chain, and disregarding fork1 which is longer than fork2 but
         # shorter than fork3.
         
-        print ("Test that reconsidermostworkchain() works")
+        logging.info ("Test that reconsidermostworkchain() works")
 
         # rollback to before fork 1 and 2, and then mine another longer fork 3
         self.nodes[0].rollbackchain(self.nodes[0].getblockcount() - 120, True)
@@ -245,7 +246,7 @@ class BlockchainTest(BitcoinTestFramework):
         try:
             self.nodes[0].reconsidermostworkchain()
         except JSONRPCException as e:
-            print (e.error['message'])
+            logging.info (e.error['message'])
             assert("You are attempting to rollback the chain by 120 blocks, however the limit is 100 blocks." in e.error['message'])
 
         # now do a reconsidermostworkchain with the override. We should now be on fork3 best block hash

--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -241,6 +241,7 @@ class BlockchainTest(BitcoinTestFramework):
         # now rollback again and make the shortest fork2 the active chain
         self.nodes[0].rollbackchain(self.nodes[0].getblockcount() - fork3blocks, True)
         self.nodes[0].reconsiderblock(bestblockhashfork2)
+        assert_equal(self.nodes[0].getbestblockhash(), bestblockhashfork2);
 
         # do a reconsidermostworkchain but without the override flag
         try:
@@ -248,6 +249,8 @@ class BlockchainTest(BitcoinTestFramework):
         except JSONRPCException as e:
             logging.info (e.error['message'])
             assert("You are attempting to rollback the chain by 120 blocks, however the limit is 100 blocks." in e.error['message'])
+        # check that nothing happened and we're still on the same chaintip
+        assert_equal(self.nodes[0].getbestblockhash(), bestblockhashfork2);
 
         # now do a reconsidermostworkchain with the override. We should now be on fork3 best block hash
         self.nodes[0].reconsidermostworkchain(True)
@@ -260,6 +263,8 @@ class BlockchainTest(BitcoinTestFramework):
         except JSONRPCException as e:
             logging.info (e.error['message'])
             assert("Nothing to do. Already on the correct chain." in e.error['message'])
+        # check that nothing happened and we're still on the same chaintip
+        assert_equal(self.nodes[0].getbestblockhash(), bestblockhashfork3);
 
     def _test_transaction_pools(self):
         node = self.nodes[0]

--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -254,6 +254,13 @@ class BlockchainTest(BitcoinTestFramework):
         assert_equal(self.nodes[0].getbestblockhash(), bestblockhashfork3);
 
 
+        # check that we can run reconsidermostworkchain when we're already on the correct chain
+        try:
+            self.nodes[0].reconsidermostworkchain()
+        except JSONRPCException as e:
+            logging.info (e.error['message'])
+            assert("Nothing to do. Already on the correct chain." in e.error['message'])
+
     def _test_transaction_pools(self):
         node = self.nodes[0]
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1247,7 +1247,10 @@ UniValue reconsidermostworkchain(const UniValue &params, bool fHelp)
 {
     if (fHelp || params.size() > 1)
         throw runtime_error("reconsidermostworkchain \"[override]\"\n"
-                            "\nWill rollback the chain if needed and then sync to the most work chain.\n"
+                            "\nWill rollback the chain if needed and then sync to the most work chain. If this\n"
+                            "client was not upgraded before a hard fork and marked the \"real\" chain as invalid,\n"
+                            "then this command should be run after upgrading the client so as to join the correct\n"
+                            "and most work chain\n"
                             "\nArguments:\n"
                             "1. override      (boolean, optional, default=false)"
                             "\nResult:\n"

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -32,6 +32,9 @@
 
 #include <boost/thread/thread.hpp> // boost::thread::interrupt
 
+// In case of operator error, limit the rollback of a chain to 100 blocks
+static uint32_t nDefaultRollbackLimit = 100;
+
 using namespace std;
 
 extern void TxToJSON(const CTransaction &tx, const uint256 hashBlock, UniValue &entry);
@@ -909,6 +912,44 @@ struct CompareBlocksByHeight
     }
 };
 
+static std::set<CBlockIndex *, CompareBlocksByHeight> GetChainTips()
+{
+    /*
+     * Idea:  the set of chain tips is chainActive.tip, plus orphan blocks which do not have another orphan building off
+     * of them.
+     * Algorithm:
+     *  - Make one pass through mapBlockIndex, picking out the orphan blocks, and also storing a set of the orphan
+     * block's pprev pointers.
+     *  - Iterate through the orphan blocks. If the block isn't pointed to by another orphan, it is a chain tip.
+     *  - add chainActive.Tip()
+     */
+    std::set<CBlockIndex *, CompareBlocksByHeight> setTips;
+    std::set<CBlockIndex *> setOrphans;
+    std::set<CBlockIndex *> setPrevs;
+
+    for (const std::pair<const uint256, CBlockIndex *> &item : mapBlockIndex)
+    {
+        if (!chainActive.Contains(item.second))
+        {
+            setOrphans.insert(item.second);
+            setPrevs.insert(item.second->pprev);
+        }
+    }
+
+    for (auto &it : setOrphans)
+    {
+        if (setPrevs.erase(it) == 0)
+        {
+            setTips.insert(it);
+        }
+    }
+
+    // Always report the currently active tip.
+    setTips.insert(chainActive.Tip());
+
+    return setTips;
+}
+
 UniValue getchaintips(const UniValue &params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
@@ -941,38 +982,9 @@ UniValue getchaintips(const UniValue &params, bool fHelp)
 
     LOCK(cs_main);
 
-    /*
-     * Idea:  the set of chain tips is chainActive.tip, plus orphan blocks which do not have another orphan building off
-     * of them.
-     * Algorithm:
-     *  - Make one pass through mapBlockIndex, picking out the orphan blocks, and also storing a set of the orphan
-     * block's pprev pointers.
-     *  - Iterate through the orphan blocks. If the block isn't pointed to by another orphan, it is a chain tip.
-     *  - add chainActive.Tip()
-     */
-    std::set<const CBlockIndex *, CompareBlocksByHeight> setTips;
-    std::set<const CBlockIndex *> setOrphans;
-    std::set<const CBlockIndex *> setPrevs;
-
-    for (const PAIRTYPE(const uint256, CBlockIndex *) & item : mapBlockIndex)
-    {
-        if (!chainActive.Contains(item.second))
-        {
-            setOrphans.insert(item.second);
-            setPrevs.insert(item.second->pprev);
-        }
-    }
-
-    for (std::set<const CBlockIndex *>::iterator it = setOrphans.begin(); it != setOrphans.end(); ++it)
-    {
-        if (setPrevs.erase(*it) == 0)
-        {
-            setTips.insert(*it);
-        }
-    }
-
-    // Always report the currently active tip.
-    setTips.insert(chainActive.Tip());
+    // Get the set of chaintips
+    std::set<CBlockIndex *, CompareBlocksByHeight> setTips;
+    setTips = GetChainTips();
 
     /* Construct the output array.  */
     UniValue res(UniValue::VARR);
@@ -1174,24 +1186,22 @@ UniValue reconsiderblock(const UniValue &params, bool fHelp)
 
 UniValue rollbackchain(const UniValue &params, bool fHelp)
 {
-    // In case of operator error, limit the rollback to 100 blocks
-    uint32_t nLimit = 100;
-
     if (fHelp || params.size() < 1 || params.size() > 2)
-        throw runtime_error(
-            "rollbackchain \"blockheight\"\n"
-            "\nRolls back the blockchain to the height indicated.\n"
-            "\nArguments:\n"
-            "1. blockheight   (int, required) the height that you want to roll the chain \
+        throw runtime_error("rollbackchain \"blockheight\"\n"
+                            "\nRolls back the blockchain to the height indicated.\n"
+                            "\nArguments:\n"
+                            "1. blockheight   (int, required) the height that you want to roll the chain \
                             back to (only maxiumum rollback of " +
-            std::to_string(nLimit) + " blocks allowed)\n"
-                                     "2. override      (boolean, optional, default=false) rollback more than the \
+                            std::to_string(nDefaultRollbackLimit) +
+                            " blocks allowed)\n"
+                            "2. override      (boolean, optional, default=false) rollback more than the \
                             allowed default limit of " +
-            std::to_string(nLimit) + " blocks)\n"
-                                     "\nResult:\n"
-                                     "\nExamples:\n" +
-            HelpExampleCli("rollbackchain", "\"501245\"") + HelpExampleCli("rollbackchain", "\"495623 true\"") +
-            HelpExampleRpc("rollbackchain", "\"blockheight\""));
+                            std::to_string(nDefaultRollbackLimit) + " blocks)\n"
+                                                                    "\nResult:\n"
+                                                                    "\nExamples:\n" +
+                            HelpExampleCli("rollbackchain", "\"501245\"") +
+                            HelpExampleCli("rollbackchain", "\"495623 true\"") +
+                            HelpExampleRpc("rollbackchain", "\"blockheight\""));
 
     int nRollBackHeight = params[0].get_int();
     bool fOverride = false;
@@ -1200,9 +1210,10 @@ UniValue rollbackchain(const UniValue &params, bool fHelp)
 
     LOCK(cs_main);
     uint32_t nRollBack = chainActive.Height() - nRollBackHeight;
-    if (nRollBack > nLimit && !fOverride)
+    if (nRollBack > nDefaultRollbackLimit && !fOverride)
         throw runtime_error("You are attempting to rollback the chain by " + std::to_string(nRollBack) +
-                            " blocks, however the limit is " + std::to_string(nLimit) + " blocks. Set " +
+                            " blocks, however the limit is " + std::to_string(nDefaultRollbackLimit) +
+                            " blocks. Set "
                             "the override to true if you want rollback more than the default");
 
     while (chainActive.Height() > nRollBackHeight)
@@ -1232,6 +1243,57 @@ UniValue rollbackchain(const UniValue &params, bool fHelp)
     return NullUniValue;
 }
 
+UniValue reconsidermostworkchain(const UniValue &params, bool fHelp)
+{
+    if (fHelp || params.size() > 1)
+        throw runtime_error("reconsidermostworkchain \"[override]\"\n"
+                            "\nWill rollback the chain if needed and then sync to the most work chain.\n"
+                            "\nArguments:\n"
+                            "1. override      (boolean, optional, default=false)"
+                            "\nResult:\n"
+                            "\nExamples:\n" +
+                            HelpExampleCli("reconsidermostworkchain", "") +
+                            HelpExampleCli("reconsidermostworkchain", "\"true\"") +
+                            HelpExampleRpc("reconsidermostworkchain", "\"true\""));
+
+    // Find pindex of most work chain regardless of whether is is valid or not.
+    LOCK(cs_main);
+
+    // Get the set of chaintips
+    std::set<CBlockIndex *, CompareBlocksByHeight> setTips;
+    setTips = GetChainTips();
+
+    // Find the longest chaintip regardless if it is currently the active one.
+    CBlockIndex *pMostWork = chainActive.Tip();
+    for (CBlockIndex *pTip : setTips)
+    {
+        if (pMostWork->nChainWork < pTip->nChainWork)
+            pMostWork = pTip;
+    }
+
+    // Find where chainActive meets the most work chaintip
+    const CBlockIndex *pFork;
+    pFork = chainActive.FindFork(pMostWork);
+
+    // Rollback to the common forkheight so that both chains will be invalidated.
+    UniValue obj(UniValue::VARR);
+    obj.push_back(pFork->nHeight);
+    if (params.size() > 0)
+    {
+        // Set the rollbackchain override flag if there was one provided.
+        obj.push_back(params[0]);
+    }
+    rollbackchain(obj, false);
+
+    // If we got here then rollbackchain() was sucessful and we didn't throw an exception.
+    // Now reconsider the most work chain.
+    UniValue obj_hash(UniValue::VARR);
+    obj_hash.push_back(pMostWork->GetBlockHash().ToString());
+    reconsiderblock(obj_hash, false);
+
+    return NullUniValue;
+}
+
 static const CRPCCommand commands[] = {
     //  category              name                      actor (function)         okSafeMode
     //  --------------------- ------------------------  -----------------------  ----------
@@ -1247,6 +1309,7 @@ static const CRPCCommand commands[] = {
     /* Not shown in help */
     {"hidden", "invalidateblock", &invalidateblock, true}, {"hidden", "reconsiderblock", &reconsiderblock, true},
     {"hidden", "rollbackchain", &rollbackchain, true},
+    {"hidden", "reconsidermostworkchain", &reconsidermostworkchain, true},
 };
 
 void RegisterBlockchainRPCCommands(CRPCTable &table)

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1276,7 +1276,7 @@ UniValue reconsidermostworkchain(const UniValue &params, bool fHelp)
 
     // If already on the longest chain then return
     if (pMostWork == chainActive.Tip())
-       throw runtime_error("Nothing to do. Already on the correct chain.");
+        throw runtime_error("Nothing to do. Already on the correct chain.");
 
     // Find where chainActive meets the most work chaintip
     const CBlockIndex *pFork;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1274,6 +1274,10 @@ UniValue reconsidermostworkchain(const UniValue &params, bool fHelp)
             pMostWork = pTip;
     }
 
+    // If already on the longest chain then return
+    if (pMostWork == chainActive.Tip())
+       throw runtime_error("Nothing to do. Already on the correct chain.");
+
     // Find where chainActive meets the most work chaintip
     const CBlockIndex *pFork;
     pFork = chainActive.FindFork(pMostWork);

--- a/src/rpc/client.cpp
+++ b/src/rpc/client.cpp
@@ -51,7 +51,8 @@ static const CRPCConvertParam vRPCConvertParams[] = {{"stop", 0}, {"setmocktime"
     {"importprivkey", 2}, {"importaddress", 2}, {"importaddress", 3}, {"importpubkey", 2}, {"verifychain", 0},
     {"verifychain", 1}, {"keypoolrefill", 0}, {"getrawmempool", 0}, {"estimatefee", 0}, {"estimatepriority", 0},
     {"estimatesmartfee", 0}, {"estimatesmartpriority", 0}, {"prioritisetransaction", 1}, {"prioritisetransaction", 2},
-    {"setban", 2}, {"setban", 3}, {"rollbackchain", 0}, {"rollbackchain", 1}};
+    {"setban", 2}, {"setban", 3}, {"rollbackchain", 0}, {"rollbackchain", 1}, {"reconsidermostworkchain", 0},
+    {"reconsidermostworkchain", 1}};
 
 class CRPCConvertTable
 {


### PR DESCRIPTION
This feature is intended to be used during fork testing but also
for node operators which have fogotten to upgrade their clients before
a fork.  Getting back on to the correct fork can be a problem if there
have been a few blocks mined on the old chain after the fork time. By
running this command the chain will automatically rollback to the forkpoint
and then join the most work chain.