### PR TITLE
test_framework/script.py: Support for pretty-printing

### DIFF
--- a/qa/rpc-tests/test_framework/script.py
+++ b/qa/rpc-tests/test_framework/script.py
@@ -14,7 +14,7 @@
 Functionality to build scripts, as well as SignatureHash().
 """
 
-
+from sys import stdout
 from .mininode import CTransaction, CTxOut, hash256
 from binascii import hexlify
 
@@ -801,6 +801,28 @@ class CScript(bytes):
                     ops.append(op)
 
         return "CScript([%s])" % ', '.join(ops)
+
+    def prettyprint(self, outfile = stdout):
+        indent = 0
+        newline = False
+        for op in iter(self):
+            if isinstance(op, bytes):
+                rop = hexlify(op).decode("ascii")
+            else:
+                rop = repr(op)
+
+            if op in [OP_ELSE, OP_ENDIF, OP_NOTIF, OP_IF] and not newline:
+                print(file = outfile)
+                newline = True
+            if op in [OP_ELSE, OP_ENDIF, OP_NOTIF]:
+                indent -=1
+            if newline:
+                print(4 * indent * " ", file = outfile, end = '')
+            newline = ("VERIFY" in rop or
+                       op in [OP_IF, OP_ELSE, OP_ENDIF, OP_NOTIF, OP_RETURN])
+            print(rop+" ", file = outfile, end='\n' if newline else '')
+            if op in [OP_ELSE, OP_IF]:
+                indent +=1
 
     def GetSigOpCount(self, fAccurate):
         """Get the SigOp count.


### PR DESCRIPTION
Use `CScript.prettyprint(..)` to create a better readable version of a `CScript`. Example output:
```
OP_DUP OP_HASH160 8b139a5274cc85e2d36d4f97922a15ae5d7f68af OP_EQUAL
OP_IF
    OP_CHECKSIG
OP_ELSE
    OP_DUP OP_HASH160 f127e6b53e2005930718681d245fe5a2b22f2b9f OP_EQUAL
    OP_IF
        OP_OVER 4 OP_PICK OP_EQUAL OP_NOT OP_VERIFY
        OP_DUP OP_TOALTSTACK OP_CHECKDATASIGVERIFY
        OP_FROMALTSTACK OP_CHECKDATASIG
    OP_ELSE
        OP_RETURN
    OP_ENDIF
OP_ENDIF
```