### PR TITLE
Set RPC warmup to finished at the very end of init.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1491,22 +1491,20 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
     StartTxAdmission(threadGroup);
     StartNode(threadGroup, scheduler);
 
-    // Monitor the chain, and alert if we get blocks much quicker or slower than expected
-    // The "bad chain alert" scheduler has been disabled because the current system gives far
-    // too many false positives, such that users are starting to ignore them.
-    // This code will be disabled for 0.12.1 while a fix is deliberated in #7568
-    // this was discussed in the IRC meeting on 2016-03-31.
-    //
-    // --- disabled ---
-    // int64_t nPowTargetSpacing = Params().GetConsensus().nPowTargetSpacing;
-    // CScheduler::Function f = boost::bind(&PartitionCheck, &IsInitialBlockDownload,
-    //                                     boost::ref(cs_main), boost::cref(pindexBestHeader), nPowTargetSpacing);
-    // scheduler.scheduleEvery(f, nPowTargetSpacing);
-    // --- end disabled ---
+// Monitor the chain, and alert if we get blocks much quicker or slower than expected
+// The "bad chain alert" scheduler has been disabled because the current system gives far
+// too many false positives, such that users are starting to ignore them.
+// This code will be disabled for 0.12.1 while a fix is deliberated in #7568
+// this was discussed in the IRC meeting on 2016-03-31.
+//
+// --- disabled ---
+// int64_t nPowTargetSpacing = Params().GetConsensus().nPowTargetSpacing;
+// CScheduler::Function f = boost::bind(&PartitionCheck, &IsInitialBlockDownload,
+//                                     boost::ref(cs_main), boost::cref(pindexBestHeader), nPowTargetSpacing);
+// scheduler.scheduleEvery(f, nPowTargetSpacing);
+// --- end disabled ---
 
-    // ********************************************************* Step 12: finished
-
-    SetRPCWarmupFinished();
+// ********************************************************* Step 12: finished
 
 #ifdef ENABLE_WALLET
     uiInterface.InitMessage(_("Reaccepting Wallet Transactions"));
@@ -1521,5 +1519,10 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
 #endif
 
     uiInterface.InitMessage(_("Done loading"));
+
+    // This should be done last in init. If not, then RPC's could be allowed before the wallet
+    // is ready.
+    SetRPCWarmupFinished();
+
     return true;
 }


### PR DESCRIPTION
Previously it was before the wallet had finished startup and
possibly at times the wallet had not finished re-accepting txns
before rpc's from python tests were executed against the wallet.
Therefore indicating rpc is ready after the wallet has loaded fully
will possibly prevent a few spurious wallet test failures.