### PR TITLE
Turn on graphene by default.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -149,7 +149,7 @@ static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 8;
 
 static const bool DEFAULT_PEERBLOOMFILTERS = true;
 static const bool DEFAULT_USE_THINBLOCKS = true;
-static const bool DEFAULT_USE_GRAPHENE_BLOCKS = false;
+static const bool DEFAULT_USE_GRAPHENE_BLOCKS = true;
 
 static const bool DEFAULT_REINDEX = false;
 static const bool DEFAULT_DISCOVER = true;


### PR DESCRIPTION
This leaves both graphene and thinblocks on by default with thinblocks being
the backup to Graphene in the event of a decode failure.

Just putting this up, I think it's time to turn this on by default, even with the decode failures it's proven itself to be working very reliably. The only time we had issues was during the stress test where we saw higher decode failure rates, but even there the failover to xthins worked just fine.  While it's maybe debatable that it's a bit early I feel that it will only improve block propagation (as jtoomim has been observing of late as an issue). At least with all BU nodes on graphene we won't be impacting the propagation between Graphene and Xthin nodes due to the 10 second graphene timer which then falls through to xthins on failure.  