### PR TITLE
Turn Graphene on by default fix

### DIFF
--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1345,7 +1345,7 @@ bool HaveGrapheneNodes()
     return false;
 }
 
-bool IsGrapheneBlockEnabled() { return GetBoolArg("-use-grapheneblocks", false); }
+bool IsGrapheneBlockEnabled() { return GetBoolArg("-use-grapheneblocks", DEFAULT_USE_GRAPHENE_BLOCKS); }
 bool CanGrapheneBlockBeDownloaded(CNode *pto)
 {
     LOCK(pto->cs_mapgrapheneblocksinflight);


### PR DESCRIPTION
When the `-use-grapheneblocks=1` flag is not specified in the bitcoin.config file or via command line, the 1.5 client falsely advertises Graphene as being on, when none of the internal plumbing actually thinks it's on.  This is due to a call to `GetBoolArg` that didn't use the `DEFAULT_USE_GRAPHENE_BLOCKS` constant.
Fixes #1380