### PR TITLE
Clarify forks.cpp. Use pindexTip rather than pindexPrev.

### DIFF
--- a/src/validation/forks.cpp
+++ b/src/validation/forks.cpp
@@ -5,37 +5,36 @@
 #include "forks.h"
 #include "unlimited.h"
 
+// For pindexTip use the current chainActive.Tip().
+
 bool IsDAAEnabled(const Consensus::Params &consensusparams, int nHeight)
 {
     return nHeight >= consensusparams.daaHeight;
 }
 
-bool IsDAAEnabled(const Consensus::Params &consensusparams, const CBlockIndex *pindexPrev)
+bool IsDAAEnabled(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip)
 {
-    if (pindexPrev == nullptr)
+    if (pindexTip == nullptr)
     {
         return false;
     }
-
-    return IsDAAEnabled(consensusparams, pindexPrev->nHeight);
+    return IsDAAEnabled(consensusparams, pindexTip->nHeight);
 }
 
-bool IsNov152018Enabled(const Consensus::Params &consensusparams, const CBlockIndex *pindexPrev)
+bool IsNov152018Enabled(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip)
 {
-    if (pindexPrev == nullptr)
+    if (pindexTip == nullptr)
     {
         return false;
     }
-
-    return pindexPrev->IsforkActiveOnNextBlock(miningForkTime.Value());
+    return pindexTip->IsforkActiveOnNextBlock(miningForkTime.Value());
 }
 
-bool IsNov152018Next(const Consensus::Params &consensusparams, const CBlockIndex *pindexPrev)
+bool IsNov152018Next(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip)
 {
-    if (pindexPrev == nullptr)
+    if (pindexTip == nullptr)
     {
         return false;
     }
-
-    return pindexPrev->forkAtNextBlock(miningForkTime.Value());
+    return pindexTip->forkAtNextBlock(miningForkTime.Value());
 }

--- a/src/validation/forks.h
+++ b/src/validation/forks.h
@@ -9,11 +9,11 @@
 #include "consensus/params.h"
 
 /** Check is Cash HF has activated. */
-bool IsDAAEnabled(const Consensus::Params &consensusparams, const CBlockIndex *pindexPrev);
+bool IsDAAEnabled(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip);
 
-bool IsNov152018Next(const Consensus::Params &consensusparams, const CBlockIndex *pindexPrev);
+bool IsNov152018Next(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip);
 
 /** Test if fork is active */
-bool IsNov152018Enabled(const Consensus::Params &consensusparams, const CBlockIndex *pindexPrev);
+bool IsNov152018Enabled(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip);
 
 #endif


### PR DESCRIPTION
pindexPrev was a carry over from the original fork where we used the
pindexPrev from the block to determine whether it was fork time. However
we don't just use the forking logic for blocks, it's also for different
types of transactions that may need to be validated. So, to be clear
we can just call this what it is, the current chaintip, or pindexTip.