### PR TITLE
[Minor] Make better use of peers tab real estate

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -978,7 +978,7 @@ QString formatServicesStr(quint64 mask)
     }
 
     if (strList.size())
-        return strList.join(" & ");
+        return strList.join(",");
     else
         return QObject::tr("None");
 }


### PR DESCRIPTION
The number of services that nodes support is growing which is causing
the peers panel in QT to use up more space. Here we reclaim two
characaters per service while still maintaining readability by
simply using a comma between services.