### PR TITLE
Optional protocol message checksums

### DIFF
--- a/qa/rpc-tests/test_framework/bunode.py
+++ b/qa/rpc-tests/test_framework/bunode.py
@@ -290,6 +290,7 @@ class BasicBUCashNode():
         protohandler.add_connection(conn)
         protohandler.add_parent(self)
         self.cnxns[id] = protohandler
+        return conn
 
     def on_block(self, frm, message):
         print("got block")

--- a/qa/rpc-tests/test_framework/nodemessages.py
+++ b/qa/rpc-tests/test_framework/nodemessages.py
@@ -906,6 +906,8 @@ class msg_xversion(object):
         res = CompactSize(len(self.xver)).serialize()
         for k, v in self.xver.items():
             res += CompactSize(k).serialize()
+            if type(v) is int:  # serialize integers in compact format inside the vector
+                v = CompactSize(v).serialize()
             res += CompactSize(len(v)).serialize()
             res += v
         return res

--- a/qa/rpc-tests/zerochecksum.py
+++ b/qa/rpc-tests/zerochecksum.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2018 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+import test_framework.loginit
+import os
+import os.path
+import time
+import sys
+if sys.version_info[0] < 3:
+    raise "Use Python 3"
+import logging
+from binascii import unhexlify
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.mininode import NetworkThread
+from test_framework.nodemessages import *
+from test_framework.bumessages import *
+from test_framework.bunode import BasicBUCashNode, BUProtocolHandler
+
+class NodeProtoHandler(BUProtocolHandler):
+    def __init__(self):
+        self.remote_xversion = None
+        self.pong_received = 0
+        BUProtocolHandler.__init__(self)
+
+    def on_version(self, conn, message):
+        self.show_debug_msg("version received\n")
+        self.remoteVersion = message.nVersion
+
+    def on_verack(self, conn, message):
+        self.show_debug_msg("verack received\n")
+        self.verack_received = True
+
+    def on_xverack(self, conn, message):
+        self.show_debug_msg("xverack received\n")
+        self.xverack_received = True
+
+    def on_xversion(self, conn, message):
+        self.show_debug_msg("xversion received\n")
+        self.remote_xversion = message
+
+    def on_pong(self, conn, message):
+        self.show_debug_msg("pong received\n")
+        self.pong_received += 1
+
+
+class MyTest(BitcoinTestFramework):
+    def __init__(self):
+        self.nodes = []
+        BitcoinTestFramework.__init__(self)
+
+    def setup_chain(self):
+        pass
+
+    def setup_network(self, split=False):
+        pass
+
+    def restart_node(self, send_initial_version = True):
+        # remove any potential banlist
+        banlist_fn = os.path.join(
+            node_regtest_dir(self.options.tmpdir, 0),
+            "banlist.dat")
+        print("Banlist file name:", banlist_fn)
+        try:
+            os.remove(banlist_fn)
+            print("Removed old banlist %s.")
+        except:
+                pass
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+        print("Initializing test directory " + self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 1)
+        self.nodes = [ start_node(0, self.options.tmpdir, ["-debug"]) ]
+        self.pynode = pynode = BasicBUCashNode()
+
+        self.hndlr = pynode.connect(0, '127.0.0.1', p2p_port(0), self.nodes[0],
+                       protohandler =NodeProtoHandler(),
+                       send_initial_version = send_initial_version)
+        self.hndlr.allow0Checksum = True
+
+        return pynode.cnxns[0]
+
+    def network_and_finish(self):
+        nt = NetworkThread()
+        nt.start()
+        nt.join()
+
+    def run_test(self):
+        logging.info("Testing xversion handling")
+
+        # test regular set up including xversion
+        conn = self.restart_node()
+        conn.allow0Checksum = True
+        nt = NetworkThread()
+        nt.start()
+
+        conn.wait_for_verack()
+        conn.send_message(msg_verack())
+
+        # now it is time for xversion
+        conn.send_message(msg_xversion({0x00020002 : 1}))
+
+        # send extra buversion and buverack, shouldn't harm
+        conn.send_message(msg_buversion(addrFromPort = 12345))
+        conn.send_message(msg_buverack())
+        conn.wait_for(lambda : conn.remote_xversion)
+
+        conn.send_message(msg_ping())
+        conn.wait_for(lambda : conn.pong_received)
+        # check that we are getting 0-value checksums from the BU node
+        assert(self.hndlr.num0Checksums > 0)
+
+        conn.connection.disconnect_node()
+        nt.join()
+
+if __name__ == '__main__':
+    xvt = MyTest()
+    xvt.main()
+
+# Create a convenient function for an interactive python debugging session
+def Test():
+    t = MyTest()
+    bitcoinConf = {
+        "debug": ["blk", "mempool", "net", "req"],
+        "blockprioritysize": 2000000,  # we don't want any transactions rejected due to insufficient fees...
+        "net.ignoreTimeouts": 1,
+        "logtimemicros": 1
+    }
+
+    # you may want these flags:
+    flags = ["--nocleanup", "--noshutdown"]
+
+    # Execution is much faster if a ramdisk is used, so use it if one exists in a typical location
+    if os.path.isdir("/ramdisk/test"):
+        flags.append("--tmpdir=/ramdisk/test/ma")
+
+    # Out-of-source builds are awkward to start because they need an additional flag
+    # automatically add this flag during testing for common out-of-source locations
+    binpath = findBitcoind()
+    flags.append("--srcdir=%s" % binpath)
+    # start the test
+    t.main(flags, bitcoinConf, None)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1216,7 +1216,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         // if it comes at all.
         CXVersionMessage xver;
         xver.set_u64c(XVer::BU_LISTEN_PORT, GetListenPort());
