### PR TITLE
changes to aid in testing and debugging

### DIFF
--- a/qa/rpc-tests/test_framework/cashlib/cashlib.py
+++ b/qa/rpc-tests/test_framework/cashlib/cashlib.py
@@ -141,6 +141,8 @@ def spendscript(*data):
     """Take binary data as parameters and return a spend script containing that data"""
     ret = []
     for d in data:
+        if type(d) is str:
+            d = unhexlify(d)
         assert type(d) is bytes, "There can only be data in spend scripts (no opcodes allowed)"
         l = len(d)
         if l == 0:  # push empty value onto the stack

--- a/qa/rpc-tests/test_framework/nodemessages.py
+++ b/qa/rpc-tests/test_framework/nodemessages.py
@@ -524,6 +524,10 @@ class CTransaction(object):
         r += struct.pack("<I", self.nLockTime)
         return r
 
+    def toHex(self):
+        """Return the hex string serialization of this object"""
+        return hexlify(self.serialize()).decode("utf-8")
+
     def rehash(self):
         self.sha256 = None
         self.calc_sha256()

--- a/qa/rpc-tests/test_framework/script.py
+++ b/qa/rpc-tests/test_framework/script.py
@@ -83,6 +83,14 @@ class CScriptOp(int):
         else:
             return False
 
+    def toHex(self):
+        """Return the hex representation of this opcode"""
+        return hexlify(self.to_bytes(1,"little")).decode()
+
+    def toBin(self):
+        """Return the binary representation of this opcode"""
+        return self.to_bytes(1,"little")
+
     def __str__(self):
         return repr(self)
 

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -199,7 +199,16 @@ class BitcoinTestFramework(object):
 
         success = False
         try:
-            os.makedirs(self.options.tmpdir, exist_ok=False)
+            try:
+                os.makedirs(self.options.tmpdir, exist_ok=False)
+            except FileExistsError as e:
+                assert (self.options.tmpdir.count(os.sep) >= 2) # sanity check that tmpdir is not the top level before I delete stuff
+                for n in range(0,8): # delete the nodeN directories so their contents dont affect the new test
+                    d = self.options.tmpdir + os.sep + ("node%d" % n)
+                    try:
+                        shutil.rmtree(d)
+                    except FileNotFoundError:
+                        pass
 
             # Not pretty but, I changed the function signature
             # of setup_chain to allow customization of the setup.

--- a/qa/rpc-tests/test_template.py
+++ b/qa/rpc-tests/test_template.py
@@ -20,7 +20,7 @@ class MyTest (BitcoinTestFramework):
     def setup_chain(self,bitcoinConfDict=None, wallets=None):
         print("Initializing test directory "+self.options.tmpdir)
         # pick this one to start from the cached 4 node 100 blocks mined configuration
