### PR TITLE
move fastfilter from gigaperf, add unit tests

### DIFF
--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -65,6 +65,7 @@ dstencode.cpp
 dstencode.h
 expedited.cpp
 expedited.h
+fastfilter.h
 globals.cpp
 hash.cpp
 hash.h
@@ -284,6 +285,7 @@ test/DoS_tests.cpp
 test/excessiveblock_test.cpp
 test/exploit_tests.cpp
 test/fork_tests.cpp
+test/fastfilter_tests.cpp
 test/getarg_tests.cpp
 test/hash_tests.cpp
 test/key_tests.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -133,6 +133,7 @@ BITCOIN_CORE_H = \
   dstencode.h \
   expedited.h \
   fast-cpp-csv-parser/csv.h \
+  fastfilter.h \
   forks_csv.h \
   fs.h \
   httprpc.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -78,6 +78,7 @@ BITCOIN_TESTS =\
   test/DoS_tests.cpp \
   test/dstencode_tests.cpp \
   test/exploit_tests.cpp \
+  test/fastfilter_tests.cpp \
   test/forkscsv_tests.cpp \
   test/getarg_tests.cpp \
   test/graphene_tests.cpp \

--- a/src/fastfilter.h
+++ b/src/fastfilter.h
@@ -1,0 +1,113 @@
+// Copyright (c) 2017 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_FAST_FILTER_H
+#define BITCOIN_FAST_FILTER_H
+
+#include "random.h"
+#include "serialize.h"
+#include <vector>
+
+class COutPoint;
+class uint256;
+
+#define REL_PRIME 27061
+/**
+ * FastFilter is a probabilistic filter.  The filter can answer whether an element
+ * definitely is NOT in the set, but only that an element is LIKELY in the set.
+ * This is similar to a Bloom filter, but much faster.
+ *
+ * This filter expects that the input elements have a random distribution (i.e. hashes)
+ *
+ * This class is thread-safe in the sense that simultaneous calls to insert and contains will not crash,
+ * but "inserts" may be lost.  However, if you are using this class as an in-ram filter before doing a more expensive
+ * operation, a lost insert may be acceptable.
+ */
+template <unsigned int FILTER_SIZE>
+class CFastFilter
+{
+protected:
+    std::vector<unsigned char> vData;
+    unsigned int grabFrom;
+    unsigned int conflicts;
+
+public:
+    enum
+    {
+        FILTER_BYTES = FILTER_SIZE / 8
+    };
+
+    CFastFilter()
+    {
+        FastRandomContext insecure_rand;
+        vData.resize(FILTER_BYTES);
+        // by sampling from a different part of the uint256, we make it harder for an attacker to generate collisions
+        grabFrom = (insecure_rand.rand32() % 7) * 4; // should be 4 byte aligned for speed
+    }
+
+    // returns true IF this function made a change (i.e. the value was previously not set).
+    bool checkAndSet(const uint256 &hash)
+    {
+        const unsigned char *mem = hash.begin();
+        const uint32_t *pos = (const uint32_t *)&(mem[grabFrom]);
+        uint32_t idx = (*pos) & (FILTER_SIZE - 1);
+
+        bool ret = vData[idx >> 3] & (1 << (idx & 7));
+        vData[idx >> 3] |= (1 << (idx & 7));
+        if (ret)
+            conflicts++;
+        return !ret;
+    }
+
+    void insert(const uint256 &hash)
+    {
+        const unsigned char *mem = hash.begin();
+        const uint32_t *pos = (const uint32_t *)&(mem[grabFrom]);
+        uint32_t idx = (*pos) & (FILTER_SIZE - 1);
+        vData[idx >> 3] |= (1 << (idx & 7));
+    }
+    bool contains(const uint256 &hash) const
+    {
+        const unsigned char *mem = hash.begin();
+        const uint32_t *pos = (const uint32_t *)&(mem[grabFrom]);
+        uint32_t idx = (*pos) & (FILTER_SIZE - 1);
+        return vData[idx >> 3] & (1 << (idx & 7));
+    }
+
+    void reset() { bzero(&vData[0], FILTER_BYTES); }
+};
+
+
+template <unsigned int FILTER_SIZE>
+class CRollingFastFilter : public CFastFilter<FILTER_SIZE>
+{
+    unsigned int erase;
+    unsigned int eraseAmt;
+
+public:
+    CRollingFastFilter(unsigned int _eraseAmt = 16)
+    {
+        FastRandomContext insecure_rand;
+        erase = insecure_rand.rand32() % CFastFilter<FILTER_SIZE>::FILTER_BYTES;
+        eraseAmt = _eraseAmt;
+    }
+    void insert(const uint256 &hash)
+    {
+        // By clearing 128 entries each time, the filter will never have a false positive rate > 1%
+        erase += REL_PRIME;
+        erase &= (CFastFilter<FILTER_SIZE>::FILTER_BYTES - 1);
+        // the loc var and repeated & is for thread safety
+        unsigned int loc = erase & (CFastFilter<FILTER_SIZE>::FILTER_BYTES - 1);
+        for (unsigned int j = 0; j < eraseAmt; j++) // todo: optimize
+        {
+            this->vData[loc] = 0;
+            loc++;
+            loc &= (CFastFilter<FILTER_SIZE>::FILTER_BYTES - 1); // wrap around
+        }
+
+        CFastFilter<FILTER_SIZE>::insert(hash);
+    }
+};
+
+#endif

