### PR TITLE
[Minor] Do not show Upgrade message in UI when not upgrading

### DIFF
--- a/src/blockstorage/blockstorage.cpp
+++ b/src/blockstorage/blockstorage.cpp
@@ -12,6 +12,7 @@
 #include "fs.h"
 #include "main.h"
 #include "sequential_files.h"
+#include "ui_interface.h"
 #include "undo.h"
 
 extern bool AbortNode(CValidationState &state, const std::string &strMessage, const std::string &userMessage = "");
@@ -137,6 +138,10 @@ void SyncStorage(const CChainParams &chainparams)
     {
         return;
     }
+
+    LOGA("Upgrading block database...\n");
+    uiInterface.InitMessage(_("Upgrading block database...This could take a while."));
+
     GetTempBlockDB(pblockdbsync, otherMode);
     AssertLockHeld(cs_main);
     if (BLOCK_DB_MODE == SEQUENTIAL_BLOCK_FILES)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3789,8 +3789,6 @@ bool static LoadBlockIndexDB()
         // by default we want to sync from disk instead of network if possible
         // run a db sync here to sync storage methods
         // may increase startup time significantly but is faster than network sync
-        LOGA("Upgrading block database...\n");
-        uiInterface.InitMessage(_("Upgrading block database...This could take a while."));
         SyncStorage(chainparams);
     }
 


### PR DESCRIPTION
Only show the upgrade message when you're actually doing a blockdb
upgrade. Currently it was showing every time you launched the app.