### PR TITLE
Allow for the downloading of initial headers from one pruned node.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6757,9 +6757,14 @@ bool SendMessages(CNode *pto)
         if (pindexBestHeader == nullptr)
             pindexBestHeader = chainActive.Tip();
         // Download if this is a nice peer, or we have no nice peers and this one might do.
-        bool fFetch = state.fPreferredDownload || (nPreferredDownload.load() == 0 && !pto->fClient && !pto->fOneShot);
-        if (!state.fSyncStarted && !pto->fClient && !fImporting && !fReindex)
+        bool fFetch = state.fPreferredDownload || (nPreferredDownload.load() == 0 && !pto->fOneShot);
+        if (!state.fSyncStarted && !fImporting && !fReindex)
         {
+            // Only allow the downloading of headers from a single pruned peer.
+            static int nSyncStartedPruned = 0;
+            if (pto->fClient && nSyncStartedPruned >= 1)
+                fFetch = false;
+
             // Only actively request headers from a single peer, unless we're close to today.
             if ((nSyncStarted < MAX_HEADER_REQS_DURING_IBD && fFetch) ||
                 chainActive.Tip()->GetBlockTime() > GetAdjustedTime() - SINGLE_PEER_REQUEST_MODE_AGE)
@@ -6782,6 +6787,9 @@ bool SendMessages(CNode *pto)
                     state.fRequestedInitialBlockAvailability = true;
                     state.nFirstHeadersExpectedHeight = pindexStart->nHeight;
                     nSyncStarted++;
+
+                    if (pto->fClient)
+                        nSyncStartedPruned++;
 
                     LOG(NET, "initial getheaders (%d) to peer=%s (startheight:%d)\n", pindexStart->nHeight,
                         pto->GetLogName(), pto->nStartingHeight);


### PR DESCRIPTION
This fixes a nuisance bug where we may have just one connection to
a pruned now while testing. This can happen when we use the connect=<ip>
and do not allow any inbound peers, in which case we would end up
not being able to sync the chain if we were behind by less than
a day's (144) blocks.