### PR TITLE
Handle n values > 255

### DIFF
--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -57,10 +57,15 @@ CTransactionRef CommitQGet(uint256 hash)
 static inline uint256 IncomingConflictHash(const COutPoint &prevout)
 {
     uint256 hash = prevout.hash;
-    unsigned char *first = hash.begin();
-    *first ^= (unsigned char)(prevout.n & 255);
-    first += 8;
-    *first ^= (unsigned char)(prevout.n & 255);
+    uint32_t *first = (uint32_t *)hash.begin();
+    *first ^= (uint32_t)(prevout.n & 65535);
+    first += 2;
+    *first ^= (uint32_t)(prevout.n & 65535);
+    first += 2;
+    *first ^= (uint32_t)(prevout.n & 65535);
+    first += 2;
+    *first ^= (uint32_t)(prevout.n & 65535);
+
     return hash;
 }
 


### PR DESCRIPTION
There are many time n values in an input that is > 255 which can
then give us a false positive when inserting into the incomingConflicts
filter.  This can happen when two inputs have the same hash but the
n values are exactly 255 apart. By futher xor'ing the high bits in the
uint32_t's n value we can ensure that both inputs will not collide.

