### PR TITLE
Add gui Top Public Labels tab via startup option -toppubliclabels.

### DIFF
--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -138,6 +138,7 @@ QT_MOC_CPP = \
   qt/moc_overviewpage.cpp \
   qt/moc_peertablemodel.cpp \
   qt/moc_paymentserver.cpp \
+  qt/moc_publiclabelview.cpp \
   qt/moc_qvalidatedlineedit.cpp \
   qt/moc_qvaluecombobox.cpp \
   qt/moc_receivecoinsdialog.cpp \
@@ -211,6 +212,7 @@ BITCOIN_QT_H = \
   qt/paymentserver.h \
   qt/peertablemodel.h \
   qt/platformstyle.h \
+  qt/publiclabelview.h \
   qt/qvalidatedlineedit.h \
   qt/qvaluecombobox.h \
   qt/receivecoinsdialog.h \
@@ -331,6 +333,7 @@ BITCOIN_QT_CPP += \
   qt/overviewpage.cpp \
   qt/paymentrequestplus.cpp \
   qt/paymentserver.cpp \
+  qt/publiclabelview.cpp \
   qt/receivecoinsdialog.cpp \
   qt/receiverequestdialog.cpp \
   qt/receivefreezedialog.cpp \

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -280,8 +280,10 @@ static void addGeneralOptions(AllowedArgs &allowedArgs, HelpMessageMode mode)
                         "(default: 0 = disable pruning blocks, >%u = target size in MiB to use for block files)"),
                     MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024))
         .addArg("reindex", optionalBool, _("Rebuild block chain index from current blk000??.dat files on startup"))
+        .addArg("toppubliclabels=<n>", requiredInt, strprintf(_("Track unspent public labels and show the Top Public "
+                        "Labels tab. Specify which public lables to track by minimum <n>umber of satoshis (default: %u). This mode requires -txindex."), DEFAULT_TOPPUBLICLABELS))
         .addArg("txindex", optionalBool,
-            strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call (default: %u)"),
+            strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call and -toppubliclabels (default: %u)"),
                     DEFAULT_TXINDEX));
 }
 

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -280,11 +280,14 @@ static void addGeneralOptions(AllowedArgs &allowedArgs, HelpMessageMode mode)
                         "(default: 0 = disable pruning blocks, >%u = target size in MiB to use for block files)"),
                     MIN_DISK_SPACE_FOR_BLOCK_FILES / 1024 / 1024))
         .addArg("reindex", optionalBool, _("Rebuild block chain index from current blk000??.dat files on startup"))
-        .addArg("toppubliclabels=<n>", requiredInt, strprintf(_("Track unspent public labels and show the Top Public "
-                        "Labels tab. Specify which public lables to track by minimum <n>umber of satoshis (default: %u). This mode requires -txindex."), DEFAULT_TOPPUBLICLABELS))
-        .addArg("txindex", optionalBool,
-            strprintf(_("Maintain a full transaction index, used by the getrawtransaction rpc call and -toppubliclabels (default: %u)"),
-                    DEFAULT_TXINDEX));
+        .addArg("toppubliclabels=<n>", requiredInt,
+            strprintf(_("Track unspent public labels and show the Top Public "
+                        "Labels tab. Specify which public lables to track by minimum <n>umber of satoshis (default: "
+                        "%u). This mode requires -txindex."),
+                    DEFAULT_TOPPUBLICLABELS))
+        .addArg("txindex", optionalBool, strprintf(_("Maintain a full transaction index, used by the getrawtransaction "
+                                                     "rpc call and -toppubliclabels (default: %u)"),
+                                             DEFAULT_TXINDEX));
 }
 
 static void addConnectionOptions(AllowedArgs &allowedArgs)

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -675,6 +675,13 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
 
     // also see: InitParameterInteraction()
 
+    // if using toppubliclabels, then must use txindex
+    if (GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS) > 0)
+    {
+        if (!GetBoolArg("-txindex", DEFAULT_TXINDEX))
+            return InitError(_("Top Public Labels mode requires -txindex."));
+    }
+
     // if using block pruning, then disable txindex
     if (GetArg("-prune", 0))
     {

--- a/src/main.h
+++ b/src/main.h
@@ -154,6 +154,7 @@ static const bool DEFAULT_USE_GRAPHENE_BLOCKS = false;
 static const bool DEFAULT_REINDEX = false;
 static const bool DEFAULT_DISCOVER = true;
 static const bool DEFAULT_PRINTTOCONSOLE = false;
+static const CAmount DEFAULT_TOPPUBLICLABELS = 0;
 
 // BU - Xtreme Thinblocks Auto Mempool Limiter - begin section
 /** The default value for -minrelaytxfee in sat/byte */

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -259,6 +259,14 @@ void BitcoinGUI::createActions()
     historyAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_4));
     tabGroup->addAction(historyAction);
 
+    publicLabelAction = new QAction(platformStyle->SingleColorIcon(":/icons/history"), tr("&Top Public Labels"), this);
+    publicLabelAction->setStatusTip(tr("Browse the top funded public labels"));
+    publicLabelAction->setToolTip(publicLabelAction->statusTip());
+    publicLabelAction->setCheckable(true);
+    publicLabelAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_5));
+    tabGroup->addAction(publicLabelAction);
+    if (GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS) == 0) { publicLabelAction->setVisible(false); }
+
 #ifdef ENABLE_WALLET
     // These showNormalIfMinimized are needed because Send Coins and Receive Coins
     // can be triggered from the tray menu, and need to show the GUI to be useful.
@@ -274,6 +282,8 @@ void BitcoinGUI::createActions()
     connect(receiveCoinsMenuAction, SIGNAL(triggered()), this, SLOT(gotoReceiveCoinsPage()));
     connect(historyAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
     connect(historyAction, SIGNAL(triggered()), this, SLOT(gotoHistoryPage()));
+    connect(publicLabelAction, SIGNAL(triggered()), this, SLOT(showNormalIfMinimized()));
+    connect(publicLabelAction, SIGNAL(triggered()), this, SLOT(gotoPublicLabelPage()));
 #endif // ENABLE_WALLET
 
     quitAction = new QAction(platformStyle->TextColorIcon(":/icons/quit"), tr("E&xit"), this);
@@ -422,6 +432,7 @@ void BitcoinGUI::createToolBars()
         toolbar->addAction(sendCoinsAction);
         toolbar->addAction(receiveCoinsAction);
         toolbar->addAction(historyAction);
+        toolbar->addAction(publicLabelAction);
         overviewAction->setChecked(true);
     }
 }
@@ -505,6 +516,7 @@ void BitcoinGUI::setWalletActionsEnabled(bool enabled)
     receiveCoinsAction->setEnabled(enabled);
     receiveCoinsMenuAction->setEnabled(enabled);
     historyAction->setEnabled(enabled);
+    publicLabelAction->setEnabled(enabled);
     encryptWalletAction->setEnabled(enabled);
     backupWalletAction->setEnabled(enabled);
     changePassphraseAction->setEnabled(enabled);
@@ -634,6 +646,12 @@ void BitcoinGUI::gotoHistoryPage()
         walletFrame->gotoHistoryPage();
 }
 
+void BitcoinGUI::gotoPublicLabelPage()
+{
+    publicLabelAction->setChecked(true);
+    if (walletFrame) walletFrame->gotoPublicLabelPage();
+}
+
 void BitcoinGUI::gotoReceiveCoinsPage()
 {
     receiveCoinsAction->setChecked(true);
@@ -641,7 +659,7 @@ void BitcoinGUI::gotoReceiveCoinsPage()
         walletFrame->gotoReceiveCoinsPage();
 }
 
-void BitcoinGUI::gotoSendCoinsPage(QString addr)
+void BitcoinGUI::gotoSendCoinsPage(QString addr, QString labelPublic)
 {
     sendCoinsAction->setChecked(true);
     if (walletFrame)

--- a/src/qt/bitcoingui.cpp
+++ b/src/qt/bitcoingui.cpp
@@ -265,7 +265,10 @@ void BitcoinGUI::createActions()
     publicLabelAction->setCheckable(true);
     publicLabelAction->setShortcut(QKeySequence(Qt::ALT + Qt::Key_5));
     tabGroup->addAction(publicLabelAction);
-    if (GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS) == 0) { publicLabelAction->setVisible(false); }
+    if (GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS) == 0)
+    {
+        publicLabelAction->setVisible(false);
+    }
 
 #ifdef ENABLE_WALLET
     // These showNormalIfMinimized are needed because Send Coins and Receive Coins
@@ -649,7 +652,8 @@ void BitcoinGUI::gotoHistoryPage()
 void BitcoinGUI::gotoPublicLabelPage()
 {
     publicLabelAction->setChecked(true);
-    if (walletFrame) walletFrame->gotoPublicLabelPage();
+    if (walletFrame)
+        walletFrame->gotoPublicLabelPage();
 }
 
 void BitcoinGUI::gotoReceiveCoinsPage()

--- a/src/qt/bitcoingui.h
+++ b/src/qt/bitcoingui.h
@@ -99,6 +99,7 @@ private:
     QMenuBar *appMenuBar;
     QAction *overviewAction;
     QAction *historyAction;
+    QAction *publicLabelAction;
     QAction *quitAction;
     QAction *sendCoinsAction;
     QAction *sendCoinsMenuAction;
@@ -201,10 +202,12 @@ private Q_SLOTS:
     void gotoOverviewPage();
     /** Switch to history (transactions) page */
     void gotoHistoryPage();
+    /** Switch to public label page */
+    void gotoPublicLabelPage();
     /** Switch to receive coins page */
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
-    void gotoSendCoinsPage(QString addr = "");
+    void gotoSendCoinsPage(QString addr = "", QString labelPublic = "");
 
     /** Show Sign/Verify Message dialog and switch to sign message tab */
     void gotoSignMessageTab(QString addr = "");

--- a/src/qt/overviewpage.cpp
+++ b/src/qt/overviewpage.cpp
@@ -222,6 +222,7 @@ void OverviewPage::setWalletModel(WalletModel *model)
         filter->setDynamicSortFilter(true);
         filter->setSortRole(Qt::EditRole);
         filter->setShowInactive(false);
+        filter->setPublicLabelFilter(false);
         filter->sort(TransactionTableModel::Status, Qt::DescendingOrder);
 
         ui->listTransactions->setModel(filter.get());