--- a/src/test/fastfilter_tests.cpp
+++ b/src/test/fastfilter_tests.cpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2018 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+#include "fastfilter.h"
+#include "hash.h"
+
+BOOST_FIXTURE_TEST_SUITE(fastfilter_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(fastfilter_tests)
+{
+    // Like a bloom filter the fast filter can have false positives but not false negatives
+    FastRandomContext insecure_rand;
+    {
+        CFastFilter<1024 * 1024> filt;
+
+        //  pick a random start point for a randomized test
+        // arith_uint256 num(insecure_rand.rand32());
+        arith_uint256 num(1);
+        arith_uint256 origNum = num;
+        int collisions = 0;
+        for (int i = 1; i < 20000; i++)
+        {
+            num += 1;
+            uint256 t1 = ArithToUint256(num);
+            // for the fastfilter to work without lots of collisions the data must be pseudo-random
+            uint256 tmp = Hash(t1.begin(), t1.end());
+            if (filt.contains(tmp))
+            {
+                collisions++;
+            }
+            filt.insert(tmp);
+            BOOST_CHECK(filt.contains(tmp));
+            BOOST_CHECK(!filt.checkAndSet(tmp));
+        }
+        // printf("collisions: %d\n", collisions);
+        BOOST_CHECK(collisions < 400); // sanity check, actual result may vary
+        // check them all again
+        num = origNum;
+        int numFalsePositives = 0;
+        for (int i = 1; i < 20000; i++)
+        {
+            num += 1;
+            uint256 t1 = ArithToUint256(num);
+            uint256 tmp = Hash(t1.begin(), t1.end());
+            BOOST_CHECK(filt.contains(tmp));
+        }
+        for (int i = 1; i < 20000; i++) // check a bunch of numbers we didn't add
+        {
+            num += 1;
+            uint256 t1 = ArithToUint256(num);
+            uint256 tmp = Hash(t1.begin(), t1.end());
+            if (filt.contains(tmp))
+                numFalsePositives++;
+        }
+        // printf("numFalsePositives: %d\n", numFalsePositives);
+        BOOST_CHECK(numFalsePositives < 2000); // sanity check, actual result may vary
+    }
+
+
+    // Test the 4 MB filter since that's what we use
+    {
+        CFastFilter<4 * 1024 * 1024> filt;
+
+        arith_uint256 num(0);
+        int collisions = 0;
+        for (int i = 0; i < 100000; i++)
+        {
+            num += 1;
+            uint256 t1 = ArithToUint256(num);
+            uint256 tmp = Hash(t1.begin(), t1.end());
+            if (!filt.checkAndSet(tmp))
+                collisions += 1;
+            BOOST_CHECK(filt.contains(tmp));
+        }
+        // printf("collisions: %d\n", collisions);
+        BOOST_CHECK(collisions < 2000); // sanity check, actual result may vary
+    }
+}
+
+BOOST_AUTO_TEST_CASE(rollingfastfilter_tests)
+{
+    // Like a bloom filter the fast filter can have false positives but not false negatives
+    FastRandomContext insecure_rand;
+    CRollingFastFilter<1024 * 1024> rfilt;
+    CFastFilter<1024 * 1024> filt;
+
+    //  pick a random start point for a randomized test
+    // arith_uint256 num(insecure_rand.rand32());
+    arith_uint256 num(1);
+    int rcollisions = 0;
+    int collisions = 0;
+    for (int i = 1; i < 2000000; i++)
+    {
+        num += 1;
+        uint256 t1 = ArithToUint256(num);
+        uint256 tmp = Hash(t1.begin(), t1.end());
+        if (filt.contains(tmp))
+        {
+            collisions++;
+        }
+        if (rfilt.contains(tmp))
+        {
+            rcollisions++;
+        }
+        filt.insert(tmp);
+        rfilt.insert(tmp);
+        BOOST_CHECK(filt.contains(tmp));
+        BOOST_CHECK(!filt.checkAndSet(tmp));
+        BOOST_CHECK(rfilt.contains(tmp));
+        BOOST_CHECK(!rfilt.checkAndSet(tmp));
+    }
+    // printf("collisions: %d  rolling collisions: %d\n", collisions, rcollisions);
+    BOOST_CHECK(rcollisions < collisions);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/fastfilter_tests.cpp
+++ b/src/test/fastfilter_tests.cpp
@@ -37,7 +37,6 @@ BOOST_AUTO_TEST_CASE(fastfilter_tests)
             BOOST_CHECK(filt.contains(tmp));
             BOOST_CHECK(!filt.checkAndSet(tmp));
         }
-        // printf("collisions: %d\n", collisions);
         BOOST_CHECK(collisions < 400); // sanity check, actual result may vary
         // check them all again
         num = origNum;
@@ -57,7 +56,6 @@ BOOST_AUTO_TEST_CASE(fastfilter_tests)
             if (filt.contains(tmp))
                 numFalsePositives++;
         }
-        // printf("numFalsePositives: %d\n", numFalsePositives);
         BOOST_CHECK(numFalsePositives < 2000); // sanity check, actual result may vary
     }
 
@@ -77,7 +75,6 @@ BOOST_AUTO_TEST_CASE(fastfilter_tests)
                 collisions += 1;
             BOOST_CHECK(filt.contains(tmp));
         }
-        // printf("collisions: %d\n", collisions);
         BOOST_CHECK(collisions < 2000); // sanity check, actual result may vary
     }
 }
@@ -114,8 +111,9 @@ BOOST_AUTO_TEST_CASE(rollingfastfilter_tests)
         BOOST_CHECK(rfilt.contains(tmp));
         BOOST_CHECK(!rfilt.checkAndSet(tmp));
     }
-    // printf("collisions: %d  rolling collisions: %d\n", collisions, rcollisions);
     BOOST_CHECK(rcollisions < collisions);
+    // This next check is probabilistic, see comment in CRollingFastFilter insert()
+    BOOST_CHECK(((double)rcollisions) / 2000000.0 < .02);
 }
 
 


### PR DESCRIPTION
This PR does not use the fastfilter object, but use will be ported over from gigaperf soon.