### PR TITLE
Use NET debug category to log connect() and getsockopt() errors

### DIFF
--- a/src/netbase.cpp
+++ b/src/netbase.cpp
@@ -572,13 +572,15 @@ bool static ConnectSocketDirectly(const CService &addrConnect, SOCKET &hSocketRe
             if (getsockopt(hSocket, SOL_SOCKET, SO_ERROR, &nRet, &nRetSize) == SOCKET_ERROR)
 #endif
             {
-                LOGA("getsockopt() for %s failed: %s\n", addrConnect.ToString(), NetworkErrorString(WSAGetLastError()));
+                LOG(NET, "getsockopt() for %s failed: %s\n", addrConnect.ToString(),
+                    NetworkErrorString(WSAGetLastError()));
                 CloseSocket(hSocket);
                 return false;
             }
             if (nRet != 0)
             {
-                LOGA("connect() to %s failed after select(): %s\n", addrConnect.ToString(), NetworkErrorString(nRet));
+                LOG(NET, "connect() to %s failed after select(): %s\n", addrConnect.ToString(),
+                    NetworkErrorString(nRet));
                 CloseSocket(hSocket);
                 return false;
             }


### PR DESCRIPTION
Previously LOGA was used and that lead to a situation where `debug.log` got cluttered with a lot of message like these, especially just after starting up `bitcoind`: 

```
2018-10-05 08:54:44 connect() to 92.116.64.36:8333 failed after select(): No route to host (113)
2018-10-05 08:55:13 connect() to 212.92.120.208:8333 failed after select(): Connection refused (111)
2018-10-05 08:55:21 connect() to 180.106.132.137:8333 failed after select(): Connection refused (111)
2018-10-05 08:55:25 connect() to [2001:0:9d38:6ab8:3c19:154:b45d:e874]:8333 failed: Network is unreachable (101)
2018-10-05 08:55:40 connect() to 114.218.100.56:8333 failed after select(): Connection refused (111)
2018-10-05 08:55:43 connect() to [2001:0:9d38:953c:8b5:2bd0:53e0:f88a]:8333 failed: Network is unreachable (101)
```