### PR TITLE
[UI] Expand services displayed in the debug dialog peer details.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5269,6 +5269,19 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         State(pfrom->GetId())->fPreferHeaders = true;
     }
 
+    // Processing this message type for statistics purposes only, BU currently doesn't support CB protocol
+    // Ignore this message if sent from a node advertising a version earlier than the first CB release (70014)
+    else if (strCommand == NetMsgType::SENDCMPCT && pfrom->nVersion >= 70014)
+    {
+        bool fHighBandwidth = false;
+        uint64_t nVersion = 0;
+        vRecv >> fHighBandwidth >> nVersion;
+
+        // BCH network currently only supports version 1 (v2 is segwit support on BTC)
+        // May need to be updated in the future if other clients deploy a new version
+        pfrom->fSupportsCompactBlocks = nVersion == 1;
+    }
+
     else if (strCommand == NetMsgType::INV)
     {
         if (fImporting || fReindex)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -529,6 +529,7 @@ void CNode::copyStats(CNodeStats &stats)
     X(nSendBytes);
     X(nRecvBytes);
     X(fWhitelisted);
+    X(fSupportsCompactBlocks);
 
     // It is common for nodes with good ping times to suddenly become lagged,
     // due to a new block arriving or other large transfer.
@@ -2826,6 +2827,9 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
     nMisbehavior = 0;
     fShouldBan = false;
     fCurrentlyConnected = false;
+
+    // For statistics only, BU doesn't support CB protocol
+    fSupportsCompactBlocks = false;
 
     // BU instrumentation
     std::string xmledName;

--- a/src/net.h
+++ b/src/net.h
@@ -233,6 +233,8 @@ public:
     double dPingWait;
     double dPingMin;
     std::string addrLocal;
+    //! Whether this peer supports CompactBlocks (for statistics only, BU doesn't support CB protocol)
+    bool fSupportsCompactBlocks;
 };
 
 
@@ -455,6 +457,9 @@ public:
     std::atomic<int64_t> nMaxBlocksInTransit;
 
     unsigned short addrFromPort;
+
+    //! Whether this peer supports CompactBlocks (for statistics only, BU doesn't support CB protocol)
+    std::atomic<bool> fSupportsCompactBlocks;
 
 protected:
     // Basic fuzz-testing

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -55,6 +55,7 @@ const char *XPEDITEDBLK = "Xb";
 const char *XPEDITEDTxn = "Xt";
 const char *BUVERSION = "buversion";
 const char *BUVERACK = "buverack";
+const char *SENDCMPCT = "sendcmpct";
 };
 
 static const char *ppszTypeName[] = {
@@ -76,7 +77,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::XTHINBLOCK, NetMsgType::XBLOCKTX, NetMsgType::GET_XBLOCKTX, NetMsgType::GET_XTHIN,
     NetMsgType::GRAPHENEBLOCK, NetMsgType::GRAPHENETX, NetMsgType::GET_GRAPHENETX, NetMsgType::GET_GRAPHENE,
     NetMsgType::XPEDITEDREQUEST, NetMsgType::XPEDITEDBLK, NetMsgType::XPEDITEDTxn, NetMsgType::BUVERSION,
-    NetMsgType::BUVERACK,
+    NetMsgType::BUVERACK, NetMsgType::SENDCMPCT,
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes,
     allNetMessageTypes + ARRAYLEN(allNetMessageTypes));

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -205,7 +205,7 @@ extern const char *PONG;
 /**
  * The notfound message is a reply to a getdata message which requested an
  * object the receiving node does not have available for relay.
- * @ince protocol version 70001.
+ * @since protocol version 70001.
  * @see https://bitcoin.org/en/developer-reference#notfound
  */
 extern const char *NOTFOUND;
@@ -285,6 +285,17 @@ extern const char *BUVERSION;
  * @since protocol version 80002.
  */
 extern const char *BUVERACK;
