### PR TITLE
Temporarily disable win32 cross compilation and unit tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,10 +60,10 @@ matrix:
         - CXX=g++ CC=gcc
         - HOST=arm-linux-gnueabihf PACKAGES="g++-arm-linux-gnueabihf" DEP_OPTS="NO_QT=1" GOAL="install" BITCOIN_CONFIG="--enable-glibc-back-compat --enable-reduce-exports"
     #Win32
-    - compiler: gcc
-      env:
-        - CXX=g++ CC=gcc
-        - HOST=i686-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-i686 wine1.6 bc" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
+    #- compiler: gcc
+    #  env:
+    #    - CXX=g++ CC=gcc
+    #    - HOST=i686-w64-mingw32 DPKG_ADD_ARCH="i386" DEP_OPTS="NO_QT=1" PACKAGES="python3 nsis g++-mingw-w64-i686 wine1.6 bc" RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-reduce-exports"
     #Linux32-bit + dash
     - compiler: gcc
       env:


### PR DESCRIPTION
It has been quite a while that Travis Win32 job is failing
during the "make check" step, which is the one that runs the
unit tests suite. This is seems to be related to some kind
of Travis cache problems. I spent quite a bit of time trying
to fix it with no success.

Taking into consideration that we are soon moving to gitlab
and that win32 is not a very widespread arch, I think that
temporarily disable this job would a good thing to do.

https://travis-ci.org/BitcoinUnlimited/BitcoinUnlimited/jobs/457568239