### PR TITLE
avoid applying new outputs to utxo that are spent in the same block [WIP]

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -225,6 +225,7 @@ BITCOIN_CORE_H = \
   util.h \
   utilmoneystr.h \
   utiltime.h \
+  validation/blockdelta.h \
   validation/forks.h \
   validation/validation.h \
   validation/verifydb.h \
@@ -326,6 +327,7 @@ libbitcoin_server_a_SOURCES = \
   utilhttp.cpp \
   utilprocess.cpp \
   requestManager.cpp \
+  validation/blockdelta.cpp \
   validation/forks.cpp \
   validation/validation.cpp \
   validation/verifydb.cpp \

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -590,7 +590,7 @@ void AddCoins(CCoinsViewCache &cache, const CTransaction &tx, int nHeight)
     }
 }
 
-void SpendCoins(const CTransaction &tx, CValidationState &state, CCoinsViewCache &inputs, CTxUndo &txundo, int nHeight)
+void SpendCoins(const CTransaction &tx, CCoinsViewCache &inputs, CTxUndo &txundo)
 {
     // mark inputs spent
     if (!tx.IsCoinBase())
@@ -604,16 +604,16 @@ void SpendCoins(const CTransaction &tx, CValidationState &state, CCoinsViewCache
     }
 }
 
-void UpdateCoins(const CTransaction &tx, CValidationState &state, CCoinsViewCache &inputs, CTxUndo &txundo, int nHeight)
+void UpdateCoins(const CTransaction &tx, CCoinsViewCache &inputs, CTxUndo &txundo, int nHeight)
 {
     // mark inputs spent
-    SpendCoins(tx, state, inputs, txundo, nHeight);
+    SpendCoins(tx, inputs, txundo);
     // add outputs
     AddCoins(inputs, tx, nHeight);
 }
 
-void UpdateCoins(const CTransaction &tx, CValidationState &state, CCoinsViewCache &inputs, int nHeight)
+void UpdateCoins(const CTransaction &tx, CCoinsViewCache &inputs, int nHeight)
 {
     CTxUndo txundo;
-    UpdateCoins(tx, state, inputs, txundo, nHeight);
+    UpdateCoins(tx, inputs, txundo, nHeight);
 }

--- a/src/coins.h
+++ b/src/coins.h
@@ -249,6 +249,7 @@ protected:
     CDeferredSharedLocker lock;
 
 public:
+    const Coin* Get() { return coin; }
     operator bool() const { return coin != nullptr; }
     const Coin *operator->() { return coin; }
     const Coin &operator*() { return *coin; }
@@ -414,16 +415,15 @@ protected:
 void AddCoins(CCoinsViewCache &cache, const CTransaction &tx, int nHeight);
 
 //! Mark a transaction's inputs as spent in the passed CCoinsViewCache, and create the needed undo information.
-void SpendCoins(const CTransaction &tx, CValidationState &state, CCoinsViewCache &utxo, CTxUndo &txundo, int nHeight);
+void SpendCoins(const CTransaction &tx, CCoinsViewCache &utxo, CTxUndo &txundo);
 
 /** Apply the effects of this transaction on the UTXO set represented by view.  This function is equivalent to
 SpendCoins(...); AddCoins(...);
 */
 void UpdateCoins(const CTransaction &tx,
-    CValidationState &state,
     CCoinsViewCache &inputs,
     CTxUndo &txundo,
     int nHeight);
-void UpdateCoins(const CTransaction &tx, CValidationState &state, CCoinsViewCache &inputs, int nHeight);
+void UpdateCoins(const CTransaction &tx, CCoinsViewCache &inputs, int nHeight);
 
 #endif // BITCOIN_COINS_H

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -14,6 +14,7 @@
 class CBlockIndex;
 class CCoinsViewCache;
 class CValidationState;
+class CBlockDelta;
 
 /** Transaction validation functions */
 
@@ -27,7 +28,7 @@ namespace Consensus
  * This does not modify the UTXO set. This does not check scripts and sigs.
  * Preconditions: tx.IsCoinBase() is false.
  */
-bool CheckTxInputs(const CTransactionRef tx, CValidationState &state, const CCoinsViewCache &inputs);
+bool CheckTxInputs(const CTransactionRef tx, CValidationState &state, const CCoinsViewCache &inputs, const CBlockDelta &blockDelta);
 } // namespace Consensus
 
 /** Auxiliary functions for transaction validation (ideally should not be exposed) */

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -18,7 +18,6 @@
 
 int ApplyTxInUndo(Coin &&undo, CCoinsViewCache &view, const COutPoint &out);
 void UpdateCoins(const CTransaction &tx,
-    CValidationState &state,
     CCoinsViewCache &inputs,
     CTxUndo &txundo,
     int nHeight);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1369,7 +1369,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             // Use the largest maxOps since this code is not meant to validate that constraint
             assert(
                 CheckInputs(it->GetSharedTx(), state, mempoolDuplicate, false, 0, MAX_OPS_PER_SCRIPT, false, nullptr));
-            UpdateCoins(tx, state, mempoolDuplicate, 1000000);
+            UpdateCoins(tx, mempoolDuplicate, 1000000);
         }
     }
     unsigned int stepsSinceLastRemove = 0;
@@ -1389,7 +1389,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
             // Use the largest maxOps since this code is not meant to validate that constraint
             assert(CheckInputs(
                 entry->GetSharedTx(), state, mempoolDuplicate, false, 0, MAX_OPS_PER_SCRIPT, false, nullptr));