+
+/**
+ * Indicates that a node accepts Compact Blocks and provides version and
+ * configuration information.
+ * @since protocol version 70014.
+ * @see https://bitcoin.org/en/developer-reference#sendcmpct
+ *
+ * NOTE: Compact Blocks is not currently supported by BU.  We only process this
+ * message for reporting which of our peers have announced they have CB enabled
+ */
+extern const char *SENDCMPCT;
 };
 
 /* Get a vector of all valid message types (see above) */

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -935,7 +935,7 @@ QString formatDurationStr(int secs)
     return strList.join(" ");
 }
 
-QString formatServicesStr(quint64 mask)
+QString formatServicesStr(quint64 mask, const QStringList &additionalServices)
 {
     QStringList strList;
 
@@ -979,6 +979,10 @@ QString formatServicesStr(quint64 mask)
             }
         }
     }
+
+    // Adds in additional services not denoted by nServices bits
+    if (additionalServices.size())
+        strList.append(additionalServices);
 
     if (strList.size())
         return strList.join(", ");

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -939,10 +939,13 @@ QString formatServicesStr(quint64 mask)
 {
     QStringList strList;
 
-    // Just scan the last 8 bits for now.
-    for (int i = 0; i < 8; i++)
+    // Scan and process until we reach the highest set bit
+    for (int i = 0; i < 32; i++)
     {
-        uint64_t check = 1 << i;
+        uint64_t check = 1ULL << i;
+        if (check > mask)
+            break;
+
         if (mask & check)
         {
             switch (check)

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -209,7 +209,7 @@ QString boostPathToQString(const fs::path &path);
 QString formatDurationStr(int secs);
 
 /* Format CNodeStats.nServices bitmask into a user-readable string */
-QString formatServicesStr(quint64 mask);
+QString formatServicesStr(quint64 mask, const QStringList &additionalServices);
 
 /* Format a CNodeCombinedStats.dPingTime into a user-readable string or display N/A, if 0*/
 QString formatPingTime(double dPingTime);

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -900,13 +900,19 @@ void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
     // Update cached nodeid
     cachedNodeid = stats->nodeStats.nodeid;
 
+    // List of services not defined by a nServices bit that we still want to display on the UI
+    // as a peer advertised service (i.e. Compact Blocks)
+    QStringList additionalServices;
+    if (stats->nodeStats.fSupportsCompactBlocks)
+        additionalServices.append("CMPCT");
+
     // update the detail ui with latest node information
     QString peerAddrDetails(QString::fromStdString(stats->nodeStats.addrName) + "<br />");
     peerAddrDetails += tr("(node id: %1)").arg(QString::number(stats->nodeStats.nodeid));
     if (!stats->nodeStats.addrLocal.empty())
         peerAddrDetails += "<br />" + tr("via %1").arg(QString::fromStdString(stats->nodeStats.addrLocal));
     ui->peerHeading->setText(peerAddrDetails);
-    ui->peerServices->setText(GUIUtil::formatServicesStr(stats->nodeStats.nServices));
+    ui->peerServices->setText(GUIUtil::formatServicesStr(stats->nodeStats.nServices, additionalServices));
     ui->peerLastSend->setText(
         stats->nodeStats.nLastSend ? GUIUtil::formatDurationStr(GetTime() - stats->nodeStats.nLastSend) : tr("never"));
     ui->peerLastRecv->setText(


### PR DESCRIPTION
The purpose of this PR is to expand what services are displayed in the peer details of the debug dialog in the Qt client.

1. Fully process `nServices` and list out any valid unknown bits being advertised by peers.  Existing code only looks at the last 8 bits, but `nServices` supports bits 1-31 (temporary experiments are supposed to use bits 24-31).
2. Add support for displaying services/protocols not advertised via a `nServices` bit.  Specifically for this PR this is used to display which nodes advertise support for Compact Blocks, but it is implemented in a way to be able to easily add support for other additional services (i.e. Xpedited, etc.)
3. Detect which peers are advertising support for Compact Blocks by reading the `sendcmpct` message and storing advertised support as part of the `CNode`/`CNodeStats`.