### PR TITLE
Fastfilter enhancements

### DIFF
--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -397,6 +397,7 @@ primitives/transaction.h
 bench/bench_bitcoin.cpp
 bench/bench.cpp
 bench/bench.h
+bench/bloom.cpp
 bench/crypto_hash.cpp
 bench/Examples.cpp
 bench/verify_script.cpp

--- a/src/Makefile.bench.include
+++ b/src/Makefile.bench.include
@@ -15,7 +15,8 @@ bench_bench_bitcoin_SOURCES = \
   bench/verify_script.cpp \
   bench/crypto_hash.cpp \
   bench/murmur_hash.cpp \
-  bench/rollingbloom.cpp
+  bench/rollingbloom.cpp \
+  bench/bloom.cpp
 
 bench_bench_bitcoin_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES) $(EVENT_CLFAGS) $(EVENT_PTHREADS_CFLAGS) -I$(builddir)/bench/
 bench_bench_bitcoin_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)

--- a/src/bench/bloom.cpp
+++ b/src/bench/bloom.cpp
@@ -1,0 +1,192 @@
+// Copyright (c) 2018 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <iostream>
+
+#include "bench.h"
+#include "bloom.h"
+#include "fastfilter.h"
+#include "utiltime.h"
+
+
+int sideEffect = 0;
+
+// Set up stuff that should not be timed
+class ALotOfSHA256
+{
+public:
+    int amt = 1000000;
+    std::vector<uint256> data;
+
+    CFastFilter<4 * 1024 * 1024, 16> filter;
+    CFastFilter<4 * 1024 * 1024, 2> filter2;
+    CBloomFilter bloom;
+
+    ALotOfSHA256() : bloom(1000000, 0.000001, 0x49393, BLOOM_UPDATE_NONE, 100000000)
+    {
+        data.reserve(amt);
+        for (int i = 0; i < amt; i++)
+        {
+            uint256 num = GetRandHash();
+            data.push_back(num);
+            if (i & 1)
+            {
+                filter.insert(num);
+                filter2.insert(num);
+                bloom.insert(num);
+            }
+        }
+    }
+};
+
+ALotOfSHA256 sha;
+
+static void BloomCheckSet(benchmark::State &state)
+{
+    CBloomFilter filter(1000000, 0.000001, 0x49393, BLOOM_UPDATE_NONE, 100000000);
+    int count = 0;
+    while (state.KeepRunning())
+    {
+        for (int i = 0; i < 1000; i++)
+        {
+            if (count >= sha.amt)
+            {
+                count = 0;
+                filter.clear();
+            }
+            if (!filter.contains(sha.data[count]))
+            {
+                filter.insert(sha.data[count]);
+            }
+            count++;
+        }
+    }
+}
+
+static void BloomContains(benchmark::State &state)
+{
+    int count = 0;
+    int contains = 0;
+    while (state.KeepRunning())
+    {
+        for (int i = 0; i < 1000; i++)
+        {
+            if (count >= sha.amt)
+            {
+                count = 0;
+            }
+            if (sha.bloom.contains(sha.data[count]))
+                contains++;
+            count++;
+        }
+    }
+    sideEffect = contains;
+}
+
+BENCHMARK(BloomCheckSet);
+BENCHMARK(BloomContains);
+
+
+static void FastFilterCheckSet(benchmark::State &state)
+{
+    CFastFilter<4 * 1024 * 1024, 16> filter;
+    int count = 0;
+    while (state.KeepRunning())
+    {
+        for (int i = 0; i < 1000; i++)
+        {
+            if (count >= sha.amt)
+            {
+                count = 0;
+                filter.reset();
+            }
+            filter.checkAndSet(sha.data[count]);
+            count++;
+        }
+    }
+}
+
+static void FastFilterCheckSet2(benchmark::State &state)
+{
+    CFastFilter<4 * 1024 * 1024, 2> filter;
+    int count = 0;
+    while (state.KeepRunning())
+    {
+        for (int i = 0; i < 1000; i++)
+        {
+            if (count >= sha.amt)
+            {
+                count = 0;
+                filter.reset();
+            }
+            filter.checkAndSet(sha.data[count]);
+            count++;
+        }
+    }
+}
+
+static void FastFilterContains(benchmark::State &state)
+{
+    int count = 0;
+    int contains = 0;
+    while (state.KeepRunning())
+    {
+        for (int i = 0; i < 1000; i++)
+        {
+            if (count >= sha.amt)
+                count = 0;
+            if (sha.filter.contains(sha.data[count]))
+                contains++;
+            count++;
+        }
+    }
+    sideEffect = contains;
+}
+
+static void FastFilterContains2(benchmark::State &state)
+{
+    int count = 0;
+    int contains = 0;
+    while (state.KeepRunning())
+    {
+        for (int i = 0; i < 1000; i++)
+        {
+            if (count >= sha.amt)
+                count = 0;
+            if (sha.filter2.contains(sha.data[count]))
+                contains++;
+            count++;
+        }
+    }
+    sideEffect = contains;
+}
+
+
+// Get data on the overhead of this benchmarking system
+static void Nothing(benchmark::State &state)
+{
+    int count = 0;
+    int contains = 0;
+    while (state.KeepRunning())
+    {
+        for (int i = 0; i < 1000; i++)
+        {
+            if (count > sha.amt)
+            {
+                count = 0;
+            }
+            count++;
+            if (count & 1)
+                contains++;
+        }
+    }
+    sideEffect = contains;
+}
+
+
+BENCHMARK(Nothing);
+BENCHMARK(FastFilterCheckSet);
+BENCHMARK(FastFilterCheckSet2);
+BENCHMARK(FastFilterContains);
+BENCHMARK(FastFilterContains2);

