### PR TITLE
DbEnv constructor param explicit cast to avoid compilation error in macOS

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -44,7 +44,7 @@ void CDBEnv::EnvShutdown()
     if (ret != 0)
         LOGA("CDBEnv::EnvShutdown: Error %d shutting down database environment: %s\n", ret, DbEnv::strerror(ret));
     if (!fMockDb)
-        DbEnv((u_int32_t)0).remove(strPath.c_str(), 0);
+        DbEnv((uint32_t)0).remove(strPath.c_str(), 0);
 }
 
 void CDBEnv::Reset()

--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -44,7 +44,7 @@ void CDBEnv::EnvShutdown()
     if (ret != 0)
         LOGA("CDBEnv::EnvShutdown: Error %d shutting down database environment: %s\n", ret, DbEnv::strerror(ret));
     if (!fMockDb)
-        DbEnv(0).remove(strPath.c_str(), 0);
+        DbEnv((u_int32_t)0).remove(strPath.c_str(), 0);
 }
 
 void CDBEnv::Reset()


### PR DESCRIPTION
(I apologize for the re-submission, I removed my repo's branch by mistake and the PR auto-closed on BitcoinUnlimited's PR queue.)