### PR TITLE
rpc-test.py: Fix a potential race

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -487,7 +487,8 @@ class RPCTestHandler:
                     # seems to make the .join() logic to work, and in turn communicate() not to fail
                     # with a timeout, even though the thread is done reading (which was another cause
                     # of a hang)
-                    comms(0.1)
+                    if not got_outputs[0]:
+                        comms(0.1)
 
                     # .communicate() can only be called once and we have to keep in mind now that
                     # communication happened properly (and the files are closed). It _has_ to be called with a non-None


### PR DESCRIPTION
This is to avoid errors like this for `rpc-tests.py`:

https://api.travis-ci.org/v3/job/433409533/log.txt

Archived (as travis seems to overwrite / forget old runs) at:

http://archive.is/Bb7ne

Relevant log part:
----
```
Starting walletbackup.py
...Traceback (most recent call last):
  File "qa/pull-tester/rpc-tests.py", line 594, in <module>
    runtests()
  File "qa/pull-tester/rpc-tests.py", line 391, in runtests
    (name, stdout, stderr, stderr_filtered, passed, duration) = job_queue.get_next()
  File "qa/pull-tester/rpc-tests.py", line 491, in get_next
    comms(0.1)
  File "qa/pull-tester/rpc-tests.py", line 477, in comms
    stdout_data, stderr_data = proc.communicate(timeout=timeout)
  File "/usr/lib/python3.4/subprocess.py", line 960, in communicate
    stdout, stderr = self._communicate(input, endtime, timeout)
  File "/usr/lib/python3.4/subprocess.py", line 1610, in _communicate
    selector.register(self.stderr, selectors.EVENT_READ)
  File "/usr/lib/python3.4/selectors.py", line 342, in register
    key = super().register(fileobj, events, data)
  File "/usr/lib/python3.4/selectors.py", line 228, in register
    key = SelectorKey(fileobj, self._fileobj_lookup(fileobj), events, data)
  File "/usr/lib/python3.4/selectors.py", line 215, in _fileobj_lookup
    return _fileobj_to_fd(fileobj)
  File "/usr/lib/python3.4/selectors.py", line 39, in _fileobj_to_fd
    "{!r}".format(fileobj)) from None
ValueError: Invalid file object: <_io.TextIOWrapper name=10 encoding='UTF-8'>

travis_time:end:15f138df:start=1537959665437157143,finish=1537959855782244932,duration=190345087789
K
;1mThe command "if [ "$RUN_TESTS" = "true" ]; then qa/pull-tester/rpc-tests.py --coverage --no-ipv6-rpc-listen; fi" exited with 1.m
travis_fold:start:cache.2
```
---

From the log it *seems* that `.poll()` can return with a not-yet-ready state, even though
`.communicate()` happened succesfully. In this case, `.communicate()` would
happen again, leading to the above error.

Sorry for the repeated rework of `rpc-tests.py` and the pipes stuff. This should likely at some point be completely reworked to use a separate process / thread for communication instead of the (broken) `.communicate(..)` method.