### PR TITLE
Make boost::multi_index comparators const (take #2)

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -56,7 +56,7 @@ class ScoreCompare
 {
 public:
     ScoreCompare() {}
-    bool operator()(const CTxMemPool::txiter a, const CTxMemPool::txiter b)
+    bool operator()(const CTxMemPool::txiter a, const CTxMemPool::txiter b) const
     {
         return CompareTxMemPoolEntryByScore()(*b, *a); // Convert to less than
     }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -279,7 +279,7 @@ public:
 class CompareTxMemPoolEntryByAncestorFee
 {
 public:
-    bool operator()(const CTxMemPoolEntry &a, const CTxMemPoolEntry &b)
+    bool operator()(const CTxMemPoolEntry &a, const CTxMemPoolEntry &b) const
     {
         double aFees = a.GetModFeesWithAncestors();
         double aSize = a.GetSizeWithAncestors();


### PR DESCRIPTION
In the previous attempt I forgot to change an operator
definition in miner.cpp and one in txmempool.h

This fix #1363.