--- a/src/qt/publiclabelview.cpp
+++ b/src/qt/publiclabelview.cpp
@@ -1,0 +1,463 @@
+// Copyright (c) 2015-2018 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "publiclabelview.h"
+
+#include "addresstablemodel.h"
+#include "bitcoinunits.h"
+#include "csvmodelwriter.h"
+#include "editaddressdialog.h"
+#include "guiutil.h"
+#include "optionsmodel.h"
+#include "platformstyle.h"
+#include "transactiondescdialog.h"
+#include "transactionfilterproxy.h"
+#include "transactionrecord.h"
+#include "transactiontablemodel.h"
+#include "walletmodel.h"
+
+#include "ui_interface.h"
+
+#include <QComboBox>
+#include <QDateTimeEdit>
+#include <QDesktopServices>
+#include <QDoubleValidator>
+#include <QHBoxLayout>
+#include <QHeaderView>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMenu>
+#include <QPoint>
+#include <QScrollBar>
+#include <QSignalMapper>
+#include <QTableView>
+#include <QUrl>
+#include <QVBoxLayout>
+
+PublicLabelView::PublicLabelView(const PlatformStyle *platformStyle, QWidget *parent) :
+    QWidget(parent), model(0), transactionProxyModel(0),
+    publicLabelView(0)
+{
+    // Build filter row
+    setContentsMargins(0,0,0,0);
+
+    QHBoxLayout *hlayout = new QHBoxLayout();
+    hlayout->setContentsMargins(0,0,0,0);
+
+    if (platformStyle->getUseExtraSpacing()) {
+        hlayout->setSpacing(5);
+        hlayout->addSpacing(26);
+    } else {
+        hlayout->setSpacing(0);
+        hlayout->addSpacing(23);
+    }
+
+    dateWidget = new QComboBox(this);
+    if (platformStyle->getUseExtraSpacing()) {
+        dateWidget->setFixedWidth(121);
+    } else {
+        dateWidget->setFixedWidth(120);
+    }
+    dateWidget->addItem(tr("All"), All);
+    dateWidget->addItem(tr("Today"), Today);
+    dateWidget->addItem(tr("This week"), ThisWeek);
+    dateWidget->addItem(tr("This month"), ThisMonth);
+    dateWidget->addItem(tr("Last month"), LastMonth);
+    dateWidget->addItem(tr("This year"), ThisYear);
+    dateWidget->addItem(tr("Range..."), Range);
+    hlayout->addWidget(dateWidget);
+
+    addressWidget = new QLineEdit(this);
+#if QT_VERSION >= 0x040700
+    addressWidget->setPlaceholderText(tr("Enter public label to search"));
+#endif
+    hlayout->addWidget(addressWidget);
+
+    amountWidget = new QLineEdit(this);
+#if QT_VERSION >= 0x040700
+    amountWidget->setPlaceholderText(tr("Min amount"));
+#endif
+    if (platformStyle->getUseExtraSpacing()) {
+        amountWidget->setFixedWidth(97);
+    } else {
+        amountWidget->setFixedWidth(100);
+    }
+    amountWidget->setValidator(new QDoubleValidator(0, 1e20, 8, this));
+    hlayout->addWidget(amountWidget);
+
+    QVBoxLayout *vlayout = new QVBoxLayout(this);
+    vlayout->setContentsMargins(0,0,0,0);
+    vlayout->setSpacing(0);
+
+    QTableView *view = new QTableView(this);
+    vlayout->addLayout(hlayout);
+    vlayout->addWidget(createDateRangeWidget());
+    vlayout->addWidget(view);
+    vlayout->setSpacing(0);
+    int width = view->verticalScrollBar()->sizeHint().width();
+    // Cover scroll bar width with spacing
+    if (platformStyle->getUseExtraSpacing()) {
+        hlayout->addSpacing(width+2);
+    } else {
+        hlayout->addSpacing(width);
+    }
+    // Always show scroll bar
+    view->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOn);
+    view->setTabKeyNavigation(false);
+    view->setContextMenuPolicy(Qt::CustomContextMenu);
+
+    view->installEventFilter(this);
+
+    minDate = new QDateTime(TransactionFilterProxy::MIN_DATE);
+    maxDate = new QDateTime(TransactionFilterProxy::MAX_DATE);
+
+    publicLabelView = view;
+
+    // Actions
+    QAction *sendAction = new QAction(tr("Send tx using public label"), this);
+    QAction *copyAddressAction = new QAction(tr("Copy public label"), this);
+    QAction *copyLabelAction = new QAction(tr("Copy label"), this);
+    QAction *copyAmountAction = new QAction(tr("Copy amount"), this);
+    QAction *copyTxIDAction = new QAction(tr("Copy transaction ID"), this);
+    QAction *copyTxHexAction = new QAction(tr("Copy raw transaction"), this);
+    QAction *showDetailsAction = new QAction(tr("Show transaction details"), this);
+
+    contextMenu = new QMenu();
+    contextMenu->addAction(sendAction);
+    contextMenu->addAction(copyAddressAction);
+    contextMenu->addAction(copyLabelAction);
+    contextMenu->addAction(copyAmountAction);
+    contextMenu->addAction(copyTxIDAction);
+    contextMenu->addAction(copyTxHexAction);
+    contextMenu->addAction(showDetailsAction);
+
+    mapperThirdPartyTxUrls = new QSignalMapper(this);
+
+    // Connect actions
+    connect(mapperThirdPartyTxUrls, SIGNAL(mapped(QString)), this, SLOT(openThirdPartyTxUrl(QString)));
+
+    connect(dateWidget, SIGNAL(activated(int)), this, SLOT(chooseDate(int)));
+    connect(addressWidget, SIGNAL(editingFinished()), this, SLOT(changedPrefix()));
+    connect(amountWidget, SIGNAL(textChanged(QString)), this, SLOT(changedAmount(QString)));
+
+    connect(view, SIGNAL(doubleClicked(QModelIndex)), this, SIGNAL(doubleClicked(QModelIndex)));
+    connect(view, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(contextualMenu(QPoint)));
+
+    connect(sendAction, SIGNAL(triggered()), this, SLOT(fillSendCoinsPage()));
+    connect(copyAddressAction, SIGNAL(triggered()), this, SLOT(copyAddress()));
+    connect(copyLabelAction, SIGNAL(triggered()), this, SLOT(copyLabel()));
+    connect(copyAmountAction, SIGNAL(triggered()), this, SLOT(copyAmount()));
+    connect(copyTxIDAction, SIGNAL(triggered()), this, SLOT(copyTxID()));
+    connect(copyTxHexAction, SIGNAL(triggered()), this, SLOT(copyTxHex()));
+    connect(showDetailsAction, SIGNAL(triggered()), this, SLOT(showDetails()));
+}
+
+void PublicLabelView::setModel(WalletModel *_model)
+{
+    this->model = _model;
+    if(_model)
+    {
+        TransactionTableModel *ttm = _model->getTransactionTableModel();
+        transactionProxyModel = new TransactionFilterProxy(this);
+        // only interested in txs which involve public labels
+        transactionProxyModel->setPublicLabelFilter(true);
+        transactionProxyModel->setSourceModel(ttm);
+        transactionProxyModel->setDynamicSortFilter(true);
+        transactionProxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);
+        transactionProxyModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
+        transactionProxyModel->setSortRole(Qt::EditRole);
+        std::vector<std::pair<std::string, CAmount>> publicLabelsGrouped = ttm->getTopPublicLabelsList(QString(), new QDateTime(), new QDateTime());
+        transactionProxyModel->setTopPublicLabelsList(publicLabelsGrouped);
+
+        publicLabelView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        publicLabelView->setModel(transactionProxyModel);
+        publicLabelView->setAlternatingRowColors(true);
+        publicLabelView->setSelectionBehavior(QAbstractItemView::SelectRows);
+        publicLabelView->setSelectionMode(QAbstractItemView::ExtendedSelection);
+        publicLabelView->setSortingEnabled(true);
+        publicLabelView->sortByColumn(TransactionTableModel::Amount, Qt::DescendingOrder);
+        publicLabelView->verticalHeader()->hide();
+
+        publicLabelView->setColumnWidth(TransactionTableModel::Status, STATUS_COLUMN_WIDTH);
+        publicLabelView->setColumnWidth(TransactionTableModel::Watchonly, WATCHONLY_COLUMN_WIDTH);
+        publicLabelView->setColumnWidth(TransactionTableModel::Date, DATE_COLUMN_WIDTH);
+        publicLabelView->setColumnWidth(TransactionTableModel::Type, TYPE_COLUMN_WIDTH);
+        publicLabelView->setColumnWidth(TransactionTableModel::Amount, AMOUNT_MINIMUM_COLUMN_WIDTH);
+
+        columnResizingFixer = new GUIUtil::TableViewLastColumnResizingFixer(
+                    publicLabelView, AMOUNT_MINIMUM_COLUMN_WIDTH, MINIMUM_COLUMN_WIDTH, this);
+
+        if (_model->getOptionsModel())
+        {
+            // Add third party transaction URLs to context menu
+            QStringList listUrls = _model->getOptionsModel()->getThirdPartyTxUrls().split("|", QString::SkipEmptyParts);
+            for (int i = 0; i < listUrls.size(); ++i)
+            {
+                QString host = QUrl(listUrls[i].trimmed(), QUrl::StrictMode).host();
+                if (!host.isEmpty())
+                {
+                    QAction *thirdPartyTxUrlAction = new QAction(host, this); // use host as menu item label
+                    if (i == 0)
+                        contextMenu->addSeparator();
+                    contextMenu->addAction(thirdPartyTxUrlAction);
+                    connect(thirdPartyTxUrlAction, SIGNAL(triggered()), mapperThirdPartyTxUrls, SLOT(map()));
+                    mapperThirdPartyTxUrls->setMapping(thirdPartyTxUrlAction, listUrls[i].trimmed());
+                }
+            }
+        }
+
+        // hide Watch-only, Type, Status columns
+        publicLabelView->setColumnHidden(TransactionTableModel::Watchonly, true);
+        publicLabelView->setColumnHidden(TransactionTableModel::Type, true);
+        publicLabelView->setColumnHidden(TransactionTableModel::Status, true);
+    }
+}
+
+void PublicLabelView::chooseDate(int idx)
+{
+    if(!transactionProxyModel)
+        return;
+    QDate current = QDate::currentDate();
+    dateRangeWidget->setVisible(false);
+    switch(dateWidget->itemData(idx).toInt())
+    {
+    case All:
+        minDate = new QDateTime(TransactionFilterProxy::MIN_DATE);
+        maxDate = new QDateTime(TransactionFilterProxy::MAX_DATE);
+        break;
+    case Today:
+        minDate = new QDateTime(current);
+        maxDate = new QDateTime(TransactionFilterProxy::MAX_DATE);
+        break;
+    case ThisWeek: {
+        // Find last Monday
+        QDate startOfWeek = current.addDays(-(current.dayOfWeek()-1));
+        minDate = new QDateTime(startOfWeek);
+        maxDate = new QDateTime(TransactionFilterProxy::MAX_DATE);
+
+        } break;
+    case ThisMonth:
+        minDate = new QDateTime(QDate(current.year(), current.month(), 1));
+        maxDate = new QDateTime(TransactionFilterProxy::MAX_DATE);
+        break;
+    case LastMonth:
+        minDate = new QDateTime(QDate(current.year(), current.month(), 1).addMonths(-1));
+        maxDate = new QDateTime(QDate(current.year(), current.month(), 1));
+        break;
+    case ThisYear:
+        minDate = new QDateTime(QDate(current.year(), 1, 1));
+        maxDate = new QDateTime(TransactionFilterProxy::MAX_DATE);
+        break;
+    case Range:
+        dateRangeWidget->setVisible(true);
+        dateRangeChanged();
+        break;
+    }
+    changedPrefix();
+}
+
+void PublicLabelView::changedPrefix()
+{
+    if(!transactionProxyModel)
+        return;
+    std::vector<std::pair<std::string, CAmount>> publicLabelsGrouped = this->model->getTransactionTableModel()->getTopPublicLabelsList(addressWidget->text(), minDate, maxDate);
+    transactionProxyModel->setTopPublicLabelsList(publicLabelsGrouped);
+    transactionProxyModel->setAddressPrefix(addressWidget->text());
+}
+
+void PublicLabelView::changedAmount(const QString &amount)
+{
+    if(!transactionProxyModel)
+        return;
+    CAmount amount_parsed = 0;
+    if(BitcoinUnits::parse(model->getOptionsModel()->getDisplayUnit(), amount, &amount_parsed))
+    {
+        transactionProxyModel->setMinAmount(amount_parsed);
+    }
+    else
+    {
+        transactionProxyModel->setMinAmount(0);
+    }
+}
+
+void PublicLabelView::exportClicked()
+{
+    // CSV is currently the only supported format
+    QString filename = GUIUtil::getSaveFileName(this,
+        tr("Export Transaction History"), QString(),
+        tr("Comma separated file (*.csv)"), NULL);
+
+    if (filename.isNull())
+        return;
+
+    CSVModelWriter writer(filename);
+
+    // name, column, role
+    writer.setModel(transactionProxyModel);
+    writer.addColumn(tr("Date"), 0, TransactionTableModel::DateRole);
+    writer.addColumn(tr("Public Label"), 0, TransactionTableModel::AddressRole);
+    writer.addColumn(BitcoinUnits::getAmountColumnTitle(model->getOptionsModel()->getDisplayUnit()), 0, TransactionTableModel::FormattedAmountRole);
+
+    if(!writer.write()) {
+        Q_EMIT message(tr("Exporting Failed"), tr("There was an error trying to save the transaction history to %1.").arg(filename),
+            CClientUIInterface::MSG_ERROR);
+    }
+    else {
+        Q_EMIT message(tr("Exporting Successful"), tr("The transaction history was successfully saved to %1.").arg(filename),
+            CClientUIInterface::MSG_INFORMATION);
+    }
+}
+
+void PublicLabelView::contextualMenu(const QPoint &point)
+{
+    QModelIndex index = publicLabelView->indexAt(point);
+    if(index.isValid())
+    {
+        contextMenu->exec(QCursor::pos());
+    }
+}
+
+void PublicLabelView::copyAddress()
+{
+    GUIUtil::copyEntryData(publicLabelView, 0, TransactionTableModel::AddressRole);
+}
+
+void PublicLabelView::copyLabel()
+{
+    GUIUtil::copyEntryData(publicLabelView, 0, TransactionTableModel::LabelRole);
+}
+
+void PublicLabelView::copyAmount()
+{
+    GUIUtil::copyEntryData(publicLabelView, 0, TransactionTableModel::FormattedAmountRole);
+}
+
+void PublicLabelView::copyTxID()
+{
+    GUIUtil::copyEntryData(publicLabelView, 0, TransactionTableModel::TxIDRole);
+}
+
+void PublicLabelView::copyTxHex()
+{
+    GUIUtil::copyEntryData(publicLabelView, 0, TransactionTableModel::TxHexRole);
+}
+
+void PublicLabelView::showDetails()
+{
+    if(!publicLabelView->selectionModel())
+        return;
+    QModelIndexList selection = publicLabelView->selectionModel()->selectedRows();
+    if(!selection.isEmpty())
+    {
+        TransactionDescDialog dlg(selection.at(0));
+        dlg.exec();
+    }
+}
+
+void PublicLabelView::fillSendCoinsPage()
+{
+    if(!publicLabelView->selectionModel())
+        return;
+    QModelIndexList selection = publicLabelView->selectionModel()->selectedRows();
+    if(!selection.isEmpty())
+    {
+        // fill the Send form: Receive address from next self address, Public Label from pl list
+        QString labelPublic = selection.at(0).data(TransactionTableModel::AddressRole).toString();
+        Q_EMIT menuActionSendPublicLabel(labelPublic);
+    }
+}
+
+void PublicLabelView::openThirdPartyTxUrl(QString url)
+{
+    if(!publicLabelView || !publicLabelView->selectionModel())
+        return;
+    QModelIndexList selection = publicLabelView->selectionModel()->selectedRows(0);
+    if(!selection.isEmpty())
+         QDesktopServices::openUrl(QUrl::fromUserInput(url.replace("%s", selection.at(0).data(TransactionTableModel::TxHashRole).toString())));
+}
+
+QWidget *PublicLabelView::createDateRangeWidget()
+{
+    dateRangeWidget = new QFrame();
+    dateRangeWidget->setFrameStyle(QFrame::Panel | QFrame::Raised);
+    dateRangeWidget->setContentsMargins(1,1,1,1);
+    QHBoxLayout *layout = new QHBoxLayout(dateRangeWidget);
+    layout->setContentsMargins(0,0,0,0);
+    layout->addSpacing(23);
+    layout->addWidget(new QLabel(tr("Range:")));
+
+    dateFrom = new QDateTimeEdit(this);
+    dateFrom->setDisplayFormat("dd/MM/yy");
+    dateFrom->setCalendarPopup(true);
+    dateFrom->setMinimumWidth(100);
+    dateFrom->setDate(QDate::currentDate().addDays(-7));
+    layout->addWidget(dateFrom);
+    layout->addWidget(new QLabel(tr("to")));
+
+    dateTo = new QDateTimeEdit(this);
+    dateTo->setDisplayFormat("dd/MM/yy");
+    dateTo->setCalendarPopup(true);
+    dateTo->setMinimumWidth(100);
+    dateTo->setDate(QDate::currentDate());
+    layout->addWidget(dateTo);
+    layout->addStretch();
+
+    // Hide by default
+    dateRangeWidget->setVisible(false);
+
+    // Notify on change
+    connect(dateFrom, SIGNAL(dateChanged(QDate)), this, SLOT(dateRangeChanged()));
+    connect(dateTo, SIGNAL(dateChanged(QDate)), this, SLOT(dateRangeChanged()));
+
+    return dateRangeWidget;
+}
+
+void PublicLabelView::dateRangeChanged()
+{
+    if(!transactionProxyModel)
+        return;
+    minDate = new QDateTime(dateFrom->date());
+    maxDate = new QDateTime(dateTo->date());
+    maxDate->addDays(1);
+    changedPrefix();
+}
+
+void PublicLabelView::focusTransaction(const QModelIndex &idx)
+{
+    if(!transactionProxyModel)
+        return;
+    QModelIndex targetIdx = transactionProxyModel->mapFromSource(idx);
+    publicLabelView->scrollTo(targetIdx);
+    publicLabelView->setCurrentIndex(targetIdx);
+    publicLabelView->setFocus();
+}
+
+// We override the virtual resizeEvent of the QWidget to adjust tables column
+// sizes as the tables width is proportional to the dialogs width.
+void PublicLabelView::resizeEvent(QResizeEvent* event)
+{
+    QWidget::resizeEvent(event);
+    columnResizingFixer->stretchColumnWidth(TransactionTableModel::ToAddress);
+}
+
+// Need to override default Ctrl+C action for amount as default behaviour is just to copy DisplayRole text
+bool PublicLabelView::eventFilter(QObject *obj, QEvent *event)
+{
+    if (event->type() == QEvent::KeyPress)
+    {
+        QKeyEvent *ke = static_cast<QKeyEvent *>(event);
+        if (ke->key() == Qt::Key_C && ke->modifiers().testFlag(Qt::ControlModifier))
+        {
+            QModelIndex i = this->publicLabelView->currentIndex();
+            if (i.isValid() && i.column() == TransactionTableModel::Amount)
+            {
+                 GUIUtil::setClipboard(i.data(TransactionTableModel::FormattedAmountRole).toString());
+                 return true;
+            }
+        }
+    }
+    return QWidget::eventFilter(obj, event);
+}
+
+

