### PR TITLE
Remove non existent configuration parameters from May '18 activation test

### DIFF
--- a/qa/rpc-tests/may152018_forkactivation_2.py
+++ b/qa/rpc-tests/may152018_forkactivation_2.py
@@ -35,9 +35,7 @@ class May152018ActivationTest(ComparisonTestFramework):
 
     def set_test_params(self):
         self.setup_clean_chain = True
-        self.extra_args = [['-whitelist=127.0.0.1',
-                            "-may152018activationtime=%d" % MAY152018_START_TIME,
-                            "-replayprotectionactivationtime=%d" % (2 * MAY152018_START_TIME)]]
+        self.extra_args = [['-whitelist=127.0.0.1']]
 
     def create_and_tx(self, count):
         node = self.nodes[0]


### PR DESCRIPTION
`may152018activationtime` and `replayprotectionactivationtime` seems to be
valid ABC parameters. Guess that this was a left over from some backport
we did in preparation for May '18 upgrade.