### PR TITLE
Turn graphene on by default

### DIFF
--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -318,6 +318,7 @@ test/pmt_tests.cpp
 test/policyestimator_tests.cpp
 test/pow_tests.cpp
 test/prevector_tests.cpp
+test/requestmanager_tests.cpp
 test/reverselock_tests.cpp
 test/rpc_tests.cpp
 test/sanity_tests.cpp

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -100,6 +100,7 @@ BITCOIN_TESTS =\
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \
   test/prevector_tests.cpp \
+  test/requestmanager_tests.cpp \
   test/reverselock_tests.cpp \
   test/rpc_tests.cpp \
   test/sanity_tests.cpp \

--- a/src/main.h
+++ b/src/main.h
@@ -149,7 +149,7 @@ static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 8;
 
 static const bool DEFAULT_PEERBLOOMFILTERS = true;
 static const bool DEFAULT_USE_THINBLOCKS = true;
-static const bool DEFAULT_USE_GRAPHENE_BLOCKS = false;
+static const bool DEFAULT_USE_GRAPHENE_BLOCKS = true;
 
 static const bool DEFAULT_REINDEX = false;
 static const bool DEFAULT_DISCOVER = true;

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -520,7 +520,7 @@ bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
     // but the grapheneblock timer has lapsed.
     if (IsChainNearlySyncd() && IsThinBlocksEnabled() && HaveThinblockNodes())
     {
-        if (!IsGrapheneBlockEnabled() || (IsGrapheneBlockEnabled() && !graphenedata.CheckGrapheneBlockTimer(obj.hash)))
+        if (!IsGrapheneBlockEnabled() || !graphenedata.CheckGrapheneBlockTimer(obj.hash))
         {
             if (thindata.CheckThinblockTimer(obj.hash))
             {

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -587,8 +587,13 @@ if(IsChainNearlySyncd() && IsThinBlocksEnabled() && HaveThinblockNodes())
     // Request a full block if graphene and thinblocks is turned off.  Also we must request a full block
     // if we've fallen behind from the state of being fully syncd, furthermore, this is crucial for initial
     // sync to function as this is the only way we request full blocks near the end of the initial sync process.
-    if (!IsChainNearlySyncd() || (!IsGrapheneBlockEnabled() && !IsThinBlocksEnabled()) || (!HaveThinblockNodes() && !HaveGrapheneNodes()))
+    if (!IsChainNearlySyncd() || (!IsGrapheneBlockEnabled() && !IsThinBlocksEnabled()) || (!HaveThinblockNodes() && !HaveGrapheneNodes()) ||
+       (!IsGrapheneBlockEnabled() && HaveGrapheneNodes() &&
+          IsThinBlocksEnabled() && !HaveThinblockNodes()) ||
+       (IsGrapheneBlockEnabled() && !HaveGrapheneNodes() &&
+          !IsThinBlocksEnabled() && HaveThinblockNodes()))
     {
+
         std::vector<CInv> vToFetch;
         inv2.type = MSG_BLOCK;
         vToFetch.push_back(inv2);

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -518,89 +518,87 @@ bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
 
     // Ask for XTHIN's if Graphene is not enabled, or, ask for XTHIN's if graphene is enabled
     // but the grapheneblock timer has lapsed.
-if(IsChainNearlySyncd() && IsThinBlocksEnabled() && HaveThinblockNodes())
-{
-    if (!IsGrapheneBlockEnabled() || (IsGrapheneBlockEnabled() && !graphenedata.CheckGrapheneBlockTimer(obj.hash)))
+    if (IsChainNearlySyncd() && IsThinBlocksEnabled() && HaveThinblockNodes())
     {
-        if (thindata.CheckThinblockTimer(obj.hash))
+        if (!IsGrapheneBlockEnabled() || (IsGrapheneBlockEnabled() && !graphenedata.CheckGrapheneBlockTimer(obj.hash)))
         {
-            // Must download an xthinblock from a XTHIN peer.
-            // We can only request one xthinblock per peer at a time.
-            if (CanThinBlockBeDownloaded(pfrom))
+            if (thindata.CheckThinblockTimer(obj.hash))
             {
-                inv2.type = MSG_XTHINBLOCK;
-                std::vector<uint256> vOrphanHashes;
+                // Must download an xthinblock from a XTHIN peer.
+                // We can only request one xthinblock per peer at a time.
+                if (CanThinBlockBeDownloaded(pfrom))
                 {
-                    READLOCK(orphanpool.cs);
-                    for (auto &mi : orphanpool.mapOrphanTransactions)
-                        vOrphanHashes.emplace_back(mi.first);
-                }
-                BuildSeededBloomFilter(filterMemPool, vOrphanHashes, inv2.hash, pfrom);
-                ss << inv2;
-                ss << filterMemPool;
+                    inv2.type = MSG_XTHINBLOCK;
+                    std::vector<uint256> vOrphanHashes;
+                    {
+                        READLOCK(orphanpool.cs);
+                        for (auto &mi : orphanpool.mapOrphanTransactions)
+                            vOrphanHashes.emplace_back(mi.first);
+                    }
+                    BuildSeededBloomFilter(filterMemPool, vOrphanHashes, inv2.hash, pfrom);
+                    ss << inv2;
+                    ss << filterMemPool;
 
-                MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
-                AddThinBlockInFlight(pfrom, inv2.hash);
-                pfrom->PushMessage(NetMsgType::GET_XTHIN, ss);
-                LOG(THIN, "Requesting xthinblock %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
-                return true;
-            }
-        }
-        else
-        {
-            // Try to download a thinblock if possible otherwise just download a regular block.
-            // We can only request one xthinblock per peer at a time.
-            if (CanThinBlockBeDownloaded(pfrom))
-            {
-                inv2.type = MSG_XTHINBLOCK;
-                std::vector<uint256> vOrphanHashes;
-                {
-                    READLOCK(orphanpool.cs);
-                    for (auto &mi : orphanpool.mapOrphanTransactions)
-                        vOrphanHashes.emplace_back(mi.first);
+                    MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
+                    AddThinBlockInFlight(pfrom, inv2.hash);
+                    pfrom->PushMessage(NetMsgType::GET_XTHIN, ss);
+                    LOG(THIN, "Requesting xthinblock %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
+                    return true;
                 }
-                BuildSeededBloomFilter(filterMemPool, vOrphanHashes, inv2.hash, pfrom);
-                ss << inv2;
-                ss << filterMemPool;
-
-                MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
-                AddThinBlockInFlight(pfrom, inv2.hash);
-                pfrom->PushMessage(NetMsgType::GET_XTHIN, ss);
-                LOG(THIN, "Requesting xthinblock %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
-                return true;
             }
             else
             {
-                std::vector<CInv> vToFetch;
-                inv2.type = MSG_BLOCK;
-                vToFetch.push_back(inv2);
+                // Try to download a thinblock if possible otherwise just download a regular block.
+                // We can only request one xthinblock per peer at a time.
+                if (CanThinBlockBeDownloaded(pfrom))
+                {
+                    inv2.type = MSG_XTHINBLOCK;
+                    std::vector<uint256> vOrphanHashes;
+                    {
+                        READLOCK(orphanpool.cs);
+                        for (auto &mi : orphanpool.mapOrphanTransactions)
+                            vOrphanHashes.emplace_back(mi.first);
+                    }
+                    BuildSeededBloomFilter(filterMemPool, vOrphanHashes, inv2.hash, pfrom);
+                    ss << inv2;
+                    ss << filterMemPool;
 
-                MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
-                pfrom->PushMessage(NetMsgType::GETDATA, vToFetch);
-                LOG(THIN, "Requesting Regular Block %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
-                return true;
+                    MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
+                    AddThinBlockInFlight(pfrom, inv2.hash);
+                    pfrom->PushMessage(NetMsgType::GET_XTHIN, ss);
+                    LOG(THIN, "Requesting xthinblock %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
+                    return true;
+                }
+                else
+                {
+                    std::vector<CInv> vToFetch;
+                    inv2.type = MSG_BLOCK;
+                    vToFetch.push_back(inv2);
+
+                    MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
+                    pfrom->PushMessage(NetMsgType::GETDATA, vToFetch);
+                    LOG(THIN, "Requesting Regular Block %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
+                    return true;
+                }
             }
         }
     }
-}
 
     // Request a full block if graphene and thinblocks is turned off.  Also we must request a full block
     // if we've fallen behind from the state of being fully syncd, furthermore, this is crucial for initial
     // sync to function as this is the only way we request full blocks near the end of the initial sync process.
-    if (!IsChainNearlySyncd() || (!IsGrapheneBlockEnabled() && !IsThinBlocksEnabled()) || (!HaveThinblockNodes() && !HaveGrapheneNodes()) ||
-       (!IsGrapheneBlockEnabled() && HaveGrapheneNodes() &&
-          IsThinBlocksEnabled() && !HaveThinblockNodes()) ||
-       (IsGrapheneBlockEnabled() && !HaveGrapheneNodes() &&
-          !IsThinBlocksEnabled() && HaveThinblockNodes()))
+    if (!IsChainNearlySyncd() || (!IsGrapheneBlockEnabled() && !IsThinBlocksEnabled()) ||
+        (!HaveThinblockNodes() && !HaveGrapheneNodes()) ||
+        (!IsGrapheneBlockEnabled() && HaveGrapheneNodes() && IsThinBlocksEnabled() && !HaveThinblockNodes()) ||
+        (IsGrapheneBlockEnabled() && !HaveGrapheneNodes() && !IsThinBlocksEnabled() && HaveThinblockNodes()))
     {
-
         std::vector<CInv> vToFetch;
         inv2.type = MSG_BLOCK;
         vToFetch.push_back(inv2);
 
         MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
         pfrom->PushMessage(NetMsgType::GETDATA, vToFetch);
-        LOG(THIN|GRAPHENE, "Requesting Regular Block %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
+        LOG(THIN | GRAPHENE, "Requesting Regular Block %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
         return true;
     }
     return false; // no block was requested

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -119,7 +119,6 @@ protected:
 #ifdef DEBUG
     friend UniValue getstructuresizes(const UniValue &params, bool fHelp);
 #endif
-
     // map of transactions
     typedef std::map<uint256, CUnknownObj> OdMap;
     OdMap mapTxnInfo;
@@ -141,9 +140,6 @@ protected:
     void cleanup(OdMap::iterator &item);
     CLeakyBucket requestPacer;
 
-    // Request a single block.
-    bool RequestBlock(CNode *pfrom, CInv obj);
-
 public:
     CRequestManager();
 
@@ -155,6 +151,9 @@ public:
      *  degree of disordering of blocks on disk (which make reindexing and in the future perhaps pruning
      *  harder). We'll probably want to make this a per-peer adaptive value at some point. */
     std::atomic<unsigned int> BLOCK_DOWNLOAD_WINDOW{1024};
+
+    // Request a single block.
+    bool RequestBlock(CNode *pfrom, CInv obj);
 
     // Get this object from somewhere, asynchronously.
     void AskFor(const CInv &obj, CNode *from, unsigned int priority = 0);

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -117,13 +117,6 @@ CBlock TestBlock1() // Thanks dagurval :)
 CBlock block = TestBlock1();
 
 
-CService ipaddress(uint32_t i, uint32_t port)
-{
-    struct in_addr s;
-    s.s_addr = i;
-    return CService(CNetAddr(s), port);
-}
-
 // create dummy test addrs
 CAddress addr1(ipaddress(0xa0b0c001, 10000));
 CAddress addr2(ipaddress(0xa0b0c002, 10001));

--- a/src/test/requestmanager_tests.cpp
+++ b/src/test/requestmanager_tests.cpp
@@ -1,0 +1,596 @@
+// Copyright (c) 2016 Bitcoin Unlimited Developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "blockrelay/graphene.h"
+#include "blockrelay/thinblock.h"
+#include "bloom.h"
+#include "chainparams.h"
+#include "dosman.h"
+#include "main.h"
+#include "net.h"
+#include "primitives/block.h"
+#include "protocol.h"
+#include "random.h"
+#include "requestManager.h"
+#include "serialize.h"
+#include "streams.h"
+#include "streams.h"
+#include "txmempool.h"
+#include "uint256.h"
+#include "unlimited.h"
+#include "util.h"
+#include "utilstrencodings.h"
+#include "validation/validation.h"
+#include "version.h"
+
+#include "test/test_bitcoin.h"
+
+#include <atomic>
+#include <boost/test/unit_test.hpp>
+#include <sstream>
+#include <string.h>
+
+// Return the netmessage string for a block/xthin/graphene request
+static std::string NetMessage(std::deque<CSerializeData> &_vSendMsg)
+{
+    BOOST_CHECK(_vSendMsg.size() != 0);
+    if (_vSendMsg.size() == 0)
+        return "none";
+
+    CInv inv_result;
+    const CSerializeData &data = _vSendMsg.front();
+    CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
+    ss.insert(ss.begin(), &data[4], &data[16]);
+
+    _vSendMsg.pop_front();
+    return ss.str();
+}
+
+static void ClearBlocksInFlight(CNode &node)
+{
+    node.mapGrapheneBlocksInFlight.clear();
+    node.mapThinBlocksInFlight.clear();
+}
+
+BOOST_FIXTURE_TEST_SUITE(requestmanager_tests, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(blockrequest_tests)
+{
+    // Test the requesting of blocks/graphenblocks/thinblocks with varying node configurations.
+    // This tests all the code paths within RequestBlock() in the request manager.
+    LOCK(cs_vNodes);
+
+    // create dummy test addrs
+    CAddress addr_xthin(ipaddress(0xa0b0c001, 10000));
+    CAddress addr_graphene(ipaddress(0xa0b0c002, 10001));
+    CAddress addr_none(ipaddress(0xa0b0c003, 10002));
+
+    // create nodes
+    CNode dummyNodeXthin(INVALID_SOCKET, addr_xthin, "", true);
+    CNode dummyNodeGraphene(INVALID_SOCKET, addr_graphene, "", true);
+    CNode dummyNodeNone(INVALID_SOCKET, addr_none, "", true);
+    dummyNodeXthin.nVersion = MIN_PEER_PROTO_VERSION;
+    dummyNodeXthin.fSuccessfullyConnected = true;
+    dummyNodeXthin.nServices |= NODE_XTHIN;
+    dummyNodeGraphene.nVersion = MIN_PEER_PROTO_VERSION;
+    dummyNodeGraphene.fSuccessfullyConnected = true;
+    dummyNodeGraphene.nServices |= NODE_GRAPHENE;
+    dummyNodeNone.nVersion = MIN_PEER_PROTO_VERSION;
+    dummyNodeNone.fSuccessfullyConnected = true;
+
+    // Create basic Inv for requesting blocks. This simulates an entry in the request manager for a block
+    // download.
+    uint256 hash = GetRandHash();
+    uint256 randhash = GetRandHash();
+    CInv inv(MSG_BLOCK, hash);
+
+    uint64_t nTime = GetTime();
+    dosMan.ClearBanned();
+
+    // Chain NOT sync'd with any nodes, graphene ON, Thinblocks ON
+    IsChainNearlySyncdSet(false);
+    SetBoolArg("-use-grapheneblocks", true);
+    SetBoolArg("-use-thinblocks", true);
+    vNodes.push_back(&dummyNodeXthin);
+    vNodes.push_back(&dummyNodeGraphene);
+    vNodes.push_back(&dummyNodeNone);
+
+    requester.RequestBlock(&dummyNodeXthin, inv);
+    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("getdata") != 0);
+
+    requester.RequestBlock(&dummyNodeGraphene, inv);
+    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("getdata") != 0);
+
+    requester.RequestBlock(&dummyNodeNone, inv);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeGraphene);
+    ClearBlocksInFlight(dummyNodeNone);
+    ClearBlocksInFlight(dummyNodeXthin);
+    vNodes.pop_back();
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+    // Chains IS sync'd,  No graphene nodes, No Thinblock nodes, Thinblocks OFF, Graphene OFF
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", false);
+    SetBoolArg("-use-thinblocks", false);
+    vNodes.push_back(&dummyNodeNone);
+
+    requester.RequestBlock(&dummyNodeNone, inv);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeNone);
+    vNodes.pop_back();
+
+    // Chains IS sync'd,  HAVE graphene nodes, NO Thinblock nodes, Thinblocks OFF, Graphene OFF
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("use-grapheneblocks", false);
+    SetBoolArg("-use-thinblocks", false);
+    vNodes.push_back(&dummyNodeGraphene);
+    vNodes.push_back(&dummyNodeNone);
+
+    requester.RequestBlock(&dummyNodeNone, inv);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeGraphene);
+    ClearBlocksInFlight(dummyNodeNone);
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+    // Chains IS sync'd,  NO graphene nodes, NO Thinblock nodes, Thinblocks ON, Graphene OFF
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", false);
+    SetBoolArg("-use-thinblocks", true);
+    vNodes.push_back(&dummyNodeNone);
+
+    requester.RequestBlock(&dummyNodeNone, inv);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeNone);
+    vNodes.pop_back();
+
+    // Chains IS sync'd,  HAVE graphene nodes, NO Thinblock nodes, Thinblocks ON, Graphene OFF
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", false);
+    SetBoolArg("-use-thinblocks", true);
+    vNodes.push_back(&dummyNodeGraphene);
+    vNodes.push_back(&dummyNodeNone);
+
+    requester.RequestBlock(&dummyNodeNone, inv);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeGraphene);
+    ClearBlocksInFlight(dummyNodeNone);
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+    // Chains IS sync'd,  NO graphene nodes, HAVE Thinblock nodes, Thinblocks OFF, Graphene ON
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", true);
+    SetBoolArg("-use-thinblocks", false);
+    vNodes.push_back(&dummyNodeXthin);
+    vNodes.push_back(&dummyNodeNone);
+
+    requester.RequestBlock(&dummyNodeNone, inv);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeNone);
+    ClearBlocksInFlight(dummyNodeXthin);
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+    // Chains IS sync'd,  NO graphene nodes, NO Thinblock nodes, Thinblocks OFF, Graphene ON
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", true);
+    SetBoolArg("-use-thinblocks", false);
+    vNodes.push_back(&dummyNodeNone);
+
+    requester.RequestBlock(&dummyNodeNone, inv);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeNone);
+    vNodes.pop_back();
+
+    // Chains IS sync'd,  NO graphene nodes, NO Thinblock nodes, Thinblocks ON, Graphene ON
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", true);
+    SetBoolArg("-use-thinblocks", true);
+    vNodes.push_back(&dummyNodeNone);
+
+    requester.RequestBlock(&dummyNodeNone, inv);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeNone);
+    vNodes.pop_back();
+
+    // Chains IS sync'd,  HAVE graphene nodes, NO Thinblock nodes, Thinblocks ON, Graphene ON
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", true);
+    SetBoolArg("-use-thinblocks", true);
+    vNodes.push_back(&dummyNodeGraphene);
+    vNodes.push_back(&dummyNodeNone);
+    requester.RequestBlock(&dummyNodeGraphene, inv);
+    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("get_graphene") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeGraphene);
+    ClearBlocksInFlight(dummyNodeNone);
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+    // Chains IS sync'd,  HAVE graphene nodes, NO Thinblock nodes, Thinblocks OFF, Graphene ON
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", true);
+    SetBoolArg("-use-thinblocks", false);
+    BOOST_CHECK(IsThinBlocksEnabled() == false);
+    vNodes.push_back(&dummyNodeGraphene);
+    vNodes.push_back(&dummyNodeNone);
+    requester.RequestBlock(&dummyNodeGraphene, inv);
+    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("get_graphene") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeGraphene);
+    ClearBlocksInFlight(dummyNodeNone);
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+    // Chains IS sync'd,  HAVE graphene nodes, HAVE Thinblock nodes, Thinblocks ON, Graphene ON
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", true);
+    SetBoolArg("-use-thinblocks", true);
+    vNodes.push_back(&dummyNodeGraphene);
+    vNodes.push_back(&dummyNodeXthin);
+    vNodes.push_back(&dummyNodeNone);
+
+    requester.RequestBlock(&dummyNodeGraphene, inv);
+    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("get_graphene") != 0);
+
+    ClearBlocksInFlight(dummyNodeGraphene);
+    ClearBlocksInFlight(dummyNodeNone);
+    ClearBlocksInFlight(dummyNodeXthin);
+    vNodes.pop_back();
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+    // Chains IS sync'd,  NO graphene nodes, HAVE Thinblock nodes, Thinblocks ON, Graphene OFF
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", false);
+    SetBoolArg("-use-thinblocks", true);
+    vNodes.push_back(&dummyNodeXthin);
+    vNodes.push_back(&dummyNodeNone);
+
+    requester.RequestBlock(&dummyNodeXthin, inv);
+    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("get_xthin") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeNone);
+    ClearBlocksInFlight(dummyNodeXthin);
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+    /******************************
+     * Check full blocks are downloaded when no block announcements come from a graphene or thinblock peer
+     * before the timers hit their limit.
+     */
+
+    // Chains IS sync'd,  HAVE graphene nodes, HAVE Thinblock nodes, Thinblocks ON, Graphene ON
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", true);
+    SetBoolArg("-use-thinblocks", true);
+    vNodes.push_back(&dummyNodeGraphene);
+    vNodes.push_back(&dummyNodeXthin);
+    vNodes.push_back(&dummyNodeNone);
+
+    // Set mocktime
+    nTime = GetTime();
+    SetMockTime(nTime);
+
+    // The first request should fail but the timers should be triggered for graphene
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == false);
+
+    // Now move the clock ahead so that the graphene timer is exceeded
+    SetMockTime(nTime + 20);
+
+    // The second request should fail because but the thinblock timer will be tripped
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == false);
+
+    // Now move the clock ahead so that the thinblock timer is exceeded
+    SetMockTime(nTime + 40);
+
+    requester.RequestBlock(&dummyNodeNone, inv);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeGraphene);
+    ClearBlocksInFlight(dummyNodeNone);
+    ClearBlocksInFlight(dummyNodeXthin);
+    vNodes.pop_back();
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+    /******************************
+     * Check full blocks are downloaded when graphene is off but thinblock timer is exceeded
+     */
+
+    // Chains IS sync'd,  HAVE graphene nodes, HAVE Thinblock nodes, Thinblocks ON, Graphene OFF
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", false);
+    SetBoolArg("-use-thinblocks", true);
+    vNodes.push_back(&dummyNodeGraphene);
+    vNodes.push_back(&dummyNodeXthin);
+    vNodes.push_back(&dummyNodeNone);
+
+    // Set mocktime
+    nTime = GetTime();
+    SetMockTime(nTime);
+
+    // The first request should fail but the xthin timer should be triggered
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == false);
+
+    // Now move the clock ahead so that the timer is exceeded and we should now
+    // download a full block
+    SetMockTime(nTime + 20);
+    requester.RequestBlock(&dummyNodeNone, inv);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeGraphene);
+    ClearBlocksInFlight(dummyNodeNone);
+    ClearBlocksInFlight(dummyNodeXthin);
+    vNodes.pop_back();
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+    /******************************
+     * Check Xthin is downloaded when graphene timer is exceeded and we have a block available from an
+     * Xthin peer
+     */
+
+    // Chains IS sync'd,  HAVE graphene nodes, HAVE Thinblock nodes, Thinblocks ON, Graphene ON
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", true);
+    SetBoolArg("-use-thinblocks", true);
+    vNodes.push_back(&dummyNodeGraphene);
+    vNodes.push_back(&dummyNodeXthin);
+    vNodes.push_back(&dummyNodeNone);
+
+    // Set mocktime
+    nTime = GetTime();
+    SetMockTime(nTime);
+
+    // The first request should fail but the timers should be triggered for both xthin and graphene
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == false);
+
+    // Now move the clock ahead so that the graphene timer is exceeded and we should now
+    // download an Xthin
+    SetMockTime(nTime + 20);
+    requester.RequestBlock(&dummyNodeXthin, inv);
+    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("get_xthin") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeGraphene);
+    ClearBlocksInFlight(dummyNodeNone);
+    ClearBlocksInFlight(dummyNodeXthin);
+    vNodes.pop_back();
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+
+    /******************************
+     * Check a Graphene block is downloaded when Graphene timer is exceeded but then we get an announcement
+     * from a graphene peer, and then request from that graphene peer before we request from any others.
+     */
+
+    // Chains IS sync'd,  HAVE graphene nodes, HAVE Thinblock nodes, Thinblocks ON, Graphene ON
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", true);
+    SetBoolArg("-use-thinblocks", true);
+    vNodes.push_back(&dummyNodeGraphene);
+    vNodes.push_back(&dummyNodeXthin);
+    vNodes.push_back(&dummyNodeNone);
+
+    // Set mocktime
+    nTime = GetTime();
+    SetMockTime(nTime);
+
+    // The first request should fail but the timers should be triggered for both xthin and graphene
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == false);
+
+    // Now move the clock ahead so that the timers are exceeded and we should now
+    // download a full block
+    SetMockTime(nTime + 20);
+    requester.RequestBlock(&dummyNodeGraphene, inv);
+    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("get_graphene") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeGraphene);
+    ClearBlocksInFlight(dummyNodeNone);
+    ClearBlocksInFlight(dummyNodeXthin);
+    vNodes.pop_back();
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+    /******************************
+     * Check a full block is downloaded when Graphene timer is exceeded but then we get an announcement
+     * from a graphene peer (thinblocks is OFF), and then request from that graphene peer before we
+     * request from any others.
+     * However this time we already have a grapheneblock in flight for this peer so we end up downloading a full block.
+     */
+
+    // Chains IS sync'd,  HAVE graphene nodes, HAVE Thinblock nodes, Thinblocks OFF, Graphene ON
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", true);
+    SetBoolArg("-use-thinblocks", false);
+    vNodes.push_back(&dummyNodeGraphene);
+    vNodes.push_back(&dummyNodeXthin);
+    vNodes.push_back(&dummyNodeNone);
+
+    // Set mocktime
+    nTime = GetTime();
+    SetMockTime(nTime);
+
+    // The first request should fail but the timers should be triggered for graphene
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == false);
+
+    // Now move the clock ahead so that the timer is exceeded and we should now
+    // download a full block
+    SetMockTime(nTime + 20);
+    randhash = GetRandHash();
+    AddGrapheneBlockInFlight(&dummyNodeGraphene, randhash);
+    requester.RequestBlock(&dummyNodeGraphene, inv);
+    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("getdata") != 0);
+    ClearGrapheneBlockInFlight(&dummyNodeGraphene, randhash);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeGraphene);
+    ClearBlocksInFlight(dummyNodeNone);
+    ClearBlocksInFlight(dummyNodeXthin);
+    vNodes.pop_back();
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+
+    /******************************
+     * Check an Xthin is downloaded when Graphene timer is exceeded but then we get an announcement
+     * from a graphene peer (thinblocks is ON), and then request from that graphene peer before we
+     * request from any others.
+     * However this time we already have a grapheneblock in flight for this peer so we end up downloading a thinblock.
+     */
+
+    // Chains IS sync'd,  HAVE graphene nodes, HAVE Thinblock nodes, Thinblocks ON, Graphene ON
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", true);
+    SetBoolArg("-use-thinblocks", true);
+    vNodes.push_back(&dummyNodeGraphene);
+    vNodes.push_back(&dummyNodeXthin);
+    vNodes.push_back(&dummyNodeNone);
+
+    // Set mocktime
+    nTime = GetTime();
+    SetMockTime(nTime);
+
+    // The first request should fail but the timers should be triggered for both xthin and graphene
+    randhash = GetRandHash();
+    AddGrapheneBlockInFlight(&dummyNodeGraphene, randhash);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeGraphene, inv) == false);
+
+    // Now move the clock ahead so that the timers are exceeded and we should now
+    // download an xthin
+    SetMockTime(nTime + 20);
+    requester.RequestBlock(&dummyNodeXthin, inv);
+    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("get_xthin") != 0);
+    ClearGrapheneBlockInFlight(&dummyNodeGraphene, randhash);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeGraphene);
+    ClearBlocksInFlight(dummyNodeNone);
+    ClearBlocksInFlight(dummyNodeXthin);
+    vNodes.pop_back();
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+    /******************************
+     * Check a Xthin is is downloaded when thinblock timer is exceeded but then we get an announcement
+     * from a thinblock peer, and then request from that thinblock peer before we request from any others.
+     */
+
+    // Chains IS sync'd,  HAVE graphene nodes, HAVE Thinblock nodes, Thinblocks ON, Graphene OFF
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", false);
+    SetBoolArg("-use-thinblocks", true);
+    vNodes.push_back(&dummyNodeGraphene);
+    vNodes.push_back(&dummyNodeXthin);
+    vNodes.push_back(&dummyNodeNone);
+
+    // Set mocktime
+    nTime = GetTime();
+    SetMockTime(nTime);
+
+    // The first request should fail but the timers should be triggered for xthin
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == false);
+
+    // Now move the clock ahead so that the timer is exceeded and we should now
+    // download a full block
+    SetMockTime(nTime + 20);
+    requester.RequestBlock(&dummyNodeXthin, inv);
+    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("get_xthin") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeGraphene);
+    ClearBlocksInFlight(dummyNodeNone);
+    ClearBlocksInFlight(dummyNodeXthin);
+    vNodes.pop_back();
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+    /******************************
+     * Check a Xthin is is downloaded when thinblock timer is exceeded but then we get an announcement
+     * from a thinblock peer, and then request from that thinblock peer before we request from any others.
+     * However this time we already have an xthin in flight for this peer so we end up downloading a full block.
+     */
+
+    // Chains IS sync'd,  HAVE graphene nodes, HAVE Thinblock nodes, Thinblocks ON, Graphene OFF
+    IsChainNearlySyncdSet(true);
+    SetBoolArg("-use-grapheneblocks", false);
+    SetBoolArg("-use-thinblocks", true);
+    vNodes.push_back(&dummyNodeGraphene);
+    vNodes.push_back(&dummyNodeXthin);
+    vNodes.push_back(&dummyNodeNone);
+
+    // Set mocktime
+    nTime = GetTime();
+    SetMockTime(nTime);
+
+    // The first request should fail but the timers should be triggered for xthin
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == false);
+
+    // Now move the clock ahead so that the timer is exceeded and we should now
+    // download a full block
+    SetMockTime(nTime + 20);
+    randhash = GetRandHash();
+    AddThinBlockInFlight(&dummyNodeXthin, randhash);
+    requester.RequestBlock(&dummyNodeXthin, inv);
+    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("getdata") != 0);
+
+    thindata.ClearThinBlockTimer(inv.hash);
+    graphenedata.ClearGrapheneBlockTimer(inv.hash);
+    ClearBlocksInFlight(dummyNodeGraphene);
+    ClearBlocksInFlight(dummyNodeNone);
+    ClearBlocksInFlight(dummyNodeXthin);
+    vNodes.pop_back();
+    vNodes.pop_back();
+    vNodes.pop_back();
+
+
+    // Final cleanup: Unset mocktime
+    SetMockTime(0);
+}
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -152,6 +152,13 @@ void StartShutdown() { exit(0); }
 bool ShutdownRequested() { return false; }
 using namespace boost::program_options;
 
