### PR TITLE
UI - Turn on word wrap for peer details (extends #1297)

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1129,9 +1129,6 @@
          <property name="alignment">
           <set>Qt::AlignHCenter|Qt::AlignTop</set>
          </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
          </property>
@@ -1233,6 +1230,9 @@
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
             </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
             <property name="textInteractionFlags">
              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
             </property>
@@ -1255,6 +1255,9 @@
             </property>
             <property name="textFormat">
              <enum>Qt::PlainText</enum>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
             </property>
             <property name="textInteractionFlags">
              <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -978,7 +978,7 @@ QString formatServicesStr(quint64 mask)
     }
 
     if (strList.size())
-        return strList.join(",");
+        return strList.join(", ");
     else
         return QObject::tr("None");
 }

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -888,7 +888,7 @@ void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
     cachedNodeid = stats->nodeStats.nodeid;
 
     // update the detail ui with latest node information
-    QString peerAddrDetails(QString::fromStdString(stats->nodeStats.addrName) + " ");
+    QString peerAddrDetails(QString::fromStdString(stats->nodeStats.addrName) + "<br />");
     peerAddrDetails += tr("(node id: %1)").arg(QString::number(stats->nodeStats.nodeid));
     if (!stats->nodeStats.addrLocal.empty())
         peerAddrDetails += "<br />" + tr("via %1").arg(QString::fromStdString(stats->nodeStats.addrLocal));


### PR DESCRIPTION
Turns on word-wrap for the User Agent and Services labels on the peers tab, peer details panel.

Due to the way that QLabel word wrap works (only on word breaks delineated by white-space, not punctuation), had to add a space after the comma the services string was changed to use in #1297.  Also tried reverting back to the original ampersand, but I think the comma delimited string looks better.

NOTE: Sometimes the agent string can wrap oddly depending on what's in it and if/where the spaces are.  Sample screen captures for a few cases below.

**Reasonable word breaks:**
![image](https://user-images.githubusercontent.com/6402604/45145309-5b4c4e80-b18e-11e8-89fc-f8dc6c2742cb.png)

**Odd word break for user agent:**
![image](https://user-images.githubusercontent.com/6402604/45145359-70c17880-b18e-11e8-8501-9d6022c16893.png)

**Long non-white-space user agent (still causes the panel to expand a lot, though not as bad as before):**
![image](https://user-images.githubusercontent.com/6402604/45145559-eaf1fd00-b18e-11e8-80c3-7aa72b4a65e0.png)
