### PR TITLE
[PORT]  depends: make osx output deterministic

### DIFF
--- a/depends/packages/native_cctools.mk
+++ b/depends/packages/native_cctools.mk
@@ -34,7 +34,8 @@ $(package)_cxx=$($(package)_extract_dir)/toolchain/bin/clang++
 endef
 
 define $(package)_preprocess_cmds
-  cd $($(package)_build_subdir); ./autogen.sh
+  cd $($(package)_build_subdir); ./autogen.sh && \
+  sed -i.old "/define HAVE_PTHREADS/d" ld64/src/ld/InputFiles.h
 endef
 
 define $(package)_config_cmds


### PR DESCRIPTION
This is a port of bitcoin/bitcoin/pull/9891

ld64 is threaded, and uses a worker for each CPU to parse input files. But there's a bug in the parser causing dependencies to be calculated differently based on which files have already been parsed.

As a result, builders with more CPUs are more likely to see non-determinism.

This looks to have been fixed in a newer version of ld64, so just disable threading for now. There's no noticeable slowdown.