### PR TITLE
Fix warning about comparing sign vs unsign in thinblock.cpp

### DIFF
--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -1346,7 +1346,7 @@ bool CThinBlockData::CheckThinblockTimer(const uint256 &hash)
         auto iter =  mapThinBlockTimer.find(hash);
         if (iter != mapThinBlockTimer.end())
         {
-            int64_t elapsed = GetTimeMillis() - iter->second.first;
+            uint64_t elapsed = GetTimeMillis() - iter->second.first;
             if (elapsed > nTimeToWait)
             {
                 // Only print out the log entry once.  Because the thinblock timer will be hit


### PR DESCRIPTION
```
blockrelay/thinblock.cpp: In member function 'bool CThinBlockData::CheckThinblockTimer(const uint256&)':
blockrelay/thinblock.cpp:1350:25: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
             if (elapsed > nTimeToWait)
                         ^
```