### PR TITLE
Improve Graphene decode rates by padding IBLT

### DIFF
--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1396,8 +1396,7 @@ void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CM
     {
         try
         {
-            uint64_t nSenderMempoolPlusBlock =
-                std::max(0, (int)(GetGrapheneMempoolInfo().nTx + pblock->vtx.size() - 1)); // exclude coinbase
+            uint64_t nSenderMempoolPlusBlock = GetGrapheneMempoolInfo().nTx + pblock->vtx.size() - 1; // exclude coinbase
 
             CGrapheneBlock grapheneBlock(MakeBlockRef(*pblock), mempoolinfo.nTx, nSenderMempoolPlusBlock);
             int nSizeBlock = pblock->GetBlockSize();

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1396,7 +1396,8 @@ void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CM
     {
         try
         {
-            uint64_t nSenderMempoolPlusBlock = GetGrapheneMempoolInfo().nTx + pblock->vtx.size() - 1; // exclude coinbase
+            uint64_t nSenderMempoolPlusBlock =
+                GetGrapheneMempoolInfo().nTx + pblock->vtx.size() - 1; // exclude coinbase
 
             CGrapheneBlock grapheneBlock(MakeBlockRef(*pblock), mempoolinfo.nTx, nSenderMempoolPlusBlock);
             int nSizeBlock = pblock->GetBlockSize();

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -53,7 +53,7 @@ public:
     CGrapheneSet *pGrapheneSet;
 
 public:
-    CGrapheneBlock(const CBlockRef pblock, uint64_t nReceiverMemPoolTx);
+    CGrapheneBlock(const CBlockRef pblock, uint64_t nReceiverMemPoolTx, uint64_t nSenderMempoolPlusBlock);
     CGrapheneBlock() : pGrapheneSet(nullptr) {}
     ~CGrapheneBlock();
     /**

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -32,7 +32,10 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
 
     // Infer various receiver quantities
     uint64_t nReceiverExcessItems =
-        std::min((int)nReceiverUniverseItems, std::max(0, (int)(nSenderUniverseItems - nItems)));
+        std::max((int)(nReceiverUniverseItems - nItems), (int)(nSenderUniverseItems - nItems));
+    nReceiverExcessItems = std::max(0, (int)nReceiverExcessItems); // must be non-negative
+    nReceiverExcessItems =
+        std::min((int)nReceiverUniverseItems, (int)nReceiverExcessItems); // must not exceed total mempool size
     uint64_t nReceiverMissingItems = std::max(1, (int)(nItems - (nReceiverUniverseItems - nReceiverExcessItems)));
 
     LOG(GRAPHENE, "receiver expected to have at most %d excess txs in mempool\n", nReceiverExcessItems);

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -43,7 +43,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
 
     // Optimal symmetric differences between receiver and sender IBLTs
     // This is the parameter "a" from the graphene paper
-    double optSymDiff = std::max(1, (int)nReceiverMissingItems);
+    double optSymDiff = nReceiverMissingItems;
     try
     {
         if (nItems <= nReceiverUniverseItems + nReceiverMissingItems)

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -50,6 +50,7 @@ public:
     // The default constructor is for 2-phase construction via deserialization
     CGrapheneSet() : ordered(false), nReceiverUniverseItems(0), pSetFilter(nullptr), pSetIblt(nullptr) {}
     CGrapheneSet(size_t _nReceiverUniverseItems,
+        uint64_t nSenderUniverseItems,
         const std::vector<uint256> &_itemHashes,
         bool _ordered = false,
         bool fDeterministic = false);
@@ -63,7 +64,10 @@ public:
      * The total size in bytes of a graphene block is given by T(a) = F(a) + L(a) as defined
      * in the code below. (Note that meta parameters for the Bloom Filter and IBLT are ignored).
      */
-    double OptimalSymDiff(uint64_t nBlockTxs, uint64_t nReceiverPoolTx);
+    double OptimalSymDiff(uint64_t nBlockTxs,
+        uint64_t nReceiverPoolTx,
+        uint64_t nReceiverExcessTxs = 0,
+        uint64_t nReceiverMissingTxs = 1);
 
     // Pass the transaction hashes that the local machine has to reconcile with the remote and return a list
     // of cheap hashes in the block in the correct order

--- a/src/test/test_bitcoin_fuzzy.cpp
+++ b/src/test/test_bitcoin_fuzzy.cpp
@@ -528,7 +528,8 @@ protected:
 
         try
         {
-            gs = std::make_shared<CGrapheneSet>(nReceiverUniverseItems, itemHashes, ordered, fDeterministic);
+            gs = std::make_shared<CGrapheneSet>(
+                nReceiverUniverseItems, nReceiverUniverseItems, itemHashes, ordered, fDeterministic);
 
             while (!ds->empty())
             {


### PR DESCRIPTION
Graphene block decode rates can be >10% at times and even under good conditions they typically hover around 2%. These failures greatly slow block propagation because an XThin block must be sent as a failover. The root of the problem is that the Graphene code optimistically assumes that the receiver mempool contains all transactions from the block. 

This PR introduces a simple accounting change that allows the sender to develop a more realistic understanding of the receiver's mempool. In a trial spanning more than 600 blocks, I observed only two decode failures compared to 16 using the baseline implementation. Compression rates are slightly worse for small blocks, but large blocks actually show slightly better compression than baseline.

Note that this patch requires no changes to the Graphene protocol specification. As such, it can be rolled out incrementally without forcing all Graphene peers to upgrade. In the event that the sender has upgraded, the receiver will experience the benefits of the patch even when running an old version of Graphene.

Detailed analysis of this approach and an alternative approach using the data structure `filterInventoryKnown` can be found [here](https://gist.github.com/bissias/561151fef0b98f6e4d8813a08aefe349).