-        # initialize_chain(self.options.tmpdir)
+        # initialize_chain(self.options.tmpdir, bitcoinConfDict, wallets)
         # pick this one to start at 0 mined blocks
         initialize_chain_clean(self.options.tmpdir, 4, bitcoinConfDict, wallets)
         # Number of nodes to initialize ----------> ^

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -224,6 +224,8 @@ CTweakRef<uint64_t> ebTweak("net.excessiveBlock",
 CTweak<uint64_t> blockSigopsPerMb("net.excessiveSigopsPerMb",
     "Excessive effort per block, denoted in cost (# inputs * txsize) per MB",
     BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS);
+CTweak<bool> ignoreNetTimeouts("net.ignoreTimeouts", "ignore inactivity timeouts, used during debugging", false);
+
 CTweak<uint64_t> blockMiningSigopsPerMb("mining.excessiveSigopsPerMb",
     "Excessive effort per block, denoted in cost (# inputs * txsize) per MB",
     BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -192,7 +192,7 @@ void Shutdown()
     /// for example if the data directory was found to be locked.
     /// Be sure that anything that writes files or flushes caches only does this if the respective
     /// module was initialized.
-    RenameThread("bitcoin-shutoff");
+    RenameThread("shutoff");
     mempool.AddTransactionsUpdated(1);
 
     {
@@ -392,7 +392,7 @@ void CleanupBlockRevFiles()
 void ThreadImport(std::vector<fs::path> vImportFiles)
 {
     const CChainParams &chainparams = Params();
-    RenameThread("bitcoin-loadblk");
+    RenameThread("loadblk");
     ScheduleBatchPriority();
 
     // -reindex

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -30,6 +30,8 @@
 #include "unlimited.h"
 #include "utilstrencodings.h"
 
+extern CTweak<bool> ignoreNetTimeouts;
+
 #ifdef WIN32
 #include <string.h>
 #else
@@ -1352,23 +1354,27 @@ void ThreadSocketHandler()
                 {
                     LOG(NET, "Node %s socket no message in first 60 seconds, %d %d from %d\n", pnode->GetLogName(),
                         pnode->nLastRecv != 0, pnode->nLastSend != 0, pnode->id);
-                    pnode->fDisconnect = true;
+                    if (ignoreNetTimeouts.Value() == false)
+                        pnode->fDisconnect = true;
                 }
                 else if (nTime - pnode->nLastSend > TIMEOUT_INTERVAL)
                 {
                     LOG(NET, "Node %s socket sending timeout: %is\n", pnode->GetLogName(), nTime - pnode->nLastSend);
-                    pnode->fDisconnect = true;
+                    if (ignoreNetTimeouts.Value() == false)
+                        pnode->fDisconnect = true;
                 }
                 else if (nTime - pnode->nLastRecv > (pnode->nVersion > BIP0031_VERSION ? TIMEOUT_INTERVAL : 90 * 60))
                 {
                     LOG(NET, "Node %s socket receive timeout: %is\n", pnode->GetLogName(), nTime - pnode->nLastRecv);
-                    pnode->fDisconnect = true;
+                    if (ignoreNetTimeouts.Value() == false)
+                        pnode->fDisconnect = true;
                 }
                 else if (pnode->nPingNonceSent && pnode->nPingUsecStart + TIMEOUT_INTERVAL * 1000000 < GetTimeMicros())
                 {
                     LOG(NET, "Node %s ping timeout: %fs\n", pnode->GetLogName(),
                         0.000001 * (GetTimeMicros() - pnode->nPingUsecStart));
-                    pnode->fDisconnect = true;
+                    if (ignoreNetTimeouts.Value() == false)
+                        pnode->fDisconnect = true;
                 }
             }
         }

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -33,7 +33,7 @@ static void HandleBlockMessageThread(CNode *pfrom, const string strCommand, CBlo
 static void AddScriptCheckThreads(int i, CCheckQueue<CScriptCheck> *pqueue)
 {
     ostringstream tName;
-    tName << "bitcoin-scriptchk" << i;
+    tName << "scriptchk" << i;
     RenameThread(tName.str().c_str());
     pqueue->Thread();
 }

--- a/src/util.h
+++ b/src/util.h
@@ -31,6 +31,11 @@
 #include <boost/signals2/signal.hpp>
 #include <boost/thread/exceptions.hpp>
 
+#ifdef DEBUG
+#define DEBUG_ASSERTION
+#define DEBUG_PAUSE
+#endif
+
 #ifdef DEBUG_ASSERTION
 /// If DEBUG_ASSERTION is enabled this asserts when the predicate is false.
 //  If DEBUG_ASSERTION is disabled and the predicate is false, it executes the execInRelease statements.
@@ -50,6 +55,15 @@
             execInRelease;                                                                                    \
         }                                                                                                     \
     } while (0)
+#endif
+
+#ifdef DEBUG_PAUSE
+// Stops this thread by taking a semaphore
+// This should not be called as part of a release so during the non --enable-debug build
+// you will get an undefined symbol compilation error.
+void DbgPause();
+// Continue the thread.  Intended to be called manually from gdb
+extern "C" void DbgResume();
 #endif
 
 #define UNIQUE2(pfx, LINE) pfx##LINE
@@ -458,8 +472,7 @@ void RenameThread(const char *name);
 template <typename Callable>
 void TraceThreads(const std::string &name, Callable func)
 {
-    std::string s = strprintf("bitcoin-%s", name);
-    RenameThread(s.c_str());
+    RenameThread(name.c_str());
     try
     {
         LOGA("%s thread start\n", name);


### PR DESCRIPTION
In QA if --tmpdir is used, then delete old data there.  Also add a few convenience functions to some objects.
  
Provide a tweak to not disconnect if timeouts triggered (if attached via gdb, the process may not respond to timeouts).  

Provide an API call DbgPause() that only is valid in --enable-debug mode that pauses the current thread in a manner that can be resumed once attached via gdb.  

Rename all threads from bitcoin-XXXX to just XXXX because the thread names get cut off and the bitcoin- prefix is not meaningful.