### PR TITLE
Make graphene use excessive-block-logic

### DIFF
--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -77,7 +77,7 @@ public:
         READWRITE(nBlockTxs);
         // This logic assumes a smallest transaction size of 100 bytes.  This is optimistic for realistic transactions
         // and the downside for pathological blocks is just that graphene won't work so we fall back to xthin
-        if (nBlockTxs > excessiveBlockSize / 100)
+        if (nBlockTxs > (excessiveBlockSize * maxMessageSizeMultiplier / 100))
             throw std::runtime_error("nBlockTxs exceeds threshold for excessive block txs");
         if (!pGrapheneSet)
             pGrapheneSet = new CGrapheneSet();


### PR DESCRIPTION
A bunch of consensus related parameter(EB, sigops per MB, etc etc)
follow an emergent consensus logic, i.e. this was not tha case for
graphene while trying to guess estimate the number of transactions
in a block. This changeset will make it so that the constraint on the
maximum number of transactions follow take into account of
MAX_MESSAGE_SIZE_MULTIPLIER