### PR TITLE
Fix a variety of issues related to the QA test suite and multithreading:

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -500,7 +500,7 @@ class RPCTestHandler:
 
                 if proc.poll() is not None:
                     if not got_outputs[0]:
-                        comms(3)
+                        comms(30)
                     log_stdout.seek(0), log_stderr.seek(0)
                     stdout = log_stdout.read()
                     stderr = log_stderr.read()

--- a/qa/rpc-tests/cashlibtest.py
+++ b/qa/rpc-tests/cashlibtest.py
@@ -88,7 +88,7 @@ class MyTest (BitcoinTestFramework):
 
         tx2id = self.nodes[0].enqueuerawtransaction(hexlify(tx2.serialize()).decode("utf-8"))
         # Check that all tx were created, and commit them
-        waitFor(6, lambda: self.nodes[0].getmempoolinfo()["size"] == 2)
+        waitFor(20, lambda: self.nodes[0].getmempoolinfo()["size"] == 2)
         blk = self.nodes[0].generate(1)
         self.sync_blocks()
         assert self.nodes[0].getmempoolinfo()["size"] == 0

--- a/qa/rpc-tests/invalidtxrequest.py
+++ b/qa/rpc-tests/invalidtxrequest.py
@@ -6,6 +6,7 @@ import test_framework.loginit
 from test_framework.test_framework import ComparisonTestFramework
 from test_framework.comptool import TestManager, TestInstance, RejectResult
 from test_framework.blocktools import *
+from test_framework.util import findBitcoind
 import time, os
 
 

--- a/qa/rpc-tests/mempool_spendcoinbase.py
+++ b/qa/rpc-tests/mempool_spendcoinbase.py
@@ -28,9 +28,8 @@ class MempoolSpendCoinbaseTest(BitcoinTestFramework):
         self.is_network_split = False
 
     def run_test(self):
-        chain_height = self.nodes[0].getblockcount()
-        assert_equal(chain_height, 200)
         node0_address = self.nodes[0].getnewaddress()
+        waitFor(30, lambda : self.nodes[0].getblockcount() == 200, "Restoration of cached blockchain failed")
 
         # Coinbase at height chain_height-100+1 ok in mempool, should
         # get mined. Coinbase at height chain_height-100+2 is

--- a/qa/rpc-tests/rawtransactions.py
+++ b/qa/rpc-tests/rawtransactions.py
@@ -46,7 +46,6 @@ class RawTransactionsTest(BitcoinTestFramework):
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.5)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),1.0)
         self.nodes[0].sendtoaddress(self.nodes[2].getnewaddress(),5.0)
-        self.sync_all()
         self.nodes[0].generate(5)
         self.sync_all()
 
@@ -85,7 +84,7 @@ class RawTransactionsTest(BitcoinTestFramework):
         txId = self.nodes[0].sendtoaddress(mSigObj, 1.2)
         self.sync_all()
         self.nodes[0].generate(1)
-        self.sync_all()
+        self.sync_blocks()
         assert_equal(self.nodes[2].getbalance(), bal+Decimal('1.20000000')) #node2 has both keys of the 2of2 ms addr., tx should affect the balance
 
 
@@ -106,9 +105,8 @@ class RawTransactionsTest(BitcoinTestFramework):
         decTx = self.nodes[0].gettransaction(txId)
         rawTx = self.nodes[0].decoderawtransaction(decTx['hex'])
         sPK = rawTx['vout'][0]['scriptPubKey']['hex']
-        self.sync_all()
         self.nodes[0].generate(1)
-        self.sync_all()
+        self.sync_blocks()
 
         #THIS IS A INCOMPLETE FEATURE
         #NODE2 HAS TWO OF THREE KEY AND THE FUNDS SHOULD BE SPENDABLE AND COUNT AT BALANCE CALCULATION

--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -49,7 +49,7 @@ except ImportError:
 
 USER_AGENT = "AuthServiceProxy/0.1"
 
-HTTP_TIMEOUT = 30
+HTTP_TIMEOUT = 60
 
 log = logging.getLogger("BitcoinRPC")
 

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -268,11 +268,11 @@ class TestManager(object):
                     hsh = c.rpc.getbestblockhash()
                     print("Quick   RPC returns", hsh)
                     t = 0
-                    # give 20 seconds to sync, this is a pretty generous number.  How much time might it take
-                    # an underpowered test node running 4-6 copies of bitcoind to sync them?  
-                    while t < 10 and hsh != hex(blockhash)[2:]:  # hex(blockhash) returns "0x..." whereas hsh does not have the "0x"
+                    # give 60 seconds to sync, this is a pretty generous number.  How much time might it take
+                    # an underpowered test node running 16 copies of bitcoind (4 simultaneous tests with 4 nodes) to sync them?
+                    while t < 30 and hsh != hex(blockhash)[2:]:  # hex(blockhash) returns "0x..." whereas hsh does not have the "0x"
                         t += 1
-                        time.sleep(2) 
+                        time.sleep(2)
                         hsh = c.rpc.getbestblockhash()
                     if t == 10:
                         print("Delayed RPC returns", hsh)

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -527,9 +527,10 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
             logging.info("Started %s %d as pid %d at %s dir %s  " % (binary, i, bitcoind_processes[i].pid, "127.0.0.1:"+str(p2p_port(i)), datadir))
             break
         except Exception as exc:
+            # this may not be an error because every once in a while bitcoind uses a port that's already in use.
             logging.error("Error bringing up bitcoind #%d (start_node, directory %s), this might be retried. Problem is: %s", i, dirname, str(exc))
             do_and_ignore_failure(lambda x: bitcoind_processes[i].kill())
