### PR TITLE
multithreaded transaction admission

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -204,6 +204,7 @@ testScripts = [ RpcTest(t) for t in [
     'getchaintips',
     'rawtransactions',
     'rest',
+    'mempool_accept',
     'mempool_spendcoinbase',
     'mempool_reorg',
     'mempool_limit',

--- a/qa/rpc-tests/cashlibtest.py
+++ b/qa/rpc-tests/cashlibtest.py
@@ -22,7 +22,7 @@ class MyTest (BitcoinTestFramework):
 
     def setup_chain(self, bitcoinConfDict=None, wallets=None):
         print("Initializing test directory " + self.options.tmpdir)
-        initialize_chain(self.options.tmpdir)
+        initialize_chain(self.options.tmpdir, bitcoinConfDict, wallets)
 
     def setup_network(self, split=False):
         self.nodes = start_nodes(2, self.options.tmpdir)
@@ -31,7 +31,6 @@ class MyTest (BitcoinTestFramework):
         self.sync_all()
 
     def run_test(self):
-
         faulted = False
         try:
             cashlib.spendscript(OP_1)
@@ -76,7 +75,7 @@ class MyTest (BitcoinTestFramework):
             n += 1
 
         txhex = hexlify(tx.serialize()).decode("utf-8")
-        txid = self.nodes[0].sendrawtransaction(txhex)
+        txid = self.nodes[0].enqueuerawtransaction(txhex)
 
         assert txid == hexlify(cashlib.txid(txhex)[::-1]).decode("utf-8")
 
@@ -87,12 +86,10 @@ class MyTest (BitcoinTestFramework):
         sig2 = cashlib.signTxInput(tx2, 0, amt, output, destPrivKey, sighashtype)
         tx2.vin[0].scriptSig = cashlib.spendscript(sig2, destPubKey)
 
-        tx2id = self.nodes[0].sendrawtransaction(hexlify(tx2.serialize()).decode("utf-8"))
-
+        tx2id = self.nodes[0].enqueuerawtransaction(hexlify(tx2.serialize()).decode("utf-8"))
         # Check that all tx were created, and commit them
-        assert self.nodes[0].getmempoolinfo()["size"] == 2
-        self.nodes[0].generate(1)
-
+        waitFor(6, lambda: self.nodes[0].getmempoolinfo()["size"] == 2)
+        blk = self.nodes[0].generate(1)
         self.sync_blocks()
         assert self.nodes[0].getmempoolinfo()["size"] == 0
         assert self.nodes[1].getmempoolinfo()["size"] == 0
@@ -117,37 +114,13 @@ if __name__ == '__main__':
 def Test():
     t = MyTest()
     bitcoinConf = {
-        "debug": ["net", "blk", "thin", "mempool", "req", "bench", "evict"],
-        "blockprioritysize": 2000000  # we don't want any transactions rejected due to insufficient fees...
+        "debug": ["rpc", "net", "blk", "thin", "mempool", "req", "bench", "evict"],
     }
 
-    flags = []
-    # you may want these additional flags:
-    # flags.append("--nocleanup")
-    # flags.append("--noshutdown")
-
-    # Execution is much faster if a ramdisk is used, so use it if one exists in a typical location
+    flags = [] # ["--nocleanup", "--noshutdown"]
     if os.path.isdir("/ramdisk/test"):
-        flags.append("--tmppfx=/ramdisk/test")
-
-    # Out-of-source builds are awkward to start because they need an additional flag
-    # automatically add this flag during testing for common out-of-source locations
-
-    objpath = None
-    here = os.path.dirname(os.path.abspath(__file__))
-    if not os.path.exists(os.path.abspath(here + "/../../src/bitcoind")):
-        dbg = os.path.abspath(here + "/../../debug/src/bitcoind")
-        rel = os.path.abspath(here + "/../../release/src/bitcoind")
-        if os.path.exists(dbg):
-            print("Running from the debug directory (%s)" % dbg)
-            flags.append("--srcdir=%s" % os.path.dirname(dbg))
-            objpath = os.path.dirname(dbg)
-        elif os.path.exists(rel):
-            print("Running from the release directory (%s)" % rel)
-            flags.append("--srcdir=%s" % os.path.dirname(rel))
-            objpath = os.path.dirname(rel)
-        cashlib.init(objpath + os.sep + ".libs" + os.sep + "libbitcoincash.so")
-    else:
-        cashlib.init(os.path.abspath(here + "/../../src/.libs/libbitcoincash.so"))
-
+        flags.append("--tmpdir=/ramdisk/test/cashlibtest")
+    binpath = findBitcoind()
+    flags.append("--srcdir=%s" % binpath)
+    cashlib.init(binpath + os.sep + ".libs" + os.sep + "libbitcoincash.so")
     t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -465,7 +465,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         fundedTx = self.nodes[2].fundrawtransaction(rawTx)
 
         signedTx = self.nodes[2].signrawtransaction(fundedTx['hex'])
-        txId = self.nodes[2].sendrawtransaction(signedTx['hex'])
+        txId = self.nodes[2].enqueuerawtransaction(signedTx['hex'], "flush")
+        
         self.sync_all()
         self.nodes[1].generate(1)
         self.sync_all()
@@ -526,7 +527,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         #now we need to unlock
         self.nodes[1].walletpassphrase("test", 100)
         signedTx = self.nodes[1].signrawtransaction(fundedTx['hex'])
-        txId = self.nodes[1].sendrawtransaction(signedTx['hex'])
+        txId = self.nodes[1].enqueuerawtransaction(signedTx['hex'],"flush")
         self.sync_all()
         self.nodes[1].generate(1)
         self.sync_all()
@@ -590,7 +591,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         rawTx = self.nodes[1].createrawtransaction(inputs, outputs)
         fundedTx = self.nodes[1].fundrawtransaction(rawTx)
         fundedAndSignedTx = self.nodes[1].signrawtransaction(fundedTx['hex'])
-        txId = self.nodes[1].sendrawtransaction(fundedAndSignedTx['hex'])
+        txId = self.nodes[1].enqueuerawtransaction(fundedAndSignedTx['hex'], "flush")
         self.sync_all()
         self.nodes[0].generate(1)
         self.sync_all()
@@ -650,7 +651,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert(not signedtx["complete"])
         signedtx = self.nodes[0].signrawtransaction(signedtx["hex"])
         assert(signedtx["complete"])
-        self.nodes[0].sendrawtransaction(signedtx["hex"])
+        self.nodes[0].enqueuerawtransaction(signedtx["hex"],"flush")
 
         self.nodes[0].generate(1)
         self.sync_all()
@@ -675,3 +676,17 @@ class RawTransactionsTest(BitcoinTestFramework):
 
 if __name__ == '__main__':
     RawTransactionsTest().main(None,{"keypool":1})
+
+def Test():
+    t = RawTransactionsTest()
+    bitcoinConf = {
+        "debug": ["rpc","net", "blk", "thin", "mempool", "req", "bench", "evict"],
+        "keypool":1
+    }
+
+    flags = [] # ["--nocleanup", "--noshutdown"]
+    if os.path.isdir("/ramdisk/test"):
+        flags.append("--tmppfx=/ramdisk/test")
+    binpath = findBitcoind()
+    flags.append("--srcdir=%s" % binpath)
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/invalidtxrequest.py
+++ b/qa/rpc-tests/invalidtxrequest.py
@@ -6,7 +6,7 @@ import test_framework.loginit
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.comptool import TestManager, TestInstance, RejectResult
 from test_framework.blocktools import *
-import time
+import time, os
 
 
 '''
@@ -69,3 +69,18 @@ class InvalidTxRequestTest(ComparisonTestFramework):
 
 if __name__ == '__main__':
     InvalidTxRequestTest().main()
+
+
+def Test():
+    t = InvalidTxRequestTest()
+    # t.drop_to_pdb = True
+    bitcoinConf = {
+        "debug": ["rpc","net", "blk", "thin", "mempool", "req", "bench", "evict"],
+    }
+
+    flags = [] # ["--nocleanup", "--noshutdown"]
+    if os.path.isdir("/ramdisk/test"):
+        flags.append("--tmppfx=/ramdisk/test")
+    binpath = findBitcoind()
+    flags.append("--srcdir=%s" % binpath)
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/mempool_accept.py
+++ b/qa/rpc-tests/mempool_accept.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+import test_framework.loginit
+# This test exercises the mempool acceptance data path.
+
+from threading import Thread
+import time
+import sys
+if sys.version_info[0] < 3:
+    raise "Use Python 3"
+import logging
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+import test_framework.cashlib as cashlib
+from test_framework.nodemessages import *
+from test_framework.script import *
+
+
+class PayDest:
+    """A payment destination.  All the info you need to send a payment here and make a subsequent payment 
+       from this address"""
+
+    def __init__(self, node=None):
+        """Pass a node to use an address from that node's wallet.  Pass None to generate a local address"""
+        if node is None:
+            self.privkey = cashlib.randombytes(32)
+        else:
+            addr = node.getnewaddress()
+            privb58 = node.dumpprivkey(addr)
+            self.privkey = decodeBase58(privb58)[1:-5]
+        self.pubkey = cashlib.pubkey(self.privkey)
+        self.hash = cashlib.addrbin(self.pubkey)
+
+    def __str__(self):
+        return "priv:%s pub:%s hash:%s" % (hexlify(self.privkey), hexlify(self.pubkey), hexlify(self.hash))
+
+
+def createConflictingTx(dests, source, count, fee=1):
+    """ Create "count" conflicting transactions that spend the "source" to "dests" evenly.  Conflicting tx are created
+    by varying the fee.  Change the base "fee" if you want which is actually the fee PER dest.
+
+    source: a dictionary in RPC listunspent format, with additional "privkey" field which is the private key in bytes
+    dests: a list of PayDest objects.
+    count: the number of conflicting tx to return
+    fee: what to deduct as the fee (in Satoshi)
+    """
+    generatedTx = []
+    hexOP_DUP = OP_DUP.toHex()
+    binOP_DUP = ord(OP_DUP.toBin())
+
+    for c in range(count):
+        w = source
+        if 1:
+            tx = CTransaction()
+            tx.vin.append(CTxIn(COutPoint(w["txid"], w["vout"]), b"", 0xffffffff))
+
+            amt = int(w["satoshi"] / len(dests)) - (fee + c)  # really total fee ends up fee*dest
+
+            i = 0
+            for d in dests:
+                script = CScript([OP_DUP, OP_HASH160, d.hash, OP_EQUALVERIFY, OP_CHECKSIG])
+                tx.vout.append(CTxOut(amt, script))
+                i += 1
+
+            sighashtype = 0x41
+            sig = cashlib.signTxInput(tx, 0, w["satoshi"], w["scriptPubKey"], w["privkey"], sighashtype)
+            # construct the signature script -- it may be one of 2 types
+            if w["scriptPubKey"][0:2] == hexOP_DUP or w["scriptPubKey"][0] == binOP_DUP:  # P2PKH starts with OP_DUP
+                tx.vin[0].scriptSig = cashlib.spendscript(sig, w["pubkey"])  # P2PKH
+            else:
+                tx.vin[0].scriptSig = cashlib.spendscript(sig)  # P2PK
+
+            generatedTx.append(tx)
+
+    return generatedTx
+
+
+def createTx(dests, sources, node, maxx=None, fee=1, nextWallet=None, generatedTx=None):
+    """ Create "maxx" transactions that spend from individual "sources" to every "dests" evenly (many fan-out 
+    transactions).  If "generatedTx" is a list the created transactions are put into it.  Otherwise they are
+    sent to "node".  If "nextWallet" is a list the outputs of all these created tx are put into it in a format
+    compatible with "sources" (you can use nextWallet as the sources input in a subsequent call to this function).
+
+    Change the base "fee" if you want which is actually the fee PER dest.
+
+    sources: list of dictionaries in RPC listunspent format, with optional additional "privkey" field which 
+       is the private key in bytes.  If "privkey" does not exist, "node" is asked for it.
+    dests: a list of PayDest objects.
+    fee: what to deduct as the fee (in Satoshi)
+    nextWallet: [output] pass an empty list to get a valid wallet if all the createdTx are committed.
+    generatedTx: [output] pass an empty list to skip submitting the tx to node, and instead return them in this list.
+
+    returns the number of transactions created.
+    """
+
+    hexOP_DUP = OP_DUP.toHex()
+    binOP_DUP = ord(OP_DUP.toBin())
+    count = 0
+    for w in sources:
+        nextOuts = []
+        if not count is None and count == maxx:
+            break
+
+        # if sources is from a bitcoind wallet, I need to grab some info in order to sign
+        if not "privkey" in w:
+            privb58 = node.dumpprivkey(w["address"])
+            privkey = decodeBase58(privb58)[1:-5]
+            pubkey = cashlib.pubkey(privkey)
+            w["privkey"] = privkey
+            w["pubkey"] = pubkey
+
+        tx = CTransaction()
+        tx.vin.append(CTxIn(COutPoint(w["txid"], w["vout"]), b"", 0xffffffff))
+
+        amt = int(w["satoshi"] / len(dests)) - fee  # really fee ends up fee*dest
+
+        i = 0
+        for d in dests:
+            script = CScript([OP_DUP, OP_HASH160, d.hash, OP_EQUALVERIFY, OP_CHECKSIG])
+            tx.vout.append(CTxOut(amt, script))
+            nextOuts.append({"vout": i, "privkey": d.privkey, "scriptPubKey": script,
+                             "satoshi": amt, "pubkey": d.pubkey})
+            i += 1
+
+        sighashtype = 0x41
+        n = 0
+        # print("amountin: %d amountout: %d outscript: %s" % (w["satoshi"], amt, w["scriptPubKey"]))
+        sig = cashlib.signTxInput(tx, n, w["satoshi"], w["scriptPubKey"], w["privkey"], sighashtype)
+
+        if w["scriptPubKey"][0:2] == hexOP_DUP or w["scriptPubKey"][0] == binOP_DUP:  # P2PKH starts with OP_DUP
+            tx.vin[n].scriptSig = cashlib.spendscript(sig, w["pubkey"])  # P2PKH
+        else:
+            tx.vin[n].scriptSig = cashlib.spendscript(sig)  # P2PK
+
+        if not type(generatedTx) is list:  # submit these tx to the node
+            txhex = hexlify(tx.serialize()).decode("utf-8")
+            txid = None
+            try:
+                txid = node.enqueuerawtransaction(txhex)
+            except JSONRPCException as e:
+                logging.error("TX submission failed because %s" % str(e))
+                logging.error("tx was: %s" % txhex)
+                logging.error("amountin: %d amountout: %d outscript: %s" % (w["satoshi"], amt, w["scriptPubKey"]))
+                raise
+        else:  # return them in generatedTx
+            generatedTx.append(tx)
+
+        for out in nextOuts:
+            tx.rehash()
+            out["txid"] = tx.hash
+            # I've already filled nextOuts with all the other needed fields
+
+        if type(nextWallet) is list:
+            nextWallet += nextOuts
+        count += 1
+    return count
+
+
+class MyTest (BitcoinTestFramework):
+    def __init__(self, bigTest=0):
+        self.bigTest = bigTest
+        BitcoinTestFramework.__init__(self)
+
+    def setup_chain(self, bitcoinConfDict=None, wallets=None):
+        logging.info("Initializing test directory " + self.options.tmpdir)
+        initialize_chain(self.options.tmpdir, bitcoinConfDict, wallets)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(2, self.options.tmpdir)
+        # Now interconnect the nodes
+        connect_nodes_bi(self.nodes, 0, 1)
+        self.is_network_split = False
+        self.sync_all()
+
+    def threadedCreateTx(self, dests, sources, nodeIdx, maxx=None):
+        """Create a bunch of transactions using multiple python threads"""
+        NUMTHREADS = 4
+        if sources is None:
+            wallets = self.nodes[nodeIdx].listunspent()
+        else:
+            wallets = sources
+        total = min(len(wallets), maxx)
+        logging.info("creating %d tx desired %d" % (total, maxx))
+
+        wchunks = []
+        count = 0
+        for i in range(NUMTHREADS - 1):
+            start = count
+            count += int(total / NUMTHREADS)
+            wchunks.append(wallets[start: count])
+        wchunks.append(wallets[count:])
+
+        threads = []
+        outputs = []
+        txPerThread = int(total / NUMTHREADS)
+        for i in range(NUMTHREADS - 1):
+            node = get_rpc_proxy(self.nodes[nodeIdx].url, nodeIdx, timeout=30)
+            t = Thread(target=createTx, args=(dests, wchunks[i], node, txPerThread, 1, outputs))
+            t.start()
+            threads.append(t)
+
+        createTx(dests, wchunks[NUMTHREADS - 1], self.nodes[nodeIdx],
+                 total - (txPerThread * (NUMTHREADS - 1)), 1, outputs)
+        for t in threads:
+            t.join()
+        return (total, outputs)
+
+    def conflictTest(self, dests0, dests1, wallet, numNodes=2):
+        """Tests issuing a bunch of conflicting transactions.  Expects that you give it a wallet with lots of free UTXO, and nothing in the mempool
+        """
+        assert(self.nodes[0].getmempoolinfo()["size"] == 0)  # Expects a clean mempool
+        if 1:  # test many conflicts
+            NTX = 50
+            i = 0
+            for c in range(NTX):
+                source = wallet.pop()
+                txs = createConflictingTx(dests0, source, c)
+
+                for t in txs:
+                    n = self.nodes[i % len(self.nodes)]
+                    n.enqueuerawtransaction(t.toHex())
+                    i += 1
+
+            for n in self.nodes:
+                waitFor(30, lambda: True if n.getmempoolinfo()["size"] >= NTX - 5 else None)
+            time.sleep(5)
+            # we have to allow < because bloom filter false positives in the node's
+            # sending logic may cause it to not get an INV
+            for n in self.nodes:
+                assert(n.getmempoolinfo()["size"] <= NTX)  # if its > then a doublespend got through
+            self.commitMempool()  # clear out this test
+
+        if 1:  # test 2 conflicting transactions
+            NTX = 100
+            wallet2 = []
+            gtx2 = []
+            amt = createTx(dests0, wallet[0:NTX], 1, NTX, 1, wallet2, gtx2)
+            wallet3 = []
+            gtx3 = []
+            # create conflicting tx with slightly different payment amounts
+            amt = createTx(dests0, wallet[0:NTX], 1, NTX, 2, wallet3, gtx3)
+
+            gtx = zip(gtx2, gtx3)
+            for g in gtx:
+                self.nodes[0].enqueuerawtransaction(g[0].toHex())
+                try:
+                    self.nodes[0].enqueuerawtransaction(g[1].toHex())
+                    # assert(0)  # double spend may not return an error because processing happens asynchronously
+                except JSONRPCException as e:
+                    if e.error["code"] != -26:  # txn-mempool-conflict
+                        raise
+
+            # forget about the tx I used above
+            wallet = wallet[NTX:]
+
+            waitFor(30, lambda: True if self.nodes[0].getmempoolinfo()["size"] >= NTX else None)
+            waitFor(30, lambda: True if self.nodes[1].getmempoolinfo()["size"] >= NTX else None)
+            time.sleep(4)  # see if any conflicts will be added to the mempool
+
+            assert(self.nodes[0].getmempoolinfo()["size"] == NTX)
+            assert(self.nodes[1].getmempoolinfo()["size"] == NTX)
+
+            NTX1 = NTX
+
+            # test conflicting tx sent to different nodes
+            NTX = 200
+            wallet2 = []
+            gtx2 = []
+            amt = createTx(dests0, wallet[0:NTX], 1, NTX, 1, wallet2, gtx2)
+            wallet3 = []
+            gtx3 = []
+            # create conflicting tx with slightly different payment amounts
+            amt = createTx(dests0, wallet[0:NTX], 1, NTX, 2, wallet3, gtx3)
+
+            gtx = zip(gtx2, gtx3)
+
+            count = 0
+            mempools = [x.getmempoolinfo() for x in self.nodes]
+            for g in gtx:
+                count += 1
+                self.nodes[count % numNodes].enqueuerawtransaction(g[0].toHex())
+                try:
+                    self.nodes[(count + 1) % numNodes].enqueuerawtransaction(g[1].toHex())
+                except JSONRPCException as e:
+                    if e.error["code"] != -26:  # txn-mempool-conflict
+                        pass  # we may get an error or not depending on propagation speed of 1st tx
+
+            # There is no good way to tell if the mempool sync process has fully
+            # completed because out of testing the process of accepting tx is never
+            # complete
+            waitFor(30, lambda: True if self.nodes[0].getmempoolinfo()["size"] >= NTX + NTX1 else None)
+            waitFor(30, lambda: True if self.nodes[1].getmempoolinfo()["size"] >= NTX + NTX1 else None)
+
+            time.sleep(4)  # see if any conflicts will be added to the mempool
+            assert(self.nodes[0].getmempoolinfo()["size"] == NTX + NTX1)
+            assert(self.nodes[1].getmempoolinfo()["size"] == NTX + NTX1)
+
+            # forget about the tx I used
+            wallet = wallet[NTX:]
+
+    def commitMempool(self):
+        """Commit all the tx in mempools on all nodes into blocks"""
+        for n in self.nodes:
+            while n.getmempoolinfo()["size"] != 0:
+                n.generate(1)
+                self.sync_blocks()
+
+    def run_test(self):
+        decContext = decimal.getcontext().prec
+        decimal.getcontext().prec = 8 + 8  # 8 digits to get to 21million, and each bitcoin is 100 million satoshis
+
+        self.nodes[0].generate(200)
+        self.sync_blocks()
+
+        # Get some addresses
+        dests1 = [PayDest(self.nodes[1]) for x in range(20)]
+        dests0 = [PayDest(self.nodes[0]) for x in range(20)]
+
+        # Create 51 transaction and ensure that they get synced
+        NTX = 101
+        (amt, wallet) = self.threadedCreateTx(dests1, None, 0, NTX)
+        assert(amt == NTX)
+        waitFor(10, lambda: True if self.nodes[0].getmempoolinfo()["size"] >= NTX else None)
+        mp = waitFor(30, lambda: [x.getmempoolinfo() for x in self.nodes] if amt - self.nodes[1].getmempoolinfo()
+                     ["size"] < 5 else None, lambda: "timeout mempool is: " + str([x.getmempoolinfo() for x in self.nodes]))
+        logging.info(mp)
+
+        w0 = wallet[0:500]
+        wallet = wallet[500:]
+        self.commitMempool()
+        self.conflictTest(dests0, dests1, w0)
+        self.commitMempool()
+
+        # Create 500 transaction and ensure that they get synced
+        NTX = 500
+        start = time.monotonic()
+        (amt, wallet) = self.threadedCreateTx(dests0, wallet, 1, NTX)
+        end = time.monotonic()
+        logging.info("created %d tx in %s seconds. On node 0.  Speed %f tx/sec" %
+                     (amt, end - start, float(amt) / (end - start)))
+        mp = waitFor(20, lambda: [x.getmempoolinfo() for x in self.nodes] if amt - self.nodes[1].getmempoolinfo()
+                     ["size"] < 10 else None, lambda: "timeout mempool is: " + str([x.getmempoolinfo() for x in self.nodes]))
+        logging.info(mp)
+
+        # Create 5000 transactions and ensure that they get synced
+        if self.bigTest:
+            self.commitMempool()
+            NTX = 5000
+            start = time.monotonic()
+            (amt, wallet) = self.threadedCreateTx(dests1, wallet, 0, NTX)
+            end = time.monotonic()
+            logging.info("created %d tx in %s seconds. On node 0.  Speed %f tx/sec" %
+                     (amt, end - start, float(amt) / (end - start)))
+            mp = waitFor(300, lambda: [x.getmempoolinfo() for x in self.nodes] if amt - self.nodes[1].getmempoolinfo()
+                     ["size"] < 20 else None, lambda: "timeout mempool is: " + str([x.getmempoolinfo() for x in self.nodes]))
+            logging.info(mp)
+
+        if self.bigTest:
+            self.commitMempool()
+            NTX = 10000
+            start = time.monotonic()
+            (amt, wallet) = self.threadedCreateTx(dests0, wallet, 1, NTX)
+            end = time.monotonic()
+            logging.info("created %d tx in %s seconds. On node 0.  Speed %f tx/sec" %
+                         (amt, end - start, float(amt) / (end - start)))
+            start = time.monotonic()
+            mp = waitFor(300, lambda: [x.getmempoolinfo() for x in self.nodes] if amt - self.nodes[0].getmempoolinfo()[
+                         "size"] < 50 else None, lambda: "timeout mempool is: " + str([x.getmempoolinfo() for x in self.nodes]))
+            end = time.monotonic()
+            logging.info("synced %d tx in %s seconds.  Speed %f tx/sec" %
+                         (amt, end - start, float(amt) / (end - start)))
+            logging.info(mp)
+
+        # Now test pushing all of the mempool tx to other nodes
+        NTX = self.nodes[0].getmempoolinfo()["size"]  # find how many I am pushing
+
+        # Start up node 3
+        self.nodes.append(start_node(2, self.options.tmpdir))
+        connect_nodes_bi(self.nodes, 0, 2)
+        sync_blocks(self.nodes)
+
+        # Push all tx to node 3 from one node
+        destName = "127.0.0.1:" + str(p2p_port(2))
+        start = time.monotonic()
+        self.nodes[0].pushtx(destName)
+        mp = waitFor(120, lambda: [x.getmempoolinfo() for x in self.nodes]
+                     if NTX - self.nodes[2].getmempoolinfo()["size"] < 30 else None)
+        end = time.monotonic()
+        logging.info("synced %d tx in %s seconds.  Speed %f tx/sec" % (NTX, end - start, float(NTX) / (end - start)))
+
+        # Start up node 4
+        self.nodes.append(start_node(3, self.options.tmpdir))
+        connect_nodes_bi(self.nodes, 0, 3)
+        connect_nodes_bi(self.nodes, 1, 3)
+        connect_nodes_bi(self.nodes, 2, 3)
+        sync_blocks(self.nodes)
+
+        # Push all tx to node 4 from many nodes
+        destName = "127.0.0.1:" + str(p2p_port(3))
+
+        start = time.monotonic()
+        self.nodes[0].pushtx(destName)
+        self.nodes[1].pushtx(destName)
+        self.nodes[2].pushtx(destName)
+        mp = waitFor(120, lambda: [x.getmempoolinfo() for x in self.nodes]
+                     if NTX - self.nodes[3].getmempoolinfo()["size"] < 30 else None)
+        end = time.monotonic()
+        logging.info("synced %d tx in %s seconds.  Speed %f tx/sec" % (NTX, end - start, float(NTX) / (end - start)))
+
+
+if __name__ == '__main__':
+    env = os.getenv("BITCOIND", None)
+    path = None
+    if env is None:
+        for arg in sys.argv:
+            if "srcdir" in arg:
+                path = arg.split("=")[1]
+                break
+        if path is None:
+            env = os.path.dirname(os.path.abspath(__file__))
+            env = env + os.sep + ".." + os.sep + ".." + os.sep + "src" + os.sep + "bitcoind"
+            env = os.path.abspath(env)
+    if path is None:
+        path = os.path.dirname(env)
+
+    try:
+        cashlib.init(path + os.sep + ".libs" + os.sep + "libbitcoincash.so")
+        MyTest().main()
+    except OSError as e:
+        print("Issue loading shared library.  This is expected during cross compilation since the native python will not load the .so: %s" % str(e))
+
+
+# Create a convenient function for an interactive python debugging session
+def Test():
+    t = MyTest(True)
+    bitcoinConf = {
+        "debug": ["blk", "mempool", "net", "req"],
+        "blockprioritysize": 2000000,  # we don't want any transactions rejected due to insufficient fees...
+        "net.ignoreTimeouts": 1,
+        "logtimemicros": 1
+    }
+
+    # you may want these flags:
+    flags = ["--nocleanup", "--noshutdown"]
+
+    # Execution is much faster if a ramdisk is used, so use it if one exists in a typical location
+    if os.path.isdir("/ramdisk/test"):
+        flags.append("--tmpdir=/ramdisk/test/ma")
+
+    # Out-of-source builds are awkward to start because they need an additional flag
+    # automatically add this flag during testing for common out-of-source locations
+    binpath = findBitcoind()
+    flags.append("--srcdir=%s" % binpath)
+
+    # load the cashlib.so from our build directory
+    cashlib.init(binpath + os.sep + ".libs" + os.sep + "libbitcoincash.so")
+    # start the test
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/mempool_limit.py
+++ b/qa/rpc-tests/mempool_limit.py
@@ -51,3 +51,18 @@ class MempoolLimitTest(BitcoinTestFramework):
 
 if __name__ == '__main__':
     MempoolLimitTest().main()
+
+def Test():
+    t = MempoolLimitTest()
+    # t.drop_to_pdb = True
+    bitcoinConf = {
+        "debug": ["blk", "mempool", "net", "req"],
+        "logtimemicros": 1
+    }
+
+    flags = [] # ["--nocleanup", "--noshutdown"]
+    if os.path.isdir("/ramdisk/test"):
+        flags.append("--tmppfx=/ramdisk/test")
+    binpath = findBitcoind()
+    flags.append("--srcdir=%s" % binpath)
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/mempool_reorg.py
+++ b/qa/rpc-tests/mempool_reorg.py
@@ -100,3 +100,16 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
 if __name__ == '__main__':
     MempoolCoinbaseTest().main()
+
+def Test():
+    t = MempoolCoinbaseTest()
+    bitcoinConf = {
+        "debug": ["rpc","net", "blk", "thin", "mempool", "req", "bench", "evict"],
+    }
+
+    flags = [] # ["--nocleanup", "--noshutdown"]
+    if os.path.isdir("/ramdisk/test"):
+        flags.append("--tmppfx=/ramdisk/test")
+    binpath = findBitcoind()
+    flags.append("--srcdir=%s" % binpath)
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -130,7 +130,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert_equal(rawTxPartialSigned['complete'], False) #node1 only has one key, can't comp. sign the tx
         rawTxSigned = self.nodes[2].signrawtransaction(rawTx, inputs)
         assert_equal(rawTxSigned['complete'], True) #node2 can sign the tx compl., own two of three keys
-        self.nodes[2].sendrawtransaction(rawTxSigned['hex'])
+        self.nodes[2].enqueuerawtransaction(rawTxSigned['hex'],"flush")
         rawTx = self.nodes[0].decoderawtransaction(rawTxSigned['hex'])
         self.sync_all()
         self.nodes[0].generate(1)
@@ -268,16 +268,15 @@ if __name__ == '__main__':
 
 def Test():
     t = RawTransactionsTest()
-    t.drop_to_pdb = True
+    #t.drop_to_pdb = True
     bitcoinConf = {
-        "debug": ["net", "blk", "thin", "mempool", "req", "bench", "evict"],  # "lck"
-        "blockprioritysize": 2000000  # we don't want any transactions rejected due to insufficient fees...
+        "debug": ["rpc","net", "blk", "thin", "mempool", "req", "bench", "evict"],
     }
 
-    flags = []
-    # you may want these additional flags:
-    # "--srcdir=<out-of-source-build-dir>/debug/src"
-    # "--nocleanup", "--noshutdown"
-    if os.path.isdir("/ramdisk/test"):  # execution is much faster if a ramdisk is used
+    flags = [] # ["--nocleanup", "--noshutdown"]
+    if os.path.isdir("/ramdisk/test"):
         flags.append("--tmppfx=/ramdisk/test")
+    binpath = findBitcoind()
+    flags.append("--srcdir=%s" % binpath)
     t.main(flags, bitcoinConf, None)
+

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -411,6 +411,7 @@ class TestManager(object):
                     invqueue = []
                 self.sync_transaction(tx.sha256, len(test_instance.blocks_and_transactions))
                 if (not self.check_mempool(tx.sha256, tx_outcome)):
+                    val = self.check_mempool(tx.sha256, tx_outcome)
                     raise AssertionError("Mempool test failed at test %d" % test_number)
 
             print("Test %d: PASS" % test_number, [ c.rpc.getblockcount() for c in self.connections ])

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -63,7 +63,7 @@ class BitcoinTestFramework(object):
         wallets: Pass a list of wallet filenames.  Each wallet file will be copied into the node's directory
         before starting the node.
         """
-        print("Initializing test directory ", self.options.tmpdir, "Bitcoin conf: ", str(bitcoinConfDict), "walletfiles: ", wallets)
+        logging.info("Initializing test directory %s Bitcoin conf: %s walletfiles: %s" % (self.options.tmpdir, str(bitcoinConfDict), wallets))
         initialize_chain(self.options.tmpdir,bitcoinConfDict, wallets, self.bins)
 
     def setup_nodes(self):
@@ -180,7 +180,7 @@ class BitcoinTestFramework(object):
         else:
             self.randomseed = int(time.time())
         random.seed(self.randomseed)
-        print("Random seed: %s" % self.randomseed)
+        logging.info("Random seed: %s" % self.randomseed)
 
         if self.options.tmpdir is None:
             self.options.tmpdir = os.path.join(self.options.tmppfx, str(self.options.port_seed))
@@ -222,42 +222,42 @@ class BitcoinTestFramework(object):
             self.run_test()
             success = True
         except JSONRPCException as e:
-            print("JSONRPC error: "+e.error['message'])
+            logging.error("JSONRPC error: "+e.error['message'])
             typ, value, tb = sys.exc_info()
             traceback.print_tb(tb)
             if self.drop_to_pdb: pdb.post_mortem(tb)
         except AssertionError as e:
-            print("Assertion failed: " + str(e))
+            logging.error("Assertion failed: " + str(e))
             typ, value, tb = sys.exc_info()
             traceback.print_tb(tb)
             if self.drop_to_pdb: pdb.post_mortem(tb)
         except KeyError as e:
-            print("key not found: "+ str(e))
+            logging.error("key not found: "+ str(e))
             typ, value, tb = sys.exc_info()
             traceback.print_tb(tb)
             if self.drop_to_pdb: pdb.post_mortem(tb)
         except Exception as e:
-            print("Unexpected exception caught during testing: " + repr(e))
+            logging.error("Unexpected exception caught during testing: " + repr(e))
             typ, value, tb = sys.exc_info()
             traceback.print_tb(tb)
             if self.drop_to_pdb: pdb.post_mortem(tb)
         except KeyboardInterrupt as e:
-            print("Exiting after " + repr(e))
+            logging.error("Exiting after " + repr(e))
 
         if not self.options.noshutdown:
-            print("Stopping nodes")
+            logging.info("Stopping nodes")
             if hasattr(self, "nodes"):  # nodes may not exist if there's a startup error
                 stop_nodes(self.nodes)
             wait_bitcoinds()
         else:
-            print("Note: bitcoinds were not stopped and may still be running")
+            logging.warning("Note: bitcoinds were not stopped and may still be running")
 
         if not self.options.nocleanup and not self.options.noshutdown and success:
-            print("Cleaning up")
+            logging.info("Cleaning up")
             shutil.rmtree(self.options.tmpdir)
 
         else:
-            print("Not cleaning up dir %s" % self.options.tmpdir)
+            logging.info("Not cleaning up dir %s" % self.options.tmpdir)
             if os.getenv("PYTHON_DEBUG", ""):
                 # Dump the end of the debug logs, to aid in debugging rare
                 # travis failures.
@@ -270,10 +270,10 @@ class BitcoinTestFramework(object):
                     print("".join(deque(open(f), MAX_LINES_TO_PRINT)))
 
         if success:
-            print("Tests successful")
+            logging.info("Tests successful")
             sys.exit(0)
         else:
-            print("Failed")
+            logging.error("Failed")
             sys.exit(1)
 
 
@@ -298,7 +298,7 @@ class ComparisonTestFramework(BitcoinTestFramework):
                           help="bitcoind binary to use for reference nodes (if any)")
 
     def setup_chain(self,bitcoinConfDict=None, wallets=None):  # BU add config params
-        print("Initializing test directory ", self.options.tmpdir)
+        logging.info("Initializing test directory %s" % self.options.tmpdir)
         initialize_chain_clean(self.options.tmpdir, self.num_nodes,bitcoinConfDict, wallets)
 
     def setup_network(self):

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -130,7 +130,7 @@ def waitFor(timeout, fn, onError="timeout in waitFor", sleepAmt=1.0):
     timeout = float(timeout)
     while 1:
         result = fn()
-        if not result is None:
+        if not (result is None or result is False):
             return result
         if timeout <= 0:
             if callable(onError):
@@ -138,7 +138,7 @@ def waitFor(timeout, fn, onError="timeout in waitFor", sleepAmt=1.0):
             raise TimeoutException(onError)
         time.sleep(sleepAmt)
         timeout -= sleepAmt
-        
+
 def expectException(fn, ExcType, comparison=None):
     try:
         fn()
@@ -1019,3 +1019,20 @@ def get_bip135_status(node, key):
     info = node.getblockchaininfo()
     return info['bip135_forks'][key]
 # bip135 end
+
+def findBitcoind():
+    """Find the bitcoind executable if you build in typical out-of-source locations (debug or release)"""
+    here = os.path.dirname(os.path.abspath(__file__))
+    objpath = os.path.abspath(here + "/../../../src/bitcoind")
+    if not os.path.exists(objpath):
+        dbg = os.path.abspath(here + "/../../../debug/src/bitcoind")
+        rel = os.path.abspath(here + "/../../../release/src/bitcoind")
+        if os.path.exists(dbg):
+            logging.info("Running from the debug directory (%s)" % dbg)
+            objpath = os.path.dirname(dbg)
+        elif os.path.exists(rel):
+            logging.info("Running from the release directory (%s)" % rel)
+            objpath = os.path.dirname(rel)
+    else:
+        objpath = os.path.dirname(objpath)
+    return objpath

--- a/qa/rpc-tests/txn_clone.py
+++ b/qa/rpc-tests/txn_clone.py
@@ -13,7 +13,7 @@ from test_framework.util import *
 import pdb
 import traceback
 
-class TxnMallTest(BitcoinTestFramework):
+class TxnCloneTest(BitcoinTestFramework):
 
     def add_options(self, parser):
         parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",
@@ -21,7 +21,7 @@ class TxnMallTest(BitcoinTestFramework):
 
     def setup_network(self):
         # Start with split network:
-        return super(TxnMallTest, self).setup_network(True)
+        return super(TxnCloneTest, self).setup_network(True)
 
     def run_test(self):
         # All nodes should start with 1,250 BTC:
@@ -133,7 +133,7 @@ class TxnMallTest(BitcoinTestFramework):
         tx1 = self.nodes[0].gettransaction(txid1)
         tx1_clone = self.nodes[0].gettransaction(txid1_clone)
         tx2 = self.nodes[0].gettransaction(txid2)
-        
+
         # Verify expected confirmations
         assert_equal(tx1["confirmations"], -2)
         assert_equal(tx1_clone["confirmations"], 2)
@@ -164,13 +164,19 @@ class TxnMallTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getbalance("from0", 0), -(tx1["amount"] + tx2["amount"]))
 
 if __name__ == '__main__':
-    TxnMallTest().main()
+    TxnCloneTest().main()
 
 def Test():
-    t = TxnMallTest()
+    t = TxnCloneTest()
     t.drop_to_pdb = True
     bitcoinConf = {
-        "debug": ["net", "blk", "thin", "mempool", "req", "bench", "evict"],  # "lck"
-        "blockprioritysize": 2000000  # we don't want any transactions rejected due to insufficient fees...
+        "debug": ["blk", "mempool", "net", "req"],
+        "logtimemicros": 1
     }
-    t.main(["--tmppfx=/ramdisk/test","--nocleanup","--noshutdown"], bitcoinConf, None)  # , "--tracerpc"])
+
+    flags = [] # ["--nocleanup", "--noshutdown"]
+    if os.path.isdir("/ramdisk/test"):
+        flags.append("--tmppfx=/ramdisk/test")
+    binpath = findBitcoind()
+    flags.append("--srcdir=%s" % binpath)
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/txn_doublespend.py
+++ b/qa/rpc-tests/txn_doublespend.py
@@ -11,7 +11,7 @@ import test_framework.loginit
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.util import *
 
-class TxnMallTest(BitcoinTestFramework):
+class TxnDoubleSpendTest(BitcoinTestFramework):
 
     def add_options(self, parser):
         parser.add_option("--mineblock", dest="mine_block", default=False, action="store_true",
@@ -19,7 +19,7 @@ class TxnMallTest(BitcoinTestFramework):
 
     def setup_network(self):
         # Start with split network:
-        return super(TxnMallTest, self).setup_network(True)
+        return super(TxnDoubleSpendTest, self).setup_network(True)
 
     def run_test(self):
         # All nodes should start with 1,250 BTC:
@@ -139,5 +139,19 @@ class TxnMallTest(BitcoinTestFramework):
         assert_equal(self.nodes[1].getbalance("from0"), 1240)
 
 if __name__ == '__main__':
-    TxnMallTest().main()
+    TxnDoubleSpendTest().main()
 
+def Test():
+    t = TxnDoubleSpendTest()
+    # t.drop_to_pdb = True
+    bitcoinConf = {
+        "debug": ["blk", "mempool", "net", "req"],
+        "logtimemicros": 1
+    }
+
+    flags = [] # ["--nocleanup", "--noshutdown"]
+    if os.path.isdir("/ramdisk/test"):
+        flags.append("--tmppfx=/ramdisk/test")
+    binpath = findBitcoind()
+    flags.append("--srcdir=%s" % binpath)
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -132,8 +132,8 @@ class WalletTest (BitcoinTestFramework):
             txns_to_send.append(self.nodes[0].signrawtransaction(raw_tx))
 
         # Have node 1 (miner) send the transactions
-        self.nodes[1].sendrawtransaction(txns_to_send[0]["hex"], True)
-        self.nodes[1].sendrawtransaction(txns_to_send[1]["hex"], True)
+        self.nodes[1].enqueuerawtransaction(txns_to_send[0]["hex"])
+        self.nodes[1].enqueuerawtransaction(txns_to_send[1]["hex"], "flush")
 
         # Have node1 mine a block to confirm transactions:
         self.nodes[1].generate(1)
@@ -472,8 +472,12 @@ if __name__ == '__main__':
 def Test():
     t = WalletTest()
     bitcoinConf = {
-        "debug": ["net", "blk", "thin", "mempool", "req", "bench", "evict"],  # "lck"
-        "blockprioritysize": 2000000  # we don't want any transactions rejected due to insufficient fees...
+        "debug": ["rpc","net", "blk", "thin", "mempool", "req", "bench", "evict"],
     }
-    # "--tmppfx=/ramdisk/test", "--srcdir=../../debug/src"
-    t.main(["--nocleanup", "--noshutdown"], bitcoinConf, None)
+
+    flags = [] # ["--nocleanup", "--noshutdown"]
+    if os.path.isdir("/ramdisk/test"):
+        flags.append("--tmppfx=/ramdisk/test")
+    binpath = findBitcoind()
+    flags.append("--srcdir=%s" % binpath)
+    t.main(flags, bitcoinConf, None)

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -130,6 +130,8 @@ torcontrol.cpp
 torcontrol.h
 tweak.cpp
 tweak.h
+txadmission.cpp
+txadmission.h
 txdb.cpp
 txdb.h
 txmempool.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -185,6 +185,7 @@ BITCOIN_CORE_H = \
   threadsafety.h \
   timedata.h \
   torcontrol.h \
+  txadmission.h \
   txdb.h \
   txmempool.h \
   txorphanpool.h \
@@ -270,6 +271,7 @@ libbitcoin_server_a_SOURCES = \
   script/ismine.cpp \
   timedata.cpp \
   torcontrol.cpp \
+  txadmission.cpp \
   txdb.cpp \
   txmempool.cpp \
   txorphanpool.cpp \

--- a/src/chain.cpp
+++ b/src/chain.cpp
@@ -14,12 +14,14 @@ using namespace std;
  */
 void CChain::SetTip(CBlockIndex *pindex)
 {
-    if (pindex == NULL)
+    if (pindex == nullptr)
     {
         vChain.clear();
+        tip = nullptr;
         return;
     }
     vChain.resize(pindex->nHeight + 1);
+    tip = pindex;
     while (pindex && vChain[pindex->nHeight] != pindex)
     {
         vChain[pindex->nHeight] = pindex;

--- a/src/fastfilter.h
+++ b/src/fastfilter.h
@@ -46,7 +46,7 @@ public:
         FastRandomContext insecure_rand;
         vData.resize(FILTER_BYTES);
         // by sampling from a different part of the uint256, we make it harder for an attacker to generate collisions
-        grabFrom = (insecure_rand.rand32() % 7) * 4; // should be 4 byte aligned for speed
+        grabFrom = (1 + (insecure_rand.rand32() % 6)) * 4; // should be 4 byte aligned for speed
     }
 
     // returns true IF this function made a change (i.e. the value was previously not set).
@@ -54,7 +54,7 @@ public:
     {
         const unsigned char *mem = hash.begin();
         const uint32_t *pos = (const uint32_t *)&(mem[grabFrom]);
-        uint32_t idx = (*pos) & (FILTER_SIZE - 1);
+        uint32_t idx = ((*pos) ^ mem[0]) & (FILTER_SIZE - 1);
 
         bool ret = vData[idx >> 3] & (1 << (idx & 7));
         vData[idx >> 3] |= (1 << (idx & 7));
@@ -67,18 +67,18 @@ public:
     {
         const unsigned char *mem = hash.begin();
         const uint32_t *pos = (const uint32_t *)&(mem[grabFrom]);
-        uint32_t idx = (*pos) & (FILTER_SIZE - 1);
+        uint32_t idx = ((*pos) ^ mem[0]) & (FILTER_SIZE - 1);
         vData[idx >> 3] |= (1 << (idx & 7));
     }
     bool contains(const uint256 &hash) const
     {
         const unsigned char *mem = hash.begin();
         const uint32_t *pos = (const uint32_t *)&(mem[grabFrom]);
-        uint32_t idx = (*pos) & (FILTER_SIZE - 1);
+        uint32_t idx = ((*pos) ^ mem[0]) & (FILTER_SIZE - 1);
         return vData[idx >> 3] & (1 << (idx & 7));
     }
 
-    void reset() { bzero(&vData[0], FILTER_BYTES); }
+    void reset() { memset(&vData[0], 0, FILTER_BYTES); }
 };
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -341,28 +341,6 @@ bool IsDAAEnabled(const Consensus::Params &consensusparams, const CBlockIndex *p
  */
 bool AreFreeTxnsDisallowed();
 
-/** Communicate what class of transaction is acceptable to add to the memory pool
- */
-enum class TransactionClass
-{
-    INVALID,
-    DEFAULT,
-    STANDARD,
-    NONSTANDARD
-};
-
-TransactionClass ParseTransactionClass(const std::string &s);
-
-/** (try to) add transaction to memory pool **/
-bool AcceptToMemoryPool(CTxMemPool &pool,
-    CValidationState &state,
-    const CTransactionRef &ptx,
-    bool fLimitFree,
-    bool *pfMissingInputs,
-    bool fOverrideMempoolLimit = false,
-    bool fRejectAbsurdFee = false,
-    TransactionClass allowedTx = TransactionClass::DEFAULT);
-
 /** Convert CValidationState to a human-readable message for logging */
 std::string FormatStateMessage(const CValidationState &state);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2489,6 +2489,7 @@ void NetCleanup()
 
 void RelayTransaction(const CTransactionRef &ptx, const bool fRespend)
 {
+    // TODO call a GetSize() function that caches the tx size
     uint64_t len = ::GetSerializeSize(*ptx, SER_NETWORK, PROTOCOL_VERSION);
     if (len > maxTxSize.Value())
     {
@@ -2767,8 +2768,7 @@ bool CAddrDB::Read(CAddrMan &addr, CDataStream &ssPeers)
 unsigned int ReceiveFloodSize() { return 1000 * GetArg("-maxreceivebuffer", DEFAULT_MAXRECEIVEBUFFER); }
 unsigned int SendBufferSize() { return 1000 * GetArg("-maxsendbuffer", DEFAULT_MAXSENDBUFFER); }
 CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNameIn, bool fInboundIn)
-    : ssSend(SER_NETWORK, INIT_PROTO_VERSION), id(connmgr->NextNodeId()), addrKnown(5000, 0.001),
-      filterInventoryKnown(50000, 0.000001)
+    : ssSend(SER_NETWORK, INIT_PROTO_VERSION), id(connmgr->NextNodeId()), addrKnown(5000, 0.001)
 {
     nServices = 0;
     hSocket = hSocketIn;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -19,6 +19,7 @@
 #include "streams.h"
 #include "sync.h"
 #include "tweak.h"
+#include "txadmission.h"
 #include "txdb.h"
 #include "txmempool.h"
 #include "txorphanpool.h"
@@ -1121,14 +1122,14 @@ UniValue invalidateblock(const UniValue &params, bool fHelp)
     uint256 hash(uint256S(strHash));
     CValidationState state;
 
-    {
-        LOCK(cs_main);
-        if (mapBlockIndex.count(hash) == 0)
-            throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+    TxAdmissionPause txlock;
+    LOCK(cs_main);
 
-        CBlockIndex *pblockindex = mapBlockIndex[hash];
-        InvalidateBlock(state, Params().GetConsensus(), pblockindex);
-    }
+    if (mapBlockIndex.count(hash) == 0)
+        throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+
+    CBlockIndex *pblockindex = mapBlockIndex[hash];
+    InvalidateBlock(state, Params().GetConsensus(), pblockindex);
 
     if (state.IsValid())
     {

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -1,0 +1,1032 @@
+// Copyright (c) 2018 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+//#include "chainparams.h"
+#include "blockstorage/blockstorage.h"
+#include "dosman.h"
+#include "init.h"
+#include "fastfilter.h"
+#include "net.h"
+#include "timedata.h"
+#include "txadmission.h"
+#include "txorphanpool.h"
+#include "consensus/tx_verify.h"
+#include "connmgr.h"
+#include "main.h" // for cs_main
+#include "respend/respenddetector.h"
+#include "unlimited.h"
+#include "util.h"
+#include "utiltime.h"
+#include "validationinterface.h"
+#include <map>
+#include <string>
+#include <vector>
+
+#include <boost/thread/thread.hpp>
+
+using namespace std;
+
+
+Snapshot txHandlerSnap;
+
+void ThreadCommitToMempool();
+void ThreadTxAdmission();
+void ProcessOrphans(std::vector<uint256> &vWorkQueue);
+
+bool CheckFinalTx(const CTransaction &tx, int flags, const Snapshot &ss);
+bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints *lp, bool useExistingLockPoints, const Snapshot &ss);
+
+
+void StartTxAdmission(boost::thread_group &threadGroup)
+{
+    txHandlerSnap.Load(); // Get an initial view for the transaction processors
+
+    // Start incoming transaction processing threads
+    for (unsigned int i = 0; i < numTxAdmissionThreads.Value(); i++)
+    {
+        threadGroup.create_thread(boost::bind(&TraceThreads<void (*)()>, strprintf("tx%d", i), &ThreadTxAdmission));
+    }
+
+    // Start tx commitment thread
+    threadGroup.create_thread(boost::bind(&TraceThread<void (*)()>, "txcommit", &ThreadCommitToMempool));
+}
+
+void StopTxAdmission()
+{
+    cvTxInQ.notify_all();
+    cvCommitQ.notify_all();
+}
+
+void FlushTxAdmission()
+{
+    bool empty = false;
+
+    while (!empty)
+    {
+        do // give the tx processing threads a chance to run
+        {
+            {
+                LOCK(csTxInQ);
+                empty = txInQ.empty() & txDeferQ.empty();
+            }
+            if (!empty)
+                MilliSleep(100);
+        } while (!empty);
+
+        {
+            boost::unique_lock<boost::mutex> lock(csCommitQ);
+            do // wait for the commit thread to commit everything
+            {
+                cvCommitQ.timed_wait(lock, boost::posix_time::milliseconds(100));
+            } while (!txCommitQ.empty());
+        }
+
+        {  // block everything and check
+            CORRAL(txProcessingCorral, CORRAL_TX_PAUSE);
+            {
+                LOCK(csTxInQ);
+                empty = txInQ.empty() & txDeferQ.empty();
+            }
+            {
+                boost::unique_lock<boost::mutex> lock(csCommitQ);
+                empty &= txCommitQ.empty();
+            }
+        }
+    }
+}
+
+// Put the tx on the tx admission queue for processing
+void EnqueueTxForAdmission(CTxInputData &txd)
+{
+    LOCK(csTxInQ);
+    bool conflict = false;
+    for (auto inp : txd.tx->vin)
+    {
+        uint256 hash = inp.prevout.hash;
+        unsigned char* first = hash.begin();
+        *first ^= (unsigned char)(inp.prevout.n & 255);
+        if (!incomingConflicts.checkAndSet(hash))
+        {
+            conflict = true;
+            break;
+        }
+    }
+    if (!conflict)
+    {
+        //LOG(MEMPOOL, "Enqueue for processing %x\n", txd.tx->GetHash().ToString());
+        txInQ.push(txd); // add this transaction onto the processing queue
+        cvTxInQ.notify_one();
+    }
+    else
+    {
+        //LOG(MEMPOOL, "Deferred %x\n", txd.tx->GetHash().ToString());
+        txDeferQ.push(txd);
+    }
+}
+
+
+unsigned int TxAlreadyHave(const CInv &inv)
+{
+    switch (inv.type)
+    {
+    case MSG_TX:
+    {
+        if (txRecentlyInBlock.contains(inv.hash))
+            return 1;
+        if (recentRejects.contains(inv.hash))
+            return 2;
+        if (mempool.exists(inv.hash))
+            return 3;
+        if (orphanpool.AlreadyHaveOrphan(inv.hash))
+            return 4;
+        return false;
+    }
+    }
+    DbgAssert(0, return false); // this fn should only be called if CInv is a tx
+}
+
+void ThreadCommitToMempool()
+{
+    while (!ShutdownRequested())
+    {
+        {
+            boost::unique_lock<boost::mutex> lock(csCommitQ);
+            do
+            {
+                cvCommitQ.timed_wait(lock, boost::posix_time::milliseconds(2000));
+            } while (txCommitQ.empty() && txDeferQ.empty());
+        }
+
+        {
+            boost::this_thread::interruption_point();
+
+            CORRAL(txProcessingCorral, CORRAL_TX_COMMITMENT);
+            LOCK(cs_main);
+            CommitTxToMempool();
+            mempool.check(pcoinsTip);
+            LOG(MEMPOOL, "MemoryPool sz %u txn, %u kB\n", mempool.size(), mempool.DynamicMemoryUsage() / 1000);
+            // BU - Xtreme Thinblocks - trim the orphan pool by entry time and do not allow it to be overidden.
+            LimitMempoolSize(mempool, GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000,
+                GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60);
+
+            // BU: update tx per second when a tx is valid and accepted
+            mempool.UpdateTransactionsPerSecond();
+            CValidationState state;
+            FlushStateToDisk(state, FLUSH_STATE_PERIODIC);
+            // The flush to disk above is only periodic therefore we need to continuously trim any excess from the
+            // cache.
+            pcoinsTip->Trim(nCoinCacheMaxSize);
+
+            // move the previously deferred txs into active processing
+            std::queue<CTxInputData> wasDeferred;
+            {
+                LOCK(csTxInQ);
+                // this could be a lot more efficient
+                while (!txDeferQ.empty())
+                {
+                    wasDeferred.push(txDeferQ.front());
+                    txDeferQ.pop();
+                }
+            }
+            if (!wasDeferred.empty())
+                LOG(MEMPOOL, "%d tx were deferred\n", wasDeferred.size());
+
+            while (!wasDeferred.empty())
+            {
+                // LOG(MEMPOOL, "attempt enqueue deferred %s\n", wasDeferred.front().tx->GetHash().ToString());
+                EnqueueTxForAdmission(wasDeferred.front());
+                wasDeferred.pop();
+            }
+        }
+    }
+}
+
+void LimitMempoolSize(CTxMemPool &pool, size_t limit, unsigned long age)
+{
+    std::vector<COutPoint> vCoinsToUncache;
+    int expired = pool.Expire(GetTime() - age, vCoinsToUncache);
+    for (const COutPoint &txin : vCoinsToUncache)
+        pcoinsTip->Uncache(txin);
+    if (expired != 0)
+        LOG(MEMPOOL, "Expired %i transactions from the memory pool\n", expired);
+
+    std::vector<COutPoint> vNoSpendsRemaining;
+    pool.TrimToSize(limit, &vNoSpendsRemaining);
+    for (const COutPoint &removed : vNoSpendsRemaining)
+        pcoinsTip->Uncache(removed);
+}
+
+void CommitTxToMempool()
+{
+    std::vector<uint256> whatChanged;
+    LOCK(cs_main); // cs_main must lock before csCommitQ
+    {
+        boost::unique_lock<boost::mutex> lock(csCommitQ);
+        for (auto &it : txCommitQ)
+        {
+            CTxCommitData &data = it.second;
+            // Store transaction in memory
+            mempool.addUnchecked(it.first, data.entry, !IsInitialBlockDownload());
+#ifdef ENABLE_WALLET
+            SyncWithWallets(data.entry.GetSharedTx(), nullptr, -1);
+#endif
+            whatChanged.push_back(data.hash);
+        }
+        txCommitQ.clear();
+    }
+
+    {
+    LOCK(csTxInQ);
+    // Clear the filter of incoming conflicts, and put all queued tx on the deferred queue since they've been deferred
+    incomingConflicts.reset();
+    while(!txInQ.empty())
+    {
+        txDeferQ.push(txInQ.front());
+        txInQ.pop();
+    }
+    LOG(MEMPOOL, "Reset incoming filter\n");
+    }
+    ProcessOrphans(whatChanged);
+}
+
+
+void ThreadTxAdmission()
+{
+    while (!ShutdownRequested())
+    {
+        boost::this_thread::interruption_point();
+
+        bool fMissingInputs = false;
+        CValidationState state;
+        // Snapshot ss;
+        CTxInputData txd;
+
+        {
+            CCriticalBlock lock(csTxInQ, "csTxInQ", __FILE__, __LINE__);
+            while (txInQ.empty() && !ShutdownRequested())
+            {
+                cvTxInQ.wait(csTxInQ);
+                boost::this_thread::interruption_point();
+            }
+            if (ShutdownRequested())
+                break;
+        }
+
+        {
+            CORRAL(txProcessingCorral, CORRAL_TX_PROCESSING);
+
+            {   // tx must be popped within the TX_PROCESSING corral or the state break between processing
+                // and commitment will not be clean
+                CCriticalBlock lock(csTxInQ, "csTxInQ", __FILE__, __LINE__);
+                if (txInQ.empty()) continue;  // abort back into wait loop if another thread got my tx
+                txd = txInQ.front(); // make copy so I can pop & release
+                txInQ.pop();
+            }
+
+            CTransactionRef &tx = txd.tx;
+            CInv inv(MSG_TX, tx->GetHash());
+
+            std::vector<COutPoint> vCoinsToUncache;
+            {
+                // Check for recently rejected (and do other quick existence checks)
+                bool have = TxAlreadyHave(inv);
+                if (have)
+                {
+                    recentRejects.insert(tx->GetHash());
+
+                    if (txd.whitelisted && GetBoolArg("-whitelistforcerelay", DEFAULT_WHITELISTFORCERELAY))
+                    {
+                        // Always relay transactions received from whitelisted peers, even
+                        // if they were already in the mempool or rejected from it due
+                        // to policy, allowing the node to function as a gateway for
+                        // nodes hidden behind it.
+                        //
+                        // Never relay transactions that we would assign a non-zero DoS
+                        // score for, as we expect peers to do the same with us in that
+                        // case.
+                        int nDoS = 0;
+                        if (!state.IsInvalid(nDoS) || nDoS == 0)
+                        {
+                            LOGA("Force relaying tx %s from whitelisted peer=%s\n", tx->GetHash().ToString(),
+                                txd.nodeName);
+                            RelayTransaction(tx);
+                        }
+                        else
+                        {
+                            LOGA("Not relaying invalid transaction %s from whitelisted peer=%d (%s)\n",
+                                tx->GetHash().ToString(), txd.nodeName, FormatStateMessage(state));
+                        }
+                    }
+                    continue;
+                }
+            }
+
+            bool isRespend = false;
+            if (ParallelAcceptToMemoryPool(
+                    txHandlerSnap, mempool, state, tx, true, &fMissingInputs, false, false, TransactionClass::DEFAULT, vCoinsToUncache, &isRespend))
+            {
+                RelayTransaction(tx);
+
+                //LOG(MEMPOOL, "AcceptToMemoryPool: peer=%s: accepted %s onto Q\n", txd.nodeName,
+                //    tx->GetHash().ToString());
+            }
+            else
+            {
+                if (fMissingInputs)
+                {
+                    // If we've forked and this is probably not a valid tx, then skip adding it to the orphan pool
+                    if (!chainActive.Tip()->IsforkActiveOnNextBlock(miningForkTime.Value()) || IsTxProbablyNewSigHash(*tx))
+                    {
+                        LOCK(orphanpool.cs);  // WRITELOCK
+                        orphanpool.AddOrphanTx(tx, txd.nodeId);
+
+                        // DoS prevention: do not allow mapOrphanTransactions to grow unbounded
+                        static unsigned int nMaxOrphanTx =
+                            (unsigned int)std::max((int64_t)0, GetArg("-maxorphantx", DEFAULT_MAX_ORPHAN_TRANSACTIONS));
+                        static uint64_t nMaxOrphanPoolSize = (uint64_t)std::max(
+                            (int64_t)0, (GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000 / 10));
+                        unsigned int nEvicted = orphanpool.LimitOrphanTxSize(nMaxOrphanTx, nMaxOrphanPoolSize);
+                        if (nEvicted > 0)
+                            LOG(MEMPOOL, "mapOrphan overflow, removed %u tx\n", nEvicted);
+                    }
+                    else
+                    {
+                        LOG(MEMPOOL, "rejected orphan as likely contains old sighash");
+                    }
+                }
+                else  // If the problem wasn't that the tx is an orphan, then uncache the inputs since we likely won't
+                      // need them again.
+                {
+                    for (const COutPoint &remove : vCoinsToUncache)
+                        pcoinsTip->Uncache(remove);
+                }
+            }
+            int nDoS = 0;
+            if (state.IsInvalid(nDoS))
+            {
+                LOG(MEMPOOL, "%s from peer=%s was not accepted: %s\n", tx->GetHash().ToString(), txd.nodeName,
+                    FormatStateMessage(state));
+                if (state.GetRejectCode() < REJECT_INTERNAL) // Never send AcceptToMemoryPool's internal codes over P2P
+                {
+                    CNodeRef from = connmgr->FindNodeFromId(txd.nodeId);
+                    if (from)
+                    {
+                        std::string strCommand = NetMsgType::TX;
+                        from->PushMessage(NetMsgType::REJECT, strCommand, (unsigned char)state.GetRejectCode(),
+                                          state.GetRejectReason().substr(0, MAX_REJECT_MESSAGE_LENGTH), inv.hash);
+                        if (nDoS > 0)
+                        {
+                            dosMan.Misbehaving(from.get(), nDoS);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+bool AcceptToMemoryPool(CTxMemPool &pool,
+    CValidationState &state,
+    const CTransactionRef &tx,
+    bool fLimitFree,
+    bool *pfMissingInputs,
+    bool fOverrideMempoolLimit,
+    bool fRejectAbsurdFee,
+                        TransactionClass allowedTx)
+                        {
+    std::vector<COutPoint> vCoinsToUncache;
+
+    bool res = false;
+
+    CORRAL(txProcessingCorral, CORRAL_TX_PAUSE);
+    CommitTxToMempool();
+
+    bool isRespend = false;
+    bool missingInputs = false;
+    res = ParallelAcceptToMemoryPool(
+        txHandlerSnap, pool, state, tx, fLimitFree, &missingInputs, fOverrideMempoolLimit, fRejectAbsurdFee, allowedTx, vCoinsToUncache, &isRespend);
+    if (res)
+    {
+        RelayTransaction(tx);
+    }
+
+    // Uncache any coins for txns that failed to enter the mempool but were NOT orphan txns
+    if (isRespend || (!res && !missingInputs))
+    {
+        for (const COutPoint &remove : vCoinsToUncache)
+            pcoinsTip->Uncache(remove);
+    }
+
+    if (pfMissingInputs) *pfMissingInputs = missingInputs;
+
+    if (res)
+    {
+        CommitTxToMempool();
+        LimitMempoolSize(mempool, GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000,
+            GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60);
+    }
+    return res;
+}
+
+bool ParallelAcceptToMemoryPool(Snapshot &ss,
+    CTxMemPool &pool,
+    CValidationState &state,
+    const CTransactionRef &tx,
+    bool fLimitFree,
+    bool *pfMissingInputs,
+    bool fOverrideMempoolLimit,
+    bool fRejectAbsurdFee,
+    TransactionClass allowedTx,
+    std::vector<COutPoint> &vCoinsToUncache,
+    bool *isRespend)
+{
+    if (isRespend)
+        *isRespend = false;
+    unsigned int nSigOps = 0;
+    ValidationResourceTracker resourceTracker;
+    unsigned int nSize = 0;
+    uint64_t start = GetStopwatch();
+    if (pfMissingInputs)
+        *pfMissingInputs = false;
+
+    // After the May, 15 hard fork, we start accepting larger op_return.
+    const CChainParams &chainparams = Params();
+    const bool hasMay152018 = IsMay152018Enabled(chainparams.GetConsensus(), chainActive.Tip());
+
+    //LOG(MEMPOOL, "Mempool: Considering Tx %s\n", tx->GetHash().ToString());
+
+    if (!CheckTransaction(*tx, state))
+        return false;
+
+    // Coinbase is only valid in a block, not as a loose transaction
+    if (tx->IsCoinBase())
+        return state.DoS(100, false, REJECT_INVALID, "coinbase");
+
+    // Reject nonstandard transactions if so configured.
+    // (-testnet/-regtest allow nonstandard, and explicit submission via RPC)
+    std::string reason;
+    bool fRequireStandard = chainparams.RequireStandard();
+
+    if (allowedTx == TransactionClass::STANDARD)
+        fRequireStandard = true;
+    else if (allowedTx == TransactionClass::NONSTANDARD)
+        fRequireStandard = false;
+    if (fRequireStandard && !IsStandardTx(*tx, reason))
+        return state.DoS(0, false, REJECT_NONSTANDARD, reason);
+
+    // Don't relay version 2 transactions until CSV is active, and we can be
+    // sure that such transactions will be mined (unless we're on
+    // -testnet/-regtest).
+    if (fRequireStandard && tx->nVersion >= 2 &&
+        VersionBitsTipState(chainparams.GetConsensus(), Consensus::DEPLOYMENT_CSV) != THRESHOLD_ACTIVE)
+    {
+        return state.DoS(0, false, REJECT_NONSTANDARD, "premature-version2-tx");
+    }
+
+    // Only accept nLockTime-using transactions that can be mined in the next
+    // block; we don't want our mempool filled up with transactions that can't
+    // be mined yet.
+    if (!CheckFinalTx(*tx, STANDARD_LOCKTIME_VERIFY_FLAGS))
+        return state.DoS(0, false, REJECT_NONSTANDARD, "non-final");
+
+    // is it already in the memory pool?
+    uint256 hash = tx->GetHash();
+    if (pool.exists(hash))
+        return state.Invalid(false, REJECT_ALREADY_KNOWN, "txn-already-in-mempool");
+
+    // Check for conflicts with in-memory transactions and triggers actions at
+    // end of scope (relay tx, sync wallet, etc)
+    respend::RespendDetector respend(pool, tx);
+    *isRespend = respend.IsRespend();
+
+    if (respend.IsRespend() && !respend.IsInteresting())
+    {
+        // Tx is a respend, and it's not an interesting one (we don't care to
+        // validate it further)
+        return state.Invalid(false, REJECT_CONFLICT, "txn-mempool-conflict");
+    }
+    {
+        CCoinsView dummy;
+        CCoinsViewCache view(&dummy);
+
+        CAmount nValueIn = 0;
+        LockPoints lp;
+        {
+            READLOCK(pool.cs);
+            CCoinsViewMemPool &viewMemPool(*ss.cvMempool);
+            view.SetBackend(viewMemPool);
+
+            // do all inputs exist?
+            if (pfMissingInputs)
+            {
+                *pfMissingInputs = false;
+                for (const CTxIn &txin : tx->vin)
+                {
+                    // At this point we begin to collect coins that are potential candidates for uncaching because as
+                    // soon as we make the call below to view.HaveCoin() any missing coins will be pulled into cache.
+                    // Therefore, any coin in this transaction that is not already in cache will be tracked here such
+                    // that if this transaction fails to enter the memory pool, we will then uncache those coins that
+                    // were not already present, unless the transaction is an orphan.
+                    //
+                    // We still want to keep orphantx coins in the event the orphantx is finally accepted into the
+                    // mempool or shows up in a block that is mined.  Therefore if pfMissingInputs returns true then
+                    // any coins in vCoinsToUncache will NOT be uncached.
+                    if (!ss.coins->HaveCoinInCache(txin.prevout))
+                    {
+                        vCoinsToUncache.push_back(txin.prevout);
+                    }
+
+                    if (!view.HaveCoin(txin.prevout))
+                    {
+                        // fMissingInputs and not state.IsInvalid() is used to detect this condition, don't set
+                        // state.Invalid()
+                        *pfMissingInputs = true;
+                        break;  // There is no point checking any more once one fails, for orphans we will recheck
+                    }
+                }
+                if (*pfMissingInputs == true)
+                {
+                    return false; // state.Invalid(false, REJECT_MISSING_INPUTS, "bad-txns-missing-inputs", "Inputs
+                                  // unavailable in ParallelAcceptToMemoryPool", false);
+                }
+            }
+
+            // Bring the best block into scope
+            view.GetBestBlock();
+
+            nValueIn = view.GetValueIn(*tx);
+
+            // we have all inputs cached now, so switch back to dummy, so we don't need to keep lock on mempool
+            view.SetBackend(dummy);
+
+            // Only accept BIP68 sequence locked transactions that can be mined in the next
+            // block; we don't want our mempool filled up with transactions that can't
+            // be mined yet.
+            // Must keep pool.cs for this unless we change CheckSequenceLocks to take a
+            // CoinsViewCache instead of create its own
+            if (!CheckSequenceLocks(*tx, STANDARD_LOCKTIME_VERIFY_FLAGS, &lp, false, ss))
+                return state.DoS(0, false, REJECT_NONSTANDARD, "non-BIP68-final");
+        }
+
+        // Check for non-standard pay-to-script-hash in inputs
+        if (fRequireStandard && !AreInputsStandard(*tx, view))
+            return state.Invalid(false, REJECT_NONSTANDARD, "bad-txns-nonstandard-inputs");
+
+        nSigOps = GetLegacySigOpCount(*tx);
+        nSigOps += GetP2SHSigOpCount(*tx, view);
+
+        CAmount nValueOut = tx->GetValueOut();
+        CAmount nFees = nValueIn - nValueOut;
+        // nModifiedFees includes any fee deltas from PrioritiseTransaction
+        CAmount nModifiedFees = nFees;
+        double nPriorityDummy = 0;
+        pool.ApplyDeltas(hash, nPriorityDummy, nModifiedFees);
+
+        CAmount inChainInputValue;
+        double dPriority = view.GetPriority(*tx, chainActive.Height(), inChainInputValue);
+
+        // Keep track of transactions that spend a coinbase, which we re-scan
+        // during reorgs to ensure COINBASE_MATURITY is still met.
+        bool fSpendsCoinbase = false;
+        for (const CTxIn &txin : tx->vin)
+        {
+            CoinAccessor coin(view, txin.prevout);
+            if (coin->IsCoinBase())
+            {
+                fSpendsCoinbase = true;
+                break;
+            }
+        }
+
+        CTxCommitData eData; // TODO awkward construction in these 4 lines
+        CTxMemPoolEntry entryTemp(tx, nFees, GetTime(), dPriority, chainActive.Height(), pool.HasNoInputsOf(*tx),
+            inChainInputValue, fSpendsCoinbase, nSigOps, lp);
+        eData.entry = entryTemp;
+        CTxMemPoolEntry &entry(eData.entry);
+        nSize = entry.GetTxSize();
+
+        // Check that the transaction doesn't have an excessive number of
+        // sigops, making it impossible to mine.
+        if (nSigOps > MAX_TX_SIGOPS)
+            return state.DoS(0, false, REJECT_NONSTANDARD, "bad-txns-too-many-sigops", false, strprintf("%d", nSigOps));
+
+        CAmount mempoolRejectFee =
+            pool.GetMinFee(GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000).GetFee(nSize);
+        if (mempoolRejectFee > 0 && nModifiedFees < mempoolRejectFee)
+        {
+            return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "mempool min fee not met", false,
+                strprintf("%d < %d", nFees, mempoolRejectFee));
+        }
+        else if (GetBoolArg("-relaypriority", DEFAULT_RELAYPRIORITY) && nModifiedFees < ::minRelayTxFee.GetFee(nSize) &&
+                 !AllowFree(entry.GetPriority(chainActive.Height() + 1)))
+        {
+            // Require that free transactions have sufficient priority to be mined in the next block.
+            LOG(MEMPOOL, "Txn fee %lld (%d - %d), priority fee delta was %lld\n", nFees, nValueIn, nValueOut,
+                nModifiedFees - nFees);
+            return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "insufficient priority");
+        }
+
+        // BU - Xtreme Thinblocks Auto Mempool Limiter - begin section
+        /* Continuously rate-limit free (really, very-low-fee) transactions
+         * This mitigates 'penny-flooding' -- sending thousands of free transactions just to
+         * be annoying or make others' transactions take longer to confirm. */
+        // maximum nMinRelay in satoshi per byte
+        static const int nLimitFreeRelay = GetArg("-limitfreerelay", DEFAULT_LIMITFREERELAY);
+
+        // get current memory pool size
+        uint64_t poolBytes = pool.GetTotalTxSize();
+
+        // Calculate nMinRelay in satoshis per byte:
+        //   When the nMinRelay is larger than the satoshiPerByte of the
+        //   current transaction then spam blocking will be in effect. However
+        //   Some free transactions will still get through based on -limitfreerelay
+        static double nMinRelay = dMinLimiterTxFee.Value();
+        static double nFreeLimit = nLimitFreeRelay;
+        static int64_t nLastTime = GetTime();
+        int64_t nNow = GetTime();
+
+        static double _dMinLimiterTxFee = dMinLimiterTxFee.Value();
+        static double _dMaxLimiterTxFee = dMaxLimiterTxFee.Value();
+
+        static CCriticalSection cs_limiter;
+        {
+            LOCK(cs_limiter);
+
+            // If the tweak values have changed then use them.
+            if (dMinLimiterTxFee.Value() != _dMinLimiterTxFee)
+            {
+                _dMinLimiterTxFee = dMinLimiterTxFee.Value();
+                nMinRelay = _dMinLimiterTxFee;
+            }
+            if (dMaxLimiterTxFee.Value() != _dMaxLimiterTxFee)
+            {
+                _dMaxLimiterTxFee = dMaxLimiterTxFee.Value();
+            }
+
+            // Limit check. Make sure minlimterfee is not > maxlimiterfee
+            if (_dMinLimiterTxFee > _dMaxLimiterTxFee)
+            {
+                dMaxLimiterTxFee.Set(dMinLimiterTxFee.Value());
+                _dMaxLimiterTxFee = _dMinLimiterTxFee;
+            }
+
+            // When the mempool starts falling use an exponentially decaying ~24 hour window:
+            // nFreeLimit = nFreeLimit + ((double)(DEFAULT_LIMIT_FREE_RELAY - nFreeLimit) / pow(1.0 - 1.0/86400,
+            // (double)(nNow - nLastTime)));
+            nFreeLimit /= std::pow(1.0 - 1.0 / 86400, (double)(nNow - nLastTime));
+
+            // When the mempool starts falling use an exponentially decaying ~24 hour window:
+            nMinRelay *= std::pow(1.0 - 1.0 / 86400, (double)(nNow - nLastTime));
+
+            uint64_t nLargestBlockSeen = LargestBlockSeen();
+
+            if (poolBytes < nLargestBlockSeen)
+            {
+                nMinRelay = std::max(nMinRelay, _dMinLimiterTxFee);
+                nFreeLimit = std::min(nFreeLimit, (double)nLimitFreeRelay);
+            }
+            else if (poolBytes < (nLargestBlockSeen * MAX_BLOCK_SIZE_MULTIPLIER))
+            {
+                // Gradually choke off what is considered a free transaction
+                nMinRelay = std::max(nMinRelay,
+                    _dMinLimiterTxFee + ((_dMaxLimiterTxFee - _dMinLimiterTxFee) * (poolBytes - nLargestBlockSeen) /
+                                            (nLargestBlockSeen * (MAX_BLOCK_SIZE_MULTIPLIER - 1))));
+
+                // Gradually choke off the nFreeLimit as well but leave at least DEFAULT_MIN_LIMITFREERELAY
+                // So that some free transactions can still get through
+                nFreeLimit = std::min(
+                    nFreeLimit, ((double)nLimitFreeRelay - ((double)(nLimitFreeRelay - DEFAULT_MIN_LIMITFREERELAY) *
+                                                               (double)(poolBytes - nLargestBlockSeen) /
+                                                               (nLargestBlockSeen * (MAX_BLOCK_SIZE_MULTIPLIER - 1)))));
+                if (nFreeLimit < DEFAULT_MIN_LIMITFREERELAY)
+                    nFreeLimit = DEFAULT_MIN_LIMITFREERELAY;
+            }
+            else
+            {
+                nMinRelay = _dMaxLimiterTxFee;
+                nFreeLimit = DEFAULT_MIN_LIMITFREERELAY;
+            }
+
+            minRelayTxFee = CFeeRate(nMinRelay * 1000);
+            LOG(MEMPOOL, "MempoolBytes:%d  LimitFreeRelay:%.5g  nMinRelay:%.4g  FeesSatoshiPerByte:%.4g  TxBytes:%d  "
+                         "TxFees:%d\n",
+                poolBytes, nFreeLimit, nMinRelay, ((double)nFees) / nSize, nSize, nFees);
+            if (fLimitFree && nFees < ::minRelayTxFee.GetFee(nSize))
+            {
+                static double dFreeCount = 0;
+
+                // Use an exponentially decaying ~10-minute window:
+                dFreeCount *= std::pow(1.0 - 1.0 / 600.0, (double)(nNow - nLastTime));
+
+                // -limitfreerelay unit is thousand-bytes-per-minute
+                // At default rate it would take over a month to fill 1GB
+                LOG(MEMPOOL, "Rate limit dFreeCount: %g => %g\n", dFreeCount, dFreeCount + nSize);
+                if ((dFreeCount + nSize) >=
+                    (nFreeLimit * 10 * 1000 * nLargestBlockSeen / BLOCKSTREAM_CORE_MAX_BLOCK_SIZE))
+                {
+                    thindata.UpdateMempoolLimiterBytesSaved(nSize);
+                    LOG(MEMPOOL, "AcceptToMemoryPool : free transaction %s rejected by rate limiter\n",
+                        hash.ToString());
+                    return state.DoS(0, false, REJECT_INSUFFICIENTFEE, "rate limited free transaction");
+                }
+                dFreeCount += nSize;
+            }
+            nLastTime = nNow;
+        }
+        // BU - Xtreme Thinblocks Auto Mempool Limiter - end section
+
+        // BU: we calculate the recommended fee by looking at what's in the mempool.  This starts at 0 though for an
+        // empty mempool.  So set the minimum "absurd" fee to 10000 satoshies per byte.  If for some reason fees rise
+        // above that, you can specify up to 100x what other txns are paying in the mempool
+        if (fRejectAbsurdFee && nFees > std::max((int64_t)100L * nSize, maxTxFee.Value()) * 100)
+            return state.Invalid(false, REJECT_HIGHFEE, "absurdly-high-fee",
+                strprintf("%d > %d", nFees, std::max((int64_t)1L, maxTxFee.Value()) * 10000));
+
+        eData.hash = hash;
+        // Calculate in-mempool ancestors, up to a limit.
+        size_t nLimitAncestors = GetArg("-limitancestorcount", DEFAULT_ANCESTOR_LIMIT);
+        size_t nLimitAncestorSize = GetArg("-limitancestorsize", DEFAULT_ANCESTOR_SIZE_LIMIT) * 1000;
+        size_t nLimitDescendants = GetArg("-limitdescendantcount", DEFAULT_DESCENDANT_LIMIT);
+        size_t nLimitDescendantSize = GetArg("-limitdescendantsize", DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000;
+        std::string errString;
+
+        // Set extraFlags as a set of flags that needs to be activated.
+        uint32_t extraFlags = 0;
+        if (hasMay152018)
+        {
+            extraFlags |= SCRIPT_ENABLE_MAY152018_OPCODES;
+        }
+
+        // Check against previous transactions
+        // This is done last to help prevent CPU exhaustion denial-of-service attacks.
+        unsigned char sighashType = 0;
+        if (!CheckInputs(*tx, state, view, true, STANDARD_SCRIPT_VERIFY_FLAGS | extraFlags, true, &resourceTracker,
+                nullptr, &sighashType))
+        {
+            LOG(MEMPOOL, "CheckInputs failed for tx: %s\n", tx->GetHash().ToString().c_str());
+            return false;
+        }
+        entry.UpdateRuntimeSigOps(resourceTracker.GetSigOps(), resourceTracker.GetSighashBytes());
+
+        // Check again against just the consensus-critical mandatory script
+        // verification flags, in case of bugs in the standard flags that cause
+        // transactions to pass as valid when they're actually invalid. For
+        // instance the STRICTENC flag was incorrectly allowing certain
+        // CHECKSIG NOT scripts to pass, even though they were invalid.
+        //
+        // There is a similar check in CreateNewBlock() to prevent creating
+        // invalid blocks, however allowing such transactions into the mempool
+        // can be exploited as a DoS attack.
+        unsigned char sighashType2 = 0;
+        if (!CheckInputs(*tx, state, view, true, MANDATORY_SCRIPT_VERIFY_FLAGS | extraFlags, true, nullptr, nullptr,
+                &sighashType2))
+        {
+            return error(
+                "%s: BUG! PLEASE REPORT THIS! ConnectInputs failed against MANDATORY but not STANDARD flags %s, %s",
+                __func__, hash.ToString(), FormatStateMessage(state));
+        }
+
+        entry.sighashType = sighashType | sighashType2;
+
+        // This code denies old style tx from entering the mempool as soon as we fork
+        if (IsUAHFforkActiveOnNextBlock(chainActive.Tip()->nHeight) && !IsTxUAHFOnly(entry))
+        {
+            return state.Invalid(false, REJECT_WRONG_FORK, "txn-uses-old-sighash-algorithm");
+        }
+
+        respend.SetValid(true);
+        if (respend.IsRespend())
+        {
+            return state.Invalid(false, REJECT_CONFLICT, "txn-mempool-conflict");
+        }
+
+        {
+            READLOCK(pool.cs);
+            CTxMemPool::setEntries setAncestors;
+            // note we could resolve ancestors to hashes and return those if that saves time in the txc thread
+            if (!pool._CalculateMemPoolAncestors(entry, setAncestors, nLimitAncestors, nLimitAncestorSize,
+                    nLimitDescendants, nLimitDescendantSize, errString))
+            {
+                return state.DoS(0, false, REJECT_NONSTANDARD, "too-long-mempool-chain", false, errString);
+            }
+        }
+
+        {
+            boost::unique_lock<boost::mutex> lock(csCommitQ);
+            txCommitQ[eData.hash] = eData;
+        }
+    }
+    uint64_t interval = (GetStopwatch() - start) / 1000;
+    // typically too much logging, but useful when optimizing tx validation
+    LOG(BENCH, "ValidateTransaction, time: %d, tx: %s, len: %d, sigops: %llu (legacy: %u), sighash: %llu, Vin: "
+               "%llu, Vout: %llu\n",
+        interval, tx->GetHash().ToString(), nSize, resourceTracker.GetSigOps(), (unsigned int)nSigOps,
+        resourceTracker.GetSighashBytes(), tx->vin.size(), tx->vout.size());
+    nTxValidationTime << interval;
+
+    return true;
+}
+
+
+TransactionClass ParseTransactionClass(const std::string &s)
+{
+    std::string low = boost::algorithm::to_lower_copy(s);
+    if (low == "nonstandard")
+    {
+        return TransactionClass::NONSTANDARD;
+    }
+    if (low == "standard")
+    {
+        return TransactionClass::STANDARD;
+    }
+    if (low == "default")
+    {
+        return TransactionClass::DEFAULT;
+    }
+
+    return TransactionClass::INVALID;
+}
+
+
+void ProcessOrphans(std::vector<uint256> &vWorkQueue)
+{
+    std::vector<uint256> vEraseQueue;
+
+    // Recursively process any orphan transactions that depended on this one
+    {
+        LOCK(orphanpool.cs);  // TODO READLOCK()
+        std::set<NodeId> setMisbehaving;
+        for (unsigned int i = 0; i < vWorkQueue.size(); i++)
+        {
+            std::map<uint256, std::set<uint256> >::iterator itByPrev = orphanpool.mapOrphanTransactionsByPrev.find(vWorkQueue[i]);
+            if (itByPrev == orphanpool.mapOrphanTransactionsByPrev.end())
+                continue;
+            for (std::set<uint256>::iterator mi = itByPrev->second.begin(); mi != itByPrev->second.end(); ++mi)
+            {
+                const uint256 &orphanHash = *mi;
+
+                // Make sure we actually have an entry on the orphan cache. While this should never fail because
+                // we always erase orphans and any mapOrphanTransactionsByPrev at the same time, still we need to
+                // be sure.
+                bool fOk = true;
+                DbgAssert(orphanpool.mapOrphanTransactions.count(orphanHash), fOk = false);
+                if (!fOk)
+                    continue;
+
+                const CTransactionRef &orphanTx = orphanpool.mapOrphanTransactions[orphanHash].ptx;
+                NodeId fromPeer = orphanpool.mapOrphanTransactions[orphanHash].fromPeer;
+                // Use a dummy CValidationState so someone can't setup nodes to counter-DoS based on orphan
+                // resolution (that is, feeding people an invalid transaction based on LegitTxX in order to get
+                // anyone relaying LegitTxX banned)
+                CValidationState stateDummy;
+
+                if (setMisbehaving.count(fromPeer))
+                    continue;
+                {
+                    CTxInputData txd;
+                    txd.tx = orphanTx;
+                    txd.nodeId = fromPeer;
+                    txd.nodeName = "orphan";
+                    txd.whitelisted = false;
+                    LOG(MEMPOOL, "Resubmitting orphan tx: %s\n", orphanTx->GetHash().ToString().c_str());
+                    EnqueueTxForAdmission(txd);
+                }
+                vEraseQueue.push_back(orphanHash);
+            }
+        }
+    }
+
+    {
+        LOCK(orphanpool.cs);  // TODO WRITELOCK
+        for (auto hash: vEraseQueue)
+            orphanpool.EraseOrphanTx(hash);
+        //  BU: Xtreme thinblocks - purge orphans that are too old
+        orphanpool.EraseOrphansByTime();
+    }
+}
+
+
+void Snapshot::Load(void)
+{
+    LOCK(cs);
+    tipHeight = chainActive.Height();
+    tip = chainActive.Tip();
+    tipMedianTimePast = tip->GetMedianTimePast();
+    adjustedTime = GetAdjustedTime();
+    coins = pcoinsTip; // TODO pcoinsTip can change
+    if (cvMempool)
+        delete cvMempool;
+
+    READLOCK(mempool.cs);
+    // ss.coins contains the UTXO set for the tip in ss
+    cvMempool = new CCoinsViewMemPool(coins, mempool);
+}
+
+bool CheckSequenceLocks(const CTransaction &tx, int flags, LockPoints *lp, bool useExistingLockPoints, const Snapshot &ss)
+{
+    AssertLockHeld(mempool.cs);
+
+    CBlockIndex *tip = ss.tip;
+    CBlockIndex index;
+    index.pprev = tip;
+    // CheckSequenceLocks() uses chainActive.Height()+1 to evaluate
+    // height based locks because when SequenceLocks() is called within
+    // ConnectBlock(), the height of the block *being*
+    // evaluated is what is used.
+    // Thus if we want to know if a transaction can be part of the
+    // *next* block, we need to use one more than chainActive.Height()
+    index.nHeight = tip->nHeight + 1;
+
+    std::pair<int, int64_t> lockPair;
+    if (useExistingLockPoints)
+    {
+        assert(lp);
+        lockPair.first = lp->height;
+        lockPair.second = lp->time;
+    }
+    else
+    {
+        // pcoinsTip contains the UTXO set for chainActive.Tip()
+        CCoinsViewMemPool &viewMemPool(*ss.cvMempool);
+        std::vector<int> prevheights;
+        prevheights.resize(tx.vin.size());
+        for (size_t txinIndex = 0; txinIndex < tx.vin.size(); txinIndex++)
+        {
+            const CTxIn &txin = tx.vin[txinIndex];
+            Coin coin;
+            if (!viewMemPool.GetCoin(txin.prevout, coin))
+            {
+                return error("%s: Missing input", __func__);
+            }
+            if (coin.nHeight == MEMPOOL_HEIGHT)
+            {
+                // Assume all mempool transaction confirm in the next block
+                prevheights[txinIndex] = tip->nHeight + 1;
+            }
+            else
+            {
+                prevheights[txinIndex] = coin.nHeight;
+            }
+        }
+        lockPair = CalculateSequenceLocks(tx, flags, &prevheights, index);
+        if (lp)
+        {
+            lp->height = lockPair.first;
+            lp->time = lockPair.second;
+            // Also store the hash of the block with the highest height of
+            // all the blocks which have sequence locked prevouts.
+            // This hash needs to still be on the chain
+            // for these LockPoint calculations to be valid
+            // Note: It is impossible to correctly calculate a maxInputBlock
+            // if any of the sequence locked inputs depend on unconfirmed txs,
+            // except in the special case where the relative lock time/height
+            // is 0, which is equivalent to no sequence lock. Since we assume
+            // input height of tip+1 for mempool txs and test the resulting
+            // lockPair from CalculateSequenceLocks against tip+1.  We know
+            // EvaluateSequenceLocks will fail if there was a non-zero sequence
+            // lock on a mempool input, so we can use the return value of
+            // CheckSequenceLocks to indicate the LockPoints validity
+            int maxInputHeight = 0;
+            for (int height : prevheights)
+            {
+                // Can ignore mempool inputs since we'll fail if they had non-zero locks
+                if (height != tip->nHeight + 1)
+                {
+                    maxInputHeight = std::max(maxInputHeight, height);
+                }
+            }
+            lp->maxInputBlock = tip->GetAncestor(maxInputHeight);
+        }
+    }
+    return EvaluateSequenceLocks(index, lockPair);
+}
+
+bool CheckFinalTx(const CTransaction &tx, int flags, const Snapshot &ss)
+{
+    // By convention a negative value for flags indicates that the
+    // current network-enforced consensus rules should be used. In
+    // a future soft-fork scenario that would mean checking which
+    // rules would be enforced for the next block and setting the
+    // appropriate flags. At the present time no soft-forks are
+    // scheduled, so no flags are set.
+    flags = std::max(flags, 0);
+
+    // CheckFinalTx() uses chainActive.Height()+1 to evaluate
+    // nLockTime because when IsFinalTx() is called within
+    // CBlock::AcceptBlock(), the height of the block *being*
+    // evaluated is what is used. Thus if we want to know if a
+    // transaction can be part of the *next* block, we need to call
+    // IsFinalTx() with one more than chainActive.Height().
+    const int nBlockHeight = ss.tipHeight + 1;
+
+    // BIP113 will require that time-locked transactions have nLockTime set to
+    // less than the median time of the previous block they're contained in.
+    // When the next block is created its previous block will be the current
+    // chain tip, so we use that to calculate the median time passed to
+    // IsFinalTx() if LOCKTIME_MEDIAN_TIME_PAST is set.
+    const int64_t nBlockTime = (flags & LOCKTIME_MEDIAN_TIME_PAST) ? ss.tipMedianTimePast : GetAdjustedTime();
+
+    return IsFinalTx(tx, nBlockHeight, nBlockTime);
+}

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -170,8 +170,6 @@ void ThreadCommitToMempool()
             LimitMempoolSize(mempool, GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000,
                 GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60);
 
-            // BU: update tx per second when a tx is valid and accepted
-            mempool.UpdateTransactionsPerSecond();
             CValidationState state;
             FlushStateToDisk(state, FLUSH_STATE_PERIODIC);
             // The flush to disk above is only periodic therefore we need to continuously trim any excess from the
@@ -232,6 +230,9 @@ void CommitTxToMempool()
             SyncWithWallets(data.entry.GetSharedTx(), nullptr, -1);
 #endif
             whatChanged.push_back(data.hash);
+
+            // Update txn per second only when a txn is valid and accepted to the mempool
+            mempool.UpdateTransactionsPerSecond();
         }
         txCommitQ.clear();
     }

--- a/src/txadmission.h
+++ b/src/txadmission.h
@@ -1,0 +1,180 @@
+// Copyright (c) 2018 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "fastfilter.h"
+#include "txmempool.h"
+#include "net.h"
+#include <queue>
+
+/**
+ * Filter for transactions that were recently rejected by
+ * AcceptToMemoryPool. These are not rerequested until the chain tip
+ * changes, at which point the entire filter is reset. Protected by
+ * cs_recentRejects
+ *
+ * Without this filter we'd be re-requesting txs from each of our peers,
+ * increasing bandwidth consumption considerably. For instance, with 100
+ * peers, half of which relay a tx we don't accept, that might be a 50x
+ * bandwidth increase. A flooding attacker attempting to roll-over the
+ * filter using minimum-sized, 60byte, transactions might manage to send
+ * 1000/sec if we have fast peers, so we pick 120,000 to give our peers a
+ * two minute window to send invs to us.
+ *
+ * Decreasing the false positive rate is fairly cheap, so we pick one in a
+ * million to make it highly unlikely for users to have issues with this
+ * filter.
+ *
+ * Memory used: 1.7MB
+ */
+
+// A consistent moment in the data state
+class Snapshot
+{
+public:
+    CCriticalSection cs;
+    uint64_t tipHeight;
+    uint64_t tipMedianTimePast;
+    int64_t adjustedTime;
+    CBlockIndex *tip; // CBlockIndexes are never deleted once created (even if the tip changes) so we can use this ptr
+    CCoinsViewCache *coins;
+    CCoinsViewMemPool *cvMempool;
+
+    void Load(void);
+
+    Snapshot() : coins(nullptr), cvMempool(nullptr) {}
+    ~Snapshot()
+    {
+        if (cvMempool)
+            delete cvMempool;
+    }
+};
+
+extern Snapshot txHandlerSnap;
+
+// Tracks data about a transaction that hasn't yet been processed
+class CTxInputData
+{
+public:
+    CTransactionRef tx;
+    NodeId nodeId; // hold the id so I don't keep a ref to the node
+    bool whitelisted;
+    std::string nodeName;
+};
+
+// Tracks data about transactions that are ready to be committed to the mempool
+class CTxCommitData
+{
+public:
+    CTxMemPoolEntry entry;
+    uint256 hash;
+};
+
+/** Communicate what class of transaction is acceptable to add to the memory pool
+ */
+enum class TransactionClass
+{
+    INVALID,
+    DEFAULT,
+    STANDARD,
+    NONSTANDARD
+};
+TransactionClass ParseTransactionClass(const std::string &s);
+
+
+// Controls all transaction admission threads
+extern CThreadCorral txProcessingCorral;
+// Corral bits
+enum
+{
+    CORRAL_TX_PROCESSING = 1,
+    CORRAL_TX_COMMITMENT = 2,
+    CORRAL_TX_PAUSE      = 3,
+};
+
+// Transaction mempool admission globals
+
+// maximum transaction mempool admission threads
+extern CTweak<unsigned int> numTxAdmissionThreads;
+
+extern CRollingFastFilter<4*1024*1024> recentRejects;
+extern CRollingFastFilter<4*1024*1024> txRecentlyInBlock;
+
+// Finds transactions that may conflict with other pending transactions
+extern CFastFilter<4*1024*1024> incomingConflicts;
+
+// Transactions that are available to be added to the mempool, and protection
+extern CCriticalSection csTxInQ;
+extern CCond cvTxInQ;
+extern std::queue<CTxInputData> txInQ;
+
+// Transactions that cannot be processed in this round (may potentially conflict with other tx)
+extern std::queue<CTxInputData> txDeferQ;
+
+// Transactions that are validated and can be committed to the mempool, and protection
+extern CWaitableCriticalSection csCommitQ;
+extern CConditionVariable cvCommitQ;
+extern std::map<uint256, CTxCommitData> txCommitQ;
+
+/** Start the transaction mempool admission threads */
+void StartTxAdmission(boost::thread_group &threadGroup);
+/** Stop the transaction mempool admission threads (assumes that ShutdownRequested() will return true) */
+void StopTxAdmission();
+/** Wait for the currently enqueued transactions to be flushed.  If new tx keep coming in, you may wait a while */
+void FlushTxAdmission();
+
+/// Put the tx on the tx admission queue for processing
+void EnqueueTxForAdmission(CTxInputData &txd);
+
+/** (try to) add transaction to memory pool **/
+bool AcceptToMemoryPool(CTxMemPool &pool,
+    CValidationState &state,
+    const CTransactionRef &ptx,
+    bool fLimitFree,
+    bool *pfMissingInputs,
+    bool fOverrideMempoolLimit = false,
+    bool fRejectAbsurdFee = false,
+    TransactionClass allowedTx = TransactionClass::DEFAULT);
+
+/** (try to) add transaction to memory pool **/
+bool ParallelAcceptToMemoryPool(Snapshot &ss,
+    CTxMemPool &pool,
+    CValidationState &state,
+    const CTransactionRef &ptx,
+    bool fLimitFree,
+    bool *pfMissingInputs,
+    bool fOverrideMempoolLimit,
+    bool fRejectAbsurdFee,
+    TransactionClass allowedTx,
+    std::vector<COutPoint> &vCoinsToUncache,
+                                bool *isRespend);
+
+/** Checks the size of the mempool and trims it if needed */
+void LimitMempoolSize(CTxMemPool &pool, size_t limit, unsigned long age);
+
+// Return > 0 if its likely that we have already dealt with this transaction. inv MUST be MSG_TX type.
+unsigned int TxAlreadyHave(const CInv &inv);
+
+// Commit all accepted tx into the mempool.  Corral with CORRAL_TX_PAUSE before calling to stop
+// threads from adding new tx into the q.
+void CommitTxToMempool();
+
+
+// This needs to be held whenever the chain state changes (block added or chain rewind) so that
+// transactions are not processed during chain state updates and so once the chain state is updated we can
+// grab a new read-only snapshot of this state in txHandlerSnap.
+class TxAdmissionPause
+{
+public:
+    TxAdmissionPause()
+    {
+        txProcessingCorral.Enter(CORRAL_TX_PAUSE);
+        CommitTxToMempool();
+    }
+
+    ~TxAdmissionPause()
+    {
+        txHandlerSnap.Load(); // Load the new block into the transaction processor's state snapshot
+        txProcessingCorral.Exit(CORRAL_TX_PAUSE);
+    }
+};

--- a/src/txadmission.h
+++ b/src/txadmission.h
@@ -3,8 +3,8 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "fastfilter.h"
-#include "txmempool.h"
 #include "net.h"
+#include "txmempool.h"
 #include <queue>
 
 /**
@@ -89,7 +89,7 @@ enum
 {
     CORRAL_TX_PROCESSING = 1,
     CORRAL_TX_COMMITMENT = 2,
-    CORRAL_TX_PAUSE      = 3,
+    CORRAL_TX_PAUSE = 3,
 };
 
 // Transaction mempool admission globals
@@ -97,11 +97,11 @@ enum
 // maximum transaction mempool admission threads
 extern CTweak<unsigned int> numTxAdmissionThreads;
 
-extern CRollingFastFilter<4*1024*1024> recentRejects;
-extern CRollingFastFilter<4*1024*1024> txRecentlyInBlock;
+extern CRollingFastFilter<4 * 1024 * 1024> recentRejects;
+extern CRollingFastFilter<4 * 1024 * 1024> txRecentlyInBlock;
 
 // Finds transactions that may conflict with other pending transactions
-extern CFastFilter<4*1024*1024> incomingConflicts;
+extern CFastFilter<4 * 1024 * 1024> incomingConflicts;
 
 // Transactions that are available to be added to the mempool, and protection
 extern CCriticalSection csTxInQ;
@@ -147,7 +147,7 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
     bool fRejectAbsurdFee,
     TransactionClass allowedTx,
     std::vector<COutPoint> &vCoinsToUncache,
-                                bool *isRespend);
+    bool *isRespend);
 
 /** Checks the size of the mempool and trims it if needed */
 void LimitMempoolSize(CTxMemPool &pool, size_t limit, unsigned long age);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -933,7 +933,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         uint256 hash = it->second.ptx->GetHash();
         indexed_transaction_set::const_iterator it2 = mapTx.find(hash);
         const CTransaction &tx = it2->GetTx();
-        assert(it2 != mapTx.end());
+        assert(it2 != mapTx.end()); // Every entry in mapNextTx should point to a mempool entry
         assert(&tx == it->second.ptx);
         assert(tx.vin.size() > it->second.n);
         assert(it->first == it->second.ptx->vin[it->second.n].prevout);

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -473,6 +473,7 @@ private:
     void _UpdateChild(txiter entry, txiter child, bool add);
 
 public:
+    // Connects an output to the transaction that spends it.
     std::map<COutPoint, CInPoint> mapNextTx;
     std::map<uint256, std::pair<double, CAmount> > mapDeltas;
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -426,8 +426,6 @@ UniValue sendtoaddress(const UniValue &params, bool fHelp)
             HelpExampleRpc(
                 "sendtoaddress", "\"1M72Sfpbz1BPpXFHz9m3CdqATR44Jvaydd\", 0.1, \"donation\", \"seans outpost\""));
 
-    LOCK2(cs_main, pwalletMain->cs_wallet);
-
     CTxDestination dest = DecodeDestination(params[0].get_str());
     if (!IsValidDestination(dest))
     {

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -25,6 +25,7 @@
 #include "script/script.h"
 #include "script/sign.h"
 #include "timedata.h"
+#include "txadmission.h"
 #include "txmempool.h"
 #include "uahf_fork.h"
 #include "ui_interface.h"
@@ -807,9 +808,18 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
         }
 
         bool fUpdated = false;
-        if (!fInsertedNew)
+        if (!fInsertedNew) // Merge
         {
-            // Merge
+            // When the tx is accepted by the mempool, it will be added to the wallet but any account info is stripped
+            // since accounts are not part of the base CTransaction.  This addition races against the wallet adding
+            // the transaction (with account info) itself.  If the mempool path wins, we may need to update the tx with
+            // account info.
+            if ((wtxIn.strFromAccount.size() > 0) && (wtx.strFromAccount.size() == 0))
+            {
+                LOGA("Add an account into wallet tx");
+                wtx.strFromAccount = wtxIn.strFromAccount;
+                fUpdated = true;
+            }
             if (!wtxIn.hashUnset() && wtxIn.hashBlock != wtx.hashBlock)
             {
                 wtx.hashBlock = wtxIn.hashBlock;
@@ -833,9 +843,9 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
             }
         }
 
-        //// debug print
-        LOGA("AddToWallet %s  %s%s\n", wtxIn.GetHash().ToString(), (fInsertedNew ? "new" : ""),
-            (fUpdated ? "update" : ""));
+        // Only useful if debugging wallet
+        // LOGA("AddToWallet %s  %s%s\n", wtxIn.GetHash().ToString(), (fInsertedNew ? "new" : ""),
+        //    (fUpdated ? "update" : ""));
 
         // Write to disk
         if (fInsertedNew || fUpdated)
@@ -1449,21 +1459,24 @@ void CWallet::ReacceptWalletTransactions()
     // If transactions aren't being broadcasted, don't let them into local mempool either
     if (!fBroadcastTransactions)
         return;
-    LOCK2(cs_main, cs_wallet);
     std::map<int64_t, CWalletTx *> mapSorted;
 
-    // Sort pending wallet transactions based on their initial wallet insertion order
-    for (PAIRTYPE(const uint256, CWalletTx) & item : mapWallet)
     {
-        const uint256 &wtxid = item.first;
-        CWalletTx &wtx = item.second;
-        assert(wtx.GetHash() == wtxid);
+        LOCK2(cs_main, cs_wallet);
 
-        int nDepth = wtx.GetDepthInMainChain();
-
-        if (!wtx.IsCoinBase() && (nDepth == 0 && !wtx.isAbandoned()))
+        // Sort pending wallet transactions based on their initial wallet insertion order
+        for (PAIRTYPE(const uint256, CWalletTx) & item : mapWallet)
         {
-            mapSorted.insert(std::make_pair(wtx.nOrderPos, &wtx));
+            const uint256 &wtxid = item.first;
+            CWalletTx &wtx = item.second;
+            assert(wtx.GetHash() == wtxid);
+
+            int nDepth = wtx.GetDepthInMainChain();
+
+            if (!wtx.IsCoinBase() && (nDepth == 0 && !wtx.isAbandoned()))
+            {
+                mapSorted.insert(std::make_pair(wtx.nOrderPos, &wtx));
+            }
         }
     }
 
@@ -1475,6 +1488,7 @@ void CWallet::ReacceptWalletTransactions()
         wtx.AcceptToMemoryPool(false);
         SyncWithWallets(MakeTransactionRef(wtx), nullptr, -1);
     }
+    CommitTxToMempool();
 }
 
 bool CWalletTx::RelayWalletTransaction()
@@ -2539,10 +2553,6 @@ bool CWallet::CreateTransaction(const vector<CRecipient> &vecSend,
 bool CWallet::CommitTransaction(CWalletTx &wtxNew, CReserveKey &reservekey)
 {
     {
-        LOCK2(cs_main, cs_wallet);
-        LOGA("CommitTransaction:\n%s", wtxNew.ToString());
-
-#if 1
         if (fBroadcastTransactions)
         {
             // Broadcast
@@ -2553,8 +2563,8 @@ bool CWallet::CommitTransaction(CWalletTx &wtxNew, CReserveKey &reservekey)
                 return false;
             }
         }
-#endif
 
+        LOCK2(cs_main, cs_wallet);
         {
             // This is only to keep the database open to defeat the auto-flush for the
             // duration of this scope.  This is the only place where this optimization
@@ -2586,17 +2596,7 @@ bool CWallet::CommitTransaction(CWalletTx &wtxNew, CReserveKey &reservekey)
 
         if (fBroadcastTransactions)
         {
-#if 0
-            // Broadcast
-            if (!wtxNew.AcceptToMemoryPool(false))
-            {
-                // This must not fail. The transaction has already been signed and recorded.
-                LOGA("CommitTransaction(): Error: Transaction not valid\n");
-                return false;
-            }
-#else
             SyncWithWallets(MakeTransactionRef(wtxNew), nullptr, -1);
-#endif
             wtxNew.RelayWalletTransaction();
         }
     }
@@ -3617,7 +3617,7 @@ int CMerkleTx::GetDepthInMainChain(const CBlockIndex *&pindexRet) const
     if (hashUnset())
         return 0;
 
-    AssertLockHeld(cs_main);
+    LOCK(cs_main);
 
     // Find the block it claims to be in
     BlockMap::iterator mi = mapBlockIndex.find(hashBlock);
@@ -3627,7 +3627,7 @@ int CMerkleTx::GetDepthInMainChain(const CBlockIndex *&pindexRet) const
     if (!pindex || !chainActive.Contains(pindex))
         return 0;
 
-    pindexRet = pindex;
+    pindexRet = pindex; // we can return a pindex out of the lock because block headers are never deleted
     return ((nIndex == -1) ? (-1) : 1) * (chainActive.Height() - pindex->nHeight + 1);
 }
 
@@ -3642,8 +3642,10 @@ int CMerkleTx::GetBlocksToMaturity() const
 bool CMerkleTx::AcceptToMemoryPool(bool fLimitFree, bool fRejectAbsurdFee)
 {
     CValidationState state;
-    return ::AcceptToMemoryPool(
-        mempool, state, MakeTransactionRef(*this), fLimitFree, nullptr, false, fRejectAbsurdFee);
+    // Skip mempool commit because the commit informs the wallet but with the accounts stripped.
+    // By not committing inline, the caller wallet code can place this tx into the wallet first
+    return ::AcceptToMemoryPool(mempool, state, MakeTransactionRef(*this), fLimitFree, nullptr, false, fRejectAbsurdFee,
+        TransactionClass::DEFAULT);
 }
 
 


### PR DESCRIPTION
... by making the mempool read-only during parallel transaction processing, and then locking tx processing and committing the changes to the mempool.  Transactions can be processed in parallel because before parallel processing they are checked for conflicts with each other using a fastfilter (bloom-like filter) of the transaction inputs.  Any tx that conflicts with any tx that has been previously put on the parallel queue is deferred for evaluation after all current tx are committed.  Parallel threads threads therefore do not need to check for conflicts with other inflight transactions and so do not need to update the mempool right away.  Periodically another thread stops all tx admission threads and commits all accepted transactions to the mempool.

This is the major architectural change coming from the giga_perf branch.  Subsequent changes will be localized optimizations of the fastfilter, network, message processing, finer-grained locking, etc.

Code dealing with mempool admission (generally from main.cpp) has been isolated into its own files called
txadmission.cpp/h.

A new test mempool_accept.py is created that exercises the parallel acceptance code, and focuses on transaction conflicts (doublespends).

This PR creates a new rpc call "enqueuerawtransaction" that allows the caller to submit transactions very rapidly.  This call should replace "sendrawtransaction" for normal use.  However, when it returns it does not guarantee that the submitted transaction is in the mempool (unless "flush" is called) so "sendrawtransaction" is still useful in QA tests that may want to create a few tx and then mine them.
  
It also showcases the use of cashlib to generate and sign transactions for testing purposes.  With cashlib and enqueuerawtransaction, I have seen creation rates of >1500+ tx/sec on my 3ghz machine.