-            UpdateCoins(entry->GetTx(), state, mempoolDuplicate, 1000000);
+            UpdateCoins(entry->GetTx(), mempoolDuplicate, 1000000);
             stepsSinceLastRemove = 0;
         }
     }

--- a/src/validation/blockdelta.cpp
+++ b/src/validation/blockdelta.cpp
@@ -1,0 +1,71 @@
+// Copyright (c) 2020 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "blockdelta.h"
+
+bool CBlockDelta::_SpendCoin(const COutPoint &outpoint, Coin *moveout)
+{
+    auto iter = blockOutputs.find(outpoint);
+    if (iter != blockOutputs.end())
+    {
+        // move the coin then erase the entry in the set
+        *moveout = std::move(iter->second);
+        blockOutputs.erase(outpoint);
+        return true;
+    }
+    return false;
+}
+
+bool CBlockDelta::AddOutputsToDelta(const CTransaction &tx, int nHeight)
+{
+    bool fCoinbase = tx.IsCoinBase();
+    const uint256 &txid = tx.GetHash();
+    // if we have an entry for this tx already, finding it again indicates a duplicate tx so we assert
+    for (size_t i = 0; i < tx.vout.size(); ++i)
+    {
+        if (blockOutputs.emplace(COutPoint(txid, i), Coin(tx.vout[i], nHeight, fCoinbase)).second == false)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+void CBlockDelta::SpendCoins(const CTransaction &tx, CCoinsViewCache &utxo, CTxUndo &txundo)
+{
+    // mark inputs spent
+    if (!tx.IsCoinBase())
+    {
+        txundo.vprevout.reserve(tx.vin.size());
+        for (const CTxIn &txin : tx.vin)
+        {
+            txundo.vprevout.emplace_back();
+            if (_SpendCoin(txin.prevout, &txundo.vprevout.back()) == false)
+            {
+                utxo.SpendCoin(txin.prevout, &txundo.vprevout.back());
+            }
+        }
+    }
+}
+
+void CBlockDelta::AddNewOutputsToView(CCoinsViewCache &cache)
+{
+    for (auto &output : blockOutputs)
+    {
+        // printf("ADD COIN HERE \n");
+        cache.AddCoin(output.first, std::move(output.second), output.second.fCoinBase);\
+        // printf("ADD COIN DONE \n");
+    }
+}
+
+bool CBlockDelta::GetCoin(const COutPoint &outpoint, Coin &coin) const
+{
+    auto it = blockOutputs.find(outpoint);
+    if (it != blockOutputs.end())
+    {
+        coin = it->second;
+        return true;
+    }
+    return false;
+}

--- a/src/validation/blockdelta.h
+++ b/src/validation/blockdelta.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+#include "undo.h"
+
+class CBlockDelta
+{
+private:
+    // attempts to spend a voin in blockOuputs, should only be called by SpendCoins
+    bool _SpendCoin(const COutPoint &outpoint, Coin *moveout);
+public:
+    std::map<COutPoint, Coin> blockOutputs;
+
+    CBlockDelta()
+    {
+        blockOutputs.clear();
+    }
+    bool AddOutputsToDelta(const CTransaction &tx, int nHeight);
+    void SpendCoins(const CTransaction &tx, CCoinsViewCache &utxo, CTxUndo &txundo);
+    void AddNewOutputsToView(CCoinsViewCache &cache);
+    bool GetCoin(const COutPoint &outpoint, Coin &coin) const;
+};

--- a/src/validation/validation.h
+++ b/src/validation/validation.h
@@ -8,6 +8,7 @@
 #ifndef BITCOIN_VALIDATION_H
 #define BITCOIN_VALIDATION_H
 
+#include "blockdelta.h"
 #include "chainparams.h"
 #include "consensus/validation.h"
 #include "forks.h"
@@ -61,6 +62,19 @@ void CheckBlockIndex(const Consensus::Params &consensusParams);
  * This does not modify the UTXO set. If pvChecks is not nullptr, script checks are pushed onto it
  * instead of being performed inline.
  */
+bool CheckInputs(const CTransactionRef &tx,
+    CValidationState &state,
+    const CCoinsViewCache &view,
+    const CBlockDelta &blockDelta,
+    bool fScriptChecks,
+    unsigned int flags,
+    unsigned int maxOps,
+    bool cacheStore,
+    ValidationResourceTracker *resourceTracker,
+    std::vector<CScriptCheck> *pvChecks = nullptr,
+    unsigned char *sighashType = nullptr,
+    CValidationDebugger *debugger = nullptr);
+
 bool CheckInputs(const CTransactionRef &tx,
     CValidationState &state,
     const CCoinsViewCache &view,


### PR DESCRIPTION
this is opposed to the current method where we apply changes after we check a transaction in a block. the idea here is to get a full list of outputs spent (inputs) and new outputs generated for the entire block, cancel out any spent outputs that were generated by previous transactions in the block, and then apply the changes to the utxo set all at once to avoid wasting time adding a new output just to mark it spent and remove it later in the same block. 

Changes: 
- Update coins is broken into its two parts, once a differential is made we spend all coins and then add all of the new outputs generated by the block. 
- added uniquevector. uniquevector is a data structure that guarantees the order of elements while also ensuring that there are no duplicate elements (a mix between a std::vector and a std::set). Internally it uses blake2bp for hashing, this is why blake2 was added to the crypto folder. blake2 is used for speed reasons. 
