### PR TITLE
Revert "Turn on graphene by default."

### DIFF
--- a/doc/release-notes-bucash.md
+++ b/doc/release-notes-bucash.md
@@ -48,15 +48,14 @@ Main Changes
 
 - Implementation of November 2018 upgrades feature (see the [specification](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/2018-nov-upgrade.md) for more details)
 - CTOR, CDSV, CLEAN_STACK, FORCE_PUSH, 100 byte TXN SIZE (as a sublist)
-- Add configuration parameters to allow miners to specify their [BIP135](https://github.com/bitcoin/bips/blob/master/bip-0135.mediawiki) votes. See this [guide]() from more details
-- Multithreaded transaction admissio to the mempool (ATMP)
+- Add configuration parameters to allow miners to specify their [BIP135](https://github.com/bitcoin/bips/blob/master/bip-0135.mediawiki) votes. See this [guide](https://github.com/BitcoinUnlimited/BitcoinUnlimited/blob/master/doc/bip135-guide.md) from more details
+- Multithreaded transaction admission to the mempool (ATMP)
 - Parallelize message processing
 - Fastfilters: a faster than Bloom Filter probabilistic data structure
 - Various improvements to the Request Manager
 - Add tracking of ancestor packages and expose ancestor/descendant information over RPC
 - Remove trickle login in dealing with transactions INV
 - Implement shared lock semantics for the UTXO
-- Turn Graphene on by default
 
 Commit details
 -------

--- a/doc/release-notes-bucash.md
+++ b/doc/release-notes-bucash.md
@@ -13,10 +13,10 @@ This is a major release version based of Bitcoin Unlimited compatible
 with the Bitcoin Cash specifications you could find here:
 
 
-https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/uahf-technical-spec.md (Aug 1st '17 Protocol Upgrade, bucash 1.1.0.0)
-https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/nov-13-hardfork-spec.md (Nov 13th '17 Protocol Upgrade, bucash 1.1.2.0)
-https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/may-2018-hardfork.md (May 15th '18 Protocol Upgrade, bucash 1.3.0.0, 1.3.0.1, 1.4.0.0)
-https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/2018-nov-upgrade.md (Nov 15th '18 Protocol Upgradem, bucash 1.5.0.0)
+- https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/uahf-technical-spec.md (Aug 1st '17 Protocol Upgrade, bucash 1.1.0.0)
+- https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/nov-13-hardfork-spec.md (Nov 13th '17 Protocol Upgrade, bucash 1.1.2.0)
+- https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/may-2018-hardfork.md (May 15th '18 Protocol Upgrade, bucash 1.3.0.0, 1.3.0.1, 1.4.0.0)
+- https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/2018-nov-upgrade.md (Nov 15th '18 Protocol Upgradem, bucash 1.5.0.0)
 
 Upgrading
 ---------
@@ -47,14 +47,18 @@ Main Changes
 ------------
 
 - Implementation of November 2018 upgrades feature (see the [specification](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/2018-nov-upgrade.md) for more details)
-- CTOR, CDSV, CLEAN_STACK, FORCE_PUSH, 100 byte TXN SIZE (as a sublist)
+    - CTOR: Canonical Transaction Ordering
+    - CDSV: OP_CHECKDATASIG[VERIFY]
+    - CLEAN_STACK: Enforce "clean stack" rule
+    - FORCE_PUSH: Enforce "push only" rule for scriptSig
+    - 00 byte MIN TXN SIZE: Enforce minimum transaction size
 - Add configuration parameters to allow miners to specify their [BIP135](https://github.com/bitcoin/bips/blob/master/bip-0135.mediawiki) votes. See this [guide](https://github.com/BitcoinUnlimited/BitcoinUnlimited/blob/master/doc/bip135-guide.md) from more details
 - Multithreaded transaction admission to the mempool (ATMP)
 - Parallelize message processing
 - Fastfilters: a faster than Bloom Filter probabilistic data structure
 - Various improvements to the Request Manager
 - Add tracking of ancestor packages and expose ancestor/descendant information over RPC
-- Remove trickle login in dealing with transactions INV
+- Remove trickle logic in dealing with transactions INV
 - Implement shared lock semantics for the UTXO
 
 Commit details

--- a/doc/release-notes/release-notes-bucash1.5.0.0.md
+++ b/doc/release-notes/release-notes-bucash1.5.0.0.md
@@ -56,7 +56,6 @@ Main Changes
 - Add tracking of ancestor packages and expose ancestor/descendant information over RPC
 - Remove trickle login in dealing with transactions INV
 - Implement shared lock semantics for the UTXO
-- Turn Graphene on by default
 
 Commit details
 -------

--- a/doc/release-notes/release-notes-bucash1.5.0.0.md
+++ b/doc/release-notes/release-notes-bucash1.5.0.0.md
@@ -13,10 +13,10 @@ This is a major release version based of Bitcoin Unlimited compatible
 with the Bitcoin Cash specifications you could find here:
 
 
-https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/uahf-technical-spec.md (Aug 1st '17 Protocol Upgrade, bucash 1.1.0.0)
-https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/nov-13-hardfork-spec.md (Nov 13th '17 Protocol Upgrade, bucash 1.1.2.0)
-https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/may-2018-hardfork.md (May 15th '18 Protocol Upgrade, bucash 1.3.0.0, 1.3.0.1, 1.4.0.0)
-https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/2018-nov-upgrade.md (Nov 15th '18 Protocol Upgradem, bucash 1.5.0.0)
+- https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/uahf-technical-spec.md (Aug 1st '17 Protocol Upgrade, bucash 1.1.0.0)
+- https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/nov-13-hardfork-spec.md (Nov 13th '17 Protocol Upgrade, bucash 1.1.2.0)
+- https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/may-2018-hardfork.md (May 15th '18 Protocol Upgrade, bucash 1.3.0.0, 1.3.0.1, 1.4.0.0)
+- https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/2018-nov-upgrade.md (Nov 15th '18 Protocol Upgradem, bucash 1.5.0.0)
 
 Upgrading
 ---------
@@ -47,14 +47,18 @@ Main Changes
 ------------
 
 - Implementation of November 2018 upgrades feature (see the [specification](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/2018-nov-upgrade.md) for more details)
-- CTOR, CDSV, CLEAN_STACK, FORCE_PUSH, 100 byte TXN SIZE (as a sublist)
+    - CTOR: Canonical Transaction Ordering
+    - CDSV: OP_CHECKDATASIG[VERIFY]
+    - CLEAN_STACK: Enforce "clean stack" rule
+    - FORCE_PUSH: Enforce "push only" rule for scriptSig
+    - 00 byte MIN TXN SIZE: Enforce minimum transaction size
 - Add configuration parameters to allow miners to specify their [BIP135](https://github.com/bitcoin/bips/blob/master/bip-0135.mediawiki) votes. See this [guide](https://github.com/BitcoinUnlimited/BitcoinUnlimited/blob/master/doc/bip135-guide.md) from more details
 - Multithreaded transaction admission to the mempool (ATMP)
 - Parallelize message processing
 - Fastfilters: a faster than Bloom Filter probabilistic data structure
 - Various improvements to the Request Manager
 - Add tracking of ancestor packages and expose ancestor/descendant information over RPC
-- Remove trickle login in dealing with transactions INV
+- Remove trickle logic in dealing with transactions INV
 - Implement shared lock semantics for the UTXO
 
 Commit details

--- a/src/main.h
+++ b/src/main.h
@@ -149,7 +149,7 @@ static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 8;
 
 static const bool DEFAULT_PEERBLOOMFILTERS = true;
 static const bool DEFAULT_USE_THINBLOCKS = true;
-static const bool DEFAULT_USE_GRAPHENE_BLOCKS = true;
+static const bool DEFAULT_USE_GRAPHENE_BLOCKS = false;
 
 static const bool DEFAULT_REINDEX = false;
 static const bool DEFAULT_DISCOVER = true;


### PR DESCRIPTION
This reverts commit 13e05138d7a06b3df1233939ec0f6c9ebf57fc7a.

This is a temporary measure. We are going to turn it on again once we
get a bunch of pythin test failures fixed.