-        xver.set_u64c(XVer::BU_MSG_CHECKSUM, 1); // we will ignore 0 value msg checksums
+        xver.set_u64c(XVer::BU_MSG_IGNORE_CHECKSUM, 1); // we will ignore 0 value msg checksums
         pfrom->PushMessage(NetMsgType::XVERSION, xver);
 
 
@@ -1294,7 +1294,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                 ConnectionStateOutgoing::ANY, pfrom))
             return false;
         vRecv >> pfrom->xVersion;
-        pfrom->skipChecksum = (pfrom->xVersion.as_u64c(XVer::BU_MSG_CHECKSUM) == 1);
+        pfrom->skipChecksum = (pfrom->xVersion.as_u64c(XVer::BU_MSG_IGNORE_CHECKSUM) == 1);
         if (pfrom->addrFromPort == 0)
         {
             pfrom->addrFromPort = pfrom->xVersion.as_u64c(XVer::BU_LISTEN_PORT) & 0xffff;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1216,6 +1216,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         // if it comes at all.
         CXVersionMessage xver;
         xver.set_u64c(XVer::BU_LISTEN_PORT, GetListenPort());
+        xver.set_u64c(XVer::BU_MSG_CHECKSUM, 1); // we will ignore 0 value msg checksums
         pfrom->PushMessage(NetMsgType::XVERSION, xver);
 
 
@@ -1293,7 +1294,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                 ConnectionStateOutgoing::ANY, pfrom))
             return false;
         vRecv >> pfrom->xVersion;
-
+        pfrom->skipChecksum = (pfrom->xVersion.as_u64c(XVer::BU_MSG_CHECKSUM) == 1);
         if (pfrom->addrFromPort == 0)
         {
             pfrom->addrFromPort = pfrom->xVersion.as_u64c(XVer::BU_LISTEN_PORT) & 0xffff;
@@ -2545,15 +2546,20 @@ bool ProcessMessages(CNode *pfrom)
         // Message size
         unsigned int nMessageSize = hdr.nMessageSize;
 
-        // Checksum
         CDataStream &vRecv = msg.vRecv;
-        uint256 hash = Hash(vRecv.begin(), vRecv.begin() + nMessageSize);
-        unsigned int nChecksum = ReadLE32((unsigned char *)&hash);
-        if (nChecksum != hdr.nChecksum)
+
+        // Checksum
+        // For optimization a 0 checksum means no checksum calculated -- TCP already has one.
+        if (hdr.nChecksum != 0)
         {
-            LOGA("%s(%s, %u bytes): CHECKSUM ERROR nChecksum=%08x hdr.nChecksum=%08x\n", __func__,
-                SanitizeString(strCommand), nMessageSize, nChecksum, hdr.nChecksum);
-            continue;
+            uint256 hash = Hash(vRecv.begin(), vRecv.begin() + nMessageSize);
+            unsigned int nChecksum = ReadLE32((unsigned char *)&hash);
+            if (nChecksum != hdr.nChecksum)
+            {
+                LOGA("%s(%s, %u bytes): CHECKSUM ERROR nChecksum=%08x hdr.nChecksum=%08x\n", __func__,
+                    SanitizeString(strCommand), nMessageSize, nChecksum, hdr.nChecksum);
+                continue;
+            }
         }
 
         // Process message

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3011,9 +3011,12 @@ void CNode::EndMessage() UNLOCK_FUNCTION(cs_vSend)
     UpdateSendStats(this, currentCommand, nSize + CMessageHeader::HEADER_SIZE, GetTimeMicros());
 
     // Set the checksum
-    uint256 hash = Hash(ssSend.begin() + CMessageHeader::HEADER_SIZE, ssSend.end());
-    unsigned int nChecksum = 0;
-    memcpy(&nChecksum, &hash, sizeof(nChecksum));
+    uint32_t nChecksum = 0; // If we can skip the checksum, we send 0 instead
+    if (!skipChecksum)
+    {
+        uint256 hash = Hash(ssSend.begin() + CMessageHeader::HEADER_SIZE, ssSend.end());
+        memcpy(&nChecksum, &hash, sizeof(nChecksum));
+    }
     assert(ssSend.size() >= CMessageHeader::CHECKSUM_OFFSET + sizeof(nChecksum));
     memcpy((char *)&ssSend[CMessageHeader::CHECKSUM_OFFSET], &nChecksum, sizeof(nChecksum));
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2824,7 +2824,7 @@ bool CAddrDB::Read(CAddrMan &addr, CDataStream &ssPeers)
 unsigned int ReceiveFloodSize() { return 1000 * GetArg("-maxreceivebuffer", DEFAULT_MAXRECEIVEBUFFER); }
 unsigned int SendBufferSize() { return 1000 * GetArg("-maxsendbuffer", DEFAULT_MAXSENDBUFFER); }
 CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNameIn, bool fInboundIn)
