### PR TITLE
parallel mining and chain rewind fixes

### DIFF
--- a/qa/rpc-tests/mempool_reorg.py
+++ b/qa/rpc-tests/mempool_reorg.py
@@ -87,6 +87,8 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
 
         for node in self.nodes:
             node.invalidateblock(last_block[0])
+
+        time.sleep(3) # wait for tx processing threads to put them back into the mempool
         assert_equal(set(self.nodes[0].getrawmempool()), {spend_101_id, spend_102_1_id, spend_103_1_id})
 
         # Use invalidateblock to re-org back and make all those coinbase spends
@@ -103,13 +105,14 @@ if __name__ == '__main__':
 
 def Test():
     t = MempoolCoinbaseTest()
+    t.drop_to_pdb = True
     bitcoinConf = {
         "debug": ["rpc","net", "blk", "thin", "mempool", "req", "bench", "evict"],
     }
 
     flags = [] # ["--nocleanup", "--noshutdown"]
     if os.path.isdir("/ramdisk/test"):
-        flags.append("--tmppfx=/ramdisk/test")
+        flags.append("--tmpdir=/ramdisk/test/ma")
     binpath = findBitcoind()
     flags.append("--srcdir=%s" % binpath)
     t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/mempool_resurrect_test.py
+++ b/qa/rpc-tests/mempool_resurrect_test.py
@@ -58,6 +58,8 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         for node in self.nodes:
             node.invalidateblock(blocks[0])
 