+CService ipaddress(uint32_t i, uint32_t port)
+{
+    struct in_addr s;
+    s.s_addr = i;
+    return CService(CNetAddr(s), port);
+}
+
 struct StartupShutdown
 {
     StartupShutdown()

--- a/src/test/test_bitcoin.h
+++ b/src/test/test_bitcoin.h
@@ -4,6 +4,7 @@
 #include "chainparamsbase.h"
 #include "fs.h"
 #include "key.h"
+#include "net.h"
 #include "pubkey.h"
 #include "txdb.h"
 #include "txmempool.h"
@@ -120,5 +121,6 @@ struct TestMemPoolEntryHelper
 // define an implicit conversion here so that uint256 may be used directly in BOOST_CHECK_*
 std::ostream &operator<<(std::ostream &os, const uint256 &num);
 
+CService ipaddress(uint32_t i, uint32_t port);
 
 #endif

--- a/src/test/thinblock_data_tests.cpp
+++ b/src/test/thinblock_data_tests.cpp
@@ -15,13 +15,6 @@
 
 using namespace std;
 
-CService ipaddress3(uint32_t i, uint32_t port)
-{
-    struct in_addr s;
-    s.s_addr = i;
-    return CService(CNetAddr(s), port);
-}
-
 class TestTBD : public CThinBlockData
 {
 protected:
@@ -50,7 +43,7 @@ BOOST_AUTO_TEST_CASE(test_thinblock_byte_tracking)
      * Do calcuations for single peer building a thinblock
      */
 
-    CAddress addr1(ipaddress3(0xa0b0c001, 10000));
+    CAddress addr1(ipaddress(0xa0b0c001, 10000));
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
 
     thindata.ResetThinBlockBytes();
@@ -95,7 +88,7 @@ BOOST_AUTO_TEST_CASE(test_thinblock_byte_tracking)
      * Add a second peer and do more calcuations for building a second thinblock
      */
 
-    CAddress addr2(ipaddress3(0xa0b0c002, 10000));
+    CAddress addr2(ipaddress(0xa0b0c002, 10000));
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
 
     thindata.AddThinBlockBytes(1000, &dummyNode2);

--- a/src/test/thinblock_tests.cpp
+++ b/src/test/thinblock_tests.cpp
@@ -94,13 +94,6 @@ CBlock TestBlock()
     return block;
 };
 
-CService ipaddress2(uint32_t i, uint32_t port)
-{
-    struct in_addr s;
-    s.s_addr = i;
-    return CService(CNetAddr(s), port);
-}
-
 
 BOOST_FIXTURE_TEST_SUITE(thinblock_tests, TestingSetup)
 
@@ -108,7 +101,7 @@ BOOST_AUTO_TEST_CASE(thinblock_test)
 {
     CBloomFilter filter;
     std::vector<uint256> vOrphanHashes;
-    CAddress addr1(ipaddress2(0xa0b0c001, 10000));
+    CAddress addr1(ipaddress(0xa0b0c001, 10000));
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
 
     // Create 10 random hashes to seed the orphanhash vector.  This way we will create a bloom filter

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1320,6 +1320,8 @@ void IsChainNearlySyncdInit()
 }
 
 bool IsChainNearlySyncd() { return fIsChainNearlySyncd.load(); }
+// Used for unit tests to artificially set the state of chain sync
+void IsChainNearlySyncdSet(bool fSync) { fIsChainNearlySyncd.store(fSync); }
 uint64_t LargestBlockSeen(uint64_t nBlockSize)
 {
     // C++98 lacks the capability to do static initialization properly

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -208,6 +208,7 @@ extern void IsInitialBlockDownloadInit(bool *fInit = nullptr);
 // Check whether we are nearly sync'd.  Used primarily to determine whether an xthin can be retrieved.
 extern bool IsChainNearlySyncd();
 extern void IsChainNearlySyncdInit();
+extern void IsChainNearlySyncdSet(bool fSync);
 extern uint64_t LargestBlockSeen(uint64_t nBlockSize = 0);
 extern int GetBlockchainHeight();
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -516,6 +516,19 @@ bool GetBoolArg(const std::string &strArg, bool fDefault)
     return fDefault;
 }
 
+// You can set the args directly, using SetArg which always will update the value or you can use
+// SoftSetArg which will only set the value if it hasn't already been set and return success/fail.
+void SetArg(const std::string &strArg, const std::string &strValue)
+{
+    mapArgs[strArg] = strValue;
+}
+void SetBoolArg(const std::string &strArg, bool fValue)
+{
+    if (fValue)
+        SetArg(strArg, std::string("1"));
+    else
+        SetArg(strArg, std::string("0"));
+}
 bool SoftSetArg(const std::string &strArg, const std::string &strValue)
 {
     if (mapArgs.count(strArg))
@@ -523,7 +536,6 @@ bool SoftSetArg(const std::string &strArg, const std::string &strValue)
     mapArgs[strArg] = strValue;
     return true;
 }
-
 bool SoftSetBoolArg(const std::string &strArg, bool fValue)
 {
     if (fValue)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -518,10 +518,7 @@ bool GetBoolArg(const std::string &strArg, bool fDefault)
 
 // You can set the args directly, using SetArg which always will update the value or you can use
 // SoftSetArg which will only set the value if it hasn't already been set and return success/fail.
-void SetArg(const std::string &strArg, const std::string &strValue)
-{
-    mapArgs[strArg] = strValue;
-}
+void SetArg(const std::string &strArg, const std::string &strValue) { mapArgs[strArg] = strValue; }
 void SetBoolArg(const std::string &strArg, bool fValue)
 {
     if (fValue)

--- a/src/util.h
+++ b/src/util.h
@@ -443,6 +443,24 @@ int64_t GetArg(const std::string &strArg, int64_t nDefault);
 bool GetBoolArg(const std::string &strArg, bool fDefault);
 
 /**
+ * Set an argument
+ *
+ * @param strArg Argument to set (e.g. "-foo")
+ * @param strValue Value (e.g. "1")
+ * @return none
+ */
+void SetArg(const std::string &strArg, const std::string &strValue);
+
+/**
+ * Set a boolean argument
+ *
+ * @param strArg Argument to set (e.g. "-foo")
+ * @param fValue Value (e.g. false)
+ * @return none
+ */
+void SetBoolArg(const std::string &strArg, bool fValue);
+
+/**
  * Set an argument if it doesn't already have a value
  *
  * @param strArg Argument to set (e.g. "-foo")

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -30,6 +30,9 @@ int64_t GetTime()
 void SetMockTime(int64_t nMockTimeIn) { nMockTime = nMockTimeIn; }
 int64_t GetTimeMillis()
 {
+    if (nMockTime)
+        return nMockTime * 1000;
+
     int64_t now = (boost::posix_time::microsec_clock::universal_time() -
                       boost::posix_time::ptime(boost::gregorian::date(1970, 1, 1)))
                       .total_milliseconds();


### PR DESCRIPTION
This also required a couple of edge cases to be fixed in the request manager which were giving us trouble in the python tests.

Still needs work adding test cases to the request manager if possible. Also this introduces  a performance issue since now we have the check for if we have peers very frequently which lock cs_vNodes; I'll add an atomic flag in there so we don't have to cycle through vNodes so many times.