### PR TITLE
Use a set instead of the fastfilter for finding conflicts

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -218,6 +218,7 @@ CCond cvTxInQ;
 
 // Finds transactions that may conflict with other pending transactions
 CFastFilter<4 * 1024 * 1024> incomingConflicts GUARDED_BY(csTxInQ);
+std::set<COutPoint> setIncomingConflicts GUARDED_BY(csTxInQ);
 
 // Tranactions that are waiting for validation and are known not to conflict with others
 std::queue<CTxInputData> txInQ GUARDED_BY(csTxInQ);

--- a/src/txadmission.h
+++ b/src/txadmission.h
@@ -102,6 +102,7 @@ extern CRollingFastFilter<4 * 1024 * 1024> txRecentlyInBlock;
 
 // Finds transactions that may conflict with other pending transactions
 extern CFastFilter<4 * 1024 * 1024> incomingConflicts;
+extern std::set<COutPoint> setIncomingConflicts;
 
 // Transactions that are available to be added to the mempool, and protection
 extern CCriticalSection csTxInQ;


### PR DESCRIPTION
Because the fast filter is probabilistic we end up at times with
a false positive. When that happens a transaction will never get out
of the deferred queue. Eventually more transactions will end up in
the deferred queue which also will have false positives resulting in
and ever large queue and also with transactions that won't propagate
into the mempool and also out through the network. To fix this we
can use a set of OutPoints to check for conflicts.

TODO: create a degraded mode where we first use the fast filter
to check for conflicts. If we find one then switch to tracking conflicts
using a set so we can filter out the false positives. This keeps the
performance characteristics of the fast filter in play for almost all
transaction processing, with the exception of the rare conflict.