### PR TITLE
[PORT] Limit the number of IPs we use from each DNS seeder

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1576,7 +1576,9 @@ static void DNSAddressSeed()
             vector<CNetAddr> vIPs;
             vector<CAddress> vAdd;
             uint64_t requiredServiceBits = NODE_NETWORK;
-            if (LookupHost(GetDNSHost(seed, requiredServiceBits).c_str(), vIPs, 0, true))
+            // Limits number of IPs learned from a DNS seed
+            unsigned int nMaxIPs = 256;
+            if (LookupHost(GetDNSHost(seed, requiredServiceBits).c_str(), vIPs, nMaxIPs, true))
             {
                 for (const CNetAddr &ip : vIPs)
                 {


### PR DESCRIPTION
A risk exists where a malicious DNS seeder eclipses a node by returning an
enormous number of IP addresses. In this commit we mitigate this risk by
limiting the number of IP addresses addrman learns to 256 per DNS seeder.

This is a port of bitcoin/bitcoin/pull/12626