### PR TITLE
Define NODE_CF service bit

### DIFF
--- a/src/protocol.h
+++ b/src/protocol.h
@@ -347,7 +347,10 @@ enum
     // do not actually support. Other service bits should be allocated via the
     // BUIP process.
 
-    NODE_WEAKBLOCKS = (1 << 7)
+    NODE_WEAKBLOCKS = (1 << 7),
+
+    // NODE_CF indicates the node is capable of serving compact block filters to SPV clients.
+    NODE_CF = (1 << 8)
 };
 
 /** A CService with information about it as peer */

--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -974,6 +974,9 @@ QString formatServicesStr(quint64 mask, const QStringList &additionalServices)
             case NODE_WEAKBLOCKS:
                 strList.append("WB");
                 break;
+            case NODE_CF:
+                strList.append("CF");
+                break;
             default:
                 strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
             }


### PR DESCRIPTION
Land grab for service bit 8 which bchd uses for compact block filters