### PR TITLE
[WIP] Change max graphene false positive rate to .0005

### DIFF
--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -52,7 +52,11 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
     if (optSymDiff >= nReceiverExcessItems)
         fpr = FILTER_FPR_MAX;
     else
+    {
         fpr = optSymDiff / float(nReceiverExcessItems);
+        if (fpr > FILTER_FPR_MAX)
+            fpr = FILTER_FPR_MAX;
+    }
 
     // Construct Bloom filter
     pSetFilter = new CBloomFilter(

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -21,7 +21,7 @@
 const uint8_t FILTER_CELL_SIZE = 1;
 const uint8_t IBLT_CELL_SIZE = 17;
 const uint32_t LARGE_MEM_POOL_SIZE = 10000000;
-const float FILTER_FPR_MAX = 0.999;
+const float FILTER_FPR_MAX = 0.0005;
 const uint8_t IBLT_CELL_MINIMUM = 2;
 const std::vector<uint8_t> IBLT_NULL_VALUE = {};
 const unsigned char WORD_BITS = 8;


### PR DESCRIPTION
This has a marked impact on reducing decode failures without affecting
bandwidth useage to any great extent.  It does require 0.2% more
bandwidth than previously but it seems like a good short term
compromise condidering decode failure rates (during the stress testing) drop
from over 50% to zero.  However it is interesting that re-requests for
missing transactions have now risen to about 20%, possibly just due to the
now increase in sucessful graphene block requests.

If you want to verify the results you need to run two nodes, both with graphene turned on and with node1 having only one connection to node2  using -connect=<ip>  and also turn off "allow inbound connections" to node1...this way you will only be receiving graphene blocks from node2 which will give the correct statistics.

I know @bissias is working on a different and perhaps more comprehensive solution  but for the time being I think this is very good tradeoff with very little impact to performance.