### PR TITLE
Remove ban if merkle root incorrect for graphene block

### DIFF
--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -144,7 +144,6 @@ bool CGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     {
         graphenedata.ClearGrapheneBlockData(pfrom, inv.hash);
 
-        dosMan.Misbehaving(pfrom, 100);
         return error("Merkle root for %s does not match computed merkle root, peer=%s", inv.hash.ToString(),
             pfrom->GetLogName());
     }


### PR DESCRIPTION
The merkle root could fail because we have an incomplete set of hashes. This
is a problem specific to graphene and doesn not happen in Xthins. Therefore
we must not ban a node for this behaviour in graphene.