### PR TITLE
[PROPOSAL] increase qa test reliability

### DIFF
--- a/qa/rpc-tests/cashlibtest.py
+++ b/qa/rpc-tests/cashlibtest.py
@@ -28,7 +28,7 @@ class MyTest (BitcoinTestFramework):
         self.nodes = start_nodes(2, self.options.tmpdir)
         connect_nodes_bi(self.nodes, 0, 1)
         self.is_network_split = False
-        self.sync_all()
+        self.sync_blocks()
 
     def run_test(self):
         faulted = False
@@ -104,7 +104,7 @@ if __name__ == '__main__':
     path = os.path.dirname(env)
     try:
         cashlib.init(path + os.sep + ".libs" + os.sep + "libbitcoincash.so")
-        MyTest().main()
+        MyTest().main(bitcoinConfDict={"net.invFiltering":0})
     except OSError as e:
         print("Issue loading shared library.  This is expected during cross compilation since the native python will not load the .so: %s" % str(e))
 
@@ -115,6 +115,7 @@ def Test():
     t = MyTest()
     bitcoinConf = {
         "debug": ["rpc", "net", "blk", "thin", "mempool", "req", "bench", "evict"],
+        "net.invFiltering":0
     }
 
     flags = [] # ["--nocleanup", "--noshutdown"]

--- a/qa/rpc-tests/notify.py
+++ b/qa/rpc-tests/notify.py
@@ -110,4 +110,4 @@ class NotifyTest(BitcoinTestFramework):
             raise AssertionError(self.touch_filename4 + "does not exist")
 
 if __name__ == '__main__':
-    NotifyTest().main()
+    NotifyTest().main(bitcoinConfDict={"debug": ["all"]})

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -46,7 +46,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.5)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.0)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),5.0)
-        self.sync_all()
         self.nodes[0].generate(5)
         self.sync_all()
 

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -270,7 +270,7 @@ class TestManager(object):
                     t = 0
                     # give 20 seconds to sync, this is a pretty generous number.  How much time might it take
                     # an underpowered test node running 4-6 copies of bitcoind to sync them?  
-                    while t < 10 and hsh != hex(blockhash)[2:]:  # hex(blockhash) returns "0x..." whereas hsh does not have the "0x"
+                    while t < 20 and hsh != hex(blockhash)[2:]:  # hex(blockhash) returns "0x..." whereas hsh does not have the "0x"
                         t += 1
                         time.sleep(2) 
                         hsh = c.rpc.getbestblockhash()

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -277,6 +277,10 @@ def sync_mempools(rpc_connections, wait=1,verbose=1):
     pools
     """
     count = 0
+    origTxFiltering = [ x.get("net.invFiltering") for x in rpc_connections]
+    for n in rpc_connections:
+        n.set("net.invFiltering=False")
+
     while True:
         count += 1
         pool = set(rpc_connections[0].getrawmempool())
@@ -304,6 +308,10 @@ def sync_mempools(rpc_connections, wait=1,verbose=1):
             rpc_connections[source].pushtx(destPeer['addr'])
             logging.info("sync_mempools: pushed tx from %d to %s" % (source, destPeer['addr']))
         time.sleep(wait)
+
+    for (n, val) in zip(rpc_connections, origTxFiltering):
+        if val:
+            n.set("net.invFiltering=%s" % val)
 
 def filterUnsupportedParams(defaults, param_keys=FILTER_PARAM_KEYS):
     """

--- a/qa/rpc-tests/walletbackup.py
+++ b/qa/rpc-tests/walletbackup.py
@@ -136,7 +136,7 @@ class WalletBackupTest(BitcoinTestFramework):
 
         # Generate 101 more blocks, so any fees paid mature
         self.nodes[3].generate(101)
-        self.sync_all()
+        self.sync_blocks()
 
         balance0 = self.nodes[0].getbalance()
         balance1 = self.nodes[1].getbalance()
@@ -199,3 +199,18 @@ class WalletBackupTest(BitcoinTestFramework):
 
 if __name__ == '__main__':
     WalletBackupTest().main()
+
+
+def Test():
+    t = WalletBackupTest()
+    # t.drop_to_pdb = True
+    bitcoinConf = {
+        # "debug": ["rpc", "net", "blk", "thin", "mempool", "req", "bench", "evict"],
+    }
+
+    flags = [] # ["--nocleanup", "--noshutdown"]
+    if os.path.isdir("/ramdisk/test"):
+        flags.append("--tmppfx=/ramdisk/test")
+    binpath = findBitcoind()
+    flags.append("--srcdir=%s" % binpath)
+    t.main(flags, bitcoinConf, None)

--- a/src/fastfilter.h
+++ b/src/fastfilter.h
@@ -95,7 +95,8 @@ public:
         erase = insecure_rand.rand32() % CFastFilter<FILTER_SIZE>::FILTER_BYTES;
         eraseAmt = _eraseAmt;
     }