-    : ssSend(SER_NETWORK, INIT_PROTO_VERSION), id(connmgr->NextNodeId()), addrKnown(5000, 0.001)
+    : ssSend(SER_NETWORK, INIT_PROTO_VERSION), skipChecksum(false), id(connmgr->NextNodeId()), addrKnown(5000, 0.001)
 {
     nServices = 0;
     hSocket = hSocketIn;

--- a/src/net.h
+++ b/src/net.h
@@ -410,7 +410,7 @@ public:
     CAddress addr;
 
     //! set to true if this node is ok with no message checksum
-    bool skipChecksum = false;
+    bool skipChecksum;
 
     //! The address the remote peer advertised it its version message
     CAddress addrFrom_advertised;

--- a/src/net.h
+++ b/src/net.h
@@ -409,6 +409,9 @@ public:
     int64_t nTimeOffset;
     CAddress addr;
 
+    //! set to true if this node is ok with no message checksum
+    bool skipChecksum = false;
+
     //! The address the remote peer advertised it its version message
     CAddress addrFrom_advertised;
 

--- a/src/xversionkeys.dat
+++ b/src/xversionkeys.dat
@@ -21,6 +21,8 @@
 # this is the listening
 KEY i BU_LISTEN_PORT                            0x0002                   0x0000         u64c
 KEY i BU_GRAPHENE_VERSION_SUPPORTED             0x0002                   0x0001         u64c
+# BU_MSG_CHECKSUM: if 0, use the standard checksum.  If 1, you may send this client messages with the checksum field==0 and the checksum won't be checked (TCP has a checksum)
+KEY i BU_MSG_CHECKSUM                           0x0002                   0x0002         u64c
 # KEY i ABC_...                                0x0000                   ...
 # KEY i XT_DOUBLESPEND_FORWARDING_SCHEME       0x0003                   ...            vector
 # ...

--- a/src/xversionkeys.dat
+++ b/src/xversionkeys.dat
@@ -22,7 +22,7 @@
 KEY i BU_LISTEN_PORT                            0x0002                   0x0000         u64c
 KEY i BU_GRAPHENE_VERSION_SUPPORTED             0x0002                   0x0001         u64c
 # BU_MSG_CHECKSUM: if 0, use the standard checksum.  If 1, you may send this client messages with the checksum field==0 and the checksum won't be checked (TCP has a checksum)
-KEY i BU_MSG_CHECKSUM                           0x0002                   0x0002         u64c
+KEY i BU_MSG_IGNORE_CHECKSUM                    0x0002                   0x0002         u64c
 # KEY i ABC_...                                0x0000                   ...
 # KEY i XT_DOUBLESPEND_FORWARDING_SCHEME       0x0003                   ...            vector
 # ...


### PR DESCRIPTION
Allow BU nodes to pass xversion config to drop checksums from passed messages.  These checksums inefficient and are not necessary for several reasons -- TCP already has message checksums, for one.