### PR TITLE
Only print out one log entry when checking the graphene/thinblock timers

### DIFF
--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -179,7 +179,7 @@ private:
     std::atomic<uint64_t> nGrapheneBlockBytes{0};
 
     CCriticalSection cs_mapGrapheneBlockTimer; // locks mapGrapheneBlockTimer
-    std::map<uint256, uint64_t> mapGrapheneBlockTimer;
+    std::map<uint256, std::pair<uint64_t, bool> > mapGrapheneBlockTimer;
 
     CCriticalSection cs_graphenestats; // locks everything below this point
 

--- a/src/blockrelay/thinblock.h
+++ b/src/blockrelay/thinblock.h
@@ -177,7 +177,7 @@ private:
     std::atomic<uint64_t> nThinBlockBytes{0};
 
     CCriticalSection cs_mapThinBlockTimer; // locks mapThinBlockTimer
-    std::map<uint256, uint64_t> mapThinBlockTimer;
+    std::map<uint256, std::pair<uint64_t, bool> > mapThinBlockTimer;
 
     CCriticalSection cs_thinblockstats; // locks everything below this point
 


### PR DESCRIPTION
Recuce the nuisance log entries every time a graphene or thinblock timer
is checked.  Only print out the log entry the very first time.

Just set a bool flag to true the first time we print the log entry and then don't do it again for this attempted block download.