### PR TITLE
Setup the number of p2p message processing threads in init.cpp

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -287,7 +287,7 @@ CTweakRef<bool> enableDataSigVerifyTweak("consensus.enableDataSigVerify",
     "true if OP_DATASIGVERIFY is enabled.",
     &enableDataSigVerify);
 
-CTweak<unsigned int> numMsgHandlerThreads("net.msgHandlerThreads", "Number of message handler threads", 4);
+CTweak<unsigned int> numMsgHandlerThreads("net.msgHandlerThreads", "Number of message handler threads", 0);
 
 CTweak<CAmount> maxTxFee("wallet.maxTxFee",
     "Maximum total fees to use in a single wallet transaction or raw transaction; setting this too low may abort large "

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -940,6 +940,15 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
     }
     // bip135 end
 
+    // Setup the number of p2p message processing threads used to process incoming messages
+    if (numMsgHandlerThreads.Value() == 0)
+    {
+        // Set the number of threads to half the available Cores.
+        int nThreads = std::max((int)(GetNumCores() * 0.5), 1);
+        numMsgHandlerThreads.Set(nThreads);
+        LOGA("Using %d Message Handler Threads\n", numMsgHandlerThreads.Value());
+    }
+
     // -par=0 means autodetect, but passing 0 to the CParallelValidation constructor means no concurrency
     int nPVThreads = GetArg("-par", DEFAULT_SCRIPTCHECK_THREADS);
     if (nPVThreads <= 0)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -126,7 +126,6 @@ extern CCriticalSection cs_vAddedNodes;
 // BITCOINUNLIMITED START
 extern vector<std::string> vUseDNSSeeds;
 extern CCriticalSection cs_vUseDNSSeeds;
-extern CTweak<unsigned int> numMsgHandlerThreads;
 // BITCOINUNLIMITED END
 
 extern CSemaphore *semOutbound;

--- a/src/net.h
+++ b/src/net.h
@@ -47,6 +47,8 @@ namespace boost
 class thread_group;
 } // namespace boost
 
+extern CTweak<unsigned int> numMsgHandlerThreads;
+
 /** Time between pings automatically sent out for latency probing and keepalive (in seconds). */
 static const int PING_INTERVAL = 2 * 60;
 /** Time after which to disconnect, after waiting for a ping response (or inactivity). */


### PR DESCRIPTION
As a default config, use half the number of available Cores with
a minimum of 1, for p2p processing threads.

The user can configure still configure however many threads they want to run
via the net.numMsgHandlerThreads tweak.