### PR TITLE
rsvg binaries are needed to convert svg to png while producing dmg on macos

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -437,6 +437,7 @@ case $host in
            AC_PATH_TOOL([INSTALLNAMETOOL], [install_name_tool], install_name_tool)
            AC_PATH_TOOL([OTOOL], [otool], otool)
            AC_PATH_PROGS([GENISOIMAGE], [genisoimage mkisofs],genisoimage)
+           AC_PATH_PROGS([RSVG_CONVERT], [rsvg-convert rsvg],rsvg-convert)
            AC_PATH_PROGS([IMAGEMAGICK_CONVERT], [convert],convert)
            AC_PATH_PROGS([TIFFCP], [tiffcp],tiffcp)
 


### PR DESCRIPTION
This PR will fix a problem with creating deterministic binaries for macOS.