--- a/src/qt/publiclabelview.h
+++ b/src/qt/publiclabelview.h
@@ -1,0 +1,117 @@
+// Copyright (c) 2015-2018 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_PUBLICLABELVIEW_H
+#define BITCOIN_QT_PUBLICLABELVIEW_H
+
+#include "guiutil.h"
+#include "transactionrecord.h"
+#include "transactiontablemodel.h"
+
+#include <QWidget>
+#include <QKeyEvent>
+
+class PlatformStyle;
+class TransactionFilterProxy;
+class WalletModel;
+
+QT_BEGIN_NAMESPACE
+class QComboBox;
+class QDateTimeEdit;
+class QFrame;
+class QLineEdit;
+class QMenu;
+class QModelIndex;
+class QSignalMapper;
+class QTableView;
+QT_END_NAMESPACE
+
+/** Widget showing the public labels in the blockchain.
+  */
+class PublicLabelView : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit PublicLabelView(const PlatformStyle *platformStyle, QWidget *parent = 0);
+
+    void setModel(WalletModel *model);
+
+    // Date ranges for filter
+    enum DateEnum
+    {
+        All,
+        Today,
+        ThisWeek,
+        ThisMonth,
+        LastMonth,
+        ThisYear,
+        Range
+    };
+
+    enum ColumnWidths
+    {
+        STATUS_COLUMN_WIDTH = 0,
+        WATCHONLY_COLUMN_WIDTH = 0,
+        DATE_COLUMN_WIDTH = 150,
+        TYPE_COLUMN_WIDTH = 0,
+        AMOUNT_MINIMUM_COLUMN_WIDTH = 150,
+        MINIMUM_COLUMN_WIDTH = 23
+    };
+
+private:
+    WalletModel *model;
+    TransactionFilterProxy *transactionProxyModel;
+    QTableView *publicLabelView;
+
+    QComboBox *dateWidget;
+    QLineEdit *addressWidget;
+    QLineEdit *amountWidget;
+
+    QMenu *contextMenu;
+    QSignalMapper *mapperThirdPartyTxUrls;
+
+    QFrame *dateRangeWidget;
+    QDateTimeEdit *dateFrom;
+    QDateTimeEdit *dateTo;
+    QDateTime *minDate;
+    QDateTime *maxDate;
+
+    QWidget *createDateRangeWidget();
+
+    GUIUtil::TableViewLastColumnResizingFixer *columnResizingFixer;
+
+    virtual void resizeEvent(QResizeEvent* event);
+
+    bool eventFilter(QObject *obj, QEvent *event);
+
+private Q_SLOTS:
+    void contextualMenu(const QPoint &);
+    void dateRangeChanged();
+    void showDetails();
+    void fillSendCoinsPage();
+    void copyAddress();
+    void copyLabel();
+    void copyAmount();
+    void copyTxID();
+    void copyTxHex();
+    void openThirdPartyTxUrl(QString url);
+
+Q_SIGNALS:
+    void doubleClicked(const QModelIndex&);
+    void menuActionSendPublicLabel(QString labelPublic);
+
+    /**  Fired when a message should be reported to the user */
+    void message(const QString &title, const QString &message, unsigned int style);
+
+public Q_SLOTS:
+    void chooseDate(int idx);
+    void changedPrefix();
+    void changedAmount(const QString &amount);
+    void exportClicked();
+    void focusTransaction(const QModelIndex&);
+
+};
+
+#endif // BITCOIN_QT_PUBLICLABELVIEW_H

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -322,8 +322,8 @@ void SendCoinsDialog::on_sendButton_clicked()
                 recipientElement.append(tr("<br><br><b>WARNING!!! DESTINATION IS A FREEZE ADDRESS<br>UNSPENDABLE "
                                            "UNTIL</b> %1 <br>*************************************************<br>")
                                             .arg(GUIUtil::HtmlEscape(rcp.freezeLockTime)));
-            }
 
+            }
         } // else if (!rcp.labelPublic.isEmpty())
 
 
@@ -472,6 +472,13 @@ void SendCoinsDialog::setAddress(const QString &address)
     }
 
     entry->setAddress(address);
+}
+
+void SendCoinsDialog::setPublicLabel(const QString labelPublic)
+{
+    // Replace the first public label
+    SendCoinsEntry *entry = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(0)->widget());
+    entry->setPublicLabel(labelPublic);
 }
 
 void SendCoinsDialog::pasteEntry(const SendCoinsRecipient &rv)

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -322,7 +322,6 @@ void SendCoinsDialog::on_sendButton_clicked()
                 recipientElement.append(tr("<br><br><b>WARNING!!! DESTINATION IS A FREEZE ADDRESS<br>UNSPENDABLE "
                                            "UNTIL</b> %1 <br>*************************************************<br>")
                                             .arg(GUIUtil::HtmlEscape(rcp.freezeLockTime)));
-
             }
         } // else if (!rcp.labelPublic.isEmpty())
 
@@ -477,7 +476,7 @@ void SendCoinsDialog::setAddress(const QString &address)
 void SendCoinsDialog::setPublicLabel(const QString labelPublic)
 {
     // Replace the first public label
-    SendCoinsEntry *entry = qobject_cast<SendCoinsEntry*>(ui->entries->itemAt(0)->widget());
+    SendCoinsEntry *entry = qobject_cast<SendCoinsEntry *>(ui->entries->itemAt(0)->widget());
     entry->setPublicLabel(labelPublic);
 }
 

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -46,6 +46,7 @@ public:
     QWidget *setupTabChain(QWidget *prev);
 
     void setAddress(const QString &address);
+    void setPublicLabel(const QString labelPublic);
     void pasteEntry(const SendCoinsRecipient &rv);
     bool handlePaymentRequest(const SendCoinsRecipient &recipient);
 
@@ -61,6 +62,8 @@ public Q_SLOTS:
         const CAmount &watchOnlyBalance,
         const CAmount &watchUnconfBalance,
         const CAmount &watchImmatureBalance);
+
+
 
 private:
     Ui::SendCoinsDialog *ui;

--- a/src/qt/sendcoinsdialog.h
+++ b/src/qt/sendcoinsdialog.h
@@ -64,7 +64,6 @@ public Q_SLOTS:
         const CAmount &watchImmatureBalance);
 
 
-
 private:
     Ui::SendCoinsDialog *ui;
     ClientModel *clientModel;

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -40,7 +40,7 @@ SendCoinsEntry::SendCoinsEntry(const PlatformStyle *_platformStyle, QWidget *par
         ui->payToLayout->setSpacing(4);
     }
     ui->addAsLabel->setPlaceholderText(tr("Enter a private label for this address to add it to your address book"));
-    ui->lineEditPublic->setPlaceholderText(tr("Enter a public label for this transaction"));
+    ui->lineEditPublic->setPlaceholderText(tr("Enter a public label for this transaction. These are stored forever in the blockchain."));
 
 
     // normal bitcoin address field
@@ -227,12 +227,24 @@ void SendCoinsEntry::setAddress(const QString &address)
     ui->payAmount->setFocus();
 }
 
+void SendCoinsEntry::setPublicLabel(const QString labelPublic)
+{
+    ui->lineEditPublic->setText(labelPublic);
+    ui->payTo->setFocus();
+}
+
 bool SendCoinsEntry::isClear()
 {
     return ui->payTo->text().isEmpty() && ui->payTo_is->text().isEmpty() && ui->payTo_s->text().isEmpty();
 }
 
+bool SendCoinsEntry::isClearPublicLabel()
+{
+    return ui->lineEditPublic->text().isEmpty();
+}
+
 void SendCoinsEntry::setFocus() { ui->payTo->setFocus(); }
+
 void SendCoinsEntry::updateDisplayUnit()
 {
     if (model && model->getOptionsModel())

--- a/src/qt/sendcoinsentry.cpp
+++ b/src/qt/sendcoinsentry.cpp
@@ -40,7 +40,8 @@ SendCoinsEntry::SendCoinsEntry(const PlatformStyle *_platformStyle, QWidget *par
         ui->payToLayout->setSpacing(4);
     }
     ui->addAsLabel->setPlaceholderText(tr("Enter a private label for this address to add it to your address book"));
-    ui->lineEditPublic->setPlaceholderText(tr("Enter a public label for this transaction. These are stored forever in the blockchain."));
+    ui->lineEditPublic->setPlaceholderText(
+        tr("Enter a public label for this transaction. These are stored forever in the blockchain."));
 
 
     // normal bitcoin address field
@@ -238,13 +239,8 @@ bool SendCoinsEntry::isClear()
     return ui->payTo->text().isEmpty() && ui->payTo_is->text().isEmpty() && ui->payTo_s->text().isEmpty();
 }
 
-bool SendCoinsEntry::isClearPublicLabel()
-{
-    return ui->lineEditPublic->text().isEmpty();
-}
-
+bool SendCoinsEntry::isClearPublicLabel() { return ui->lineEditPublic->text().isEmpty(); }
 void SendCoinsEntry::setFocus() { ui->payTo->setFocus(); }
-
 void SendCoinsEntry::updateDisplayUnit()
 {
     if (model && model->getOptionsModel())

--- a/src/qt/sendcoinsentry.h
+++ b/src/qt/sendcoinsentry.h
@@ -37,9 +37,12 @@ public:
 
     /** Return whether the entry is still empty and unedited */
     bool isClear();
+    bool isClearPublicLabel();
 
     void setValue(const SendCoinsRecipient &value);
     void setAddress(const QString &address);
+    void setPublicLabel(const QString labelPublic);
+
 
     /** Set up the tab chain manually, as Qt messes up the tab chain by default in some cases
      *  (issue https://bugreports.qt-project.org/browse/QTBUG-10907).

--- a/src/qt/transactiondesc.cpp
+++ b/src/qt/transactiondesc.cpp
@@ -77,7 +77,7 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
 
         CAmount totalPublicLabelSatoshisUnspent = 0;
         int countMatching = 0;
-        std::vector<std::pair<CWalletTx, int>> txoutMatchingPLs = wallet->GetTopPublicLabelTxs(labelPublic);
+        std::vector<std::pair<CWalletTx, int> > txoutMatchingPLs = wallet->GetTopPublicLabelTxs(labelPublic);
         for (const std::pair<CWalletTx, int> &txoutPL : txoutMatchingPLs)
         {
             CTxOut txout = txoutPL.first.vout[txoutPL.second + 1];
@@ -89,9 +89,11 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
             CTxDestination address;
             if (ExtractDestination(txout.scriptPubKey, address))
             {
-                strHTML += "<b>" + tr("Unspent") + ":</b>" + BitcoinUnits::formatHtmlWithUnit(unit, txout.nValue, true) + "<br>";
+                strHTML += "<b>" + tr("Unspent") + ":</b>" +
+                           BitcoinUnits::formatHtmlWithUnit(unit, txout.nValue, true) + "<br>";
                 strHTML += "<b>" + tr("Address") + ":</b> " + GUIUtil::HtmlEscape(EncodeDestination(address)) + "<br>";
-                strHTML += "<b>" + tr("Date") + ":</b> " + (txoutPL.first.GetTxTime() ? GUIUtil::dateTimeStr(txoutPL.first.GetTxTime()) : "") + "<br>";
+                strHTML += "<b>" + tr("Date") + ":</b> " +
+                           (txoutPL.first.GetTxTime() ? GUIUtil::dateTimeStr(txoutPL.first.GetTxTime()) : "") + "<br>";
                 countMatching += 1;
             }
         }
@@ -99,7 +101,8 @@ QString TransactionDesc::toHTML(CWallet *wallet, CWalletTx &wtx, TransactionReco
             strHTML += "None <br>";
         else
             // display network total including selected public label
-            strHTML += "<b>" + tr("Total unspent for public label") + ":</b>" + BitcoinUnits::formatHtmlWithUnit(unit, totalPublicLabelSatoshisUnspent, true) + "<br>";
+            strHTML += "<b>" + tr("Total unspent for public label") + ":</b>" +
+                       BitcoinUnits::formatHtmlWithUnit(unit, totalPublicLabelSatoshisUnspent, true) + "<br>";
         return strHTML;
     }
 

--- a/src/qt/transactionfilterproxy.cpp
+++ b/src/qt/transactionfilterproxy.cpp
@@ -49,7 +49,7 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
         return false;
     if (publicLabelFilter && !involvesPublicLabelAddress)
         return false;
-    if(datetime < dateFrom || datetime > dateTo)
+    if (datetime < dateFrom || datetime > dateTo)
         return false;
     if (!address.contains(addrPrefix, Qt::CaseInsensitive) && !label.contains(addrPrefix, Qt::CaseInsensitive))
         return false;
@@ -58,10 +58,13 @@ bool TransactionFilterProxy::filterAcceptsRow(int sourceRow, const QModelIndex &
     if (publicLabelFilter && type == TransactionRecord::TopPublicLabel)
     {
         // Exclude public labels that are not in the Top 20
-        auto plit = std::find_if( publicLabelsGrouped.begin(), publicLabelsGrouped.end(),
-            [&address](const std::pair<std::string, CAmount>& element){ return element.first == address.toStdString();} );
+        auto plit = std::find_if(publicLabelsGrouped.begin(), publicLabelsGrouped.end(),
+            [&address](const std::pair<std::string, CAmount> &element) {
+                return element.first == address.toStdString();
+            });
 
-        if (plit == publicLabelsGrouped.end()) return false;
+        if (plit == publicLabelsGrouped.end())
+            return false;
     }
 
     return true;
@@ -104,7 +107,7 @@ void TransactionFilterProxy::setPublicLabelFilter(bool filter)
     invalidateFilter();
 }
 
-void TransactionFilterProxy::setTopPublicLabelsList(std::vector<std::pair<std::string, CAmount>> &_publicLabelsGrouped)
+void TransactionFilterProxy::setTopPublicLabelsList(std::vector<std::pair<std::string, CAmount> > &_publicLabelsGrouped)
 {
     this->publicLabelsGrouped = _publicLabelsGrouped;
     invalidateFilter();
@@ -128,4 +131,3 @@ int TransactionFilterProxy::rowCount(const QModelIndex &parent) const
         return QSortFilterProxyModel::rowCount(parent);
     }
 }
-

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -44,7 +44,7 @@ public:
     void setMinAmount(const CAmount &minimum);
     void setWatchOnlyFilter(WatchOnlyFilter filter);
     void setPublicLabelFilter(bool filter);
-    void setTopPublicLabelsList(std::vector<std::pair<std::string, CAmount>> &_publicLabelsGrouped);
+    void setTopPublicLabelsList(std::vector<std::pair<std::string, CAmount> > &_publicLabelsGrouped);
 
     /** Set maximum number of rows returned, -1 if unlimited. */
     void setLimit(int limit);
@@ -61,14 +61,13 @@ private:
     QDateTime dateFrom;
     QDateTime dateTo;
     QString addrPrefix;
-    std::vector<std::pair<std::string, CAmount>> publicLabelsGrouped;
+    std::vector<std::pair<std::string, CAmount> > publicLabelsGrouped;
     quint32 typeFilter;
     WatchOnlyFilter watchOnlyFilter;
     bool publicLabelFilter;
     CAmount minAmount;
     int limitRows;
     bool showInactive;
-
 };
 
 #endif // BITCOIN_QT_TRANSACTIONFILTERPROXY_H

--- a/src/qt/transactionfilterproxy.h
+++ b/src/qt/transactionfilterproxy.h
@@ -36,12 +36,15 @@ public:
 
     void setDateRange(const QDateTime &from, const QDateTime &to);
     void setAddressPrefix(const QString &addrPrefix);
+
     /**
       @note Type filter takes a bit field created with TYPE() or ALL_TYPES
      */
     void setTypeFilter(quint32 modes);
     void setMinAmount(const CAmount &minimum);
     void setWatchOnlyFilter(WatchOnlyFilter filter);
+    void setPublicLabelFilter(bool filter);
+    void setTopPublicLabelsList(std::vector<std::pair<std::string, CAmount>> &_publicLabelsGrouped);
 
     /** Set maximum number of rows returned, -1 if unlimited. */
     void setLimit(int limit);
@@ -58,12 +61,14 @@ private:
     QDateTime dateFrom;
     QDateTime dateTo;
     QString addrPrefix;
+    std::vector<std::pair<std::string, CAmount>> publicLabelsGrouped;
     quint32 typeFilter;
     WatchOnlyFilter watchOnlyFilter;
     bool publicLabelFilter;
     CAmount minAmount;
     int limitRows;
     bool showInactive;
+
 };
 
 #endif // BITCOIN_QT_TRANSACTIONFILTERPROXY_H

--- a/src/qt/transactionrecord.cpp
+++ b/src/qt/transactionrecord.cpp
@@ -30,7 +30,9 @@ bool TransactionRecord::showTransaction(const CWalletTx &wtx)
 /*
  * Decompose CWallet transaction to model transaction records.
  */
-QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *wallet, const CWalletTx &wtx, bool isTopPublicLabel)
+QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *wallet,
+    const CWalletTx &wtx,
+    bool isTopPublicLabel)
 {
     QList<TransactionRecord> parts;
     int64_t nTime = wtx.GetTxTime();
@@ -44,7 +46,7 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
     // some outputs may be in the wallet because
     // they have public labels not because they are mine
     AddressList listAllAddresses;
-    for (const CTxOut& txout: wtx.vout)
+    for (const CTxOut &txout : wtx.vout)
     {
         CTxDestination address;
         std::string labelPublic = getLabelPublic(txout.scriptPubKey);
@@ -72,7 +74,8 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
 
     } // end load all tx addresses for user display/filter
 
-    if (isTopPublicLabel) return parts;
+    if (isTopPublicLabel)
+        return parts;
 
     if (nNet > 0 || wtx.IsCoinBase())
     {
@@ -223,24 +226,23 @@ QList<TransactionRecord> TransactionRecord::decomposeTransaction(const CWallet *
         } // else if (fAllFromMe)
         else
         {
-
             // Check if at least one of the inputs/outputs are mine
             // They could be public label txs that are not mine
             bool atLeastOneMine = false;
-            for (const CTxIn& txin: wtx.vin)
+            for (const CTxIn &txin : wtx.vin)
             {
                 isminetype mine = wallet->IsMine(txin);
-                if(mine)
+                if (mine)
                 {
                     atLeastOneMine = true;
                     break;
                 }
             }
             if (!atLeastOneMine)
-                for (const CTxOut& txout: wtx.vout)
+                for (const CTxOut &txout : wtx.vout)
                 {
                     isminetype mine = wallet->IsMine(txout);
-                    if(mine)
+                    if (mine)
                     {
                         atLeastOneMine = true;
                         break;

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -85,7 +85,7 @@ public:
         RecvWithAddress,
         RecvFromOther,
         SendToSelf,
-        PublicLabel
+        TopPublicLabel
     };
 
     /** Number of confirmation recommended for accepting a transaction */
@@ -110,7 +110,7 @@ public:
     /** Decompose CWallet transaction to model transaction records.
      */
     static bool showTransaction(const CWalletTx &wtx);
-    static QList<TransactionRecord> decomposeTransaction(const CWallet *wallet, const CWalletTx &wtx);
+    static QList<TransactionRecord> decomposeTransaction(const CWallet *wallet, const CWalletTx &wtx, bool isTopPublicLabel);
 
     /** @name Immutable transaction attributes
       @{*/
@@ -130,6 +130,9 @@ public:
 
     /** Whether the transaction was sent/received with a watch-only address */
     bool involvesWatchAddress;
+
+    /** Whether the transaction involves a public label */
+    bool involvesPublicLabel;
 
     /** Return the unique identifier for this transaction (part) */
     QString getTxID() const;

--- a/src/qt/transactionrecord.h
+++ b/src/qt/transactionrecord.h
@@ -110,7 +110,9 @@ public:
     /** Decompose CWallet transaction to model transaction records.
      */
     static bool showTransaction(const CWalletTx &wtx);
-    static QList<TransactionRecord> decomposeTransaction(const CWallet *wallet, const CWalletTx &wtx, bool isTopPublicLabel);
+    static QList<TransactionRecord> decomposeTransaction(const CWallet *wallet,
+        const CWalletTx &wtx,
+        bool isTopPublicLabel);
 
     /** @name Immutable transaction attributes
       @{*/

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -80,7 +80,7 @@ public:
 
                 // sort txs by datetime descending
                 std::sort(sortedTopPublicLabels.begin(), sortedTopPublicLabels.end(),
-                            [](std::pair<int64_t, CWalletTx> &left, std::pair<int64_t, CWalletTx> &right)
+                            [](const std::pair<int64_t, CWalletTx> left, const std::pair<int64_t, CWalletTx> right)
                             { return left.first < right.first; });
 
                 for (std::pair<int64_t, CWalletTx> it: sortedTopPublicLabels)

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -334,10 +334,10 @@ void TransactionTableModel::updateConfirmations()
     Q_EMIT dataChanged(index(0, ToAddress), index(priv->size() - 1, ToAddress));
 }
 
-std::vector<std::pair<std::string, CAmount>> TransactionTableModel::getTopPublicLabelsList(QString addrPrefix)
+std::vector<std::pair<std::string, CAmount>> TransactionTableModel::getTopPublicLabelsList(QString addrPrefix, QDateTime* minDate, QDateTime* maxDate)
 {
     // Build a list of the Top 20 public labels using the addrPrefix filter
-     return wallet->GroupTopPublicLabels(20, addrPrefix.toStdString());
+     return wallet->GroupTopPublicLabels(20, addrPrefix.toStdString(), minDate->toMSecsSinceEpoch() / 1000, maxDate->toMSecsSinceEpoch() / 1000);
 }
 
 int TransactionTableModel::rowCount(const QModelIndex &parent) const

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -25,9 +25,9 @@
 #include <QDebug>
 #include <QIcon>
 #include <QList>
-#include <vector>
 #include <map>
 #include <set>
+#include <vector>
 
 // Amount column is right-aligned it contains numbers
 static int column_alignments[] = {
@@ -74,39 +74,47 @@ public:
             if (GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS) > 0)
             {
                 // copy to a vector for sorting by datetime
-                std::vector<std::pair<int64_t, CWalletTx>> sortedTopPublicLabels;
-                for (PAIRTYPE(uint256, CWalletTx) item: wallet->mapWalletTopPublicLabels)
-                    { sortedTopPublicLabels.push_back(std::make_pair(item.second.GetTxTime(), item.second)); }
+                std::vector<std::pair<int64_t, CWalletTx> > sortedTopPublicLabels;
+                for (PAIRTYPE(uint256, CWalletTx) item : wallet->mapWalletTopPublicLabels)
+                {
+                    sortedTopPublicLabels.push_back(std::make_pair(item.second.GetTxTime(), item.second));
+                }
 
                 // sort txs by datetime descending
                 std::sort(sortedTopPublicLabels.begin(), sortedTopPublicLabels.end(),
-                            [](const std::pair<int64_t, CWalletTx> left, const std::pair<int64_t, CWalletTx> right)
-                            { return left.first < right.first; });
+                    [](const std::pair<int64_t, CWalletTx> left, const std::pair<int64_t, CWalletTx> right) {
+                        return left.first < right.first;
+                    });
 
-                for (std::pair<int64_t, CWalletTx> it: sortedTopPublicLabels)
+                for (std::pair<int64_t, CWalletTx> it : sortedTopPublicLabels)
                 {
                     if (TransactionRecord::showTransaction(it.second))
                     {
-                        QList<TransactionRecord> recList = TransactionRecord::decomposeTransaction(wallet, it.second, true);
-                        for (TransactionRecord &recNew: recList)
+                        QList<TransactionRecord> recList =
+                            TransactionRecord::decomposeTransaction(wallet, it.second, true);
+                        for (TransactionRecord &recNew : recList)
                         {
                             // Exclude public labels that already exist
-                            for (const TransactionRecord &rec: cachedWallet)
-                                if (rec.addresses.begin()->first == recNew.addresses.begin()->first) goto recNew_Next;
+                            for (const TransactionRecord &rec : cachedWallet)
+                                if (rec.addresses.begin()->first == recNew.addresses.begin()->first)
+                                    goto recNew_Next;
 
                             cachedWallet.append(recNew);
 
-                            recNew_Next: {}
+                        recNew_Next:
+                        {
+                        }
                             // Continue
                         }
                     }
                 }
             }
 
-            for (std::map<uint256, CWalletTx>::iterator it = wallet->mapWallet.begin(); it != wallet->mapWallet.end();++it)
+            for (std::map<uint256, CWalletTx>::iterator it = wallet->mapWallet.begin(); it != wallet->mapWallet.end();
+                 ++it)
             {
                 if (TransactionRecord::showTransaction(it->second))
-                                    cachedWallet.append(TransactionRecord::decomposeTransaction(wallet, it->second, false));
+                    cachedWallet.append(TransactionRecord::decomposeTransaction(wallet, it->second, false));
             }
         }
     }
