### PR TITLE
Improve propagatation of non-final and too-long-mempool-chain

### DIFF
--- a/src/consensus/validation.h
+++ b/src/consensus/validation.h
@@ -18,6 +18,7 @@ static const unsigned char REJECT_NONSTANDARD = 0x40;
 static const unsigned char REJECT_DUST = 0x41;
 static const unsigned char REJECT_INSUFFICIENTFEE = 0x42;
 static const unsigned char REJECT_CHECKPOINT = 0x43;
+static const unsigned char REJECT_WAITING = 0x44;
 
 /** Capture information about block/transaction validation */
 class CValidationState

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -78,7 +78,7 @@ CChain chainActive GUARDED_BY(cs_main); // however, chainActive.Tip() is lock fr
 // - moved CCriticalSection cs_main;
 // - moved BlockMap mapBlockIndex;
 // - movedCChain chainActive;
-CBlockIndex *pindexBestHeader GUARDED_BY(cs_main) = nullptr;
+std::atomic<CBlockIndex *> pindexBestHeader{nullptr};
 CFeeRate minRelayTxFee GUARDED_BY(cs_main) = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
 // The allowed size of the in memory UTXO cache
 int64_t nCoinCacheMaxSize GUARDED_BY(cs_main) = 0;
@@ -223,6 +223,12 @@ std::queue<CTxInputData> txInQ GUARDED_BY(csTxInQ);
 
 // Transaction that cannot be processed in this round (may potentially conflict with other tx)
 std::queue<CTxInputData> txDeferQ GUARDED_BY(csTxInQ);
+
+// Transactions that arrive when the chain is not syncd can be place here at times when we've received
+// the block announcement but havn't yet downloaded the block and updated the tip. In this case there can
+// be txns that are perfectly valid yet are flagged as being non-final or has too many ancestors.
+std::queue<CTxInputData> txWaitNextBlockQ GUARDED_BY(csTxInQ);
+;
 
 // Transactions that have been validated and are waiting to be committed into the mempool
 CWaitableCriticalSection csCommitQ;

--- a/src/main.h
+++ b/src/main.h
@@ -197,7 +197,7 @@ extern CTweak<CAmount> maxTxFee;
 extern int64_t nMaxTipAge;
 
 /** Best header we've seen so far (used for getheaders queries' starting points). */
-extern CBlockIndex *pindexBestHeader;
+extern std::atomic<CBlockIndex *> pindexBestHeader;
 
 /** Used to determine whether it is time to check the orphan pool for any txns that can be evicted. */
 extern int64_t nLastOrphanCheck;

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1080,7 +1080,7 @@ UniValue getblockchaininfo(const UniValue &params, bool fHelp)
     UniValue obj(UniValue::VOBJ);
     obj.push_back(Pair("chain", Params().NetworkIDString()));
     obj.push_back(Pair("blocks", (int)chainActive.Height()));
-    obj.push_back(Pair("headers", pindexBestHeader ? pindexBestHeader->nHeight : -1));
+    obj.push_back(Pair("headers", pindexBestHeader ? pindexBestHeader.load()->nHeight : -1));
     obj.push_back(Pair("bestblockhash", chainActive.Tip()->GetBlockHash().GetHex()));
     obj.push_back(Pair("difficulty", (double)GetDifficulty()));
     obj.push_back(Pair("mediantime", (int64_t)chainActive.Tip()->GetMedianTimePast()));

--- a/src/txadmission.h
+++ b/src/txadmission.h
@@ -104,12 +104,20 @@ extern CRollingFastFilter<4 * 1024 * 1024> txRecentlyInBlock;
 extern CFastFilter<4 * 1024 * 1024> incomingConflicts;
 
 // Transactions that are available to be added to the mempool, and protection
+// Guarded by csTxInQ
 extern CCriticalSection csTxInQ;
 extern CCond cvTxInQ;
 extern std::queue<CTxInputData> txInQ;
 
 // Transactions that cannot be processed in this round (may potentially conflict with other tx)
+// Guarded by csTxInQ
 extern std::queue<CTxInputData> txDeferQ;
+
+// Transactions that arrive when the chain is not syncd can be place here at times when we've received
+// the block announcement but havn't yet downloaded the block and updated the tip. In this case there can
+// be txns that are perfectly valid yet are flagged as being non-final or has too many ancestors.
+// Guarded by csTxInQ
+extern std::queue<CTxInputData> txWaitNextBlockQ;
 
 // Transactions that are validated and can be committed to the mempool, and protection
 extern CWaitableCriticalSection csCommitQ;

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -218,6 +218,7 @@ extern void IsInitialBlockDownloadInit(bool *fInit = nullptr);
 
 // Check whether we are nearly sync'd.  Used primarily to determine whether an xthin can be retrieved.
 extern bool IsChainNearlySyncd();
+extern bool IsChainSyncd();
 extern void IsChainNearlySyncdInit();
 extern void IsChainNearlySyncdSet(bool fSync);
 extern uint64_t LargestBlockSeen(uint64_t nBlockSize = 0);


### PR DESCRIPTION
When we have received a new block announcement but haven't yet updated
the chain tip there is a period of time where we can receive valid
transactions but are rejected as non-final or too-long-mempool-chain.
This happens because transactions can propagate faster than the block
and as a result the transaction which was created just after the block
was mined arrives at times before the previous block and as a result
can appear to be invalid.  In order to prevent this from happening
we simply defer the transactions validation until the chaintip matches
the best header.

NOTE: this is problem is one cause of incomplete mempool sync and occurs frequently (10 to 20 times a day, based on rough observation) and is possibly seen more often than one would expect due to the graphene and thinblock timers. 