### PR TITLE
DbEnv constructor parameter explicit cast to avoid compilation error in macOS

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -44,7 +44,7 @@ void CDBEnv::EnvShutdown()
     if (ret != 0)
         LOGA("CDBEnv::EnvShutdown: Error %d shutting down database environment: %s\n", ret, DbEnv::strerror(ret));
     if (!fMockDb)
-        DbEnv(0).remove(strPath.c_str(), 0);
+        DbEnv((u_int32_t)0).remove(strPath.c_str(), 0);
 }
 
 void CDBEnv::Reset()


### PR DESCRIPTION
Without the explicit cast to  on the value passed to the `DbEnv` constructor in `db.cpp`
the clang++ compiler on macOS will throw

`error: ambiguous conversion for functional-style cast from 'int' to 'DbEnv'`

when building the following tests:
```
src/wallet/test/accounting_tests.cpp
src/wallet/test/wallet_test_fixture.cpp
src/wallet/test/walletdb_tests.cpp
```