@@ -235,7 +243,8 @@ public:
     {
         {
             LOCK2(cs_main, wallet->cs_wallet);
-            std::map<uint256, CWalletTx> walletMap = (rec->type == TransactionRecord::TopPublicLabel ? wallet->mapWalletTopPublicLabels : wallet->mapWallet);
+            std::map<uint256, CWalletTx> walletMap =
+                (rec->type == TransactionRecord::TopPublicLabel ? wallet->mapWalletTopPublicLabels : wallet->mapWallet);
             std::map<uint256, CWalletTx>::iterator mi = walletMap.find(rec->hash);
             if (mi != walletMap.end())
             {
@@ -248,7 +257,8 @@ public:
     QString getTxHex(TransactionRecord *rec)
     {
         LOCK2(cs_main, wallet->cs_wallet);
-        std::map<uint256, CWalletTx> walletMap = (rec->type == TransactionRecord::TopPublicLabel ? wallet->mapWalletTopPublicLabels : wallet->mapWallet);
+        std::map<uint256, CWalletTx> walletMap =
+            (rec->type == TransactionRecord::TopPublicLabel ? wallet->mapWalletTopPublicLabels : wallet->mapWallet);
         std::map<uint256, CWalletTx>::iterator mi = walletMap.find(rec->hash);
         if (mi != walletMap.end())
         {
@@ -305,7 +315,6 @@ void TransactionTableModel::updateTransaction(const QString &hash, int status, b
 
     priv->updateWallet(updated, status, showTransaction);
     publicLabelTotals.clear();
-
 }
 
 void TransactionTableModel::updateConfirmations()
@@ -318,10 +327,13 @@ void TransactionTableModel::updateConfirmations()
     Q_EMIT dataChanged(index(0, ToAddress), index(priv->size() - 1, ToAddress));
 }
 
-std::vector<std::pair<std::string, CAmount>> TransactionTableModel::getTopPublicLabelsList(QString addrPrefix, QDateTime* minDate, QDateTime* maxDate)
+std::vector<std::pair<std::string, CAmount> > TransactionTableModel::getTopPublicLabelsList(QString addrPrefix,
+    QDateTime *minDate,
+    QDateTime *maxDate)
 {
     // Build a list of the Top 20 public labels using the addrPrefix filter
-     return wallet->GroupTopPublicLabels(20, addrPrefix.toStdString(), minDate->toMSecsSinceEpoch() / 1000, maxDate->toMSecsSinceEpoch() / 1000);
+    return wallet->GroupTopPublicLabels(
+        20, addrPrefix.toStdString(), minDate->toMSecsSinceEpoch() / 1000, maxDate->toMSecsSinceEpoch() / 1000);
 }
 
 int TransactionTableModel::rowCount(const QModelIndex &parent) const
@@ -480,7 +492,6 @@ QString TransactionTableModel::formatTxToAddress(const TransactionRecord *wtx, b
         return QString::fromStdString(addressList) + watchAddress;
     else
         return label + " " + QString::fromStdString(addressList) + watchAddress;
-
 }
 
 QVariant TransactionTableModel::addressColor(const TransactionRecord *wtx) const
@@ -518,8 +529,7 @@ QString TransactionTableModel::formatTxAmount(const TransactionRecord *wtx,
     else
         amt = wtx->credit + wtx->debit;
 
-    QString str = BitcoinUnits::format(
-    walletModel->getOptionsModel()->getDisplayUnit(), amt, false, separators);
+    QString str = BitcoinUnits::format(walletModel->getOptionsModel()->getDisplayUnit(), amt, false, separators);
     if (showUnconfirmed && wtx->type != TransactionRecord::TopPublicLabel)
     {
         if (!wtx->status.countsForBalance)
@@ -584,11 +594,13 @@ QVariant TransactionTableModel::txWatchonlyDecoration(const TransactionRecord *w
 CAmount TransactionTableModel::unspentPublicLabelTotal(std::string publicLabel) const
 {
     // Returns the total of public label unspent amounts related to the specified public label string
-    if (publicLabelTotals.contains(publicLabel)) return publicLabelTotals[publicLabel];
+    if (publicLabelTotals.contains(publicLabel))
+        return publicLabelTotals[publicLabel];
 
     LOCK2(cs_main, wallet->cs_wallet);
     CAmount amt = 0;
-    for(std::map<uint256, CWalletTx>::iterator it = wallet->mapWalletTopPublicLabels.begin(); it != wallet->mapWalletTopPublicLabels.end(); ++it)
+    for (std::map<uint256, CWalletTx>::iterator it = wallet->mapWalletTopPublicLabels.begin();
+         it != wallet->mapWalletTopPublicLabels.end(); ++it)
     {
         CTransaction tx(it->second);
         amt += wallet->UnspentPublicLabelAmount(tx, publicLabel).first;
@@ -691,7 +703,8 @@ QVariant TransactionTableModel::data(const QModelIndex &index, int role) const
         return column_alignments[index.column()];
     case Qt::ForegroundRole:
         // Non-confirmed (but not immature) as transactions are grey
-        if (!rec->status.countsForBalance && rec->status.status != TransactionStatus::Immature && rec->type != TransactionRecord::TopPublicLabel)
+        if (!rec->status.countsForBalance && rec->status.status != TransactionStatus::Immature &&
+            rec->type != TransactionRecord::TopPublicLabel)
         {
             return COLOR_UNCONFIRMED;
         }

--- a/src/qt/transactiontablemodel.cpp
+++ b/src/qt/transactiontablemodel.cpp
@@ -163,7 +163,7 @@ public:
                     break;
                 }
                 // Added -- insert at the right position
-                QList<TransactionRecord> toInsert = TransactionRecord::decomposeTransaction(wallet, mi->second);
+                QList<TransactionRecord> toInsert = TransactionRecord::decomposeTransaction(wallet, mi->second, false);
                 if (!toInsert.isEmpty()) /* only if something to insert */
                 {
                     parent->beginInsertRows(QModelIndex(), lowerIndex, lowerIndex + toInsert.size() - 1);

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -127,7 +127,9 @@ public Q_SLOTS:
     void updateAmountColumnTitle();
     void updateAddressColumnTitle();
     void updatePublicLabelColumnTitle();
-    std::vector<std::pair<std::string, CAmount>> getTopPublicLabelsList(QString addrPrefix, QDateTime* minDate, QDateTime* maxDate);
+    std::vector<std::pair<std::string, CAmount> > getTopPublicLabelsList(QString addrPrefix,
+        QDateTime *minDate,
+        QDateTime *maxDate);
 
     /* Needed to update fProcessingQueuedTransactions through a QueuedConnection */
     void setProcessingQueuedTransactions(bool value) { fProcessingQueuedTransactions = value; }

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -107,11 +107,15 @@ private:
     QString formatTooltip(const TransactionRecord *rec) const;
 #ifdef ENABLE_WALLET
     QString pickLabelWithAddress(AddressList listAddresses, std::string &address) const;
+
 #endif
 
     QVariant txStatusDecoration(const TransactionRecord *wtx) const;
     QVariant txWatchonlyDecoration(const TransactionRecord *wtx) const;
     QVariant txAddressDecoration(const TransactionRecord *wtx) const;
+
+    mutable QMap<std::string, CAmount> publicLabelTotals;
+    CAmount unspentPublicLabelTotal(std::string publicLabel) const;
 
 public Q_SLOTS:
     /* New transaction, or transaction changed status */
@@ -121,6 +125,10 @@ public Q_SLOTS:
     /** Updates the column title to "Amount (DisplayUnit)" and emits headerDataChanged() signal for table headers to
      * react. */
     void updateAmountColumnTitle();
+    void updateAddressColumnTitle();
+    void updatePublicLabelColumnTitle();
+    std::vector<std::pair<std::string, CAmount>> getTopPublicLabelsList(QString addrPrefix);
+
     /* Needed to update fProcessingQueuedTransactions through a QueuedConnection */
     void setProcessingQueuedTransactions(bool value) { fProcessingQueuedTransactions = value; }
     friend class TransactionTablePriv;

--- a/src/qt/transactiontablemodel.h
+++ b/src/qt/transactiontablemodel.h
@@ -127,7 +127,7 @@ public Q_SLOTS:
     void updateAmountColumnTitle();
     void updateAddressColumnTitle();
     void updatePublicLabelColumnTitle();
-    std::vector<std::pair<std::string, CAmount>> getTopPublicLabelsList(QString addrPrefix);
+    std::vector<std::pair<std::string, CAmount>> getTopPublicLabelsList(QString addrPrefix, QDateTime* minDate, QDateTime* maxDate);
 
     /* Needed to update fProcessingQueuedTransactions through a QueuedConnection */
     void setProcessingQueuedTransactions(bool value) { fProcessingQueuedTransactions = value; }

--- a/src/qt/transactionview.cpp
+++ b/src/qt/transactionview.cpp
@@ -196,6 +196,7 @@ void TransactionView::setModel(WalletModel *_model)
     if (_model)
     {
         transactionProxyModel = new TransactionFilterProxy(this);
+        transactionProxyModel->setPublicLabelFilter(false);
         transactionProxyModel->setSourceModel(_model->getTransactionTableModel());
         transactionProxyModel->setDynamicSortFilter(true);
         transactionProxyModel->setSortCaseSensitivity(Qt::CaseInsensitive);

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -114,7 +114,7 @@ void WalletFrame::gotoHistoryPage()
 
 void WalletFrame::gotoPublicLabelPage()
 {
-    QMap<QString, WalletView*>::const_iterator i;
+    QMap<QString, WalletView *>::const_iterator i;
     for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
         i.value()->gotoPublicLabelPage();
 }

--- a/src/qt/walletframe.cpp
+++ b/src/qt/walletframe.cpp
@@ -112,6 +112,13 @@ void WalletFrame::gotoHistoryPage()
         i.value()->gotoHistoryPage();
 }
 
+void WalletFrame::gotoPublicLabelPage()
+{
+    QMap<QString, WalletView*>::const_iterator i;
+    for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
+        i.value()->gotoPublicLabelPage();
+}
+
 void WalletFrame::gotoReceiveCoinsPage()
 {
     QMap<QString, WalletView *>::const_iterator i;
@@ -119,11 +126,11 @@ void WalletFrame::gotoReceiveCoinsPage()
         i.value()->gotoReceiveCoinsPage();
 }
 
-void WalletFrame::gotoSendCoinsPage(QString addr)
+void WalletFrame::gotoSendCoinsPage(QString labelPublic)
 {
     QMap<QString, WalletView *>::const_iterator i;
     for (i = mapWalletViews.constBegin(); i != mapWalletViews.constEnd(); ++i)
-        i.value()->gotoSendCoinsPage(addr);
+        i.value()->gotoSendCoinsPage(labelPublic);
 }
 
 void WalletFrame::gotoSignMessageTab(QString addr)

--- a/src/qt/walletframe.h
+++ b/src/qt/walletframe.h
@@ -58,10 +58,12 @@ public Q_SLOTS:
     void gotoOverviewPage();
     /** Switch to history (transactions) page */
     void gotoHistoryPage();
+    /** Switch to public label page */
+    void gotoPublicLabelPage();
     /** Switch to receive coins page */
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
-    void gotoSendCoinsPage(QString addr = "");
+    void gotoSendCoinsPage(QString labelPublic);
 
     /** Show Sign/Verify Message dialog and switch to sign message tab */
     void gotoSignMessageTab(QString addr = "");

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -533,7 +533,8 @@ CPubKey WalletModel::getNewPubKey()
 {
     // Generate a new address to associate with a new send transaction
     CPubKey newKey;
-    if(wallet->GetKeyFromPool(newKey)) return newKey;
+    if (wallet->GetKeyFromPool(newKey))
+        return newKey;
 }
 
 bool WalletModel::IsSpendable(const CTxDestination &dest) const { return wallet->IsMine(dest) & ISMINE_SPENDABLE; }

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -529,6 +529,13 @@ bool WalletModel::getPubKey(const CKeyID &address, CPubKey &vchPubKeyOut) const
     return wallet->GetPubKey(address, vchPubKeyOut);
 }
 
+CPubKey WalletModel::getNewPubKey()
+{
+    // Generate a new address to associate with a new send transaction
+    CPubKey newKey;
+    if(wallet->GetKeyFromPool(newKey)) return newKey;
+}
+
 bool WalletModel::IsSpendable(const CTxDestination &dest) const { return wallet->IsMine(dest) & ISMINE_SPENDABLE; }
 // returns a list of COutputs from COutPoints
 void WalletModel::getOutputs(const std::vector<COutPoint> &vOutpoints, std::vector<COutput> &vOutputs)

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -214,6 +214,7 @@ public:
     UnlockContext requestUnlock();
 
     bool getPubKey(const CKeyID &address, CPubKey &vchPubKeyOut) const;
+    CPubKey getNewPubKey();
     bool IsSpendable(const CTxDestination &dest) const;
     void getOutputs(const std::vector<COutPoint> &vOutpoints, std::vector<COutput> &vOutputs);
     bool isSpent(const COutPoint &outpoint) const;

--- a/src/qt/walletview.cpp
+++ b/src/qt/walletview.cpp
@@ -9,18 +9,18 @@
 #include "askpassphrasedialog.h"
 #include "bitcoingui.h"
 #include "clientmodel.h"
+#include "dstencode.h"
 #include "guiutil.h"
 #include "optionsmodel.h"
 #include "overviewpage.h"
 #include "platformstyle.h"
+#include "publiclabelview.h"
 #include "receivecoinsdialog.h"
 #include "sendcoinsdialog.h"
 #include "signverifymessagedialog.h"
 #include "transactiontablemodel.h"
 #include "transactionview.h"
-#include "publiclabelview.h"
 #include "walletmodel.h"
-#include "dstencode.h"
 
 #include "ui_interface.h"
 
@@ -55,7 +55,6 @@ WalletView::WalletView(const PlatformStyle *_platformStyle, const Config *cfg, Q
     transactionsPage->setLayout(vbox);
 
 
-
     publicLabelPage = new QWidget(this);
     QVBoxLayout *vbox2 = new QVBoxLayout();
     publicLabelView = new PublicLabelView(platformStyle, this);
@@ -78,7 +77,8 @@ WalletView::WalletView(const PlatformStyle *_platformStyle, const Config *cfg, Q
     addWidget(sendCoinsPage);
 
     // Clicking on a transaction on the overview pre-selects the transaction on the transaction history page
-    connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), transactionView, SLOT(focusTransaction(QModelIndex)));
+    connect(
+        overviewPage, SIGNAL(transactionClicked(QModelIndex)), transactionView, SLOT(focusTransaction(QModelIndex)));
 
     // Double-clicking on a transaction on the transaction history or public label list page shows details
     connect(transactionView, SIGNAL(doubleClicked(QModelIndex)), transactionView, SLOT(showDetails()));
@@ -92,9 +92,11 @@ WalletView::WalletView(const PlatformStyle *_platformStyle, const Config *cfg, Q
         SIGNAL(message(QString, QString, unsigned int)));
     // Pass through messages from transactionView
 
-    connect(transactionView, SIGNAL(message(QString,QString,unsigned int)), this, SIGNAL(message(QString,QString,unsigned int)));
+    connect(transactionView, SIGNAL(message(QString, QString, unsigned int)), this,
+        SIGNAL(message(QString, QString, unsigned int)));
     // Pass through messages from publicLabelView
-    connect(publicLabelView, SIGNAL(message(QString,QString,unsigned int)), this, SIGNAL(message(QString,QString,unsigned int)));
+    connect(publicLabelView, SIGNAL(message(QString, QString, unsigned int)), this,
+        SIGNAL(message(QString, QString, unsigned int)));
 }
 
 WalletView::~WalletView() {}
@@ -105,11 +107,13 @@ void WalletView::setBitcoinGUI(BitcoinGUI *gui)
         // Clicking on a transaction on the overview page simply sends you to transaction history page
         connect(overviewPage, SIGNAL(transactionClicked(QModelIndex)), gui, SLOT(gotoHistoryPage()));
 
-        // Menu action Send public label on the public labe page sends you to the send tx page with the public label pre-filled
+        // Menu action Send public label on the public labe page sends you to the send tx page with the public label
+        // pre-filled
         connect(publicLabelView, SIGNAL(menuActionSendPublicLabel(QString)), gui, SLOT(gotoSendCoinsPage(QString)));
 
         // Receive and report messages
-        connect(this, SIGNAL(message(QString, QString, unsigned int)), gui, SLOT(message(QString, QString, unsigned int)));
+        connect(
+            this, SIGNAL(message(QString, QString, unsigned int)), gui, SLOT(message(QString, QString, unsigned int)));
 
         // Pass through encryption status changed signals
         connect(this, SIGNAL(encryptionStatusChanged(int)), gui, SLOT(setEncryptionStatus(int)));
@@ -207,7 +211,8 @@ void WalletView::gotoSendCoinsPage(QString labelPublic)
 {
     setCurrentWidget(sendCoinsPage);
 
-    if (!labelPublic.isEmpty()) sendCoinsPage->setPublicLabel(labelPublic);
+    if (!labelPublic.isEmpty())
+        sendCoinsPage->setPublicLabel(labelPublic);
 }
 
 void WalletView::gotoSignMessageTab(QString addr)

--- a/src/qt/walletview.h
+++ b/src/qt/walletview.h
@@ -18,6 +18,7 @@ class ReceiveCoinsDialog;
 class SendCoinsDialog;
 class SendCoinsRecipient;
 class TransactionView;
+class PublicLabelView;
 class WalletModel;
 class AddressBookPage;
 class Config;
@@ -63,12 +64,14 @@ private:
 
     OverviewPage *overviewPage;
     QWidget *transactionsPage;
+    QWidget *publicLabelPage;
     ReceiveCoinsDialog *receiveCoinsPage;
     SendCoinsDialog *sendCoinsPage;
     AddressBookPage *usedSendingAddressesPage;
     AddressBookPage *usedReceivingAddressesPage;
 
     TransactionView *transactionView;
+    PublicLabelView *publicLabelView;
 
     QProgressDialog *progressDialog;
     const PlatformStyle *platformStyle;
@@ -78,10 +81,12 @@ public Q_SLOTS:
     void gotoOverviewPage();
     /** Switch to history (transactions) page */
     void gotoHistoryPage();
+    /** Switch to public label page */
+    void gotoPublicLabelPage();
     /** Switch to receive coins page */
     void gotoReceiveCoinsPage();
     /** Switch to send coins page */
-    void gotoSendCoinsPage(QString addr = "");
+    void gotoSendCoinsPage(QString labelPublic);
 
     /** Show Sign/Verify Message dialog and switch to sign message tab */
     void gotoSignMessageTab(QString addr = "");

--- a/src/wallet/rpcdump.cpp
+++ b/src/wallet/rpcdump.cpp
@@ -489,7 +489,7 @@ UniValue importprunedfunds(const UniValue &params, bool fHelp)
     if (pwalletMain->IsMine(tx))
     {
         CWalletDB walletdb(pwalletMain->strWalletFile, "r+", false);
-        pwalletMain->AddToWallet(wtx, false, &walletdb);
+        pwalletMain->AddToWallet(wtx, false, &walletdb, false);
         return NullUniValue;
     }
 

--- a/src/wallet/test/accounting_tests.cpp
+++ b/src/wallet/test/accounting_tests.cpp
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
     pwalletMain->AddAccountingEntry(ae, walletdb);
 
     wtx.mapValue["comment"] = "z";
-    pwalletMain->AddToWallet(wtx, false, &walletdb);
+    pwalletMain->AddToWallet(wtx, false, &walletdb, false);
     vpwtx.push_back(&pwalletMain->mapWallet[wtx.GetHash()]);
     vpwtx[0]->nTimeReceived = (unsigned int)1333333335;
     vpwtx[0]->nOrderPos = -1;
@@ -91,7 +91,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
         --tx.nLockTime;  // Just to change the hash :)
         *static_cast<CTransaction*>(&wtx) = CTransaction(tx);
     }
-    pwalletMain->AddToWallet(wtx, false, &walletdb);
+    pwalletMain->AddToWallet(wtx, false, &walletdb, false);
     vpwtx.push_back(&pwalletMain->mapWallet[wtx.GetHash()]);
     vpwtx[1]->nTimeReceived = (unsigned int)1333333336;
 
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(acc_orderupgrade)
         --tx.nLockTime;  // Just to change the hash :)
         *static_cast<CTransaction*>(&wtx) = CTransaction(tx);
     }
-    pwalletMain->AddToWallet(wtx, false, &walletdb);
+    pwalletMain->AddToWallet(wtx, false, &walletdb, false);
     vpwtx.push_back(&pwalletMain->mapWallet[wtx.GetHash()]);
     vpwtx[2]->nTimeReceived = (unsigned int)1333333329;
     vpwtx[2]->nOrderPos = -1;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -34,8 +34,8 @@
 
 #include <assert.h>
 
-#include <boost/algorithm/string/replace.hpp>
 #include <boost/algorithm/string/find.hpp>
+#include <boost/algorithm/string/replace.hpp>
 #include <boost/thread.hpp>
 
 using namespace std;
@@ -301,7 +301,6 @@ bool CWallet::RemoveWatchOnly(const CScript &dest)
 }
 
 bool CWallet::LoadWatchOnly(const CScript &dest) { return CCryptoKeyStore::AddWatchOnly(dest); }
-
 bool CWallet::Unlock(const SecureString &strWalletPassphrase)
 {
     CCrypter crypter;
@@ -768,7 +767,8 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
             {
                 LOGA("Top Public Label transaction found but it should be deleted. %s", wtxIn.GetHash().ToString());
             }
-            else wtx.BindWallet(this);
+            else
+                wtx.BindWallet(this);
         }
     }
     else
@@ -787,7 +787,8 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
         {
             wtx.nTimeReceived = GetAdjustedTime();
             wtx.nOrderPos = IncOrderPosNext(pwalletdb);
-            if (!isTopPublicLabel) wtxOrdered.insert(make_pair(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry *)0)));
+            if (!isTopPublicLabel)
+                wtxOrdered.insert(make_pair(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry *)0)));
 
             wtx.nTimeSmart = wtx.nTimeReceived;
             if (!wtxIn.hashUnset())
@@ -832,7 +833,8 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
                     LOGA("AddToWallet(): found %s in block %s not in index\n", wtxIn.GetHash().ToString(),
                         wtxIn.hashBlock.ToString());
             }
-            if (!isTopPublicLabel) AddToSpends(hash);
+            if (!isTopPublicLabel)
+                AddToSpends(hash);
         }
 
         bool fUpdated = false;
@@ -878,17 +880,19 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
                 if (wtx.WriteTopPublicLabel(pwalletdb))
                 {
                     //// debug print
-                    LOGA("AddToWallet TopPublicLabel %s  %s%s\n", wtxIn.GetHash().ToString(), (fInsertedNew ? "new" : ""),
-                        (fUpdated ? "update" : ""));
+                    LOGA("AddToWallet TopPublicLabel %s  %s%s\n", wtxIn.GetHash().ToString(),
+                        (fInsertedNew ? "new" : ""), (fUpdated ? "update" : ""));
                 }
-                else return false;
+                else
+                    return false;
             else if (wtx.WriteToDisk(pwalletdb))
             {
                 //// debug print
                 LOGA("AddToWallet %s  %s%s\n", wtxIn.GetHash().ToString(), (fInsertedNew ? "new" : ""),
                     (fUpdated ? "update" : ""));
             }
