### PR TITLE
Add requesting a block by hash to requestmanager

### DIFF
--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -213,7 +213,8 @@ void CRequestManager::AskForDuringIBD(const std::vector<CInv> &objArray, CNode *
     // This is block and peer that was selected in FindNextBlocksToDownload() so we want to add it as a block
     // source first so that it gets requested first.
     LOCK(cs_objDownloader);
-    AskFor(objArray, from, priority);
+    if (from)
+        AskFor(objArray, from, priority);
 
     // Add the other peers as potential sources in the event the RequestManager needs to make a re-request
     // for this block. Only add NETWORK nodes that have block availability.
@@ -426,6 +427,15 @@ bool CUnknownObj::AddSource(CNode *from)
         return true;
     }
     return false;
+}
+
+void CRequestManager::RequestCorruptedBlock(const uint256 &blockHash)
+{
+    // set it to MSG_BLOCK here but it should get overwritten in RequestBlock
+    CInv obj(MSG_BLOCK, blockHash);
+    std::vector<CInv> vGetBlocks;
+    vGetBlocks.push_back(obj);
+    AskForDuringIBD(vGetBlocks, nullptr);
 }
 
 bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -181,6 +181,9 @@ public:
     // Indicate that getting this object was rejected
     void Rejected(const CInv &obj, CNode *from, unsigned char reason = 0);
 
+    // request a block by its hash
+    void RequestCorruptedBlock(const uint256 &blockHash);
+
     // Resets the last request time to zero when a node disconnects and has blocks in flight.
     void ResetLastBlockRequestTime(const uint256 &hash);
 


### PR DESCRIPTION
This is useful for whenever we want to request a block we want data for 
but are missing. instead of failing we can just redownload it from the 
network