### PR TITLE
Configure travis to use an Ubuntu 18.04 docker container 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: xenial
 os: linux
 language: generic
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: trusty
 os: linux
 language: generic
 cache:
+  ccache: true
   directories:
   - depends/built
   - depends/sdk-sources
@@ -13,127 +14,160 @@ env:
     - MAKEJOBS=-j2
     - RUN_TESTS=false
     - RUN_FORMATTING_CHECK=false
+    - DOCKER_NAME_TAG=ubuntu:18.04
     - CHECK_DOC=0
     - BOOST_TEST_RANDOM=1$TRAVIS_BUILD_ID
     - CCACHE_SIZE=100M
     - CCACHE_TEMPDIR=/tmp/.ccache-temp
     - CCACHE_COMPRESS=1
+    - CCACHE_DIR=$HOME/.ccache
     - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
     - USE_CLANG=false
     - SDK_URL=https://www.bitcoinunlimited.info/sdks
+    - LINTER_DEB_URL=https://www.bitcoinunlimited.info/depends-sources/
     - PYTHON_DEBUG=1
     - WINEDEBUG=fixme-all
-    - PPA=ppa:bitcoin-unlimited/bu-ppa
-    - PPA2=ppa:sickpig/boost
+    - DOCKER_PACKAGES="build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git ca-certificates ccache"
+    - LC_ALL=C.UTF-8
 
 matrix:
   include:
-    #bitcoind clang
+    #bitcoind clang (no depend, only system lib installed via apt)
     - compiler: clang
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - clang-5.0
       env:
         - USE_CLANG=true
         - CXX=clang++-5.0 CC=clang-5.0
         - CXXFLAGS="-std=c++11"
         - HOST=x86_64-unknown-linux-gnu
         - RUN_TESTS=false
-        - PACKAGES="python3-zmq libzmq3-dev clang-format-3.8 build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils libboost-all-dev qtbase5-dev protobuf-compiler qttools5-dev-tools qttools5-dev"
-        - GOAL="install" BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 CC=clang-5.0 CXX=clang++-5.0 CPPFLAGS=-DDEBUG_LOCKORDER"
+        - PACKAGES="python3-zmq libzmq3-dev qttools5-dev-tools qttools5-dev clang-5.0 libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-program-options-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev"
+        - GOAL="install"
+        - BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 CC=clang-5.0 --with-incompatible-bdb CXX=clang++-5.0 CPPFLAGS=-DDEBUG_LOCKORDER CXXFLAGS=\"-std=c++11\""
     #bitcoind
     - compiler: gcc
       env:
         - CXX=g++ CC=gcc
-        - HOST=x86_64-unknown-linux-gnu PACKAGES="python3-zmq clang-format-3.8" DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1" RUN_TESTS=true RUN_FORMATTING_CHECK=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER"
+        - HOST=x86_64-unknown-linux-gnu
+        - PACKAGES="libedit2 python python3-zmq"
+        - DEP_OPTS="NO_QT=1 NO_UPNP=1 DEBUG=1"
+        - RUN_TESTS=true
+        - RUN_FORMATTING_CHECK=true
+        - GOAL="install"
+        - BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER" #need to test also libdb 4.8
     #ARM64
     - compiler: gcc
       env:
         - CXX=g++ CC=gcc
-        - HOST=aarch64-linux-gnu PACKAGES="g++-aarch64-linux-gnu" DEP_OPTS="NO_QT=1" GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
+        - HOST=aarch64-linux-gnu
+        - PACKAGES="g++-aarch64-linux-gnu"
+        - DEP_OPTS="NO_QT=1"
+        - GOAL="install"
+        - BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports CXXFLAGS=-Wno-psabi"
     #ARM32
     - compiler: gcc
       env:
         - CXX=g++ CC=gcc
-        - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf" DEP_OPTS="NO_QT=1" GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
+        - HOST=arm-linux-gnueabihf
+        - PACKAGES="g++-arm-linux-gnueabihf"
+        - DEP_OPTS="NO_QT=1" GOAL="install"
+        - BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
     #Win32
-    #- compiler: gcc
-    #  env:
-    #    - CXX=g++ CC=gcc
-    #    - HOST=i686-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-i686 wine1.6 bc" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
-    #Linux32-bit + dash
     - compiler: gcc
       env:
         - CXX=g++ CC=gcc
