### PR TITLE
Add RPC call 'logline' to add lines to debug.log

### DIFF
--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -119,6 +119,16 @@ UniValue getinfo(const UniValue &params, bool fHelp)
     return obj;
 }
 
+UniValue logline(const UniValue &params, bool fHelp)
+{
+    if (fHelp || params.size() != 1)
+        throw runtime_error("logline 'string'\n"
+                            "Writes a string into the log (prefixed with 'rpc-logline: ').\n"
+                            "\nResult: None\n");
+    LOGA("rpc-logline: %s\n", params[0].get_str());
+    return NullUniValue;
+}
+
 #ifdef ENABLE_WALLET
 class DescribeAddressVisitor : public boost::static_visitor<UniValue>
 {
@@ -439,6 +449,7 @@ static const CRPCCommand commands[] = {
     {"control", "getinfo", &getinfo, true}, /* uses wallet if enabled */
     {"util", "validateaddress", &validateaddress, true}, /* uses wallet if enabled */
     {"util", "createmultisig", &createmultisig, true}, {"util", "verifymessage", &verifymessage, true},
+    {"util", "logline", &logline, true},
 
     /* Not shown in help */
     {"hidden", "setmocktime", &setmocktime, true},


### PR DESCRIPTION
This is useful for example to better figure out the timing
between `debug.log` and the output of a python RPC test script
itself. By inserting `node.logline(..)` calls into the RPC script,
common points in time between the different logs can be established.