### PR TITLE
Prevent the re-requesting of txns we already have

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5037,6 +5037,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
 
         CInv inv(MSG_TX, txd.tx->GetHash());
         pfrom->AddInventoryKnown(inv);
+        requester.UpdateTxnResponseTime(inv, pfrom);
     }
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5037,7 +5037,6 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
 
         CInv inv(MSG_TX, txd.tx->GetHash());
         pfrom->AddInventoryKnown(inv);
-        requester.Received(inv, pfrom, msgSize);
     }
 
 

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -285,14 +285,14 @@ void CRequestManager::Received(const CInv &obj, CNode *pfrom)
         LOG(REQ, "ReqMgr: TX received for %s.\n", item->second.obj.ToString().c_str());
         cleanup(item);
     }
-    else if (pfrom && (obj.type == MSG_BLOCK || obj.type == MSG_THINBLOCK || obj.type == MSG_XTHINBLOCK))
+    else if (obj.type == MSG_BLOCK || obj.type == MSG_THINBLOCK || obj.type == MSG_XTHINBLOCK)
     {
         OdMap::iterator item = mapBlkInfo.find(obj.hash);
         if (item == mapBlkInfo.end())
             return;
 
         LOG(BLK, "%s removed from request queue (received from %s).\n", item->second.obj.ToString().c_str(),
-            pfrom->GetLogName());
+            pfrom ? pfrom->GetLogName() : "unknown");
         cleanup(item);
     }
 }

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -172,8 +172,8 @@ public:
     // of the same blocks.
     bool AlreadyAskedForBlock(const uint256 &hash);
 
-    // Indicate that we got this object, from and bytes are optional (for node performance tracking)
-    void Received(const CInv &obj, CNode *from, int bytes = 0);
+    // Indicate that we got this object
+    void Received(const CInv &obj, CNode *pfrom);
 
     // Indicate that we previously got this object
     void AlreadyReceived(CNode *pnode, const CInv &obj);

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -172,6 +172,9 @@ public:
     // of the same blocks.
     bool AlreadyAskedForBlock(const uint256 &hash);
 
+    // Update the response time for this transaction request
+    void UpdateTxnResponseTime(const CInv &obj, CNode *pfrom);
+
     // Indicate that we got this object
     void Received(const CInv &obj, CNode *pfrom);
 


### PR DESCRIPTION
We were indicating that we had the txn when it was received however
if INV's were arriving after then we would end up re-requesting them
becuase the item had already been cleaned up from the requestmanager
queue. To fix this we just need to indicate that we received the txn
when it was either submitted to the mempool or the orphanpool. This
works because the request manager checks whether we have a txn in
either of those pools before requesting.

This is the same approach we have for blocks, where we don't indicate
we have the block until it is stored fully on disk and the blockindex
updated.
