### PR TITLE
Fix two new warnings spotted while using clang

### DIFF
--- a/src/txdb.h
+++ b/src/txdb.h
@@ -113,7 +113,7 @@ public:
     bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
     bool HaveCoin(const COutPoint &outpoint) const override;
     uint256 GetBestBlock() const;
-    uint256 _GetBestBlock() const;
+    uint256 _GetBestBlock() const override;
     uint256 GetBestBlock(BlockDBMode mode) const;
     uint256 _GetBestBlock(BlockDBMode mode) const;
     void WriteBestBlock(const uint256 &hashBlock);


### PR DESCRIPTION
- Add missing override attribute to `_GetBestBlock()`
- Change the way we access node state from reference to pointer 