### PR TITLE
Various minor simplifications (QA and cashlib)

### DIFF
--- a/qa/rpc-tests/bip135-grace-failed.py
+++ b/qa/rpc-tests/bip135-grace-failed.py
@@ -77,24 +77,6 @@ class BIP135ForksTest(ComparisonTestFramework):
         NetworkThread().start() # Start up network handling in another thread
         self.test.run()
 
-    def create_transaction(self, node, coinbase, to_address, amount):
-        from_txid = node.getblock(coinbase)['tx'][0]
-        inputs = [{ "txid" : from_txid, "vout" : 0}]
-        outputs = { to_address : amount }
-        rawtx = node.createrawtransaction(inputs, outputs)
-        tx = CTransaction()
-        f = BytesIO(hex_str_to_bytes(rawtx))
-        tx.deserialize(f)
-        tx.nVersion = 2
-        return tx
-
-    def sign_transaction(self, node, tx):
-        signresult = node.signrawtransaction(bytes_to_hex_str(tx.serialize()))
-        tx = CTransaction()
-        f = BytesIO(hex_str_to_bytes(signresult['hex']))
-        tx.deserialize(f)
-        return tx
-
     def generate_blocks(self, number, version, test_blocks = []):
         for i in range(number):
             #logging.info ("generate_blocks: creating block on tip %x, height %d, time %d" % (self.tip, self.height, self.last_block_time + 1))

--- a/qa/rpc-tests/bip135-grace.py
+++ b/qa/rpc-tests/bip135-grace.py
@@ -115,24 +115,6 @@ class BIP135ForksTest(ComparisonTestFramework):
         NetworkThread().start() # Start up network handling in another thread
         self.test.run()
 
-    def create_transaction(self, node, coinbase, to_address, amount):
-        from_txid = node.getblock(coinbase)['tx'][0]
-        inputs = [{ "txid" : from_txid, "vout" : 0}]
-        outputs = { to_address : amount }
-        rawtx = node.createrawtransaction(inputs, outputs)
-        tx = CTransaction()
-        f = BytesIO(hex_str_to_bytes(rawtx))
-        tx.deserialize(f)
-        tx.nVersion = 2
-        return tx
-
-    def sign_transaction(self, node, tx):
-        signresult = node.signrawtransaction(bytes_to_hex_str(tx.serialize()))
-        tx = CTransaction()
-        f = BytesIO(hex_str_to_bytes(signresult['hex']))
-        tx.deserialize(f)
-        return tx
-
     def generate_blocks(self, number, version, test_blocks = []):
         for i in range(number):
             #logging.info ("generate_blocks: creating block on tip %x, height %d, time %d" % (self.tip, self.height, self.last_block_time + 1))

--- a/qa/rpc-tests/bip135-threshold.py
+++ b/qa/rpc-tests/bip135-threshold.py
@@ -92,24 +92,6 @@ class BIP135ForksTest(ComparisonTestFramework):
         NetworkThread().start() # Start up network handling in another thread
         self.test.run()
 
-    def create_transaction(self, node, coinbase, to_address, amount):
-        from_txid = node.getblock(coinbase)['tx'][0]
-        inputs = [{ "txid" : from_txid, "vout" : 0}]
-        outputs = { to_address : amount }
-        rawtx = node.createrawtransaction(inputs, outputs)
-        tx = CTransaction()
-        f = BytesIO(hex_str_to_bytes(rawtx))
-        tx.deserialize(f)
-        tx.nVersion = 2
-        return tx
-
-    def sign_transaction(self, node, tx):
-        signresult = node.signrawtransaction(bytes_to_hex_str(tx.serialize()))
-        tx = CTransaction()
-        f = BytesIO(hex_str_to_bytes(signresult['hex']))
-        tx.deserialize(f)
-        return tx
-
     def generate_blocks(self, number, version, test_blocks = []):
         for i in range(number):
             old_tip = self.tip