--- a/src/fastfilter.h
+++ b/src/fastfilter.h
@@ -29,12 +29,18 @@ constexpr bool isPow2(unsigned int num) { return num && !(num & (num - 1)); }
  * uint256 numbers that are sensitive to deliberately constructed collisions, be sure to keep NUM_HASH_FNS high enough
  * that the creation of collisions in the used bits is not feasible.
  *
+ * Note also that the input bits are used without obfuscation or mixing so if an attacker can control some input bits
+ * the attacker can cause collisions in some of the fast filter entries for his inputs.  This will cause higher false
+ * positive rates for these transactions.  For example, if the attacker can control 32 bits of the input, he can
+ * effectively reduce the number of hash functions in the fast filter by 2 because he has engineered a guaranteed
+ * collision for the two functions that use those bits.
+ *
  * This class is thread-safe in the sense that simultaneous calls to member functions will not crash,
  * but "inserts" may be lost.  However, if you are using this class as an in-ram filter before doing a more expensive
  * operation, a lost insert may be acceptable.
  *
- * FILTER_SIZE must be a power of 2, and NUM_HASH_FNs may range from 2 to 16 inclusive.  Since hashes are calculated
- * in pairs of 2, odd values of NUM_HASH_FNs are rounded down.
+ * FILTER_SIZE must be a power of 2, and NUM_HASH_FNS may range from 2 to 16 inclusive.  Since hashes are calculated
+ * in pairs of 2, odd values of NUM_HASH_FNS are rounded down.
  */
 template <unsigned int FILTER_SIZE, unsigned int NUM_HASH_FNS = 16>
 class CFastFilter

--- a/src/test/fastfilter_tests.cpp
+++ b/src/test/fastfilter_tests.cpp
@@ -23,7 +23,7 @@ BOOST_AUTO_TEST_CASE(fastfilter_tests)
         arith_uint256 num(1);
         arith_uint256 origNum = num;
         int collisions = 0;
-        for (int i = 1; i < 20000; i++)
+        for (int i = 1; i < 50000; i++)
         {
             num += 1;
             uint256 t1 = ArithToUint256(num);
@@ -37,18 +37,18 @@ BOOST_AUTO_TEST_CASE(fastfilter_tests)
             BOOST_CHECK(filt.contains(tmp));
             BOOST_CHECK(!filt.checkAndSet(tmp));
         }
-        BOOST_CHECK(collisions < 400); // sanity check, actual result may vary
+        BOOST_CHECK(collisions < 10); // sanity check, actual result may vary
         // check them all again
         num = origNum;
         int numFalsePositives = 0;
-        for (int i = 1; i < 20000; i++)
+        for (int i = 1; i < 50000; i++)
         {
             num += 1;
             uint256 t1 = ArithToUint256(num);
             uint256 tmp = Hash(t1.begin(), t1.end());
             BOOST_CHECK(filt.contains(tmp));
         }
-        for (int i = 1; i < 20000; i++) // check a bunch of numbers we didn't add
+        for (int i = 1; i < 50000; i++) // check a bunch of numbers we didn't add
         {
             num += 1;
             uint256 t1 = ArithToUint256(num);
@@ -56,16 +56,18 @@ BOOST_AUTO_TEST_CASE(fastfilter_tests)
             if (filt.contains(tmp))
                 numFalsePositives++;
         }
-        BOOST_CHECK(numFalsePositives < 2000); // sanity check, actual result may vary
+        BOOST_CHECK(numFalsePositives < 10); // sanity check, actual result may vary
     }
 
 
     // Test the 4 MB filter since that's what we use
     {
-        CFastFilter<4 * 1024 * 1024> filt;
+        CFastFilter<4 * 1024 * 1024, 2> filt;
+        CFastFilter<4 * 1024 * 1024, 8> filt2;
 
         arith_uint256 num(0);
         int collisions = 0;
+        int collisions2 = 0;
         for (int i = 0; i < 100000; i++)
         {
             num += 1;
@@ -73,9 +75,13 @@ BOOST_AUTO_TEST_CASE(fastfilter_tests)
             uint256 tmp = Hash(t1.begin(), t1.end());
             if (!filt.checkAndSet(tmp))
                 collisions += 1;
+            if (!filt2.checkAndSet(tmp))
+                collisions2 += 1;
             BOOST_CHECK(filt.contains(tmp));
+            BOOST_CHECK(filt2.contains(tmp));
         }
-        BOOST_CHECK(collisions < 2000); // sanity check, actual result may vary
+        BOOST_CHECK(collisions < 100); // sanity check, actual result may vary
+        BOOST_CHECK(collisions2 < 10); // sanity check, actual result may vary
     }
 }
 


### PR DESCRIPTION
Implement filters with K (# hashes) between 2 and 16.  Add a salt to prevent hash collision attacks.

Currently many filters are configured for m=4 million bits.  With k=16 and n=100000 transactions, this results in a false positive rate of  1.94 × 10^-8, based on the FP rate equation (1-e^(-kn/m))^k.