-        - HOST=i686-pc-linux-gnu PACKAGES="g++-multilib bc python3-zmq" DEP_OPTS="NO_QT=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++" USE_SHELL="/bin/dash"
+        - HOST=i686-w64-mingw32
+        - DPKG_ADD_ARCH="i386"
+        - DEP_OPTS="NO_QT=1"
+        - PACKAGES="python3 nsis g++-mingw-w64-i686 wine32 wine-binfmt"
+        - RUN_TESTS=true GOAL="install"
+        - BITCOIN_CONFIG="--enable-reduce-exports"
     #Win64
     - compiler: gcc
       env:
         - CXX=g++ CC=gcc
-        - HOST=x86_64-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine1.6 bc" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
+        - HOST=x86_64-w64-mingw32
+        - DEP_OPTS="NO_QT=1"
+        - PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine64 wine-binfmt"
+        - RUN_TESTS=true GOAL="install"
+        - BITCOIN_CONFIG="--enable-reduce-exports"
+    #Linux32-bit + dash
+    - compiler: gcc
+      env:
+        - CXX=g++ CC=gcc
+        - HOST=i686-pc-linux-gnu
+        - PACKAGES="g++-multilib bc python3-zmq"
+        - DEP_OPTS="NO_QT=1" RUN_TESTS=true GOAL="install"
+        - BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++"
+        - USE_SHELL="/bin/dash"
     #x86_64 Linux, No wallet (uses qt5 dev package instead of depends Qt to speed up build and avoid timeout)
     - compiler: gcc
       env:
         - CXX=g++ CC=gcc
-        - HOST=x86_64-unknown-linux-gnu PACKAGES="python3 qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev" DEP_OPTS="NO_WALLET=1 NO_QT=1 ALLOW_HOST_PACKAGES=1" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
+        - HOST=x86_64-unknown-linux-gnu
+        - PACKAGES="python3 qtbase5-dev qttools5-dev-tools protobuf-compiler libdbus-1-dev libharfbuzz-dev libprotobuf-dev"
+        - DEP_OPTS="NO_WALLET=1 NO_QT=1 ALLOW_HOST_PACKAGES=1"
+        - RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports"
     #Cross-Mac
     - compiler: gcc
       env:
-        - HOST=x86_64-apple-darwin11 PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev clang-3.8 libc++-dev" BITCOIN_CONFIG="--enable-reduce-exports" OSX_SDK=10.11 GOAL="deploy"
+        - HOST=x86_64-apple-darwin11
+        - PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev python3-setuptools-git"
+        - BITCOIN_CONFIG="--enable-reduce-exports"
+        - OSX_SDK=10.11 GOAL="deploy"
 
 before_install:
     - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
