### PR TITLE
Test framework improvements (#2)

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -234,7 +234,8 @@ testScripts = [ RpcTest(t) for t in [
     'importprunedfunds',
     'thinblocks',
     'checkdatasig_activation',
-    'xversion'
+    'xversion',
+    'sighashmatch'
 ] ]
 
 testScriptsExt = [ RpcTest(t) for t in [

--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -9,7 +9,7 @@ from test_framework.comptool import TestManager, TestInstance, RejectResult
 from test_framework.blocktools import *
 import time
 from test_framework.key import CECKey
-from test_framework.script import CScript, SignatureHash, SIGHASH_ALL, OP_TRUE, OP_FALSE
+from test_framework.script import CScript, SignatureHashLegacy, SIGHASH_ALL, OP_TRUE, OP_FALSE
 
 class PreviousSpendableOutput(object):
     def __init__(self, tx = CTransaction(), n = -1):
@@ -85,7 +85,7 @@ class FullBlockTest(ComparisonTestFramework):
                 scriptSig = CScript([OP_TRUE])
             else:
                 # We have to actually sign it
-                (sighash, err) = SignatureHash(spend.tx.vout[spend.n].scriptPubKey, tx, 0, SIGHASH_ALL)
+                (sighash, err) = SignatureHashLegacy(spend.tx.vout[spend.n].scriptPubKey, tx, 0, SIGHASH_ALL)
                 scriptSig = CScript([self.coinbase_key.sign(sighash) + bytes(bytearray([SIGHASH_ALL]))])
             tx.vin[0].scriptSig = scriptSig
             # Now add the transaction to the block

--- a/qa/rpc-tests/p2p-fullblocktest.py
+++ b/qa/rpc-tests/p2p-fullblocktest.py
@@ -9,7 +9,7 @@ from test_framework.comptool import TestManager, TestInstance, RejectResult
 from test_framework.blocktools import *
 import time
 from test_framework.key import CECKey
-from test_framework.script import CScript, SignatureHashLegacy, SIGHASH_ALL, OP_TRUE, OP_FALSE
+from test_framework.script import CScript, SIGHASH_ALL, OP_TRUE, OP_FALSE
 
 class PreviousSpendableOutput(object):
     def __init__(self, tx = CTransaction(), n = -1):
@@ -85,7 +85,7 @@ class FullBlockTest(ComparisonTestFramework):
                 scriptSig = CScript([OP_TRUE])
             else:
                 # We have to actually sign it
-                (sighash, err) = SignatureHashLegacy(spend.tx.vout[spend.n].scriptPubKey, tx, 0, SIGHASH_ALL)
+                (sighash, err) = tx.SignatureHashLegacy(spend.tx.vout[spend.n].scriptPubKey, 0, SIGHASH_ALL)
                 scriptSig = CScript([self.coinbase_key.sign(sighash) + bytes(bytearray([SIGHASH_ALL]))])
             tx.vin[0].scriptSig = scriptSig
             # Now add the transaction to the block

--- a/qa/rpc-tests/sighashmatch.py
+++ b/qa/rpc-tests/sighashmatch.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+# parts taken from weirdtx.py
+
+import test_framework.loginit
+
+import time
+import sys
+if sys.version_info[0] < 3:
+    raise "Use Python 3"
+import logging
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.blocktools import *
+from test_framework.script import *
+from test_framework.key import *
+from binascii import unhexlify, hexlify
+
+def Hash256Puzzle(s):
+    if type(s) is str:
+        s = s.encode()
+    ret = CScript([OP_HASH256, hash256(s), OP_EQUAL])
+    return ret
+
+
+def MatchString(s):
+    if type(s) is str:
+        s = s.encode()
+    ret = CScript([s, OP_EQUAL])
+    return ret
+
+
+def p2pkh_list(addr):
+    return [OP_DUP, OP_HASH160, bitcoinAddress2bin(addr), OP_EQUALVERIFY, OP_CHECKSIG]
+
+
+def SignWithAorB(twoAddrs):
+    ret = CScript([OP_IF] + p2pkh_list(twoAddrs[0]) + [OP_ELSE] + p2pkh_list(twoAddrs[1]) + [OP_ENDIF])
+    return ret
+
+
+class SigHashMatchTest(BitcoinTestFramework):
+    def setup_chain(self, bitcoinConfDict, wallets=None):
+        print("Initializing test directory " + self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 2, bitcoinConfDict, wallets)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(2, self.options.tmpdir)
+        connect_nodes_bi(self.nodes, 0, 1)
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test(self):
+        # generate enough blocks so that nodes[0] has a balance
+        self.sync_blocks()
+        self.nodes[0].generate(150)
+        self.sync_blocks()
+
+        unspents = self.nodes[0].listunspent()
+        unspents.sort(key=lambda x: x["amount"], reverse=False)
+        utxo = unspents.pop()
+        amt = utxo["amount"]
+        addr = utxo["address"]
+        outp = {"dummy" : amt - decimal.Decimal(.0001)}  # give some fee
+        txn = CTransaction().deserialize(createrawtransaction([utxo], outp, p2pkh))
+
+        # create signature manually using txn.SignatureHash() calculation
+        # plus the new signdata RPC call, append the sighashbyte and make sure
+        # it is accepted by the node.
+
+        privkey = self.nodes[0].dumpprivkey(addr)
+        key = CECKey()
+        key.set_secretbytes(decodeBase58(privkey)[1:-5])
+        key.set_compressed(True)
+        pub = key.get_pubkey()
+
+        sighashcode = CScript([pub, OP_CHECKSIG])
+        sighash = txn.SignatureHash(0, bytes(sighashcode),
+                                    int((amt)*100000000))
+        txn_mansig = unhexlify(self.nodes[0].signdata(addr, "hash",
+                                            hexlify(sighash).decode("ascii")))
+        fullsig = txn_mansig+b"\x41"
+        txn.vin[0].scriptSig = CScript([fullsig])
+        txid = self.nodes[0].sendrawtransaction(txn.toHex())
+        assert len(txid) == 64
+
+if __name__ == '__main__':
+    SigHashMatchTest().main(bitcoinConfDict = {"usecashaddr" : 0})
+
+# Create a convenient function for an interactive python debugging session
+
+
+def Test():
+    t = SigHashMatchTest()
+    bitcoinConf = {
+        "debug": ["net", "blk", "thin", "mempool", "req", "bench", "evict"],
+        "blockprioritysize": 2000000,  # we don't want any transactions rejected due to insufficient fees...
+        "usecashaddr" : False
+    }
+
+    # you may want these additional flags:
+    # "--srcdir=<out-of-source-build-dir>/debug/src"
+    # "--tmppfx=/ramdisk/test"
+    flags = []  # "--nocleanup", "--noshutdown"
+    if os.path.isdir("/ramdisk/test"):  # execution is much faster if a ramdisk is used
+        flags.append("--tmppfx=/ramdisk/test")
+
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/test_framework/nodemessages.py
+++ b/qa/rpc-tests/test_framework/nodemessages.py
@@ -8,6 +8,8 @@ import time
 from codecs import encode
 from threading import RLock
 from io import BytesIO
+import copy
+
 MY_VERSION = 60001  # past bip-31 for ping/pong
 MY_SUBVERSION = b"/python-mininode-tester:0.0.3/"
 
@@ -1257,3 +1259,8 @@ def Test():
     import doctest
     import sys
     print(doctest.testmod(sys.modules[__name__],verbose=True))
+
+## py.test code
+def testCTransactionCopyConstruct():
+    a = CTransaction()
+    b = CTransaction(a)

--- a/qa/rpc-tests/test_framework/script.py
+++ b/qa/rpc-tests/test_framework/script.py
@@ -878,7 +878,7 @@ def FindAndDelete(script, sig):
     return CScript(r)
 
 
-def SignatureHash(script, txTo, inIdx, hashtype):
+def SignatureHashLegacy(script, txTo, inIdx, hashtype):
     """Consensus-correct SignatureHash
 
     Returns (hash, err) to precisely match the consensus-critical behavior of


### PR DESCRIPTION
This mainly adds the new signature hash function to the test framework, as far as I can see we didn't have a python implementation yet.  This code is based on what I used to do the ZCF CDS/-V proof-of-concept.

~~TODO: Code needs (py.)tests.~~
