### PR TITLE
Remove check for is UAHF active in signrawtransaction()

### DIFF
--- a/qa/rpc-tests/signrawtransactions.py
+++ b/qa/rpc-tests/signrawtransactions.py
@@ -39,12 +39,24 @@ class SignRawTransactionsTest(BitcoinTestFramework):
         rawTx = self.nodes[0].createrawtransaction(inputs, outputs)
         rawTxSigned = self.nodes[0].signrawtransaction(rawTx, inputs, privKeys)
 
+        #### Sign with default forkid
         # 1) The transaction has a complete set of signatures
         assert 'complete' in rawTxSigned
         assert_equal(rawTxSigned['complete'], True)
 
         # 2) No script verification error occurred
         assert 'errors' not in rawTxSigned
+
+        #### Make sure you can still sign with NOFORKID for doing cross chain signing with legacy Bitcoin
+        rawTxSigned_noforkid = self.nodes[0].signrawtransaction(rawTx, inputs, privKeys, "ALL|NOFORKID")
+
+        # 1) The transaction has a complete set of signatures
+        assert 'complete' in rawTxSigned_noforkid
+        assert_equal(rawTxSigned_noforkid['complete'], True)
+
+        # 2) No script verification error occurred
+        assert 'errors' not in rawTxSigned_noforkid
+
 
     def script_verification_error_test(self):
         """Creates and signs a raw transaction with valid (vin 0), invalid (vin 1) and one missing (vin 2) input script.

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -947,7 +947,7 @@ def create_lots_of_big_transactions(node, txouts, utxos, num, fee):
         newtx = rawtx[0:92]
         newtx = newtx + txouts
         newtx = newtx + rawtx[94:]
-        signresult = node.signrawtransaction(newtx, None, None, "NONE")
+        signresult = node.signrawtransaction(newtx, None, None, "FORKID")
         txid = node.sendrawtransaction(signresult["hex"], True)
         txids.append(txid)
     return txids

--- a/qa/rpc-tests/txn_clone.py
+++ b/qa/rpc-tests/txn_clone.py
@@ -84,7 +84,7 @@ class TxnMallTest(BitcoinTestFramework):
 
         # Use a different signature hash type to sign.  This creates an equivalent but malleated clone.
         # Don't send the clone anywhere yet
-        tx1_clone = self.nodes[0].signrawtransaction(clone_raw, None, None, "ALL|ANYONECANPAY")
+        tx1_clone = self.nodes[0].signrawtransaction(clone_raw, None, None, "ALL|ANYONECANPAY|FORKID")
         assert_equal(tx1_clone["complete"], True)
 
         # Have node0 mine a block, if requested:

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -256,11 +256,6 @@ CTweak<uint64_t> miningForkMG("mining.forkBlockSize",
     "Set the maximum block generation size to this value at the time of the fork.",
     8000000);
 
-CTweak<bool> walletSignWithForkSig("wallet.useNewSig",
-    "Once the fork occurs, sign transactions using the new signature scheme so that they will only be valid on the "
-    "fork.",
-    true);
-
 CTweak<unsigned int> maxTxSize("net.excessiveTx", "Largest transaction size in bytes", DEFAULT_LARGEST_TRANSACTION);
 CTweakRef<unsigned int> eadTweak("net.excessiveAcceptDepth",
     "Excessive block chain acceptance depth in blocks",

--- a/src/miner.h
+++ b/src/miner.h
@@ -59,9 +59,6 @@ private:
     int lastFewTxs;
     bool blockFinished;
 
-    // will be initialized by IsUAHFforkActiveOnNextBlock
-    bool uahfChainBlock;
-
 public:
     BlockAssembler(const CChainParams &chainparams);
     /** Construct a new block template with coinbase to scriptPubKeyIn */

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2439,11 +2439,7 @@ bool CWallet::CreateTransaction(const vector<CRecipient> &vecSend,
                 }
 
                 // Sign
-                unsigned int sighashType = SIGHASH_ALL;
-                if (IsUAHFforkActiveOnNextBlock(chainActive.Tip()->nHeight) && walletSignWithForkSig.Value())
-                {
-                    sighashType |= SIGHASH_FORKID;
-                }
+                unsigned int sighashType = SIGHASH_ALL | SIGHASH_FORKID;
                 int nIn = 0;
                 CTransaction txNewConst(txNew);
                 for (const PAIRTYPE(const CWalletTx *, unsigned int) & coin : setCoins)


### PR DESCRIPTION
This was left of from the original CASH fork and was needed then
to make sure that after the fork , anyone could sign a transaction correctly.
However, now it's preventing anyone, who doesn't have a sync'd chain, from
signing a transaction.