-    #  temp fix with riak repo, by the way we don't need riak at all
-    - sudo rm -vf /etc/apt/sources.list.d/*riak*
-    - sudo apt-get update
 
 install:
-    - if [ -n "$PPA" ]; then for i in `seq 0 4`; do sudo add-apt-repository "$PPA" -y 2>&1|tee /dev/stderr|grep -q "imported" && break; sleep 30; done; fi
-    - if [ -n "$PPA2" ]; then for i in `seq 0 4`; do sudo add-apt-repository "$PPA2" -y 2>&1|tee /dev/stderr|grep -q "imported" && break; sleep 30; done; fi
-    - if [ -n "$DPKG_ADD_ARCH" ]; then sudo dpkg --add-architecture "$DPKG_ADD_ARCH" ; fi
-    - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get update; fi
-    - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES; fi
-    - if { [ -n "$DEP_OPTS" ] && [[ $DEP_OPTS =~ .*NO_WALLET=1.* ]]; }; then echo "Skip Berkeley DB installation"; else travis_retry sudo apt-get install --no-install-recommends --no-upgrade -qq libdb4.8-dev libdb4.8++-dev; fi
-    - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install -y -qq libboost1.58-dev ; fi
-    - if [ -n "$PACKAGES" ]; then travis_retry sudo apt-get install -y -qq libboost1.58-tools-dev libboost-system1.58-dev libboost-filesystem1.58-dev libboost-program-options1.58-dev libboost-thread1.58-dev libboost-test1.58-dev; fi
-
+    - travis_retry docker pull "$DOCKER_NAME_TAG"
+    - env | grep -E '^(CCACHE_|WINEDEBUG|LC_ALL|BOOST_TEST_RANDOM|CONFIG_SHELL)' | tee /tmp/env
+    - if [[ $HOST = *-mingw32 ]]; then
+        DOCKER_ADMIN="--cap-add SYS_ADMIN";
+      fi
+    - DOCKER_ID=$(docker run $DOCKER_ADMIN -idt --mount type=bind,src=$TRAVIS_BUILD_DIR,dst=$TRAVIS_BUILD_DIR --mount type=bind,src=$CCACHE_DIR,dst=$CCACHE_DIR -w $TRAVIS_BUILD_DIR --env-file /tmp/env $DOCKER_NAME_TAG)
+    - DOCKER_EXEC () {
+        docker exec $DOCKER_ID bash -c "cd $PWD && $*";
+      }
+    - if [ -n "$DPKG_ADD_ARCH" ]; then
+        DOCKER_EXEC dpkg --add-architecture "$DPKG_ADD_ARCH";
+      fi
+    - travis_retry DOCKER_EXEC apt-get update
+    - travis_retry DOCKER_EXEC apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES $DOCKER_PACKAGES
+    - if [ $RUN_FORMATTING_CHECK = "true" ]; then
+        curl --location $LINTER_DEB_URL/libllvm3.8_3.8.1-27ubuntu1_amd64.deb -o llvm-3.8.deb;
+        curl --location $LINTER_DEB_URL/clang-format-3.8_3.8.1-27ubuntu1_amd64.deb -o clang-format-3.8.deb;
+        DOCKER_EXEC dpkg -i llvm-3.8.deb clang-format-3.8.deb;
+      fi
 before_script:
     - unset CC; unset CXX
-    - if [ "$CHECK_DOC" = 1 ]; then contrib/devtools/check-doc.py; fi
+    - if [ "$CHECK_DOC" = 1 ]; then DOCKER_EXEC contrib/devtools/check-doc.py; fi
     - mkdir -p depends/SDKs depends/sdk-sources
     - if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
     - if [ -n "$OSX_SDK" -a -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
     - echo "USE_CLANG=$USE_CLANG"
-    - if [ "$USE_CLANG" = "false" ]; then make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS; fi
+    - if [[ $HOST = *-mingw32 ]]; then DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\); fi
+    - if [ "$USE_CLANG" = "false" ]; then DOCKER_EXEC CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS; fi #use sys libraries for clang
 script:
     - export TRAVIS_COMMIT_LOG=`git log --format=fuller -1`
     - if [ -n "$USE_SHELL" ]; then export CONFIG_SHELL="$USE_SHELL"; fi
     - OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
     - BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib";
-    - if [ "$USE_CLANG" = "false" ]; then depends/$HOST/native/bin/ccache --max-size=$CCACHE_SIZE; fi
-    - test -n "$USE_SHELL" && eval '"$USE_SHELL" -c "./autogen.sh 2>&1 > autogen.out"' || ./autogen.sh 2>&1 > autogen.out || ( cat autogen.out && false)
+    - if [ "$USE_CLANG" = "false" ]; then DOCKER_EXEC ccache --max-size=$CCACHE_SIZE; fi
+    - test -n "$USE_SHELL" && DOCKER_EXEC "$CONFIG_SHELL" -c "./autogen.sh 2>&1 > autogen.out" || ./autogen.sh 2>&1 > autogen.out || (cat autogen.out && false)
     - mkdir build && cd build
     - echo "BITCOIN_CONFIG_ALL=$BITCOIN_CONFIG_ALL"
     - echo "BITCOIN_CONFIG=$BITCOIN_CONFIG"
     - echo "GOAL=$GOAL"
-    - ../configure $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG 2>&1 > configure.out || ( cat configure.out && cat config.log && false)
-    - if [ "$USE_CLANG" = "true" ]; then
-         cat configure.out;
-         head config.log;
+    - DOCKER_EXEC ../configure --cache-file=config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
+    - if [ "$RUN_FORMATTING_CHECK" = "true" ]; then DOCKER_EXEC make $MAKEJOBS check-formatting VERBOSE=1; fi
+    - DOCKER_EXEC make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && DOCKER_EXEC make $GOAL V=1 ; false ) ;
+    - if [ "$RUN_TESTS" = "true" ] && { [ "$HOST" = "i686-w64-mingw32" ] || [ "$HOST" = "x86_64-w64-mingw32" ]; }; then
+        travis_wait DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1;
       fi
-    - if [ "$RUN_FORMATTING_CHECK" = "true" ]; then make $MAKEJOBS check-formatting VERBOSE=1; fi
-    - if [ "$USE_CLANG" = "false" ]; then
-        stdbuf -i0 -o0 -e0 make $MAKEJOBS $GOAL 2>&1 | ../contrib/devtools/buildsilence.py || ( echo "Build failure. Verbose build follows." && make $GOAL V=1 ; false ) ;
-      else
-         CXXFLAGS="-std=c++11 -Werror" make $MAKEJOBS $GOAL;
+    - if [ "$RUN_TESTS" = "true" ] && ! { [ "$HOST" = "i686-w64-mingw32" ] || [ "$HOST" = "x86_64-w64-mingw32" ]; }; then
+        DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1;
       fi
-    - if [ "USE_CLANG" = "false" ]; then export LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib; fi
-    - if [ "$RUN_TESTS" = "true" ] && { [ "$HOST" = "i686-w64-mingw32" ] || [ "$HOST" = "x86_64-w64-mingw32" ]; }; then travis_wait make $MAKEJOBS check VERBOSE=1; fi
-    - if [ "$RUN_TESTS" = "true" ] && ! { [ "$HOST" = "i686-w64-mingw32" ] || [ "$HOST" = "x86_64-w64-mingw32" ]; }; then make $MAKEJOBS check VERBOSE=1; fi
-    - if [ "$RUN_TESTS" = "true" ]; then qa/pull-tester/rpc-tests.py --coverage --no-ipv6-rpc-listen; fi
+    - if [ "$RUN_TESTS" = "true" ]; then DOCKER_EXEC qa/pull-tester/rpc-tests.py --coverage --no-ipv6-rpc-listen; fi
 after_script:
     - echo $TRAVIS_COMMIT_RANGE
     - echo $TRAVIS_COMMIT_LOG

--- a/.travis.yml
+++ b/.travis.yml
@@ -162,7 +162,7 @@ script:
     - if [ "$RUN_FORMATTING_CHECK" = "true" ]; then DOCKER_EXEC make $MAKEJOBS check-formatting VERBOSE=1; fi
     - DOCKER_EXEC make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && DOCKER_EXEC make $GOAL V=1 ; false ) ;
     - if [ "$RUN_TESTS" = "true" ] && { [ "$HOST" = "i686-w64-mingw32" ] || [ "$HOST" = "x86_64-w64-mingw32" ]; }; then
-        travis_wait DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1;
+        travis_wait 30 DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1;
       fi
     - if [ "$RUN_TESTS" = "true" ] && ! { [ "$HOST" = "i686-w64-mingw32" ] || [ "$HOST" = "x86_64-w64-mingw32" ]; }; then
         DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 dist: xenial
 os: linux
-language: generic
+language: minimal
 cache:
   ccache: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -169,7 +169,7 @@ script:
     - if [ "$RUN_FORMATTING_CHECK" = "true" ]; then DOCKER_EXEC make $MAKEJOBS check-formatting VERBOSE=1; fi
     - DOCKER_EXEC make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && DOCKER_EXEC make $GOAL V=1 ; false ) ;
     - if [ "$RUN_TESTS" = "true" ] && { [ "$HOST" = "i686-w64-mingw32" ] || [ "$HOST" = "x86_64-w64-mingw32" ]; }; then
-        travis_wait 30 DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1;
+        travis_wait 50 DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1;
       fi
     - if [ "$RUN_TESTS" = "true" ] && ! { [ "$HOST" = "i686-w64-mingw32" ] || [ "$HOST" = "x86_64-w64-mingw32" ]; }; then
         DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1;

--- a/.travis.yml
+++ b/.travis.yml
@@ -159,6 +159,13 @@ script:
     - echo "BITCOIN_CONFIG=$BITCOIN_CONFIG"
     - echo "GOAL=$GOAL"
     - DOCKER_EXEC ../configure --cache-file=config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
+    - if [ "$HOST" = "x86_64-apple-darwin11" ]; then
+        DOCKER_EXEC echo $TRAVIS_BUILD_DIR ;
+        DOCKER_EXEC python3 --version ;
+        docker exec $DOCKER_ID bash -c "$TRAVIS_BUILD_DIR/contrib/devtools/xversionkeys.py > $TRAVIS_BUILD_DIR/src/xversionkeys.h < $TRAVIS_BUILD_DIR/src/xversionkeys.dat" ;
+        DOCKER_EXEC cat $TRAVIS_BUILD_DIR/src/xversionkeys.h ;
+        DOCKER_EXEC cat $TRAVIS_BUILD_DIR/src/xversionkeys.dat ;
+      fi
     - if [ "$RUN_FORMATTING_CHECK" = "true" ]; then DOCKER_EXEC make $MAKEJOBS check-formatting VERBOSE=1; fi
     - DOCKER_EXEC make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && DOCKER_EXEC make $GOAL V=1 ; false ) ;
     - if [ "$RUN_TESTS" = "true" ] && { [ "$HOST" = "i686-w64-mingw32" ] || [ "$HOST" = "x86_64-w64-mingw32" ]; }; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ matrix:
         - HOST=x86_64-w64-mingw32
         - DEP_OPTS="NO_QT=1"
         - PACKAGES="python3 nsis g++-mingw-w64-x86-64 wine64 wine-binfmt"
-        - RUN_TESTS=true GOAL="install"
+        - RUN_TESTS=false GOAL="install"
         - BITCOIN_CONFIG="--enable-reduce-exports"
     #Linux32-bit + dash
     - compiler: gcc
@@ -160,11 +160,7 @@ script:
     - echo "GOAL=$GOAL"
     - DOCKER_EXEC ../configure --cache-file=config.cache $BITCOIN_CONFIG_ALL $BITCOIN_CONFIG || ( cat config.log && false)
     - if [ "$HOST" = "x86_64-apple-darwin11" ]; then
-        DOCKER_EXEC echo $TRAVIS_BUILD_DIR ;
-        DOCKER_EXEC python3 --version ;
         docker exec $DOCKER_ID bash -c "$TRAVIS_BUILD_DIR/contrib/devtools/xversionkeys.py > $TRAVIS_BUILD_DIR/src/xversionkeys.h < $TRAVIS_BUILD_DIR/src/xversionkeys.dat" ;
-        DOCKER_EXEC cat $TRAVIS_BUILD_DIR/src/xversionkeys.h ;
-        DOCKER_EXEC cat $TRAVIS_BUILD_DIR/src/xversionkeys.dat ;
       fi
     - if [ "$RUN_FORMATTING_CHECK" = "true" ]; then DOCKER_EXEC make $MAKEJOBS check-formatting VERBOSE=1; fi
     - DOCKER_EXEC make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && DOCKER_EXEC make $GOAL V=1 ; false ) ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ env:
     - LINTER_DEB_URL=https://www.bitcoinunlimited.info/depends-sources/
     - PYTHON_DEBUG=1
     - WINEDEBUG=fixme-all
-    - DOCKER_PACKAGES="build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git ca-certificates ccache"
+    - DOCKER_PACKAGES="build-essential libtool autotools-dev automake pkg-config bsdmainutils curl git ca-certificates ccache python3"
     - LC_ALL=C.UTF-8
 
 matrix:

--- a/contrib/devtools/clang-format.py
+++ b/contrib/devtools/clang-format.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 '''
 Wrapper script for clang-format
 
@@ -13,7 +13,7 @@ import os
 import sys
 import subprocess
 import difflib
-import StringIO
+from io import StringIO
 import pdb
 import tempfile
 
@@ -29,12 +29,11 @@ def check_clang_format_version(clang_format_exe):
     try:
         output = subprocess.check_output([clang_format_exe, '-version'])
         for ver in tested_versions:
-            if ver in output:
-                #print>>sys.stderr, "Detected clang-format version " + ver
+            if ver in output.decode('utf8'):
                 return
         raise RuntimeError("Untested version: " + output)
     except Exception as e:
-        print 'Could not verify version of ' + clang_format_exe + '.'
+        print('Could not verify version of ' + clang_format_exe + '.')
         raise e
 
 def check_command_line_args(argv):
@@ -43,11 +42,11 @@ def check_command_line_args(argv):
 
     if(len(argv) < len(required_args) + 1):
         for word in (['Usage:', argv[0]] + required_args):
-            print word,
-        print ''
+            print(word),
+        print('')
         for word in (['E.g:', argv[0]] + example_args):
-            print word,
-        print ''
+            print(word),
+        print('')
         sys.exit(1)
 
 def run_clang_check(clang_format_exe, files):
@@ -66,14 +65,14 @@ def run_clang_check(clang_format_exe, files):
             subprocess.check_call([trailing_comment_exe, str(max_col_len)], stdin=open(target,"rb"), stdout=trailingCommentFile, stderr=subprocess.STDOUT)
             trailingCommentFile.seek(0)
             subprocess.check_call([clang_format_exe,'-style=file','-assume-filename=%s' % target], stdin=trailingCommentFile, stdout=formattedFile, stderr=subprocess.STDOUT)
-            with open(target,"rb") as f: inputContents = f.readlines()
+            with open(target,"rb") as f: inputContents = [ x.decode('utf8') for x in f.readlines() ]
             formattedFile.seek(0)
-            formattedContents = formattedFile.readlines()
+            formattedContents = [ x.decode('utf8') for x in formattedFile.readlines() ]
             for l in difflib.unified_diff(inputContents,formattedContents, target, target+"_formatted"):
                 sys.stdout.write(l)
                 changed.add(target)
         else:
-            print "Skip " + target
+            print("Skip " + target)
     if nonexistent:
         print("\nNonexistent files: " + ",".join(nonexistent))
     if changed:
@@ -103,16 +102,16 @@ def run_clang_format(clang_format_exe, files, stdout=False):
                                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
                 sout, serr = cfe_pipe.communicate()
-                sys.stdout.write(sout)
-                sys.stderr.write(serr)
+                sys.stdout.write(sout.decode())
+                sys.stderr.write(serr.decode())
             else:
-                print "Format " + target
+                print("Format " + target)
                 subprocess.check_call([trailing_comment_exe, str(max_col_len), target])
                 subprocess.check_call([clang_format_exe, '-i', '-style=file', target],
                                       stdout=open(os.devnull, 'wb'), stderr=subprocess.STDOUT)
 
         else:
-            print "Skip " + target
+            print("Skip " + target)
 
 def main(argv):
     global trailing_comment_exe

--- a/contrib/devtools/clang-format.py
+++ b/contrib/devtools/clang-format.py
@@ -20,6 +20,8 @@ import tempfile
 # A set of versions known to produce the same output
 tested_versions = ['3.8.0',
                    '3.8.1',  # 3.8.1-12ubuntu1 on yakkety works
+                   '3.9.0',
+                   '3.9.1',
                   ]
 accepted_file_extensions = ('.h', '.cpp') # Files to format
 trailing_comment_exe = "trailing-comment.py"

--- a/qa/rpc-tests/mempool_persist.py
+++ b/qa/rpc-tests/mempool_persist.py
@@ -101,13 +101,12 @@ class MempoolPersistTest(BitcoinTestFramework):
         waitFor(10, lambda: len(self.nodes[1].getrawmempool()) == 5)
 
         logging.info("Prevent bitcoind from writing mempool.dat to disk. Verify that `savemempool` fails")
-        # to test the exception we are setting bad permissions on a tmp file called mempool.dat.new
+        # try to dump mempool content on a directory rather than a file
         # which is an implementation detail that could change and break this test
         mempooldotnew1 = mempooldat1 + '.new'
-        with os.fdopen(os.open(mempooldotnew1, os.O_CREAT, 0o000), 'w'):
-            pass
+        os.mkdir(mempooldotnew1)
         assert_raises_rpc_error(-1, "Unable to dump mempool to disk", self.nodes[1].savemempool)
-        os.remove(mempooldotnew1)
+        os.rmdir(mempooldotnew1)
 
 if __name__ == '__main__':
     MempoolPersistTest().main()


### PR DESCRIPTION
Basically this perform the same build/test jobs on an Ubuntu 18.04 env (via docker) rather than on a trusty one. 

This is PR vastly predate the work done by core on various PRs, the main one is bitcoin/bitcoin/pull/13215.

Will work out these items on a following PR: 

- print `config.log` on the log only if an error occurs. 
- add travis_fold to nicely display job log on travis

This PR is built on top of #1449 

edit: seems like travis is not caching `depends` builds across runs, this is weird cause it is doing it properly on my branch see e.g.: 
https://travis-ci.org/sickpig/BitcoinUnlimited/jobs/451975524

edit2:  Switch the host OS on which we are running docker from trusty (14.04) to xenial (16.04). Docker images are still bionic (18.04) based.

edit3: take out of WIP.