### PR TITLE
UI - Add running "time since last block" counter to debug dialog

### DIFF
--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -30,7 +30,7 @@ static int64_t nLastBlockTipUpdateNotification = 0;
 
 ClientModel::ClientModel(OptionsModel *_optionsModel, UnlimitedModel *ul, QObject *parent)
     : QObject(parent), unlimitedModel(ul), optionsModel(_optionsModel), peerTableModel(0), banTableModel(0),
-      pollTimer1(0), pollTimer2(0)
+      pollTimer1(0), pollTimer2(0), lastBlockTime(0)
 {
     peerTableModel = new PeerTableModel(this);
     banTableModel = new BanTableModel(this);
@@ -74,9 +74,11 @@ QDateTime ClientModel::getLastBlockDate() const
     LOCK(cs_main);
 
     if (chainActive.Tip())
-        return QDateTime::fromTime_t(chainActive.Tip()->GetBlockTime());
+        lastBlockTime = chainActive.Tip()->GetBlockTime();
+    else
+        lastBlockTime = Params().GenesisBlock().GetBlockTime(); // Genesis block's time of current network
 
-    return QDateTime::fromTime_t(Params().GenesisBlock().GetBlockTime()); // Genesis block's time of current network
+    return QDateTime::fromTime_t(lastBlockTime);
 }
 
 long ClientModel::getMempoolSize() const { return mempool.size(); }
@@ -103,6 +105,10 @@ void ClientModel::updateTimer1()
     // the following calls will acquire the required lock
     Q_EMIT mempoolSizeChanged(getMempoolSize(), getMempoolDynamicUsage());
     Q_EMIT transactionsPerSecondChanged(getTransactionsPerSecond());
+
+    // only request updates to time since last block if we aren't in initial sync
+    if (IsChainNearlySyncd())
+        Q_EMIT timeSinceLastBlockChanged(lastBlockTime);
 }
 
 void ClientModel::updateTimer2()
@@ -187,12 +193,13 @@ static void BlockTipChanged(ClientModel *clientmodel, bool initialSync, const CB
     if (initialSync)
         now = GetTimeMillis();
 
+    clientmodel->lastBlockTime = pIndex->GetBlockTime();
     // if we are in-sync, update the UI regardless of last update time
     if (!initialSync || now - nLastBlockTipUpdateNotification > MODEL_UPDATE_DELAY1)
     {
         // pass a async signal to the UI thread
         QMetaObject::invokeMethod(clientmodel, "numBlocksChanged", Qt::QueuedConnection, Q_ARG(int, pIndex->nHeight),
-            Q_ARG(QDateTime, QDateTime::fromTime_t(pIndex->GetBlockTime())),
+            Q_ARG(QDateTime, QDateTime::fromTime_t(clientmodel->lastBlockTime)),
             Q_ARG(double, clientmodel->getVerificationProgress(pIndex)));
         nLastBlockTipUpdateNotification = now;
     }

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -92,6 +92,10 @@ public:
     QString dataDir() const;
     UnlimitedModel *unlimitedModel;
 
+    //! Cache last block time so that we can make fast updates (every 250 ms)
+    //! to time since last block without having to take the cs_main lock every time
+    mutable std::atomic<qint64> lastBlockTime;
+
 private:
     OptionsModel *optionsModel;
     PeerTableModel *peerTableModel;
@@ -109,6 +113,7 @@ private:
 Q_SIGNALS:
     void numConnectionsChanged(int count);
     void numBlocksChanged(int count, const QDateTime &blockDate, double nVerificationProgress);
+    void timeSinceLastBlockChanged(qint64 lastBlockTime);
     void mempoolSizeChanged(long count, size_t mempoolSizeInBytes);
     void orphanPoolSizeChanged(long count);
     void alertsChanged(const QString &warnings);

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -96,7 +96,7 @@
        <item row="12" column="0">
         <widget class="QLabel" name="labelLastBlockTime">
          <property name="text">
-          <string>Last block time</string>
+          <string>Last block time (time since)</string>
          </property>
         </widget>
        </item>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -48,6 +48,8 @@ const int CONSOLE_HISTORY = 50;
 const int INITIAL_TRAFFIC_GRAPH_MINS = 30;
 const QSize FONT_RANGE(4, 40);
 const char fontSizeSettingsKey[] = "consoleFontSize";
+const QString duration_format = "H:mm:ss";
+const QString time_format = "MMM  d yyyy, HH:mm:ss";
 
 const struct
 {
@@ -385,6 +387,7 @@ void RPCConsole::setClientModel(ClientModel *model)
         setNumBlocks(model->getNumBlocks(), model->getLastBlockDate(), model->getVerificationProgress(NULL));
         connect(
             model, SIGNAL(numBlocksChanged(int, QDateTime, double)), this, SLOT(setNumBlocks(int, QDateTime, double)));
+        connect(model, SIGNAL(timeSinceLastBlockChanged(qint64)), this, SLOT(updateTimeSinceLastBlock(qint64)));
 
         updateTrafficStats(model->getTotalBytesRecv(), model->getTotalBytesSent());
         connect(model, SIGNAL(bytesChanged(quint64, quint64)), this, SLOT(updateTrafficStats(quint64, quint64)));
@@ -625,9 +628,19 @@ void RPCConsole::setNumConnections(int count)
 void RPCConsole::setNumBlocks(int count, const QDateTime &blockDate, double nVerificationProgress)
 {
     ui->numberOfBlocks->setText(QString::number(count));
-
-    QString time_format = "MMM  d yyyy, HH:mm:ss";
     ui->lastBlockTime->setText(blockDate.toString(time_format));
+}
+
+void RPCConsole::updateTimeSinceLastBlock(qint64 lastBlockTime)
+{
+    // Recompute seconds since last block locally as this is called asynchronously
+    // otherwise the UI updates can become noticeably longer than 1 second
+    qint64 secs = GetTime() - lastBlockTime;
+    // Prevent negative duration (likely indicates local system clock sync issue)
+    if (secs < 0)
+        secs = 0;
+    ui->lastBlockTime->setText(QDateTime::fromTime_t(lastBlockTime).toString(time_format) + " (" +
+                               QDateTime::fromTime_t(secs).toUTC().toString(duration_format) + ")");
 }
 
 void RPCConsole::setMempoolSize(long numberOfTxs, size_t dynUsage)

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -94,6 +94,8 @@ public Q_SLOTS:
     void setNumConnections(int count);
     /** Set number of blocks and last block date shown in the UI */
     void setNumBlocks(int count, const QDateTime &blockDate, double nVerificationProgress);
+    /** Set time since last block shown in the UI */
+    void updateTimeSinceLastBlock(qint64 blockDate);
     /** Set size (number of transactions and memory usage) of the mempool in the UI */
     void setMempoolSize(long numberOfTxs, size_t dynUsage);
     /** Set number of transactions in ophan pool in the UI */


### PR DESCRIPTION
Adds an actively updating "time since last block" duration (H:mm:ss format) to the information tab on the debug dialog.  I simply added this in as part of the existing "Last block time" label.

* Updates every 250 ms based on one of the existing timers for other updates to the screen.
* Caches the last block time rather than redetermining it for every update to avoid unnecessary `cs_main` locks.
* Protects against negative duration (potential system clock sync issues)
* Skips updates during IBD


**Example screen capture:**
![image](https://user-images.githubusercontent.com/6402604/45146344-b2532300-b190-11e8-84bd-0ff76153e24d.png)
