### PR TITLE
DRY refactor in rpc/blockchain.cpp

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -938,31 +938,35 @@ static UniValue SoftForkDesc(const std::string &name,
 
 
 static void pushBackThresholdStatus(UniValue &rv,
-                                    const Consensus::Params &consensusParams,
-                                    const ThresholdState thresholdState,
-                                    Consensus::DeploymentPos id,
-                                    VersionBitBIP versionBitBIP) {
-    if (versionBitBIP == BIP_135) {
-        rv.pushKV("bit", (int) id);
+    const Consensus::Params &consensusParams,
+    const ThresholdState thresholdState,
+    Consensus::DeploymentPos id,
+    VersionBitBIP versionBitBIP)
+{
+    if (versionBitBIP == BIP_135)
+    {
+        rv.pushKV("bit", (int)id);
     }
-    switch (thresholdState) {
-        case THRESHOLD_DEFINED:
-            rv.pushKV("status", "defined");
-            break;
-        case THRESHOLD_STARTED:
-            rv.pushKV("status", "started");
-            break;
-        case THRESHOLD_LOCKED_IN:
-            rv.pushKV("status", "locked_in");
-            break;
-        case THRESHOLD_ACTIVE:
-            rv.pushKV("status", "active");
-            break;
-        case THRESHOLD_FAILED:
-            rv.pushKV("status", "failed");
-            break;
+    switch (thresholdState)
+    {
+    case THRESHOLD_DEFINED:
+        rv.pushKV("status", "defined");
+        break;
+    case THRESHOLD_STARTED:
+        rv.pushKV("status", "started");
+        break;
+    case THRESHOLD_LOCKED_IN:
+        rv.pushKV("status", "locked_in");
+        break;
+    case THRESHOLD_ACTIVE:
+        rv.pushKV("status", "active");
+        break;
+    case THRESHOLD_FAILED:
+        rv.pushKV("status", "failed");
+        break;
     }
-    if (versionBitBIP == BIP_009 && THRESHOLD_STARTED == thresholdState) {
+    if (versionBitBIP == BIP_009 && THRESHOLD_STARTED == thresholdState)
+    {
         rv.pushKV("bit", consensusParams.vDeployments[id].bit);
     }
     rv.pushKV("startTime", consensusParams.vDeployments[id].nStartTime);

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -30,9 +30,10 @@ enum ThresholdState
 };
 
 // used in pushBackThresholdStatus to determine when/how to insert the bit id
-enum VersionBitBIP {
+enum VersionBitBIP
+{
     BIP_009, // Version bits with timeout and delay
-    BIP_135  // Generalized version bits voting
+    BIP_135 // Generalized version bits voting
 };
 
 // A map that gives the state for blocks whose height is a multiple of Period().

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -29,6 +29,12 @@ enum ThresholdState
     THRESHOLD_FAILED
 };
 
+// used in pushBackThresholdStatus to determine when/how to insert the bit id
+enum VersionBitBIP {
+    BIP_009, // Version bits with timeout and delay
+    BIP_135  // Generalized version bits voting
+};
+
 // A map that gives the state for blocks whose height is a multiple of Period().
 // The map is indexed by the block's parent, however, so all keys in the map
 // will either be NULL or a block with (height + 1) % Period() == 0.


### PR DESCRIPTION
I've refactored a switch statement that was repeated in `BIP9SoftForkDesc` and `BIP135ForkDesc`.

I've also used the opportunity to include in this new method the logic for when `Pair("bit", (int)id)` gets pushed back into the `UniValue`, and also refactored repeated code that pushed back the `startTime` and `timeout` values.

I decided to introduce an enum that specifies the BIP context from where the function is called from (BIP9 or BIP135) in case there will be other version bit related bips. If this is overkill, we can replace that parameter with a `bool isBIP9` to act either way.