### PR TITLE
[WIP] Keep track of sigops count in CBlock and CBlockIndex

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -201,6 +201,8 @@ public:
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     uint32_t nSequenceId;
 
+    // Number of signature operation according to GetLegacySigOpCount
+    uint64_t nSigOps;
 
     void SetNull()
     {
@@ -216,6 +218,7 @@ public:
         nChainTx = 0;
         nStatus = 0;
         nSequenceId = 0;
+        nSigOps = 0;
 
         nVersion = 0;
         hashMerkleRoot = uint256();

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -81,6 +81,7 @@ public:
     // 0.11: mutable std::vector<uint256> vMerkleTree;
     mutable bool fChecked;
     mutable bool fExcessive; // BU: is the block "excessive" (bigger than this node prefers to accept)
+    mutable uint64_t nSigOps;
 
     CBlock() { SetNull(); }
     CBlock(const CBlockHeader &header)
@@ -162,6 +163,7 @@ public:
         fChecked = false;
         fExcessive = false;
         nBlockSize = 0;
+        nSigOps = 0;
     }
 
     CBlockHeader GetBlockHeader() const

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -917,7 +917,7 @@ bool CheckExcessive(const CBlock &block, uint64_t blockSize, uint64_t nSigOps, u
         }
     }
 
-    LOGA("Acceptable block: ver:%x time:%d size: %" PRIu64 " Tx:%" PRIu64 " Sig:%d\n", block.nVersion, block.nTime,
+    LOG(BLK, "Acceptable block: ver:%x time:%d size: %" PRIu64 " Tx:%" PRIu64 " Sig:%d\n", block.nVersion, block.nTime,
         blockSize, nTx, nSigOps);
     return false;
 }


### PR DESCRIPTION
A new attributes has been added to `CBlock` and `CBlockIndex` to keep track of number of signature operations according to `GetLegacySigOpCount()`.

All these data are memory only so there's no change in the on-disk data format.

Slightly changed the way we log a successful update of the chain tip, namely we added number of transactions and number of sigops to the logged info. Furthermore a change has been made to `CheckExcessive()` to conditionally log for non excessive block. To get the old behavior back you need to turn on the NET debug category.