-            else return false;
+            else
+                return false;
         }
         if (!isTopPublicLabel)
         {
@@ -968,8 +972,10 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef &ptx, const CBlock 
         // SetBestChain-mechanism
         CWalletDB walletdb(strWalletFile, "r+", false);
 
-        if (IsUnspentPublicLabel) AddToWallet(wtx, false, &walletdb, true);
-        if (fExisted || IsMine(*ptx) || IsFromMe(*ptx) ) return AddToWallet(wtx, false, &walletdb, false);
+        if (IsUnspentPublicLabel)
+            AddToWallet(wtx, false, &walletdb, true);
+        if (fExisted || IsMine(*ptx) || IsFromMe(*ptx))
+            return AddToWallet(wtx, false, &walletdb, false);
     }
     return false;
 }
@@ -1154,11 +1160,12 @@ bool CWallet::IsMine(const CTransaction &tx) const
     {
         if (IsMine(txout) != ISMINE_NO)
             return true;
-	}
+    }
     return false;
 }
 
-std::pair<CAmount, int> CWallet::UnspentPublicLabelAmount(const CTransaction& tx, const std::string comparePublicLabel) const
+std::pair<CAmount, int> CWallet::UnspentPublicLabelAmount(const CTransaction &tx,
+    const std::string comparePublicLabel) const
 { // Returns unspent output amount associated with public label
 
     // A public label exists BEFORE its txout buddy
@@ -1180,10 +1187,10 @@ std::pair<CAmount, int> CWallet::UnspentPublicLabelAmount(const CTransaction& tx
                     // found unspent outputs related to public label
                     return make_pair(nValue, i);
                 }
-
             }
