### PR TITLE
Reduce Transaction re-requests under heavy load

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1611,12 +1611,17 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         // Put the tx on the tx admission queue for processing
         CTxInputData txd;
         vRecv >> txd.tx;
+
+        // Indicate that the tx was received and is now in the commitQ but not necessarily in the mempool.
+        CInv inv(MSG_TX, txd.tx->GetHash());
+        requester.Processing(inv, pfrom);
+
+        // Enqueue the transaction
         txd.nodeId = pfrom->id;
         txd.nodeName = pfrom->GetLogName();
         txd.whitelisted = pfrom->fWhitelisted;
         EnqueueTxForAdmission(txd);
 
-        CInv inv(MSG_TX, txd.tx->GetHash());
         pfrom->AddInventoryKnown(inv);
         requester.UpdateTxnResponseTime(inv, pfrom);
     }

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -834,6 +834,11 @@ void CRequestManager::SendRequests()
         ++sendIter; // move it forward up here in case we need to erase the item we are working with.
         CUnknownObj &item = itemIter->second;
 
+        // If we've already received the item and it's in processing then skip it here so we don't
+        // end up re-requesting it again.
+        if (item.fProcessing)
+            continue;
+
         // if never requested then lastRequestTime==0 so this will always be true
         if (now - item.lastRequestTime > _txReqRetryInterval)
         {

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -272,6 +272,32 @@ void CRequestManager::UpdateTxnResponseTime(const CInv &obj, CNode *pfrom)
     }
 }
 
+// Indicate that we are processing this object.
+void CRequestManager::Processing(const CInv &obj, CNode *pfrom)
+{
+    LOCK(cs_objDownloader);
+    if (obj.type == MSG_TX)
+    {
+        OdMap::iterator item = mapTxnInfo.find(obj.hash);
+        if (item == mapTxnInfo.end())
+            return;
+
+        item->second.fProcessing = true;
+        LOG(REQ, "ReqMgr: Processing %s (received from %s).\n", item->second.obj.ToString(),
+            pfrom ? pfrom->GetLogName() : "unknown");
+    }
+    else if (obj.type == MSG_BLOCK || obj.type == MSG_THINBLOCK || obj.type == MSG_XTHINBLOCK)
+    {
+        OdMap::iterator item = mapBlkInfo.find(obj.hash);
+        if (item == mapBlkInfo.end())
+            return;
+
+        item->second.fProcessing = true;
+        LOG(BLK, "ReqMgr: Processing %s (received from %s).\n", item->second.obj.ToString(),
+            pfrom ? pfrom->GetLogName() : "unknown");
+    }
+}
+
 // Indicate that we got this object.
 void CRequestManager::Received(const CInv &obj, CNode *pfrom)
 {

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -675,11 +675,11 @@ void CRequestManager::SendRequests()
     {
         now = GetTimeMicros();
         OdMap::iterator itemIter = sendBlkIter;
-        CUnknownObj &item = itemIter->second;
-
-        ++sendBlkIter; // move it forward up here in case we need to erase the item we are working with.
         if (itemIter == mapBlkInfo.end())
             break;
+
+        ++sendBlkIter; // move it forward up here in case we need to erase the item we are working with.
+        CUnknownObj &item = itemIter->second;
 
         // if never requested then lastRequestTime==0 so this will always be true
         if (now - item.lastRequestTime > _blkReqRetryInterval)
@@ -828,11 +828,11 @@ void CRequestManager::SendRequests()
     {
         now = GetTimeMicros();
         OdMap::iterator itemIter = sendIter;
-        CUnknownObj &item = itemIter->second;
-
-        ++sendIter; // move it forward up here in case we need to erase the item we are working with.
         if (itemIter == mapTxnInfo.end())
             break;
+
+        ++sendIter; // move it forward up here in case we need to erase the item we are working with.
+        CUnknownObj &item = itemIter->second;
 
         // if never requested then lastRequestTime==0 so this will always be true
         if (now - item.lastRequestTime > _txReqRetryInterval)

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -60,7 +60,8 @@ public:
     bool operator<(const CNodeRequestData &rhs) const { return desirability < rhs.desirability; }
 };
 
-struct MatchCNodeRequestData // Compare a CNodeRequestData object to a node
+// Compare a CNodeRequestData object to a node
+struct MatchCNodeRequestData
 {
     CNode *node;
     MatchCNodeRequestData(CNode *n) : node(n){};

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -73,6 +73,7 @@ public:
     typedef std::list<CNodeRequestData> ObjectSourceList;
     CInv obj;
     bool rateLimited;
+    bool fProcessing; // object was received but is still being processed
     int64_t lastRequestTime; // In microseconds, 0 means no request
     unsigned int outstandingReqs;
     ObjectSourceList availableFrom;
@@ -81,6 +82,7 @@ public:
     CUnknownObj()
     {
         rateLimited = false;
+        fProcessing = false;
         outstandingReqs = 0;
         lastRequestTime = 0;
         priority = 0;
@@ -174,6 +176,9 @@ public:
 
     // Update the response time for this transaction request
     void UpdateTxnResponseTime(const CInv &obj, CNode *pfrom);
+
+    // Indicate that we are processing this object.
+    void Processing(const CInv &obj, CNode *pfrom);
 
     // Indicate that we got this object
     void Received(const CInv &obj, CNode *pfrom);

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -260,6 +260,11 @@ void CommitTxToMempool()
             vWhatChanged.push_back(data.hash);
             // Update txn per second only when a txn is valid and accepted to the mempool
             mempool.UpdateTransactionsPerSecond();
+
+            // Indicate that this tx was fully processed/accepted and can now be removed from the
+            // request manager.
+            CInv inv(MSG_TX, data.hash);
+            requester.Received(inv, nullptr);
         }
         txCommitQ.clear();
     }
@@ -439,6 +444,10 @@ void ThreadTxAdmission()
                             for (const COutPoint &remove : vCoinsToUncache)
                                 pcoinsTip->Uncache(remove);
                         }
+
+                        // Mark tx as received if invalid or an orphan. If it's a valid Tx we mark it received
+                        // only when it's finally accepted into the mempool.
+                        requester.Received(inv, nullptr);
                     }
                     int nDoS = 0;
                     if (state.IsInvalid(nDoS))
@@ -461,9 +470,6 @@ void ThreadTxAdmission()
                             }
                         }
                     }
-
-                    // Mark tx as received regardless of whether it was a valid tx, orphan or invalid.
-                    requester.Received(inv, nullptr);
                 }
             }
         }


### PR DESCRIPTION
Use a flag to indicate the txn is received but being processed and only remove it from the request manager once it's been fully validated.  And finally do not re-request any txns that are currently being processed.