### PR TITLE
Proper multi-threaded multi-line logging and no more empty lines

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -389,12 +389,21 @@ static void HTTPWorkQueueRun(WorkQueue<HTTPClosure> *queue)
 }
 
 /** libevent event log callback */
-static void libevent_log_cb(int severity, const char *msg)
+static void libevent_log_cb(int severity, const char *_msg)
 {
 #ifndef EVENT_LOG_WARN
 // EVENT_LOG_WARN was added in 2.0.19; but before then _EVENT_LOG_WARN existed.
 #define EVENT_LOG_WARN _EVENT_LOG_WARN
 #endif
+    std::string msg(_msg);
+    if (msg.empty())
+        return;
+
+    // messages to this call back sometimes seem to have an
+    // extra newline that can be removed.
+    if (msg[msg.size() - 1] == '\n')
+        msg = msg.substr(0, msg.size() - 1);
+
     if (severity >= EVENT_LOG_WARN) // Log warn messages and higher without debug category
         LOGA("libevent: %s\n", msg);
     else


### PR DESCRIPTION
This fixes an issue which sporadically causes log lines to be
interleaved. The problem was a single boolean shared between
all threads that was meant to keep track of partial log messages.
It has been replaced with a string keeping track of the partial
log message that is in thread local storage.

Note that this includes a subtle behavioral change:
No partial log messages are printed anymore, only when they are
finished with a new line.

To test this, run a RPC test, such as sendheaders.py and
then check the resulting log for the problem with and without
this commit applied, for example like this:

grep -E ".2018-..-.....:..:.." debug.log