-            else if ((comparePublicLabel != "" && txPublicLabel == comparePublicLabel)  // matches the specified public label
-                     || (comparePublicLabel == "" && txPublicLabel != ""))              // matches for any public label
+            // matches the specified public label
+            else if ((comparePublicLabel != "" && txPublicLabel == comparePublicLabel) ||
+                     (comparePublicLabel == "" && txPublicLabel != "")) // matches for any public label
             {
                 // if the public label exists the next txout.nValue is the target
                 nextIsPublicLabelBuddy = true;
@@ -1470,7 +1477,6 @@ void CWalletTx::GetAccountAmounts(const string &strAccount,
 
 bool CWalletTx::WriteToDisk(CWalletDB *pwalletdb) { return pwalletdb->WriteTx(GetHash(), *this); }
 bool CWalletTx::WriteTopPublicLabel(CWalletDB *pwalletdb) { return pwalletdb->WriteTopPublicLabel(GetHash(), *this); }
-
 /**
  * Scan the block chain (starting in pindexStart) for transactions
  * from or to us. If fUpdate is true, found transactions that already
@@ -1506,13 +1512,12 @@ int CWallet::ScanForWalletTransactions(CBlockIndex *pindexStart, bool fUpdate)
         // our wallet birthday (as adjusted for block time variability)
         // in -toppubliclabels mode public labels with unspent utxos
         // within 1 year are tracked so don't skip beyond then
-        while (pindex && nTimeFirstKey && (pindex->GetBlockTime() < (nTimeFirstKey - 7200))
-               && !((GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS) > 0)
-                        && (pindex->GetBlockTime() > (chainActive.Tip()->GetBlockTime() - 31557600))))
+        while (pindex && nTimeFirstKey && (pindex->GetBlockTime() < (nTimeFirstKey - 7200)) &&
+               !((GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS) > 0) &&
+                   (pindex->GetBlockTime() > (chainActive.Tip()->GetBlockTime() - 31557600))))
             pindex = chainActive.Next(pindex);
 
-        LOGA("Rescanning last %i blocks (from block %i)...\n", chainActive.Height() - pindex->nHeight,
-            pindex->nHeight);
+        LOGA("Rescanning last %i blocks (from block %i)...\n", chainActive.Height() - pindex->nHeight, pindex->nHeight);
 
         // show rescan progress in GUI as dialog or on splashscreen, if -rescan on startup
         ShowProgress(_("Rescanning..."), 0);
@@ -2715,31 +2720,35 @@ bool CWallet::AddAccountingEntry(const CAccountingEntry &acentry, CWalletDB &pwa
     return true;
 }
 
-std::vector<std::pair<std::string, CAmount>> CWallet::GroupTopPublicLabels(int listLength, std::string addrPrefix, int64_t minDate, int64_t maxDate)
+std::vector<std::pair<std::string, CAmount> > CWallet::GroupTopPublicLabels(int listLength,
+    std::string addrPrefix,
+    int64_t minDate,
+    int64_t maxDate)
 {
     // Make a list of all top public labels grouped by unspent outputs
     std::map<std::string, CAmount> listTopPublicLabels;
-    for (PAIRTYPE(uint256, CWalletTx) item: mapWalletTopPublicLabels)
+    for (PAIRTYPE(uint256, CWalletTx) item : mapWalletTopPublicLabels)
     {
-        const uint256& wtxid = item.first;
-        CWalletTx& wtx = item.second;
+        const uint256 &wtxid = item.first;
+        CWalletTx &wtx = item.second;
         assert(wtx.GetHash() == wtxid);
 
         for (unsigned int i = 0; i < wtx.vout.size(); i++)
         {
             // filter by date range
-            if (wtx.GetTxTime() < minDate || (wtx.GetTxTime() > maxDate && maxDate != 0)) continue;
+            if (wtx.GetTxTime() < minDate || (wtx.GetTxTime() > maxDate && maxDate != 0))
+                continue;
             CTxOut txoutPL = wtx.vout[i];
             std::string txPublicLabel = getLabelPublic(txoutPL.scriptPubKey);
 
             // find case insenstive
-            bool foundPrefix = boost:: ifind_first(txPublicLabel, addrPrefix);
+            bool foundPrefix = boost::ifind_first(txPublicLabel, addrPrefix);
 
             if (txPublicLabel != "" && (foundPrefix || addrPrefix.empty()))
             {
                 CTxOut txoutPLvalue = wtx.vout[i + 1];
 
-                std::map<std::string, CAmount>::iterator mi =  listTopPublicLabels.find(txPublicLabel);
+                std::map<std::string, CAmount>::iterator mi = listTopPublicLabels.find(txPublicLabel);
                 if (mi != listTopPublicLabels.end())
                     listTopPublicLabels[txPublicLabel] += txoutPLvalue.nValue;
                 else
@@ -2749,30 +2758,39 @@ std::vector<std::pair<std::string, CAmount>> CWallet::GroupTopPublicLabels(int l
     }
 
     // copy to a vector for sorting by amount
-    std::vector<std::pair<std::string, CAmount>> sortedTopPublicLabels;
+    std::vector<std::pair<std::string, CAmount> > sortedTopPublicLabels;
     for (std::pair<std::string, CAmount> tplPair : listTopPublicLabels)
-        { sortedTopPublicLabels.push_back(make_pair(tplPair.first, tplPair.second)); }
+    {
+        sortedTopPublicLabels.push_back(make_pair(tplPair.first, tplPair.second));
+    }
 
     // sort by satoshis descending
     std::sort(sortedTopPublicLabels.begin(), sortedTopPublicLabels.end(),
-                [](const std::pair<std::string, CAmount> left, const std::pair<std::string, CAmount> right)
-                { return left.second > right.second; });
+        [](const std::pair<std::string, CAmount> left, const std::pair<std::string, CAmount> right) {
+            return left.second > right.second;
+        });
 
     // only return the top items by listLength
-    for (std::vector<std::pair<std::string, CAmount>>::iterator si = sortedTopPublicLabels.begin(); si != sortedTopPublicLabels.end();)
-        { if (std::distance(sortedTopPublicLabels.begin(), si) > listLength) sortedTopPublicLabels.erase(si); else ++si; }
+    for (std::vector<std::pair<std::string, CAmount> >::iterator si = sortedTopPublicLabels.begin();
+         si != sortedTopPublicLabels.end();)
+    {
+        if (std::distance(sortedTopPublicLabels.begin(), si) > listLength)
+            sortedTopPublicLabels.erase(si);
+        else
+            ++si;
+    }
 
     return sortedTopPublicLabels;
 }
 
-std::vector<std::pair<CWalletTx, int>> CWallet::GetTopPublicLabelTxs(const std::string comparePublicLabel)
+std::vector<std::pair<CWalletTx, int> > CWallet::GetTopPublicLabelTxs(const std::string comparePublicLabel)
 {
     // Make a list of all public label txs with unspent outputs that match the specified public label
-    std::vector<std::pair<CWalletTx, int>> listPublicLabelTxs;
-    for (PAIRTYPE(uint256, CWalletTx) item: mapWalletTopPublicLabels)
+    std::vector<std::pair<CWalletTx, int> > listPublicLabelTxs;
+    for (PAIRTYPE(uint256, CWalletTx) item : mapWalletTopPublicLabels)
     {
-        const uint256& wtxid = item.first;
-        CWalletTx& wtx = item.second;
+        const uint256 &wtxid = item.first;
+        CWalletTx &wtx = item.second;
         assert(wtx.GetHash() == wtxid);
 
         for (unsigned int i = 0; i < wtx.vout.size(); i++)
@@ -2786,16 +2804,18 @@ std::vector<std::pair<CWalletTx, int>> CWallet::GetTopPublicLabelTxs(const std::
                 {
                     CTxOut txoutPLvalue = wtx.vout[i + 1];
                     // Add to list if the public label's buddy is unspent
-                    if (txoutPLvalue.nValue > 0) listPublicLabelTxs.push_back(make_pair(wtx, i));
+                    if (txoutPLvalue.nValue > 0)
+                        listPublicLabelTxs.push_back(make_pair(wtx, i));
                 }
             }
         }
     }
 
     // sort by satoshis descending
-    std::sort(listPublicLabelTxs.begin(), listPublicLabelTxs.end(), 
-                [](const std::pair<CWalletTx, int> left, const std::pair<CWalletTx, int> right)
-                { return left.first.vout[left.second + 1].nValue > right.first.vout[right.second + 1].nValue; });
+    std::sort(listPublicLabelTxs.begin(), listPublicLabelTxs.end(),
+        [](const std::pair<CWalletTx, int> left, const std::pair<CWalletTx, int> right) {
+            return left.first.vout[left.second + 1].nValue > right.first.vout[right.second + 1].nValue;
+        });
 
     return listPublicLabelTxs;
 }
@@ -2907,17 +2927,19 @@ void CWallet::ZapSpentTopPublicLabels()
     // Delete/remove all public label txs with spent outputs
     std::vector<CWalletTx> vWtx;
     CAmount minPublicLabelSatoshis = GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS);
-    for (PAIRTYPE(uint256, CWalletTx) item: mapWalletTopPublicLabels)
+    for (PAIRTYPE(uint256, CWalletTx) item : mapWalletTopPublicLabels)
     {
-        const uint256& wtxid = item.first;
+        const uint256 &wtxid = item.first;
         CWalletTx wtx = item.second;
         assert(wtx.GetHash() == wtxid);
 
         std::pair<CAmount, int> utxoPublicLabel = UnspentPublicLabelAmount(wtx, "");
-        if (utxoPublicLabel.first < minPublicLabelSatoshis) vWtx.push_back(wtx);
+        if (utxoPublicLabel.first < minPublicLabelSatoshis)
+            vWtx.push_back(wtx);
 
     } // for mapWalletTopPublicLabels
-    if (!vWtx.empty()) ZapWalletTx(vWtx, "pl");
+    if (!vWtx.empty())
+        ZapWalletTx(vWtx, "pl");
 }
 
 
@@ -3652,11 +3674,13 @@ bool CWallet::InitLoadWallet()
     }
 
     // If -toppubliclabels mode and public labels map is empty then rescan to find public label transactions
-    if (GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS) > 0
-            && walletInstance->mapWalletTopPublicLabels.begin() == walletInstance->mapWalletTopPublicLabels.end())
+    if (GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS) > 0 &&
+        walletInstance->mapWalletTopPublicLabels.begin() == walletInstance->mapWalletTopPublicLabels.end())
     {
         if (SoftSetBoolArg("-rescan", true))
-            LOGA("%s: Top public labels mode (-toppubliclabels>0) but public labels map is empty so setting -rescan=1\n", __func__);
+            LOGA(
+                "%s: Top public labels mode (-toppubliclabels>0) but public labels map is empty so setting -rescan=1\n",
+                __func__);
     }
 
     LOGA(" wallet      %15dms\n", GetTimeMillis() - nStart);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2754,7 +2754,7 @@ std::vector<std::pair<std::string, CAmount>> CWallet::GroupTopPublicLabels(int l
 
     // sort by satoshis descending
     std::sort(sortedTopPublicLabels.begin(), sortedTopPublicLabels.end(),
-                [](std::pair<std::string, CAmount> &left, std::pair<std::string, CAmount> &right)
+                [](const std::pair<std::string, CAmount> left, const std::pair<std::string, CAmount> right)
                 { return left.second > right.second; });
 
     // only return the top items by listLength
@@ -2793,7 +2793,7 @@ std::vector<std::pair<CWalletTx, int>> CWallet::GetTopPublicLabelTxs(const std::
 
     // sort by satoshis descending
     std::sort(listPublicLabelTxs.begin(), listPublicLabelTxs.end(), 
-                [](std::pair<CWalletTx, int> &left, std::pair<CWalletTx, int> &right)
+                [](const std::pair<CWalletTx, int> left, const std::pair<CWalletTx, int> right)
                 { return left.first.vout[left.second + 1].nValue > right.first.vout[right.second + 1].nValue; });
 
     return listPublicLabelTxs;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -35,6 +35,7 @@
 #include <assert.h>
 
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/find.hpp>
 #include <boost/thread.hpp>
 
 using namespace std;
@@ -300,6 +301,7 @@ bool CWallet::RemoveWatchOnly(const CScript &dest)
 }
 
 bool CWallet::LoadWatchOnly(const CScript &dest) { return CCryptoKeyStore::AddWatchOnly(dest); }
+
 bool CWallet::Unlock(const SecureString &strWalletPassphrase)
 {
     CCrypter crypter;
@@ -582,6 +584,7 @@ void CWallet::AddToSpends(const uint256 &wtxid)
 {
     assert(mapWallet.count(wtxid));
     CWalletTx &thisTx = mapWallet[wtxid];
+
     if (thisTx.IsCoinBase()) // Coinbases don't spend anything!
         return;
 
@@ -724,34 +727,59 @@ void CWallet::MarkDirty()
     }
 }
 
-bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletDB *pwalletdb)
+bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletDB *pwalletdb, bool isTopPublicLabel)
 {
     uint256 hash = wtxIn.GetHash();
 
     LOCK2(cs_main, cs_wallet);
+
     if (fFromLoadWallet)
     {
-        mapWallet[hash] = wtxIn;
-        CWalletTx &wtx = mapWallet[hash];
-        wtx.BindWallet(this);
-        wtxOrdered.insert(make_pair(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry *)0)));
-        AddToSpends(hash);
-        for (const CTxIn &txin : wtx.vin)
+        if (!isTopPublicLabel)
         {
-            if (mapWallet.count(txin.prevout.hash))
+            mapWallet[hash] = wtxIn;
+            CWalletTx &wtx = mapWallet[hash];
+            wtx.BindWallet(this);
+            wtxOrdered.insert(make_pair(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry *)0)));
+            AddToSpends(hash);
+            for (const CTxIn &txin : wtx.vin)
             {
-                CWalletTx &prevtx = mapWallet[txin.prevout.hash];
-                if (prevtx.nIndex == -1 && !prevtx.hashUnset())
+                if (mapWallet.count(txin.prevout.hash))
                 {
-                    MarkConflicted(prevtx.hashBlock, wtx.GetHash());
+                    CWalletTx &prevtx = mapWallet[txin.prevout.hash];
+                    if (prevtx.nIndex == -1 && !prevtx.hashUnset())
+                    {
+                        MarkConflicted(prevtx.hashBlock, wtx.GetHash());
+                    }
                 }
             }
+        }
+        else
+        {
+            // add tx to the top public labels map
+            mapWalletTopPublicLabels[hash] = wtxIn;
+            CWalletTx &wtx = mapWalletTopPublicLabels[hash];
+
+            // if tx is a top public label and -toppubliclabels mode is off
+            // or the unspent amount < mininum then remove the tx
+            CAmount minPublicLabelSatoshis = GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS);
+            CAmount unspentPublicLabelAmount = UnspentPublicLabelAmount(wtxIn, "").first;
+            if (minPublicLabelSatoshis == 0 || unspentPublicLabelAmount < minPublicLabelSatoshis)
+            {
+                LOGA("Top Public Label transaction found but it should be deleted. %s", wtxIn.GetHash().ToString());
+            }
+            else wtx.BindWallet(this);
         }
     }
     else
     {
+        pair<map<uint256, CWalletTx>::iterator, bool> ret;
         // Inserts only if not already there, returns tx inserted or tx found
-        pair<map<uint256, CWalletTx>::iterator, bool> ret = mapWallet.insert(make_pair(hash, wtxIn));
+        if (isTopPublicLabel)
+            ret = mapWalletTopPublicLabels.insert(make_pair(hash, wtxIn));
+        else
+            ret = mapWallet.insert(make_pair(hash, wtxIn));
+
         CWalletTx &wtx = (*ret.first).second;
         wtx.BindWallet(this);
         bool fInsertedNew = ret.second;
@@ -759,7 +787,7 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
         {
             wtx.nTimeReceived = GetAdjustedTime();
             wtx.nOrderPos = IncOrderPosNext(pwalletdb);
-            wtxOrdered.insert(make_pair(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry *)0)));
+            if (!isTopPublicLabel) wtxOrdered.insert(make_pair(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry *)0)));
 
             wtx.nTimeSmart = wtx.nTimeReceived;
             if (!wtxIn.hashUnset())
@@ -804,7 +832,7 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
                     LOGA("AddToWallet(): found %s in block %s not in index\n", wtxIn.GetHash().ToString(),
                         wtxIn.hashBlock.ToString());
             }
-            AddToSpends(hash);
+            if (!isTopPublicLabel) AddToSpends(hash);
         }
 
         bool fUpdated = false;
@@ -843,15 +871,27 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
             }
         }
 
-        // Only useful if debugging wallet
-        // LOGA("AddToWallet %s  %s%s\n", wtxIn.GetHash().ToString(), (fInsertedNew ? "new" : ""),
-        //    (fUpdated ? "update" : ""));
-
         // Write to disk
         if (fInsertedNew || fUpdated)
-            if (!wtx.WriteToDisk(pwalletdb))
-                return false;
-
+        {
+            if (isTopPublicLabel)
+                if (wtx.WriteTopPublicLabel(pwalletdb))
+                {
+                    //// debug print
+                    LOGA("AddToWallet TopPublicLabel %s  %s%s\n", wtxIn.GetHash().ToString(), (fInsertedNew ? "new" : ""),
+                        (fUpdated ? "update" : ""));
+                    return true;
+                }
+                else return false;
+            else if (wtx.WriteToDisk(pwalletdb))
+            {
+                //// debug print
+                LOGA("AddToWallet %s  %s%s\n", wtxIn.GetHash().ToString(), (fInsertedNew ? "new" : ""),
+                    (fUpdated ? "update" : ""));
+                return true;
+            }
+            else return false;
+        }
         // Break debit/credit balance caches:
         wtx.MarkDirty();
 
@@ -902,7 +942,19 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef &ptx, const CBlock 
     bool fExisted = mapWallet.count(ptx->GetHash()) != 0;
     if (fExisted && !fUpdate)
         return false;
-    if (fExisted || IsMine(*ptx) || IsFromMe(*ptx))
+
+    // If toppubliclabels mode then include public labels if they are unspent
+    bool IsUnspentPublicLabel = false;
+    std::pair<CAmount, int> pltxout;
+    if (GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS) > 0)
+    {
+        CAmount minPublicLabelSatoshis = GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS);
+        pltxout = UnspentPublicLabelAmount(*ptx, "");
+        if (pltxout.first >= minPublicLabelSatoshis)
+            IsUnspentPublicLabel = true;
+    }
+
+    if (fExisted || IsMine(*ptx) || IsFromMe(*ptx) || IsUnspentPublicLabel)
     {
         CWalletTx wtx(this, *ptx);
 
@@ -915,7 +967,8 @@ bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef &ptx, const CBlock 
         // SetBestChain-mechanism
         CWalletDB walletdb(strWalletFile, "r+", false);
 
-        return AddToWallet(wtx, false, &walletdb);
+        if (IsUnspentPublicLabel) AddToWallet(wtx, false, &walletdb, true);
+        if (fExisted || IsMine(*ptx) || IsFromMe(*ptx) ) return AddToWallet(wtx, false, &walletdb, false);
     }
     return false;
 }
@@ -1100,8 +1153,44 @@ bool CWallet::IsMine(const CTransaction &tx) const
     {
         if (IsMine(txout) != ISMINE_NO)
             return true;
-    }
+	}
     return false;
+}
+
+std::pair<CAmount, int> CWallet::UnspentPublicLabelAmount(const CTransaction& tx, const std::string comparePublicLabel) const
+{ // Returns unspent output amount associated with public label
+
+    // A public label exists BEFORE its txout buddy
+    bool nextIsPublicLabelBuddy = false;
+    int i = 0;
+    for (const CTxOut &txout : tx.vout)
+    {
+        // Speeds up the search but doesn't effect the result
+        if ((!nextIsPublicLabelBuddy && txout.nValue == 0) || (nextIsPublicLabelBuddy && txout.nValue > 0))
+        {
+            std::string txPublicLabel = getLabelPublic(txout.scriptPubKey);
+
+            if (nextIsPublicLabelBuddy)
+            {
+                // This is the target txout.nValue
+                CAmount nValue = IsSpent(tx.GetHash(), i) ? 0 : txout.nValue;
+                if (nValue > 0)
+                {
+                    // found unspent outputs related to public label
+                    return make_pair(nValue, i);
+                }
+
+            }
+            else if ((comparePublicLabel != "" && txPublicLabel == comparePublicLabel)  // matches the specified public label
+                     || (comparePublicLabel == "" && txPublicLabel != ""))              // matches for any public label
+            {
+                // if the public label exists the next txout.nValue is the target
+                nextIsPublicLabelBuddy = true;
+            }
+        }
+        i++;
+    }
+    return make_pair(0, NULL);
 }
 
 CAmount CWallet::GetCredit(const CTxOut &txout, const isminefilter &filter) const
@@ -1379,6 +1468,8 @@ void CWalletTx::GetAccountAmounts(const string &strAccount,
 
 
 bool CWalletTx::WriteToDisk(CWalletDB *pwalletdb) { return pwalletdb->WriteTx(GetHash(), *this); }
+bool CWalletTx::WriteTopPublicLabel(CWalletDB *pwalletdb) { return pwalletdb->WriteTopPublicLabel(GetHash(), *this); }
+
 /**
  * Scan the block chain (starting in pindexStart) for transactions
  * from or to us. If fUpdate is true, found transactions that already
@@ -1412,14 +1503,22 @@ int CWallet::ScanForWalletTransactions(CBlockIndex *pindexStart, bool fUpdate)
 
         // no need to read and scan block, if block was created before
         // our wallet birthday (as adjusted for block time variability)
-        while (pindex && nTimeFirstKey && (pindex->GetBlockTime() < (nTimeFirstKey - 7200)))
+        // in -toppubliclabels mode public labels with unspent utxos
+        // within 1 year are tracked so don't skip beyond then
+        while (pindex && nTimeFirstKey && (pindex->GetBlockTime() < (nTimeFirstKey - 7200))
+               && !((GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS) > 0)
+                        && (pindex->GetBlockTime() > (chainActive.Tip()->GetBlockTime() - 31557600))))
             pindex = chainActive.Next(pindex);
+
+        LOGA("Rescanning last %i blocks (from block %i)...\n", chainActive.Height() - pindex->nHeight,
+            pindex->nHeight);
 
         // show rescan progress in GUI as dialog or on splashscreen, if -rescan on startup
         ShowProgress(_("Rescanning..."), 0);
         double dProgressStart = Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), pindex, false);
         double dProgressTip =
             Checkpoints::GuessVerificationProgress(chainParams.Checkpoints(), chainActive.Tip(), false);
+
         while (pindex)
         {
             if (pindex->nHeight % 100 == 0 && dProgressTip - dProgressStart > 0.0)
@@ -2576,7 +2675,7 @@ bool CWallet::CommitTransaction(CWalletTx &wtxNew, CReserveKey &reservekey)
 
             // Add tx to wallet, because if it has change it's also ours,
             // otherwise just for transaction history.
-            AddToWallet(wtxNew, false, pwalletdb);
+            AddToWallet(wtxNew, false, pwalletdb, false);
 
             // Notify that old coins are spent
             set<CWalletTx *> setCoins;
@@ -2613,6 +2712,89 @@ bool CWallet::AddAccountingEntry(const CAccountingEntry &acentry, CWalletDB &pwa
     wtxOrdered.insert(make_pair(entry.nOrderPos, TxPair((CWalletTx *)0, &entry)));
 
     return true;
+}
+
+std::vector<std::pair<std::string, CAmount>> CWallet::GroupTopPublicLabels(int listLength, std::string addrPrefix)
+{
+    // Make a list of all top public labels grouped by unspent outputs
+    std::map<std::string, CAmount> listTopPublicLabels;
+    for (PAIRTYPE(uint256, CWalletTx) item: mapWalletTopPublicLabels)
+    {
+        const uint256& wtxid = item.first;
+        CWalletTx& wtx = item.second;
+        assert(wtx.GetHash() == wtxid);
+
+        for (unsigned int i = 0; i < wtx.vout.size(); i++)
+        {
+            CTxOut txoutPL = wtx.vout[i];
+            std::string txPublicLabel = getLabelPublic(txoutPL.scriptPubKey);
+
+            // find case insenstive
+            bool foundPrefix = boost:: ifind_first(txPublicLabel, addrPrefix);
+
+            if (txPublicLabel != "" && (foundPrefix || addrPrefix.empty()))
+            {
+                CTxOut txoutPLvalue = wtx.vout[i + 1];
+
+                std::map<std::string, CAmount>::iterator mi =  listTopPublicLabels.find(txPublicLabel);
+                if (mi != listTopPublicLabels.end())
+                    listTopPublicLabels[txPublicLabel] += txoutPLvalue.nValue;
+                else
+                    listTopPublicLabels.insert(make_pair(txPublicLabel, txoutPLvalue.nValue));
+            }
+        }
+    }
+
+    // copy to a vector for sorting by amount
+    std::vector<std::pair<std::string, CAmount>> sortedTopPublicLabels;
+    for (std::pair<std::string, CAmount> tplPair : listTopPublicLabels)
+        { sortedTopPublicLabels.push_back(make_pair(tplPair.first, tplPair.second)); }
+
+    // sort by satoshis descending
+    std::sort(sortedTopPublicLabels.begin(), sortedTopPublicLabels.end(),
+                [](std::pair<std::string, CAmount> &left, std::pair<std::string, CAmount> &right)
+                { return left.second > right.second; });
+
+    // only return the top items by listLength
+    for (std::vector<std::pair<std::string, CAmount>>::iterator si = sortedTopPublicLabels.begin(); si != sortedTopPublicLabels.end();)
+        { if (std::distance(sortedTopPublicLabels.begin(), si) > listLength) sortedTopPublicLabels.erase(si); else ++si; }
+
+    return sortedTopPublicLabels;
+}
+
+std::vector<std::pair<CWalletTx, int>> CWallet::GetTopPublicLabelTxs(const std::string comparePublicLabel)
+{
+    // Make a list of all public label txs with unspent outputs that match the specified public label
+    std::vector<std::pair<CWalletTx, int>> listPublicLabelTxs;
+    for (PAIRTYPE(uint256, CWalletTx) item: mapWalletTopPublicLabels)
+    {
+        const uint256& wtxid = item.first;
+        CWalletTx& wtx = item.second;
+        assert(wtx.GetHash() == wtxid);
+
+        for (unsigned int i = 0; i < wtx.vout.size(); i++)
+        {
+            CTxOut txoutPL = wtx.vout[i];
+            std::string txPublicLabel = getLabelPublic(txoutPL.scriptPubKey);
+
+            if (txPublicLabel == comparePublicLabel)
+            {
+                if (i + 1 < wtx.vout.size())
+                {
+                    CTxOut txoutPLvalue = wtx.vout[i + 1];
+                    // Add to list if the public label's buddy is unspent
+                    if (txoutPLvalue.nValue > 0) listPublicLabelTxs.push_back(make_pair(wtx, i));
+                }
+            }
+        }
+    }
+
+    // sort by satoshis descending
+    std::sort(listPublicLabelTxs.begin(), listPublicLabelTxs.end(), 
+                [](std::pair<CWalletTx, int> &left, std::pair<CWalletTx, int> &right)
+                { return left.first.vout[left.second + 1].nValue > right.first.vout[right.second + 1].nValue; });
+
+    return listPublicLabelTxs;
 }
 
 CAmount CWallet::GetRequiredFee(unsigned int nTxBytes)
@@ -2694,11 +2876,11 @@ DBErrors CWallet::ZapSelectTx(vector<uint256> &vHashIn, vector<uint256> &vHashOu
     return DB_LOAD_OK;
 }
 
-DBErrors CWallet::ZapWalletTx(std::vector<CWalletTx> &vWtx)
+DBErrors CWallet::ZapWalletTx(std::vector<CWalletTx> &vWtx, std::string txType)
 {
     if (!fFileBacked)
         return DB_LOAD_OK;
-    DBErrors nZapWalletTxRet = CWalletDB(strWalletFile, "cr+").ZapWalletTx(this, vWtx);
+    DBErrors nZapWalletTxRet = CWalletDB(strWalletFile, "cr+").ZapWalletTx(this, vWtx, txType);
     if (nZapWalletTxRet == DB_NEED_REWRITE)
     {
         if (CDB::Rewrite(strWalletFile, "\x04pool"))
@@ -2715,6 +2897,24 @@ DBErrors CWallet::ZapWalletTx(std::vector<CWalletTx> &vWtx)
         return nZapWalletTxRet;
 
     return DB_LOAD_OK;
+}
+
+void CWallet::ZapSpentTopPublicLabels()
+{
+    // Delete/remove all public label txs with spent outputs
+    std::vector<CWalletTx> vWtx;
+    CAmount minPublicLabelSatoshis = GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS);
+    for (PAIRTYPE(uint256, CWalletTx) item: mapWalletTopPublicLabels)
+    {
+        const uint256& wtxid = item.first;
+        CWalletTx wtx = item.second;
+        assert(wtx.GetHash() == wtxid);
+
+        std::pair<CAmount, int> utxoPublicLabel = UnspentPublicLabelAmount(wtx, "");
+        if (utxoPublicLabel.first < minPublicLabelSatoshis) vWtx.push_back(wtx);
+
+    } // for mapWalletTopPublicLabels
+    if (!vWtx.empty()) ZapWalletTx(vWtx, "pl");
 }
 
 
@@ -3341,7 +3541,22 @@ bool CWallet::InitLoadWallet()
         uiInterface.InitMessage(_("Zapping all transactions from wallet..."));
 
         CWallet *tempWallet = new CWallet(walletFile);
-        DBErrors nZapWalletRet = tempWallet->ZapWalletTx(vWtx);
+        DBErrors nZapWalletRet = tempWallet->ZapWalletTx(vWtx, "tx");
+        if (nZapWalletRet != DB_LOAD_OK)
+        {
+            return InitError(strprintf(_("Error loading %s: Wallet corrupted"), walletFile));
+        }
+
+        delete tempWallet;
+        tempWallet = nullptr;
+    }
+
+    if (GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS) == 0)
+    {
+        uiInterface.InitMessage(_("Zapping all top public label transactions from wallet..."));
+
+        CWallet *tempWallet = new CWallet(walletFile);
+        DBErrors nZapWalletRet = tempWallet->ZapWalletTx(vWtx, "pl");
         if (nZapWalletRet != DB_LOAD_OK)
         {
             return InitError(strprintf(_("Error loading %s: Wallet corrupted"), walletFile));
@@ -3433,6 +3648,14 @@ bool CWallet::InitLoadWallet()
                 strprintf(_("Error loading %s: You can't enable HD on a already existing non-HD wallet"), walletFile));
     }
 
+    // If -toppubliclabels mode and public labels map is empty then rescan to find public label transactions
+    if (GetArg("-toppubliclabels", DEFAULT_TOPPUBLICLABELS) > 0
+            && walletInstance->mapWalletTopPublicLabels.begin() == walletInstance->mapWalletTopPublicLabels.end())
+    {
+        if (SoftSetBoolArg("-rescan", true))
+            LOGA("%s: Top public labels mode (-toppubliclabels>0) but public labels map is empty so setting -rescan=1\n", __func__);
+    }
+
     LOGA(" wallet      %15dms\n", GetTimeMillis() - nStart);
 
     RegisterValidationInterface(walletInstance);
@@ -3449,6 +3672,7 @@ bool CWallet::InitLoadWallet()
         else
             pindexRescan = chainActive.Genesis();
     }
+
     if (chainActive.Tip() && chainActive.Tip() != pindexRescan)
     {
         // We can't rescan beyond non-pruned blocks, stop and throw an error
@@ -3467,8 +3691,6 @@ bool CWallet::InitLoadWallet()
         }
 
         uiInterface.InitMessage(_("Rescanning..."));
-        LOGA("Rescanning last %i blocks (from block %i)...\n", chainActive.Height() - pindexRescan->nHeight,
-            pindexRescan->nHeight);
         nStart = GetTimeMillis();
         walletInstance->ScanForWalletTransactions(pindexRescan, true);
         LOGA(" rescan      %15dms\n", GetTimeMillis() - nStart);

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -892,19 +892,22 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
             }
             else return false;
         }
-        // Break debit/credit balance caches:
-        wtx.MarkDirty();
-
-        // Notify UI of new or updated transaction
-        NotifyTransactionChanged(this, hash, fInsertedNew ? CT_NEW : CT_UPDATED);
-
-        // notify an external script when a wallet transaction comes in or is updated
-        std::string strCmd = GetArg("-walletnotify", "");
-
-        if (!strCmd.empty())
+        if (!isTopPublicLabel)
         {
-            boost::replace_all(strCmd, "%s", wtxIn.GetHash().GetHex());
-            boost::thread t(runCommand, strCmd); // thread runs free
+            // Break debit/credit balance caches:
+            wtx.MarkDirty();
+
+            // Notify UI of new or updated transaction
+            NotifyTransactionChanged(this, hash, fInsertedNew ? CT_NEW : CT_UPDATED);
+
+            // notify an external script when a wallet transaction comes in or is updated
+            std::string strCmd = GetArg("-walletnotify", "");
+
+            if (!strCmd.empty())
+            {
+                boost::replace_all(strCmd, "%s", wtxIn.GetHash().GetHex());
+                boost::thread t(runCommand, strCmd); // thread runs free
+            }
         }
     }
     return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -2714,7 +2714,7 @@ bool CWallet::AddAccountingEntry(const CAccountingEntry &acentry, CWalletDB &pwa
     return true;
 }
 
-std::vector<std::pair<std::string, CAmount>> CWallet::GroupTopPublicLabels(int listLength, std::string addrPrefix)
+std::vector<std::pair<std::string, CAmount>> CWallet::GroupTopPublicLabels(int listLength, std::string addrPrefix, int64_t minDate, int64_t maxDate)
 {
     // Make a list of all top public labels grouped by unspent outputs
     std::map<std::string, CAmount> listTopPublicLabels;
@@ -2726,6 +2726,8 @@ std::vector<std::pair<std::string, CAmount>> CWallet::GroupTopPublicLabels(int l
 
         for (unsigned int i = 0; i < wtx.vout.size(); i++)
         {
+            // filter by date range
+            if (wtx.GetTxTime() < minDate || (wtx.GetTxTime() > maxDate && maxDate != 0)) continue;
             CTxOut txoutPL = wtx.vout[i];
             std::string txPublicLabel = getLabelPublic(txoutPL.scriptPubKey);
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -773,8 +773,8 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
     }
     else
     {
-        pair<map<uint256, CWalletTx>::iterator, bool> ret;
         // Inserts only if not already there, returns tx inserted or tx found
+        pair<map<uint256, CWalletTx>::iterator, bool> ret;
         if (isTopPublicLabel)
             ret = mapWalletTopPublicLabels.insert(make_pair(hash, wtxIn));
         else
@@ -880,7 +880,6 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
                     //// debug print
                     LOGA("AddToWallet TopPublicLabel %s  %s%s\n", wtxIn.GetHash().ToString(), (fInsertedNew ? "new" : ""),
                         (fUpdated ? "update" : ""));
-                    return true;
                 }
                 else return false;
             else if (wtx.WriteToDisk(pwalletdb))
@@ -888,7 +887,6 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
                 //// debug print
                 LOGA("AddToWallet %s  %s%s\n", wtxIn.GetHash().ToString(), (fInsertedNew ? "new" : ""),
                     (fUpdated ? "update" : ""));
-                return true;
             }
             else return false;
         }

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -802,7 +802,7 @@ public:
     int64_t GetOldestKeyPoolTime();
     void GetAllReserveKeys(std::set<CKeyID> &setAddress) const;
 
-    std::vector<std::pair<std::string, CAmount>> GroupTopPublicLabels(int listLength, std::string addrPrefix);
+    std::vector<std::pair<std::string, CAmount>> GroupTopPublicLabels(int listLength, std::string addrPrefix, int64_t minDate, int64_t maxDate);
     std::vector<std::pair<CWalletTx, int>> GetTopPublicLabelTxs(const std::string comparePublicLabel);
     std::set<std::set<CTxDestination> > GetAddressGroupings();
     std::map<CTxDestination, CAmount> GetAddressBalances();

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -388,6 +388,7 @@ public:
     bool IsTrusted() const;
 
     bool WriteToDisk(CWalletDB *pwalletdb);
+    bool WriteTopPublicLabel(CWalletDB *pwalletdb);
 
     int64_t GetTxTime() const;
     int GetRequestCount() const;
@@ -625,6 +626,8 @@ public:
     }
 
     std::map<uint256, CWalletTx> mapWallet;
+    std::map<uint256, CWalletTx> mapWalletTopPublicLabels;
+
     std::list<CAccountingEntry> laccentries;
 
     typedef std::pair<CWalletTx *, CAccountingEntry *> TxPair;
@@ -737,7 +740,7 @@ public:
     int64_t IncOrderPosNext(CWalletDB *pwalletdb = nullptr);
 
     void MarkDirty();
-    bool AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletDB *pwalletdb);
+    bool AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletDB *pwalletdb, bool isTopPublicLabel);
     void SyncTransaction(const CTransactionRef &ptx, const CBlock *pblock, int txIndex = -1);
     bool AddToWalletIfInvolvingMe(const CTransactionRef &ptx, const CBlock *pblock, bool fUpdate, int txIndex = -1);
     int ScanForWalletTransactions(CBlockIndex *pindexStart, bool fUpdate = false);
@@ -799,6 +802,8 @@ public:
     int64_t GetOldestKeyPoolTime();
     void GetAllReserveKeys(std::set<CKeyID> &setAddress) const;
 
+    std::vector<std::pair<std::string, CAmount>> GroupTopPublicLabels(int listLength, std::string addrPrefix);
+    std::vector<std::pair<CWalletTx, int>> GetTopPublicLabelTxs(const std::string comparePublicLabel);
     std::set<std::set<CTxDestination> > GetAddressGroupings();
     std::map<CTxDestination, CAmount> GetAddressBalances();
 
@@ -809,6 +814,7 @@ public:
     isminetype IsMine(const CTxDestination &dest) const;
     bool IsMine(const CTransaction &tx) const;
 
+    std::pair<CAmount, int> UnspentPublicLabelAmount(const CTransaction& tx, const std::string comparePublicLabel) const;
     CAmount GetDebit(const CTxIn &txin, const isminefilter &filter) const;
     CAmount GetCredit(const CTxOut &txout, const isminefilter &filter) const;
     bool IsChange(const CTxOut &txout) const;
@@ -822,8 +828,9 @@ public:
     void SetBestChain(const CBlockLocator &loc);
 
     DBErrors LoadWallet(bool &fFirstRunRet);
-    DBErrors ZapWalletTx(std::vector<CWalletTx> &vWtx);
+    DBErrors ZapWalletTx(std::vector<CWalletTx> &vWtx, std::string txType);
     DBErrors ZapSelectTx(std::vector<uint256> &vHashIn, std::vector<uint256> &vHashOut);
+    void ZapSpentTopPublicLabels();
 
     bool SetAddressBook(const CTxDestination &address, const std::string &strName, const std::string &purpose);
 

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -802,8 +802,11 @@ public:
     int64_t GetOldestKeyPoolTime();
     void GetAllReserveKeys(std::set<CKeyID> &setAddress) const;
 
-    std::vector<std::pair<std::string, CAmount>> GroupTopPublicLabels(int listLength, std::string addrPrefix, int64_t minDate, int64_t maxDate);
-    std::vector<std::pair<CWalletTx, int>> GetTopPublicLabelTxs(const std::string comparePublicLabel);
+    std::vector<std::pair<std::string, CAmount> > GroupTopPublicLabels(int listLength,
+        std::string addrPrefix,
+        int64_t minDate,
+        int64_t maxDate);
+    std::vector<std::pair<CWalletTx, int> > GetTopPublicLabelTxs(const std::string comparePublicLabel);
     std::set<std::set<CTxDestination> > GetAddressGroupings();
     std::map<CTxDestination, CAmount> GetAddressBalances();
 
@@ -814,7 +817,8 @@ public:
     isminetype IsMine(const CTxDestination &dest) const;
     bool IsMine(const CTransaction &tx) const;
 
-    std::pair<CAmount, int> UnspentPublicLabelAmount(const CTransaction& tx, const std::string comparePublicLabel) const;
+    std::pair<CAmount, int> UnspentPublicLabelAmount(const CTransaction &tx,
+        const std::string comparePublicLabel) const;
     CAmount GetDebit(const CTxIn &txin, const isminefilter &filter) const;
     CAmount GetCredit(const CTxOut &txout, const isminefilter &filter) const;
     bool IsChange(const CTxOut &txout) const;

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -774,7 +774,10 @@ DBErrors CWalletDB::LoadWallet(CWallet *pwallet)
     return result;
 }
 
-DBErrors CWalletDB::FindWalletTx(CWallet *pwallet, vector<uint256> &vTxHash, vector<CWalletTx> &vWtx, std::string txType)
+DBErrors CWalletDB::FindWalletTx(CWallet *pwallet,
+    vector<uint256> &vTxHash,
+    vector<CWalletTx> &vWtx,
+    std::string txType)
 {
     pwallet->vchDefaultKey = CPubKey();
     bool fNoncriticalErrors = false;
@@ -901,8 +904,12 @@ DBErrors CWalletDB::ZapWalletTx(CWallet *pwallet, vector<CWalletTx> &vWtx, std::
     // erase each wallet TX
     for (uint256 &hash : vTxHash)
     {
-        if (txType == "tx") if (!EraseTx(hash)) return DB_CORRUPT;
-        if (txType == "pl") if (!EraseTopPublicLabel(hash)) return DB_CORRUPT;
+        if (txType == "tx")
+            if (!EraseTx(hash))
+                return DB_CORRUPT;
+        if (txType == "pl")
+            if (!EraseTopPublicLabel(hash))
+                return DB_CORRUPT;
     }
 
     return DB_LOAD_OK;

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -141,6 +141,8 @@ public:
 
     bool WriteCScript(const uint160 &hash, const CScript &redeemScript);
 
+    bool WriteTopPublicLabel(uint256 hash, const CWalletTx &wtx);
+    bool EraseTopPublicLabel(uint256 hash);
     bool WriteWatchOnly(const CScript &script);
     bool EraseWatchOnly(const CScript &script);
 
@@ -174,8 +176,8 @@ public:
 
     DBErrors ReorderTransactions(CWallet *pwallet);
     DBErrors LoadWallet(CWallet *pwallet);
-    DBErrors FindWalletTx(CWallet *pwallet, std::vector<uint256> &vTxHash, std::vector<CWalletTx> &vWtx);
-    DBErrors ZapWalletTx(CWallet *pwallet, std::vector<CWalletTx> &vWtx);
+    DBErrors FindWalletTx(CWallet *pwallet, std::vector<uint256> &vTxHash, std::vector<CWalletTx> &vWtx, std::string txType);
+    DBErrors ZapWalletTx(CWallet *pwallet, std::vector<CWalletTx> &vWtx, std::string txType);
     DBErrors ZapSelectTx(CWallet *pwallet, std::vector<uint256> &vHashIn, std::vector<uint256> &vHashOut);
     static bool Recover(CDBEnv &dbenv, const std::string &filename, bool fOnlyKeys);
     static bool Recover(CDBEnv &dbenv, const std::string &filename);

--- a/src/wallet/walletdb.h
+++ b/src/wallet/walletdb.h
@@ -176,7 +176,10 @@ public:
 
     DBErrors ReorderTransactions(CWallet *pwallet);
     DBErrors LoadWallet(CWallet *pwallet);
-    DBErrors FindWalletTx(CWallet *pwallet, std::vector<uint256> &vTxHash, std::vector<CWalletTx> &vWtx, std::string txType);
+    DBErrors FindWalletTx(CWallet *pwallet,
+        std::vector<uint256> &vTxHash,
+        std::vector<CWalletTx> &vWtx,
+        std::string txType);
     DBErrors ZapWalletTx(CWallet *pwallet, std::vector<CWalletTx> &vWtx, std::string txType);
     DBErrors ZapSelectTx(CWallet *pwallet, std::vector<uint256> &vHashIn, std::vector<uint256> &vHashOut);
     static bool Recover(CDBEnv &dbenv, const std::string &filename, bool fOnlyKeys);


### PR DESCRIPTION
Screen shot: https://i.redd.it/9mna2tlpzlv11.png

This gui PR contains features to display the Top Public Labels in the blockchain, grouping UTXOs that have matching public labels and ranking them by the aggregated unspent amounts total. This facilitates a user voting mechanism that is impossible to game so that BCH stakeholders can communicate with other stakeholders via the blockchain. Stakeholders move the most important messages to the top of the rankings by sending txs using the public label they wish to promote higher. The UTXO amount will be applied in aggregate with other UTXOs that have matching public labels. Since all messages are in the blockchain all messages and rankings are 100% verified by the client. Just like bitcoinvoice.io but all done in the BU client so no need to trust a 3rd party website for the results.

The command line parameter is -toppubliclabels n , where n is the minimum number of satoshis to track for public labels. Public Labels with UTXO amounts below this value will not be tracked. Upon first startup the wallet will do a rescan to populate the wallet file with the all public labels that have UTXO amounts greater than this value within the last 12 months. The txindex=1 must also be turned on for top public labels to be tracked.

Further there is a hard code in the tab list which will only display the Top 20 public labels for any filter. Its probably a good idea to create a special conf file which contains a special wallet and -toppubliclabels startup.

Example toppubliclabels.conf:
txindex=1
toppubliclabels=10000000
wallet=wallet.toppubliclabels.dat