--- a/qa/rpc-tests/bip68-112-113-p2p.py
+++ b/qa/rpc-tests/bip68-112-113-p2p.py
@@ -117,18 +117,12 @@ class BIP68_112_113Test(ComparisonTestFramework):
         inputs = [{ "txid" : txid, "vout" : 0}]
         outputs = { to_address : amount }
         rawtx = node.createrawtransaction(inputs, outputs)
-        tx = CTransaction()
-        f = BytesIO(hex_str_to_bytes(rawtx))
-        tx.deserialize(f)
-        return tx
+        return CTransaction().deserialize(rawtx)
 
     def sign_transaction(self, node, unsignedtx):
         rawtx = ToHex(unsignedtx)
         signresult = node.signrawtransaction(rawtx)
-        tx = CTransaction()
-        f = BytesIO(hex_str_to_bytes(signresult['hex']))
-        tx.deserialize(f)
-        return tx
+        return CTransaction().deserialize(signresult['hex'])
 
     def generate_blocks(self, number, version, test_blocks = []):
         for i in range(number):

--- a/qa/rpc-tests/bip9-softforks.py
+++ b/qa/rpc-tests/bip9-softforks.py
@@ -52,18 +52,13 @@ class BIP9SoftForksTest(ComparisonTestFramework):
         inputs = [{ "txid" : from_txid, "vout" : 0}]
         outputs = { to_address : amount }
         rawtx = node.createrawtransaction(inputs, outputs)
-        tx = CTransaction()
-        f = BytesIO(hex_str_to_bytes(rawtx))
-        tx.deserialize(f)
+        tx = CTransaction().deserialize(rawtx)
         tx.nVersion = 2
         return tx
 
     def sign_transaction(self, node, tx):
         signresult = node.signrawtransaction(bytes_to_hex_str(tx.serialize()))
-        tx = CTransaction()
-        f = BytesIO(hex_str_to_bytes(signresult['hex']))
-        tx.deserialize(f)
-        return tx
+        return CTransaction().deserialize(signresult['hex'])
 
     def generate_blocks(self, number, version, test_blocks = []):
         for i in range(number):

--- a/qa/rpc-tests/bipdersig-p2p.py
+++ b/qa/rpc-tests/bipdersig-p2p.py
@@ -65,10 +65,7 @@ class BIP66Test(ComparisonTestFramework):
         outputs = { to_address : amount }
         rawtx = node.createrawtransaction(inputs, outputs)
         signresult = node.signrawtransaction(rawtx)
-        tx = CTransaction()
-        f = BytesIO(hex_str_to_bytes(signresult['hex']))
-        tx.deserialize(f)
-        return tx
+        return CTransaction().deserialize(signresult['hex'])
 
     def get_tests(self):
 

--- a/qa/rpc-tests/decodescript.py
+++ b/qa/rpc-tests/decodescript.py
@@ -131,7 +131,7 @@ class DecodeScriptTest(BitcoinTestFramework):
         assert_equal('OP_DUP OP_HASH160 dc863734a218bfe83ef770ee9d41a27f824a6e56 OP_EQUALVERIFY OP_CHECKSIG', rpc_result['vout'][0]['scriptPubKey']['asm'])
         assert_equal('OP_HASH160 2a5edea39971049a540474c6a99edf0aa4074c58 OP_EQUAL', rpc_result['vout'][1]['scriptPubKey']['asm'])
         txSave = CTransaction()