-            traceback.print_exc(file=sys.stdout)
+            # commented out because looks like an error: traceback.print_exc(file=sys.stdout)
             remap_ports(i)
             fixup_ports_in_configfile(i)
     else:

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -960,7 +960,7 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
     }
 
     // Create the parallel block validator
-    PV.reset(new CParallelValidation(&threadGroup));
+    PV.reset(new CParallelValidation());
 
     // Start the lightweight task scheduler thread
     CScheduler::Function serviceLoop = boost::bind(&CScheduler::serviceQueue, &scheduler);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4541,8 +4541,8 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         UpdatePreferredDownload(pfrom, State(pfrom->GetId()));
 
         // Send VERACK handshake message
-        pfrom->PushMessage(NetMsgType::VERACK);
         pfrom->fVerackSent = true;
+        pfrom->PushMessage(NetMsgType::VERACK);
 
         // Change version
         pfrom->ssSend.SetVersion(std::min(pfrom->nVersion, PROTOCOL_VERSION));
@@ -4665,8 +4665,8 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         // The BUVERSION message is active from the protocol EXPEDITED_VERSION onwards.
         if (pfrom->nVersion >= EXPEDITED_VERSION)
         {
-            pfrom->PushMessage(NetMsgType::BUVERSION, GetListenPort());
             pfrom->fBUVersionSent = true;
+            pfrom->PushMessage(NetMsgType::BUVERSION, GetListenPort());
         }
     }
 
@@ -6132,6 +6132,8 @@ bool SendMessages(CNode *pto)
         }
 
         CNodeState &state = *State(pto->GetId());
+        if (&state == nullptr)
+            return true;
 
         // If a sync has been started check whether we received the first batch of headers requested within the timeout
         // period. If not then disconnect and ban the node and a new node will automatically be selected to start the

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -553,9 +553,9 @@ void CNode::copyStats(CNodeStats &stats)
 }
 #undef X
 
-// requires LOCK(cs_vRecvMsg)
 bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes)
 {
+    AssertLockHeld(cs_vRecvMsg);
     while (nBytes > 0)
     {
         // get current incomplete message, or create a new one

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -5,6 +5,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "nodestate.h"
+#include "main.h"
 
 /**
 * Default constructor initializing all local member variables to "null" values
@@ -32,6 +33,7 @@ CNodeState::CNodeState(CAddress addrIn, std::string addrNameIn) : address(addrIn
 */
 CNodeState *State(NodeId nId)
 {
+    LOCK(cs_main);
     std::map<NodeId, CNodeState>::iterator it = mapNodeState.find(nId);
     if (it == mapNodeState.end())
         return nullptr;

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -81,7 +81,10 @@ private:
     std::vector<uint256> vPreviousBlock;
     // Vector of script check queues
     std::vector<CCheckQueue<CScriptCheck> *> vQueues;
+    // Number of threads
     unsigned int nThreads;
+    // All threads currently running
+    boost::thread_group threadGroup;
     // The semaphore limits the number of parallel validation threads
     CSemaphore semThreadCount;
 
@@ -111,7 +114,7 @@ public:
      *                          are created.
      * @param[in] threadGroup   The thread group threads will be created in
      */
-    CParallelValidation(boost::thread_group *threadGroup);
+    CParallelValidation();
 
     ~CParallelValidation();
 

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -66,7 +66,7 @@ TestingSetup::TestingSetup(const std::string &chainName) : BasicTestingSetup(cha
 
     // Make sure there are 3 script check threads running for each queue
     SoftSetArg("-par", std::to_string(3));
-    PV.reset(new CParallelValidation(&threadGroup));
+    PV.reset(new CParallelValidation());
 
     RegisterNodeSignals(GetNodeSignals());
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -378,6 +378,14 @@ static void MonitorLogfile()
     }
 }
 
+void LogFlush()
+{
+    if (fPrintToDebugLog)
+    {
+        fflush(fileout);
+    }
+}
+
 int LogPrintStr(const std::string &str)
 {
     int ret = 0; // Returns total number of characters written

--- a/src/util.h
+++ b/src/util.h
@@ -318,6 +318,9 @@ inline void LogWrite(const std::string &str)
 #define LOGA(...) Logging::LogWrite(__VA_ARGS__)
 //
 
+// Flush log file (if you know you are about to abort)
+void LogFlush();
+
 // Log tests:
 UniValue setlog(const UniValue &params, bool fHelp);
 // END logging.
@@ -487,11 +490,13 @@ void TraceThreads(const std::string &name, Callable func)
     catch (const std::exception &e)
     {
         PrintExceptionContinue(&e, name.c_str());
+        LogFlush();
         throw;
     }
     catch (...)
     {
         PrintExceptionContinue(NULL, name.c_str());
+        LogFlush();
         throw;
     }
 }


### PR DESCRIPTION
1. ensure that version messages are marked as sent BEFORE they are sent so parallel processing won't see them as not sent.  Check NodeState in case it has been deleted in another thread

2. lock cs_vSend to protect member variables since we are no longer holding cs_main across this code

3. limit scope of cs_wallet lock

4. Running the qa test framework on VMs or laptops with spinning disks results in timeouts as up to 16 bitcoind instances may be fighting for CPU and disk.  Increase these default timeouts so we don't get so many spurious errors

5. fix occasional delete of scriptqueue before the thread that is using it quits during shutdown