### PR TITLE
Optimization 2

### DIFF
--- a/qa/rpc-tests/parallel.py
+++ b/qa/rpc-tests/parallel.py
@@ -1125,7 +1125,7 @@ def Test():
 
     # Execution is much faster if a ramdisk is used, so use it if one exists in a typical location
     if os.path.isdir("/ramdisk/test"):
-        flags.append("--tmppfx=/ramdisk/test")
+        flags.append("--tmpdir=/ramdisk/test/t")
 
     # Out-of-source builds are awkward to start because they need an additional flag
     # automatically add this flag during testing for common out-of-source locations

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1534,7 +1534,7 @@ CMemPoolInfo GetGrapheneMempoolInfo()
     uint64_t nCommitQ = 0;
     {
         boost::unique_lock<boost::mutex> lock(csCommitQ);
-        nCommitQ = txCommitQ.size();
+        nCommitQ = txCommitQ->size();
     }
     return CMemPoolInfo(mempool.size() + orphanpool.GetOrphanPoolSize() + nCommitQ);
 }

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -1862,7 +1862,7 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
     // Also add all the transaction hashes currently in the txCommitQ
     {
         boost::unique_lock<boost::mutex> lock(csCommitQ);
-        for (auto &it : txCommitQ)
+        for (auto &it : *txCommitQ)
         {
             setHighScoreMemPoolHashes.insert(it.first);
         }

--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -70,6 +70,7 @@ int GetTotalBlocksEstimate(const CCheckpointData &data)
 
 CBlockIndex *GetLastCheckpoint(const CCheckpointData &data)
 {
+    AssertLockHeld(cs_main); // for mapBlockIndex
     const MapCheckpoints &checkpoints = data.mapCheckpoints;
     for (auto i = checkpoints.rbegin(); i != checkpoints.rend(); i++)
     {

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -233,7 +233,7 @@ std::queue<CTxInputData> txWaitNextBlockQ GUARDED_BY(csTxInQ);
 // Transactions that have been validated and are waiting to be committed into the mempool
 CWaitableCriticalSection csCommitQ;
 CConditionVariable cvCommitQ GUARDED_BY(csCommitQ);
-std::map<uint256, CTxCommitData> txCommitQ;
+std::map<uint256, CTxCommitData> *txCommitQ = nullptr;
 
 // Control the execution of the parallel tx validation and serial mempool commit phases
 CThreadCorral txProcessingCorral;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1058,6 +1058,7 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
     LOGA("* Using %.1fMiB for in-memory UTXO set\n", nCoinCacheMaxSize * (1.0 / 1024 / 1024));
 
     bool fLoaded = false;
+    StartTxAdmission(threadGroup);
     while (!fLoaded)
     {
         bool fReset = fReindex;
@@ -1262,6 +1263,7 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
 
     uiInterface.InitMessage(_("Activating best chain..."));
     // scan for better chains in the block chain database, that are not yet connected in the active best chain
+
     CValidationState state;
     if (!ActivateBestChain(state, chainparams))
     {
@@ -1486,7 +1488,6 @@ bool AppInit2(Config &config, boost::thread_group &threadGroup, CScheduler &sche
     if (GetBoolArg("-listenonion", DEFAULT_LISTEN_ONION))
         StartTorControl(threadGroup, scheduler);
 
-    StartTxAdmission(threadGroup);
     StartNode(threadGroup, scheduler);
 
 // Monitor the chain, and alert if we get blocks much quicker or slower than expected

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -135,14 +135,11 @@ int nLastBlockFile = 0;
 
 namespace
 {
-int GetHeight()
+int GetHeight() { return chainActive.Height(); }
+void UpdatePreferredDownload(CNode *node)
 {
-    LOCK(cs_main);
-    return chainActive.Height();
-}
-
-void UpdatePreferredDownload(CNode *node, CNodeState *state)
-{
+    CNodeStateAccessor state(nodestate, node->GetId());
+    DbgAssert(state != nullptr, return );
     nPreferredDownload.fetch_sub(state->fPreferredDownload);
 
     // Whether this node should be marked as a preferred download node.
@@ -168,13 +165,17 @@ void InitializeNode(const CNode *pnode)
 
 void FinalizeNode(NodeId nodeid)
 {
+    {
+        CNodeStateAccessor state(nodestate, nodeid);
+        DbgAssert(state != nullptr, return );
+
+        if (state->fSyncStarted)
+            nSyncStarted--;
+
+        nPreferredDownload.fetch_sub(state->fPreferredDownload);
+    }
+
     LOCK(cs_main);
-    CNodeState *state = nodestate.State(nodeid);
-    DbgAssert(state != nullptr, return );
-
-    if (state->fSyncStarted)
-        nSyncStarted--;
-
     std::vector<uint256> vBlocksInFlight;
     requester.GetBlocksInFlight(vBlocksInFlight, nodeid);
     for (const uint256 &hash : vBlocksInFlight)
@@ -185,7 +186,6 @@ void FinalizeNode(NodeId nodeid)
         // Reset all requests times to zero so that we can immediately re-request these blocks
         requester.ResetLastBlockRequestTime(hash);
     }
-    nPreferredDownload.fetch_sub(state->fPreferredDownload);
 
     nodestate.RemoveNodeState(nodeid);
     requester.RemoveNodeState(nodeid);
@@ -198,7 +198,7 @@ void FinalizeNode(NodeId nodeid)
 }
 
 // Requires cs_main
-bool PeerHasHeader(CNodeState *state, CBlockIndex *pindex)
+bool PeerHasHeader(const CNodeState *state, CBlockIndex *pindex)
 {
     if (pindex == nullptr)
         return false;
@@ -223,8 +223,7 @@ bool GetNodeStateStats(NodeId nodeid, CNodeStateStats &stats)
     if (!node)
         return false;
 
-    LOCK(cs_main);
-    CNodeState *state = nodestate.State(nodeid);
+    CNodeStateAccessor state(nodestate, nodeid);
     DbgAssert(state != nullptr, return false);
 
     stats.nMisbehavior = node->nMisbehavior;
@@ -963,9 +962,9 @@ static bool BasicThinblockChecks(CNode *pfrom, const CChainParams &chainparams)
     // If they make more than 20 requests in 10 minutes then disconnect them
     if (Params().NetworkIDString() != "regtest")
     {
-        if (pfrom->nGetXthinLastTime <= 0)
-            pfrom->nGetXthinLastTime = GetTime();
         uint64_t nNow = GetTime();
+        if (pfrom->nGetXthinLastTime <= 0)
+            pfrom->nGetXthinLastTime = nNow;
         double tmp = pfrom->nGetXthinCount;
         while (!pfrom->nGetXthinCount.compare_exchange_weak(
             tmp, (tmp * std::pow(1.0 - 1.0 / 600.0, (double)(nNow - pfrom->nGetXthinLastTime)) + 1)))
@@ -1159,7 +1158,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         pfrom->fClient = !(pfrom->nServices & NODE_NETWORK);
 
         // Potentially mark this peer as a preferred download peer.
-        UpdatePreferredDownload(pfrom, nodestate.State(pfrom->GetId()));
+        UpdatePreferredDownload(pfrom);
 
         // Send VERACK handshake message
         pfrom->PushMessage(NetMsgType::VERACK);
@@ -1402,8 +1401,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
 
     else if (strCommand == NetMsgType::SENDHEADERS)
     {
-        LOCK(cs_main);
-        nodestate.State(pfrom->GetId())->fPreferHeaders = true;
+        CNodeStateAccessor(nodestate, pfrom->GetId())->fPreferHeaders = true;
     }
 
     // Processing this message type for statistics purposes only, BU currently doesn't support CB protocol
@@ -1626,8 +1624,8 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         uint256 hashStop;
         vRecv >> locator >> hashStop;
 
-        LOCK(cs_main);
-        CNodeState *state = nodestate.State(pfrom->GetId());
+        LOCK(cs_main); // for mapBlockIndex and chainActive
+        CNodeStateAccessor state(nodestate, pfrom->GetId());
         CBlockIndex *pindex = nullptr;
         if (locator.IsNull())
         {
@@ -1862,10 +1860,11 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             pfrom->PushMessage(NetMsgType::GETHEADERS, chainActive.GetLocator(pindexLast), uint256());
 
             {
-                CNodeState *state = nodestate.State(pfrom->GetId());
+                int64_t now = GetTime();
+                CNodeStateAccessor state(nodestate, pfrom->GetId());
                 DbgAssert(state != nullptr, );
-                if (state)
-                    state->nSyncStartTime = GetTime(); // reset the time because more headers needed
+                if (state != nullptr)
+                    state->nSyncStartTime = now; // reset the time because more headers needed
             }
 
             // During the process of IBD we need to update block availability for every connected peer. To do that we
@@ -1890,14 +1889,18 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                 {
                     if (!pnode->fClient && pnode != pfrom)
                     {
-                        LOCK(cs_main);
-                        CNodeState *state = nodestate.State(pfrom->GetId());
-                        DbgAssert(state != nullptr, ); // do not return, we need to release refs later.
-                        if (state == nullptr)
-                            continue;
+                        bool ask = false;
+                        {
+                            CNodeStateAccessor state(nodestate, pfrom->GetId());
+                            DbgAssert(state != nullptr, ); // do not return, we need to release refs later.
+                            if (state == nullptr)
+                                continue;
 
-                        if (state->pindexBestKnownBlock == nullptr ||
-                            pindexLast->nChainWork > state->pindexBestKnownBlock->nChainWork)
+                            ask = (state->pindexBestKnownBlock == nullptr ||
+                                   pindexLast->nChainWork > state->pindexBestKnownBlock->nChainWork);
+                        } // let go of the CNodeState lock before we PushMessage since that is trapping op.
+
+                        if (ask)
                         {
                             // We only want one single header so we pass a null for CBlockLocator.
                             pnode->PushMessage(NetMsgType::GETHEADERS, CBlockLocator(), pindexLast->GetBlockHash());
@@ -1915,26 +1918,30 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         }
 
         bool fCanDirectFetch = CanDirectFetch(chainparams.GetConsensus());
-        CNodeState *state = nodestate.State(pfrom->GetId());
-        DbgAssert(state != nullptr, return false);
 
-        // During the initial peer handshake we must receive the initial headers which should be greater
-        // than or equal to our block height at the time of requesting GETHEADERS. This is because the peer has
-        // advertised a height >= to our own. Furthermore, because the headers max returned is as much as 2000 this
-        // could not be a mainnet re-org.
-        if (!state->fFirstHeadersReceived)
         {
-            // We want to make sure that the peer doesn't just send us any old valid header. The block height of the
-            // last header they send us should be equal to our block height at the time we made the GETHEADERS request.
-            if (pindexLast && state->nFirstHeadersExpectedHeight <= pindexLast->nHeight)
-            {
-                state->fFirstHeadersReceived = true;
-                LOG(NET, "Initial headers received for peer=%s\n", pfrom->GetLogName());
-            }
+            CNodeStateAccessor state(nodestate, pfrom->GetId());
+            DbgAssert(state != nullptr, return false);
 
-            // Allow for very large reorgs (> 2000 blocks) on the nol test chain or other test net.
-            if (Params().NetworkIDString() != "main" && Params().NetworkIDString() != "regtest")
-                state->fFirstHeadersReceived = true;
+            // During the initial peer handshake we must receive the initial headers which should be greater
+            // than or equal to our block height at the time of requesting GETHEADERS. This is because the peer has
+            // advertised a height >= to our own. Furthermore, because the headers max returned is as much as 2000 this
+            // could not be a mainnet re-org.
+            if (!state->fFirstHeadersReceived)
+            {
+                // We want to make sure that the peer doesn't just send us any old valid header. The block height of the
+                // last header they send us should be equal to our block height at the time we made the GETHEADERS
+                // request.
+                if (pindexLast && state->nFirstHeadersExpectedHeight <= pindexLast->nHeight)
+                {
+                    state->fFirstHeadersReceived = true;
+                    LOG(NET, "Initial headers received for peer=%s\n", pfrom->GetLogName());
+                }
+
+                // Allow for very large reorgs (> 2000 blocks) on the nol test chain or other test net.
+                if (Params().NetworkIDString() != "main" && Params().NetworkIDString() != "regtest")
+                    state->fFirstHeadersReceived = true;
+            }
         }
 
         // update the syncd status.  This should come before we make calls to requester.AskFor().
@@ -2138,12 +2145,12 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                 SendExpeditedBlock(*pblock, pfrom);
         }
 
-        {
-            LOCK(cs_main);
-            CNodeState *state = nodestate.State(pfrom->GetId());
+        { // reset the getheaders time because block can consume all bandwidth
+            int64_t now = GetTime();
+            CNodeStateAccessor state(nodestate, pfrom->GetId());
             DbgAssert(state != nullptr, );
-            if (state)
-                state->nSyncStartTime = GetTime(); // reset the getheaders time because block can consume all bandwidth
+            if (state != nullptr)
+                state->nSyncStartTime = now; // reset the time because more headers needed
         }
         pfrom->nPingUsecStart = GetTimeMicros(); // Reset ping time because block can consume all bandwidth
 
@@ -2760,10 +2767,15 @@ bool SendMessages(CNode *pto)
                 pto->PushMessage(NetMsgType::ADDR, vAddr);
         }
 
-        CNodeState *state = nodestate.State(pto->GetId());
-        if (state == nullptr)
+        CNodeState statem(CAddress(), "");
+        const CNodeState *state = &statem;
         {
-            return true;
+            CNodeStateAccessor stateAccess(nodestate, pto->GetId());
+            if (state == nullptr)
+            {
+                return true;
+            }
+            statem = *stateAccess;
         }
 
         // If a sync has been started check whether we received the first batch of headers requested within the timeout
@@ -2805,10 +2817,11 @@ bool SendMessages(CNode *pto)
                 // BU Bug fix for Core:  Don't start downloading headers unless our chain is shorter
                 if (pindexStart->nHeight < pto->nStartingHeight)
                 {
-                    state->fSyncStarted = true;
-                    state->nSyncStartTime = GetTime();
-                    state->fRequestedInitialBlockAvailability = true;
-                    state->nFirstHeadersExpectedHeight = pindexStart->nHeight;
+                    CNodeStateAccessor modableState(nodestate, pto->GetId());
+                    modableState->fSyncStarted = true;
+                    modableState->nSyncStartTime = GetTime();
+                    modableState->fRequestedInitialBlockAvailability = true;
+                    modableState->nFirstHeadersExpectedHeight = pindexStart->nHeight;
                     nSyncStarted++;
 
                     if (pto->fClient)
@@ -2830,7 +2843,7 @@ bool SendMessages(CNode *pto)
         {
             if (!pto->fClient)
             {
-                state->fRequestedInitialBlockAvailability = true;
+                CNodeStateAccessor(nodestate, pto->GetId())->fRequestedInitialBlockAvailability = true;
 
                 // We only want one single header so we pass a null CBlockLocator.
                 pto->PushMessage(NetMsgType::GETHEADERS, CBlockLocator(), pindexBestHeader.load()->GetBlockHash());
@@ -2870,7 +2883,10 @@ bool SendMessages(CNode *pto)
             std::vector<CBlock> vHeaders;
             bool fRevertToInv = (!state->fPreferHeaders || pto->vBlockHashesToAnnounce.size() > MAX_BLOCKS_TO_ANNOUNCE);
             CBlockIndex *pBestIndex = nullptr; // last header queued for delivery
-            requester.ProcessBlockAvailability(pto->id); // ensure pindexBestKnownBlock is up-to-date
+            {
+                LOCK(cs_main);
+                requester.ProcessBlockAvailability(pto->id); // ensure pindexBestKnownBlock is up-to-date
+            }
 
             if (!fRevertToInv)
             {
@@ -2989,9 +3005,11 @@ bool SendMessages(CNode *pto)
                     LOG(NET, "%s: sending header %s to peer=%d\n", __func__, vHeaders.front().GetHash().ToString(),
                         pto->id);
                 }
-                LOCK(pto->cs_vSend);
-                pto->PushMessage(NetMsgType::HEADERS, vHeaders);
-                state->pindexBestHeaderSent = pBestIndex;
+                {
+                    LOCK(pto->cs_vSend);
+                    pto->PushMessage(NetMsgType::HEADERS, vHeaders);
+                }
+                CNodeStateAccessor(nodestate, pto->GetId())->pindexBestHeaderSent = pBestIndex;
             }
         }
 
@@ -3056,9 +3074,16 @@ bool SendMessages(CNode *pto)
             }
         }
 
-        // Request the next blocks. Mostly this will get exucuted during IBD but sometimes even
-        // when the chain is syncd a block will get request via this method.
-        requester.RequestNextBlocksToDownload(pto);
+        {
+            TRY_LOCK(cs_main, locked);
+            static int rarely = 0;
+            if (locked && ((++rarely) & 7) == 0)
+            { // I don't need to deal w/ blocks as often as tx and this is time consuming
+                // Request the next blocks. Mostly this will get executed during IBD but sometimes even
+                // when the chain is syncd a block will get request via this method.
+                requester.RequestNextBlocksToDownload(pto);
+            }
+        }
     }
     return true;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3076,8 +3076,7 @@ bool SendMessages(CNode *pto)
 
         {
             TRY_LOCK(cs_main, locked);
-            static int rarely = 0;
-            if (locked && ((++rarely) & 7) == 0)
+            if (locked)
             { // I don't need to deal w/ blocks as often as tx and this is time consuming
                 // Request the next blocks. Mostly this will get executed during IBD but sometimes even
                 // when the chain is syncd a block will get request via this method.

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -31,9 +31,8 @@ CNodeState::CNodeState(CAddress addrIn, std::string addrNameIn) : address(addrIn
 * @param[in] pnode  The NodeId to return CNodeState* for
 * @return CNodeState* matching the NodeId, or nullptr if NodeId is not matched
 */
-CNodeState *CState::State(const NodeId id)
+CNodeState *CState::_GetNodeState(const NodeId id)
 {
-    LOCK(cs_main);
     std::map<NodeId, CNodeState>::iterator it = mapNodeState.find(id);
     if (it == mapNodeState.end())
         return nullptr;
@@ -48,7 +47,7 @@ CNodeState *CState::State(const NodeId id)
 */
 void CState::InitializeNodeState(const CNode *pnode)
 {
-    LOCK(cs_main);
+    LOCK(cs);
     mapNodeState.emplace_hint(mapNodeState.end(), std::piecewise_construct, std::forward_as_tuple(pnode->GetId()),
         std::forward_as_tuple(pnode->addr, pnode->addrName));
 }
@@ -61,6 +60,6 @@ void CState::InitializeNodeState(const CNode *pnode)
 */
 void CState::RemoveNodeState(const NodeId id)
 {
-    LOCK(cs_main);
+    LOCK(cs);
     mapNodeState.erase(id);
 }

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -90,7 +90,7 @@ CRequestManagerNodeState::CRequestManagerNodeState()
 CRequestManager::CRequestManager()
     : inFlightTxns("reqMgr/inFlight", STAT_OP_MAX), receivedTxns("reqMgr/received"), rejectedTxns("reqMgr/rejected"),
       droppedTxns("reqMgr/dropped", STAT_KEEP), pendingTxns("reqMgr/pending", STAT_KEEP),
-      requestPacer(512, 256) // Max and average # of requests that can be made per second
+      requestPacer(10000, 5000) // Max and average # of requests that can be made per second
 {
     inFlight = 0;
     nOutbound = 0;
@@ -235,7 +235,7 @@ void CRequestManager::AskForDuringIBD(const std::vector<CInv> &objArray, CNode *
         ProcessBlockAvailability(pnode->id);
 
         // check block availability for this peer and only askfor a block if it is available.
-        CNodeState *state = nodestate.State(pnode->id);
+        CNodeStateAccessor state(nodestate, pnode->id);
         if (state != nullptr)
         {
             if (state->pindexBestKnownBlock != nullptr &&
@@ -969,9 +969,9 @@ void CRequestManager::SendRequests()
 // Check whether the last unknown block a peer advertised is not yet known.
 void CRequestManager::ProcessBlockAvailability(NodeId nodeid)
 {
-    LOCK(cs_main); // TODO fine grained lock around mapBlockIndex
+    AssertLockHeld(cs_main); // TODO fine grained lock around mapBlockIndex
 
-    CNodeState *state = nodestate.State(nodeid);
+    CNodeStateAccessor state(nodestate, nodeid);
     DbgAssert(state != nullptr, return );
 
     if (!state->hashLastUnknownBlock.IsNull())
@@ -992,9 +992,9 @@ void CRequestManager::ProcessBlockAvailability(NodeId nodeid)
 // Update tracking information about which blocks a peer is assumed to have.
 void CRequestManager::UpdateBlockAvailability(NodeId nodeid, const uint256 &hash)
 {
-    AssertLockHeld(cs_main);
+    AssertLockHeld(cs_main); // mapBlockIndex
 
-    CNodeState *state = nodestate.State(nodeid);
+    CNodeStateAccessor state(nodestate, nodeid);
     DbgAssert(state != nullptr, return );
 
     ProcessBlockAvailability(nodeid);
@@ -1054,11 +1054,13 @@ void CRequestManager::FindNextBlocksToDownload(CNode *node, unsigned int count, 
 
     NodeId nodeid = node->GetId();
     vBlocks.reserve(vBlocks.size() + count);
-    CNodeState *state = nodestate.State(nodeid);
-    DbgAssert(state != nullptr, return );
 
     // Make sure pindexBestKnownBlock is up to date, we'll need it.
+    LOCK(cs_main);
     ProcessBlockAvailability(nodeid);
+
+    CNodeStateAccessor state(nodestate, nodeid);
+    DbgAssert(state != nullptr, return );
 
     if (state->pindexBestKnownBlock == nullptr ||
         state->pindexBestKnownBlock->nChainWork < chainActive.Tip()->nChainWork)
@@ -1067,7 +1069,6 @@ void CRequestManager::FindNextBlocksToDownload(CNode *node, unsigned int count, 
         return;
     }
 
-    LOCK(cs_main);
 
     if (state->pindexLastCommonBlock == nullptr)
     {

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -21,6 +21,7 @@
 #include "rpc/register.h"
 #include "rpc/server.h"
 #include "test/testutil.h"
+#include "txadmission.h"
 #include "txdb.h"
 #include "txmempool.h"
 #include "ui_interface.h"
@@ -62,6 +63,7 @@ TestingSetup::TestingSetup(const std::string &chainName) : BasicTestingSetup(cha
     pblocktree = new CBlockTreeDB(1 << 20, "", true);
     pcoinsdbview = new CCoinsViewDB(1 << 23, true);
     pcoinsTip = new CCoinsViewCache(pcoinsdbview);
+    txCommitQ = new std::map<uint256, CTxCommitData>();
     bool worked = InitBlockIndex(chainparams);
     assert(worked);
 

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -40,8 +40,8 @@ void ProcessOrphans(std::vector<uint256> &vWorkQueue);
 CTransactionRef CommitQGet(uint256 hash)
 {
     boost::unique_lock<boost::mutex> lock(csCommitQ);
-    std::map<uint256, CTxCommitData>::iterator it = txCommitQ.find(hash);
-    if (it == txCommitQ.end())
+    std::map<uint256, CTxCommitData>::iterator it = txCommitQ->find(hash);
+    if (it == txCommitQ->end())
         return nullptr;
     return it->second.entry.GetSharedTx();
 }
@@ -63,6 +63,9 @@ static inline uint256 IncomingConflictHash(const COutPoint &prevout)
 
 void StartTxAdmission(boost::thread_group &threadGroup)
 {
+    if (txCommitQ == nullptr)
+        txCommitQ = new std::map<uint256, CTxCommitData>();
+
     txHandlerSnap.Load(); // Get an initial view for the transaction processors
 
     // Start incoming transaction processing threads
@@ -102,7 +105,7 @@ void FlushTxAdmission()
             do // wait for the commit thread to commit everything
             {
                 cvCommitQ.timed_wait(lock, boost::posix_time::milliseconds(100));
-            } while (!txCommitQ.empty());
+            } while (!txCommitQ->empty());
         }
 
         { // block everything and check
@@ -113,7 +116,7 @@ void FlushTxAdmission()
             }
             {
                 boost::unique_lock<boost::mutex> lock(csCommitQ);
-                empty &= txCommitQ.empty();
+                empty &= txCommitQ->empty();
             }
         }
     }
@@ -167,8 +170,8 @@ unsigned int TxAlreadyHave(const CInv &inv)
             return 2;
         {
             boost::unique_lock<boost::mutex> lock(csCommitQ);
-            const auto &elem = txCommitQ.find(inv.hash);
-            if (elem != txCommitQ.end())
+            const auto &elem = txCommitQ->find(inv.hash);
+            if (elem != txCommitQ->end())
             {
                 return 5;
             }
@@ -192,25 +195,32 @@ void ThreadCommitToMempool()
             do
             {
                 cvCommitQ.timed_wait(lock, boost::posix_time::milliseconds(2000));
-            } while (txCommitQ.empty() && txDeferQ.empty());
+            } while (txCommitQ->empty() && txDeferQ.empty());
         }
 
         {
             boost::this_thread::interruption_point();
 
             CORRAL(txProcessingCorral, CORRAL_TX_COMMITMENT);
-            LOCK(cs_main);
-            CommitTxToMempool();
-            mempool.check(pcoinsTip);
-            LOG(MEMPOOL, "MemoryPool sz %u txn, %u kB\n", mempool.size(), mempool.DynamicMemoryUsage() / 1000);
-            LimitMempoolSize(mempool, GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000,
-                GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60);
+            {
+                LOCK(cs_main);
+                CommitTxToMempool();
+                LOG(MEMPOOL, "MemoryPool sz %u txn, %u kB\n", mempool.size(), mempool.DynamicMemoryUsage() / 1000);
+                LimitMempoolSize(mempool, GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000,
+                    GetArg("-mempoolexpiry", DEFAULT_MEMPOOL_EXPIRY) * 60 * 60);
 
-            CValidationState state;
-            FlushStateToDisk(state, FLUSH_STATE_PERIODIC);
-            // The flush to disk above is only periodic therefore we need to continuously trim any excess from the
-            // cache.
-            pcoinsTip->Trim(nCoinCacheMaxSize);
+                CValidationState state;
+                FlushStateToDisk(state, FLUSH_STATE_PERIODIC);
+                // The flush to disk above is only periodic therefore we need to continuously trim any excess from the
+                // cache.
+                pcoinsTip->Trim(nCoinCacheMaxSize);
+            }
+
+            // CheckInputs needs cs_main (for static int GetSpendHeight(const CCoinsViewCache &inputs)), but it has
+            // improper order with mempool so skip assert until cs_main dependency removed
+            // LOCK(cs_main);
+
+            mempool.check(pcoinsTip);
         }
     }
 }
@@ -233,33 +243,45 @@ void LimitMempoolSize(CTxMemPool &pool, size_t limit, unsigned long age)
 void CommitTxToMempool()
 {
     std::vector<uint256> vWhatChanged;
+    std::map<uint256, CTxCommitData> *q;
     {
+        boost::unique_lock<boost::mutex> lock(csCommitQ);
+        LOG(MEMPOOL, "txadmission committing %d tx\n", txCommitQ->size());
+        q = txCommitQ;
+        txCommitQ = new std::map<uint256, CTxCommitData>();
+    }
+
+    // These transactions have already been validated so store them directly into the mempool.
+    for (auto &it : *q)
+    {
+        CTxCommitData &data = it.second;
+        mempool.addUnchecked(it.first, data.entry, !IsInitialBlockDownload());
+        vWhatChanged.push_back(data.hash);
+        // Update txn per second only when a txn is valid and accepted to the mempool
+        mempool.UpdateTransactionsPerSecond();
+
+        // Indicate that this tx was fully processed/accepted and can now be removed from the
+        // request manager.
+        CInv inv(MSG_TX, data.hash);
+        requester.Received(inv, nullptr);
+    }
+
 #ifdef ENABLE_WALLET
+    {
         // cs_main is taken again in SyncWithWallets but must be locked before csCommitQ
         // to maintain correct locking order.
         LOCK(cs_main);
-#endif
-        boost::unique_lock<boost::mutex> lock(csCommitQ);
-        LOG(MEMPOOL, "txadmission committing %d tx\n", txCommitQ.size());
-        for (auto &it : txCommitQ)
-        {
-            // This transaction has already been validated so store it directly into the mempool.
-            CTxCommitData &data = it.second;
-            mempool.addUnchecked(it.first, data.entry, !IsInitialBlockDownload());
-#ifdef ENABLE_WALLET
-            SyncWithWallets(data.entry.GetSharedTx(), nullptr, -1);
-#endif
-            vWhatChanged.push_back(data.hash);
-            // Update txn per second only when a txn is valid and accepted to the mempool
-            mempool.UpdateTransactionsPerSecond();
 
-            // Indicate that this tx was fully processed/accepted and can now be removed from the
-            // request manager.
-            CInv inv(MSG_TX, data.hash);
-            requester.Received(inv, nullptr);
+        for (auto &it : *q)
+        {
+            CTxCommitData &data = it.second;
+            SyncWithWallets(data.entry.GetSharedTx(), nullptr, -1);
         }
-        txCommitQ.clear();
     }
+#endif
+    q->clear();
+    delete q;
+
 
     std::map<uint256, CTxInputData> mapWasDeferred;
     {
@@ -934,7 +956,7 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
 
         {
             boost::unique_lock<boost::mutex> lock(csCommitQ);
-            txCommitQ[eData.hash] = eData;
+            (*txCommitQ)[eData.hash] = eData;
         }
     }
     uint64_t interval = (GetStopwatch() - start) / 1000;

--- a/src/txadmission.h
+++ b/src/txadmission.h
@@ -122,7 +122,7 @@ extern std::queue<CTxInputData> txWaitNextBlockQ;
 // Transactions that are validated and can be committed to the mempool, and protection
 extern CWaitableCriticalSection csCommitQ;
 extern CConditionVariable cvCommitQ;
-extern std::map<uint256, CTxCommitData> txCommitQ;
+extern std::map<uint256, CTxCommitData> *txCommitQ;
 
 // returns a transaction ref, if it exists in the commitQ
 CTransactionRef CommitQGet(uint256 hash);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -850,7 +850,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
     uint64_t checkTotal = 0;
     uint64_t innerUsage = 0;
 
-    WRITELOCK(cs);
+    READLOCK(cs);
     LOG(MEMPOOL, "Checking mempool with %u transactions and %u inputs\n", (unsigned int)mapTx.size(),
         (unsigned int)mapNextTx.size());
 
@@ -944,7 +944,9 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         {
             CValidationState state;
             // Use the largest maxOps since this code is not meant to validate that constraint
-            assert(CheckInputs(tx, state, mempoolDuplicate, false, 0, SV_MAX_OPS_PER_SCRIPT, false, NULL));
+            // takes cs_main so comment out for now
+            // TODO: put back when not taking main:
+            // assert(CheckInputs(tx, state, mempoolDuplicate, false, 0, SV_MAX_OPS_PER_SCRIPT, false, NULL));
             UpdateCoins(tx, state, mempoolDuplicate, 1000000);
         }
     }

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -2133,7 +2133,7 @@ extern std::map<std::pair<void *, void *>, LockStack> lockorders;
 extern std::vector<std::string> vUseDNSSeeds;
 extern std::list<CNode *> vNodesDisconnected;
 extern std::set<CNetAddr> setservAddNodeAddresses;
-extern std::map<uint256, CTxCommitData> txCommitQ;
+extern std::map<uint256, CTxCommitData> *txCommitQ;
 extern std::queue<CTxInputData> txDeferQ;
 extern std::queue<CTxInputData> txInQ;
 extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
@@ -2195,7 +2195,8 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
     ret.push_back(Pair("xpeditedBlkUp", (uint64_t)nExpeditedUpstream));
     ret.push_back(Pair("xpeditedTxn", (uint64_t)nExpeditedTxs));
 
-    ret.push_back(Pair("txCommitQ", (uint64_t)txCommitQ.size()));
+    if (txCommitQ)
+        ret.push_back(Pair("txCommitQ", (uint64_t)txCommitQ->size()));
     ret.push_back(Pair("txInQ", (uint64_t)txInQ.size()));
     ret.push_back(Pair("txDeferQ", (uint64_t)txDeferQ.size()));
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -877,7 +877,6 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
  */
 bool CWallet::AddToWalletIfInvolvingMe(const CTransactionRef &ptx, const CBlock *pblock, bool fUpdate, int txIndex)
 {
-    AssertLockHeld(cs_main);
     AssertLockHeld(cs_wallet);
 
     if (pblock)


### PR DESCRIPTION
This PR is built on top of #1484.

Remove cs_main locking around nodestate (replace with finer grained lock).  Make txCommitQ a pointer so that it can be efficiently swapped out.  Allow requestManager to make 10k burst and 5k sustained requests per second.