+        time.sleep(3) # wait for tx processing threads to put them back into the mempool
+
         # mempool should be empty, all txns confirmed
         assert_equal(set(self.nodes[0].getrawmempool()), set(spends1_id+spends2_id))
         for txid in spends1_id+spends2_id:

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -365,12 +365,6 @@ pblockOut -A copy of the block if not NULL
 */
 UniValue mkblocktemplate(const UniValue &params, int64_t coinbaseSize, CBlock *pblockOut)
 {
-    {
-        // This code flushes pending tx out to the mempool
-        // For lowest latency, should we just go with the tx we have in the mempool?
-        TxAdmissionPause lock;
-        CommitTxToMempool();
-    }
     LOCK(cs_main);
 
     std::string strMode = "template";

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -365,6 +365,12 @@ pblockOut -A copy of the block if not NULL
 */
 UniValue mkblocktemplate(const UniValue &params, int64_t coinbaseSize, CBlock *pblockOut)
 {
+    {
+        // This code flushes pending tx out to the mempool
+        // For lowest latency, should we just go with the tx we have in the mempool?
+        TxAdmissionPause lock;
+        CommitTxToMempool();
+    }
     LOCK(cs_main);
 
     std::string strMode = "template";
@@ -524,10 +530,8 @@ UniValue mkblocktemplate(const UniValue &params, int64_t coinbaseSize, CBlock *p
         if (coinbaseScript->reserveScript.empty())
             throw JSONRPCError(RPC_INTERNAL_ERROR, "No coinbase script available (mining requires a wallet)");
 
-        {
-            TxAdmissionPause lock; // should be able to relax this later and just flush any pending tx
-            pblocktemplate = BlockAssembler(Params()).CreateNewBlock(coinbaseScript->reserveScript, coinbaseSize);
-        }
+
+        pblocktemplate = BlockAssembler(Params()).CreateNewBlock(coinbaseScript->reserveScript, coinbaseSize);
         if (!pblocktemplate)
             throw JSONRPCError(RPC_OUT_OF_MEMORY, "Out of memory");
 
@@ -816,12 +820,6 @@ UniValue SubmitBlock(CBlock &block)
     submitblock_StateCatcher sc(block.GetHash());
     LOG(RPC, "Received block %s via RPC.\n", block.GetHash().ToString());
     RegisterValidationInterface(&sc);
-
-
-    // We take a cs_main lock here even though it will also be aquired in ProcessNewBlock.  We want
-    // to make sure we give priority to our own blocks.  This is in order to prevent any other Parallel
-    // Blocks to validate when we've just mined one of our own blocks.
-    LOCK(cs_main);
 
     // In we are mining our own block or not running in parallel for any reason
     // we must terminate any block validation threads that are currently running,

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -153,7 +153,7 @@ void EnqueueTxForAdmission(CTxInputData &txd)
     }
     else
     {
-        // LOG(MEMPOOL, "Fastfilter collision, deferred %x\n", txd.tx->GetHash().ToString());
+        LOG(MEMPOOL, "Fastfilter collision, deferred %x\n", txd.tx->GetHash().ToString());
         txDeferQ.push(txd);
 
         // By notifying the commitQ, the deferred queue can be processed right way which helps
@@ -248,6 +248,7 @@ void CommitTxToMempool()
         LOCK(cs_main);
 #endif
         boost::unique_lock<boost::mutex> lock(csCommitQ);
+        LOG(MEMPOOL, "txadmission committing %d tx\n", txCommitQ.size());
         for (auto &it : txCommitQ)
         {
             // This transaction has already been validated so store it directly into the mempool.
@@ -380,11 +381,13 @@ void ThreadTxAdmission()
                         acceptedSomething = true;
                         RelayTransaction(tx);
 
-                        // LOG(MEMPOOL, "AcceptToMemoryPool: peer=%s: accepted %s onto Q\n", txd.nodeName,
-                        //    tx->GetHash().ToString());
+                        // LOG(MEMPOOL, "Accepted tx: peer=%s: accepted %s onto Q\n", txd.nodeName,
+                        //     tx->GetHash().ToString());
                     }
                     else
                     {
+                        LOG(MEMPOOL, "Rejected tx: %s(%d): %s. peer %s  hash %s \n", state.GetRejectReason(), state.GetRejectCode(), state.GetDebugMessage(), txd.nodeName, tx->GetHash().ToString());
+
                         if (fMissingInputs)
                         {
                             LOCK(orphanpool.cs); // WRITELOCK

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -386,7 +386,8 @@ void ThreadTxAdmission()
                     }
                     else
                     {
-                        LOG(MEMPOOL, "Rejected tx: %s(%d): %s. peer %s  hash %s \n", state.GetRejectReason(), state.GetRejectCode(), state.GetDebugMessage(), txd.nodeName, tx->GetHash().ToString());
+                        LOG(MEMPOOL, "Rejected tx: %s(%d): %s. peer %s  hash %s \n", state.GetRejectReason(),
+                            state.GetRejectCode(), state.GetDebugMessage(), txd.nodeName, tx->GetHash().ToString());
 
                         if (fMissingInputs)
                         {

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -35,6 +35,7 @@
 #include "timedata.h"
 #include "tinyformat.h"
 #include "tweak.h"
+#include "txadmission.h"
 #include "txmempool.h"
 #include "txorphanpool.h"
 #include "ui_interface.h"
@@ -1740,7 +1741,6 @@ UniValue getminingcandidate(const UniValue &params, bool fHelp)
     UniValue ret(UniValue::VOBJ);
     CMiningCandidate candid;
     int64_t coinbaseSize = -1; // If -1 then not used to set coinbase size
-    LOCK(cs_main);
 
     if (fHelp || params.size() > 1)
     {
@@ -2059,6 +2059,9 @@ extern std::map<std::pair<void *, void *>, LockStack> lockorders;
 extern std::vector<std::string> vUseDNSSeeds;
 extern std::list<CNode *> vNodesDisconnected;
 extern std::set<CNetAddr> setservAddNodeAddresses;
+extern std::map<uint256, CTxCommitData> txCommitQ;
+extern std::queue<CTxInputData> txDeferQ;
+extern std::queue<CTxInputData> txInQ;
 extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
 {
     UniValue ret(UniValue::VOBJ);
@@ -2117,6 +2120,10 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
     ret.push_back(Pair("xpeditedBlk", (uint64_t)nExpeditedBlocks));
     ret.push_back(Pair("xpeditedBlkUp", (uint64_t)nExpeditedUpstream));
     ret.push_back(Pair("xpeditedTxn", (uint64_t)nExpeditedTxs));
+
+    ret.push_back(Pair("txCommitQ", (uint64_t)txCommitQ.size()));
+    ret.push_back(Pair("txInQ", (uint64_t)txInQ.size()));
+    ret.push_back(Pair("txDeferQ", (uint64_t)txDeferQ.size()));
 
 #ifdef DEBUG_LOCKORDER
     ret.push_back(Pair("lockorders", (uint64_t)lockorders.size()));

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -2829,6 +2829,12 @@ bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusPa
         }
     }
 
+    // these bloom filters stop us from doing duplicate work on tx we already know about.
+    // but since we rewound, we need to do this duplicate work -- clear them so tx we have already processed
+    // can be processed again.
+    txRecentlyInBlock.reset();
+    recentRejects.reset();
+
     // Update chainActive and related variables.
     UpdateTip(pindexDelete->pprev);
     // Let wallets know transactions went from 1-confirmed to


### PR DESCRIPTION
fix some locking problems with block creation, add tx queues to the dumpstructuresizes debugging RPC call, and optimize block rewind (making rewinds of very large blocks practical) by enqueuing uncommitted tx rather than putting them in the mempool sequentially and in a single thread