-    void insert(const uint256 &hash)
+
+    void roll()
     {
         // By clearing some entries each time, the filter's false positive rate is limited.
         // Every time insert is called 1 entry is added and eraseAmt*8 entries are cleared.
@@ -115,7 +116,11 @@ public:
             loc++;
             loc &= (CFastFilter<FILTER_SIZE>::FILTER_BYTES - 1); // wrap around
         }
+    }
 
+    void insert(const uint256 &hash)
+    {
+        roll();
         CFastFilter<FILTER_SIZE>::insert(hash);
     }
 };

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -248,6 +248,9 @@ CTweak<uint64_t> blockSigopsPerMb("net.excessiveSigopsPerMb",
     "Excessive effort per block, denoted in cost (# inputs * txsize) per MB",
     BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS);
 CTweak<bool> ignoreNetTimeouts("net.ignoreTimeouts", "ignore inactivity timeouts, used during debugging", false);
+CTweak<bool> invFiltering("net.invFiltering",
+    "Use performance enhancing INV message filtering, but its possible to miss a transaction",
+    true);
 
 CTweak<uint64_t> blockMiningSigopsPerMb("mining.excessiveSigopsPerMb",
     "Excessive effort per block, denoted in cost (# inputs * txsize) per MB",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6395,7 +6395,7 @@ bool SendMessages(CNode *pto)
                         if (fChokeTxInv)
                             continue;
                         // skip if we already know about this one
-                        if (pto->filterInventoryKnown.contains(inv.hash))
+                        if (invFiltering.Value() && pto->filterInventoryKnown.contains(inv.hash))
                             continue;
                     }
                     vInvSend.push_back(inv);

--- a/src/net.h
+++ b/src/net.h
@@ -49,6 +49,9 @@ class thread_group;
 } // namespace boost
 
 extern CTweak<unsigned int> numMsgHandlerThreads;
+/** True (default) if filters should be used to eliminate duplicate INVs.  These filters can sometimes
+    incorrectly filter a non-duplicate. */
+extern CTweak<bool> invFiltering;
 
 /** Time between pings automatically sent out for latency probing and keepalive (in seconds). */
 static const int PING_INTERVAL = 2 * 60;
@@ -632,7 +635,7 @@ public:
     {
         {
             LOCK(cs_inventory);
-            if (inv.type == MSG_TX && filterInventoryKnown.contains(inv.hash))
+            if (invFiltering.Value() && inv.type == MSG_TX && filterInventoryKnown.contains(inv.hash))
                 return;
             vInventoryToSend.push_back(inv);
         }

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -38,6 +38,25 @@ private:
     const std::string m_reason;
 };
 
+class HasEitherReason
+{
+public:
+    HasEitherReason(const std::string &reason, const std::string &reason2) : m_reason(reason), m_reason2(reason2) {}
+    bool operator()(const std::runtime_error &e) const
+    {
+        std::string what(e.what());
+        bool ret = false;
+        printf("Exception Reason: %s\n", what.c_str());
+        ret |= what.find(m_reason) != std::string::npos;
+        ret |= what.find(m_reason2) != std::string::npos;
+        return ret;
+    };
+
+private:
+    const std::string m_reason;
+    const std::string m_reason2;
+};
+
 
 static struct
 {
@@ -330,7 +349,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     hash = tx.GetHash();
     mempool.addUnchecked(hash, entry.Fee(1000000).Time(GetTime()).SpendsCoinbase(false).FromTx(tx));
     BOOST_CHECK_EXCEPTION(BlockAssembler(chainparams_regtest).CreateNewBlock(scriptPubKey), std::runtime_error,
-        HasReason("bad-blk-signatures"));
+        HasEitherReason("mandatory-script-verify-flag-failed", "bad-blk-signatures"));
     mempool.clear();
 
     // double spend txn pair in mempool, template creation fails

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -136,9 +136,10 @@ unsigned int TxAlreadyHave(const CInv &inv)
     {
     case MSG_TX:
     {
-        if (txRecentlyInBlock.contains(inv.hash))
+        bool filtering = invFiltering.Value();
+        if (filtering && txRecentlyInBlock.contains(inv.hash))
             return 1;
-        if (recentRejects.contains(inv.hash))
+        if (filtering && recentRejects.contains(inv.hash))
             return 2;
         if (mempool.exists(inv.hash))
             return 3;


### PR DESCRIPTION
In 2 ways:

1. sync_mempools has never worked reliably because there is a bloom filter in front of INV relay and bloom filters are probabilistic.  This change forces INVs to be pushed between nodes randomly if the mempool is not syncing.

2. Either error message can be returned when a block's transaction validation fails.