### PR TITLE
Use the txCommitQ to check for validated txns for xthin and graphene blocks

### DIFF
--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -234,6 +234,7 @@ bool CRequestGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
 
     // Check for Misbehaving and DOS
     // If they make more than 20 requests in 10 minutes then disconnect them
+    if (Params().NetworkIDString() != "regtest")
     {
         if (pfrom->nGetGrapheneBlockTxLastTime <= 0)
             pfrom->nGetGrapheneBlockTxLastTime = GetTime();

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -463,6 +463,7 @@ bool CXRequestThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
 
     // Check for Misbehaving and DOS
     // If they make more than 20 requests in 10 minutes then disconnect them
+    if (Params().NetworkIDString() != "regtest")
     {
         if (pfrom->nGetXBlockTxLastTime <= 0)
             pfrom->nGetXBlockTxLastTime = GetTime();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4418,6 +4418,7 @@ static bool BasicThinblockChecks(CNode *pfrom, const CChainParams &chainparams)
 
     // Check for Misbehaving and DOS
     // If they make more than 20 requests in 10 minutes then disconnect them
+    if (Params().NetworkIDString() != "regtest")
     {
         if (pfrom->nGetXthinLastTime <= 0)
             pfrom->nGetXthinLastTime = GetTime();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4367,7 +4367,11 @@ bool static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                 if (!fPushed && inv.type == MSG_TX)
                 {
                     CTransactionRef ptx = nullptr;
-                    ptx = mempool.get(inv.hash);
+                    ptx = CommitQGet(inv.hash);
+                    if (!ptx)
+                    {
+                        ptx = mempool.get(inv.hash);
+                    }
                     if (ptx)
                     {
                         pfrom->PushMessage(NetMsgType::TX, ptx);

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -42,6 +42,15 @@ bool CheckSequenceLocks(const CTransaction &tx,
     const Snapshot &ss);
 
 
+CTransactionRef CommitQGet(uint256 hash)
+{
+    boost::unique_lock<boost::mutex> lock(csCommitQ);
+    std::map<uint256, CTxCommitData>::iterator it = txCommitQ.find(hash);
+    if (it == txCommitQ.end())
+        return nullptr;
+    return it->second.entry.GetSharedTx();
+}
+
 void StartTxAdmission(boost::thread_group &threadGroup)
 {
     txHandlerSnap.Load(); // Get an initial view for the transaction processors

--- a/src/txadmission.h
+++ b/src/txadmission.h
@@ -116,6 +116,9 @@ extern CWaitableCriticalSection csCommitQ;
 extern CConditionVariable cvCommitQ;
 extern std::map<uint256, CTxCommitData> txCommitQ;
 
+// returns a transaction ref, if it exists in the commitQ
+CTransactionRef CommitQGet(uint256 hash);
+
 /** Start the transaction mempool admission threads */
 void StartTxAdmission(boost::thread_group &threadGroup);
 /** Stop the transaction mempool admission threads (assumes that ShutdownRequested() will return true) */


### PR DESCRIPTION
There are fully validated txns we can use in the the get_xthin and get_graphene messages and also we can use them in the reconstruction of blocks.