### PR TITLE
Cleanup and simplify the initialization of the parallel block validator.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -949,13 +949,8 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
         LOGA("Using %d Message Handler Threads\n", numMsgHandlerThreads.Value());
     }
 
-    // -par=0 means autodetect, but passing 0 to the CParallelValidation constructor means no concurrency
-    int nPVThreads = GetArg("-par", DEFAULT_SCRIPTCHECK_THREADS);
-    if (nPVThreads <= 0)
-        nPVThreads += GetNumCores();
-
-    // BU: create the parallel block validator
-    PV.reset(new CParallelValidation(nPVThreads, &threadGroup));
+    // Create the parallel block validator
+    PV.reset(new CParallelValidation(&threadGroup));
 
     // Start the lightweight task scheduler thread
     CScheduler::Function serviceLoop = boost::bind(&CScheduler::serviceQueue, &scheduler);

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -38,25 +38,35 @@ static void AddScriptCheckThreads(int i, CCheckQueue<CScriptCheck> *pqueue)
     pqueue->Thread();
 }
 
-CParallelValidation::CParallelValidation(int threadCount, boost::thread_group *threadGroup)
-    : semThreadCount(nScriptCheckQueues)
+CParallelValidation::CParallelValidation(boost::thread_group *threadGroup) : semThreadCount(nScriptCheckQueues)
 {
-    // A single thread has no parallelism so just use the main thread.  Equivalent to parallel being turned off.
-    if (threadCount <= 1)
-        threadCount = 0;
-    else if (threadCount > MAX_SCRIPTCHECK_THREADS)
-        threadCount = MAX_SCRIPTCHECK_THREADS;
-    nThreads = threadCount;
+    // There are nScriptCheckQueues which are used to validate blocks in parallel. Each block
+    // that validates will use one script check queue which must *not* be shared with any other
+    // validating block. Furthermore, each script check queue has a number of threads which it
+    // controls and which do the actual validating of scripts.
 
-    LOGA("Using %d threads for script verification\n", threadCount);
+    // Determine the number of threads to use for each check queue.
+    //
+    //-par=0 means autodetect number of cores.
+    int nThreadCount = GetArg("-par", DEFAULT_SCRIPTCHECK_THREADS);
+    if (nThreadCount <= 0)
+        nThreadCount += GetNumCores();
+    // A single thread has no parallelism so just use the main thread
+    // (Equivalent to parallel being turned off).
+    if (nThreadCount <= 1)
+        nThreadCount = 0;
+    else if (nThreadCount > MAX_SCRIPTCHECK_THREADS)
+        nThreadCount = MAX_SCRIPTCHECK_THREADS;
 
+    // Create each script check queue with all associated threads.
+    LOGA("Launching %d ScriptQueues each using %d threads for script verification\n", nScriptCheckQueues, nThreadCount);
     while (QueueCount() < nScriptCheckQueues)
     {
         auto queue = new CCheckQueue<CScriptCheck>(128);
-
-        for (unsigned int i = 0; i < nThreads; i++)
+        for (int i = 0; i < nThreadCount; i++)
+        {
             threadGroup->create_thread(boost::bind(&AddScriptCheckThreads, i + 1, queue));
-
+        }
         vQueues.push_back(queue);
     }
 }

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -111,7 +111,7 @@ public:
      *                          are created.
      * @param[in] threadGroup   The thread group threads will be created in
      */
-    CParallelValidation(int threadCount, boost::thread_group *threadGroup);
+    CParallelValidation(boost::thread_group *threadGroup);
 
     ~CParallelValidation();
 

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -64,7 +64,10 @@ TestingSetup::TestingSetup(const std::string &chainName) : BasicTestingSetup(cha
     bool worked = InitBlockIndex(chainparams);
     assert(worked);
 
-    PV.reset(new CParallelValidation(3, &threadGroup));
+    // Make sure there are 3 script check threads running for each queue
+    SoftSetArg("-par", std::to_string(3));
+    PV.reset(new CParallelValidation(&threadGroup));
+
     RegisterNodeSignals(GetNodeSignals());
 }
 


### PR DESCRIPTION
Move the detection of Cores out of init.cpp and into the constructor
of the parallel validator. This keeps everthing in one place as far as
the initialization of all the control queues and associated threads.

This was a code move only with some naming and comment changes.