### PR TITLE
Change settings in leveldb to prevent write pauses during reindex or …

### DIFF
--- a/patches/leveldb/level-db-stopwritetrigger.diff
+++ b/patches/leveldb/level-db-stopwritetrigger.diff
@@ -1,0 +1,17 @@
+diff --git a/src/leveldb/db/dbformat.h b/src/leveldb/db/dbformat.h
+index ea897b13c..a05ded145 100644
+--- a/src/leveldb/db/dbformat.h
++++ b/src/leveldb/db/dbformat.h
+@@ -25,10 +25,10 @@ static const int kNumLevels = 7;
+ static const int kL0_CompactionTrigger = 4;
+ 
+ // Soft limit on number of level-0 files.  We slow down writes at this point.
+-static const int kL0_SlowdownWritesTrigger = 8;
++static const int kL0_SlowdownWritesTrigger = 4092;
+ 
+ // Maximum number of level-0 files.  We stop writes at this point.
+-static const int kL0_StopWritesTrigger = 12;
++static const int kL0_StopWritesTrigger = 4096;
+ 
+ // Maximum level to which a new compacted memtable is pushed if it
+ // does not create overlap.  We try to push to level 2 to avoid the

--- a/src/leveldb/db/dbformat.h
+++ b/src/leveldb/db/dbformat.h
@@ -25,10 +25,10 @@ static const int kNumLevels = 7;
 static const int kL0_CompactionTrigger = 4;
 
 // Soft limit on number of level-0 files.  We slow down writes at this point.
-static const int kL0_SlowdownWritesTrigger = 8;
+static const int kL0_SlowdownWritesTrigger = 4092;
 
 // Maximum number of level-0 files.  We stop writes at this point.
-static const int kL0_StopWritesTrigger = 12;
+static const int kL0_StopWritesTrigger = 4096;
 
 // Maximum level to which a new compacted memtable is pushed if it
 // does not create overlap.  We try to push to level 2 to avoid the


### PR DESCRIPTION
…initial sync

The reindex or sync process can be severely lengthened in time due to
the compaction process falling behind. There are settings in leveldb
that prevent writing to the database in the event that there are 12
uncompacted Level-0 files. This causes bitcoin to halt the sync/reindex
process until compaction has reduced the number of files neededing
compaction. This causes delays and hangups in the bitcoin process which
gives the appearance that the node is hung...and indeed it is for a
time.  Furthermore this halting process is very apparent when running
with -tindex=1, which creates even more compaction which then conflicts
with the compaction happening in the utxo set.

Set the leveldb stop write trigger to 4096 files (up from just 12). This
should prevent, even on slower and memory deficient systems, from
hitting the limits and stopping the sync or reindex process.

NOTE: this halting process can be easily seen by running with txindex=1 and syncing or reindexing on a spinning disk. This issues was first brought up a few months back from, I believe @digitsu ,  who was having a very slow sync when running with txindex=1. 

TESTING NOTE:  Testing without this patch and reindexing on a spinning disk with -txindex=1, yeilded took 9hr 12min, while with the patch 4hr 10 min; And while the reindex with patch finished much faster, there is a period of time after the reindex is complete where performance is slightly degraded until the compactions are complete. However by running a few getrawtransactions which hit the txindex the degradation is not all that much, (still sub second retrievals) and block processing performance doesn't seem to be impacted during this compaction period.