### PR TITLE
Moved DNS Max IPs constant to net.h and other cleanups in net.h

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1576,9 +1576,7 @@ static void DNSAddressSeed()
             vector<CNetAddr> vIPs;
             vector<CAddress> vAdd;
             uint64_t requiredServiceBits = NODE_NETWORK;
-            // Limits number of IPs learned from a DNS seed
-            unsigned int nMaxIPs = 256;
-            if (LookupHost(GetDNSHost(seed, requiredServiceBits).c_str(), vIPs, nMaxIPs, true))
+            if (LookupHost(GetDNSHost(seed, requiredServiceBits).c_str(), vIPs, MAX_DNS_SEEDED_IPS, true))
             {
                 for (const CNetAddr &ip : vIPs)
                 {

--- a/src/net.h
+++ b/src/net.h
@@ -75,14 +75,12 @@ static const bool DEFAULT_UPNP = USE_UPNP;
 #else
 static const bool DEFAULT_UPNP = false;
 #endif
-/** The maximum number of entries in mapAskFor */
-static const size_t MAPASKFOR_MAX_SZ = MAX_INV_SZ;
-/** The maximum number of entries in setAskFor (larger due to getdata latency)*/
-static const size_t SETASKFOR_MAX_SZ = 2 * MAX_INV_SZ;
 /** The maximum number of peer connections to maintain. */
 static const unsigned int DEFAULT_MAX_PEER_CONNECTIONS = 125;
-/** BU: The maximum numer of outbound peer connections */
+/** BU: The maximum number of outbound peer connections */
 static const unsigned int DEFAULT_MAX_OUTBOUND_CONNECTIONS = 16;
+/** Limits number of IPs learned from a DNS seed */
+static const unsigned int MAX_DNS_SEEDED_IPS = 256;
 /** BU: The minimum number of xthin nodes to connect */
 static const uint8_t MIN_XTHIN_NODES = 8;
 /** BU: The daily maximum disconnects while searching for xthin nodes to connect */


### PR DESCRIPTION
 - Moved max number of IPs learned from a DNS seed to net.h (Re: Will do by @sickpig https://bit.ly/2pJDBKw)
 - Fixed a typo in comment for `DEFAULT_MAX_OUTBOUND_CONNECTIONS` (s/numer/number)
 - Removed 2 unused symbols from net.h (`MAPASKFOR_MAX_SZ`, `SETASKFOR_MAX_SZ`)