-        txSave.deserialize(BytesIO(hex_str_to_bytes(tx)))
+        txSave.deserialize(tx)
 
         # make sure that a specifically crafted op_return value will not pass all the IsDERSignature checks and then get decoded as a sighash type
         tx = '01000000015ded05872fdbda629c7d3d02b194763ce3b9b1535ea884e3c8e765d42e316724020000006b48304502204c10d4064885c42638cbff3585915b322de33762598321145ba033fc796971e2022100bb153ad3baa8b757e30a2175bd32852d2e1cb9080f84d7e32fcdfd667934ef1b012103163c0ff73511ea1743fb5b98384a2ff09dd06949488028fd819f4d83f56264efffffffff0200000000000000000b6a0930060201000201000180380100000000001976a9141cabd296e753837c086da7a45a6c2fe0d49d7b7b88ac00000000'

--- a/qa/rpc-tests/listtransactions.py
+++ b/qa/rpc-tests/listtransactions.py
@@ -13,10 +13,7 @@ from io import BytesIO
 
 
 def txFromHex(hexstring):
-    tx = CTransaction()
-    f = BytesIO(hex_str_to_bytes(hexstring))
-    tx.deserialize(f)
-    return tx
+    return CTransaction().deserialize(hexstring)
 
 
 class ListTransactionsTest(BitcoinTestFramework):

--- a/qa/rpc-tests/miningtest.py
+++ b/qa/rpc-tests/miningtest.py
@@ -100,8 +100,7 @@ class MyTest (BitcoinTestFramework):
         assert_equal(0x123456, block["version"])
 
         # change the coinbase
-        tx = CTransaction()
-        tx.deserialize(BytesIO(unhexlify(c["coinbase"])))
+        tx = CTransaction().deserialize(c["coinbase"])
         tx.vout[0].scriptPubKey = CScript([OP_1])
 
         nonce = 0

--- a/qa/rpc-tests/test_framework/cashlib/__init__.py
+++ b/qa/rpc-tests/test_framework/cashlib/__init__.py
@@ -2,4 +2,4 @@
 # Distributed under the MIT software license, see the accompanying
 # file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-from test_framework.cashlib.cashlib import init, bin2hex, signTxInput, randombytes, pubkey, spendscript, addrbin, txid, SIGHASH_ALL, SIGHASH_NONE, SIGHASH_SINGLE, SIGHASH_FORKID, SIGHASH_ANYONECANPAY
+from .cashlib import init, bin2hex, signTxInput, randombytes, pubkey, spendscript, addrbin, txid, SIGHASH_ALL, SIGHASH_NONE, SIGHASH_SINGLE, SIGHASH_FORKID, SIGHASH_ANYONECANPAY

--- a/qa/rpc-tests/test_framework/nodemessages.py
+++ b/qa/rpc-tests/test_framework/nodemessages.py
@@ -509,12 +509,18 @@ class CTransaction(object):
             self.hash = None
 
     def deserialize(self, f):
+        if isinstance(f, str):
+            # str - assumed to be hex string
+            f = BytesIO(unhexlify(f))
+        elif isinstance(f, bytes):
+            f = BytesIO(f)
         self.nVersion = struct.unpack("<i", f.read(4))[0]
         self.vin = deser_vector(f, CTxIn)
         self.vout = deser_vector(f, CTxOut)
         self.nLockTime = struct.unpack("<I", f.read(4))[0]
         self.sha256 = None
         self.hash = None
+        return self
 
     def serialize(self):
         r = b""
@@ -545,7 +551,7 @@ class CTransaction(object):
         s = ["Transaction: %064x\n" % self.sha256]
         s.append("%d inputs\n" % len(self.vin))
         for vin in self.vin:
-            s.append("  %064x.%d\n" % (vin.prevout.hash, vin.prevout.n))
+            s.append("  %064x:%d\n" % (vin.prevout.hash, vin.prevout.n))
         s.append("%d outputs\n" % len(self.vout))
         for vout in self.vout:
             s.append("  %12d %s\n" % (vout.nValue, hexlify((vout.scriptPubKey))))


### PR DESCRIPTION
- use `os.urandom` in `cashlib` (Python docs assert it is safe for cryptographic use) 
- remove a few unused methods in QA/RPC tests
- simplify `CTransaction` deserialization