### PR TITLE
mempool descendant/ancestor tracking

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -856,7 +856,10 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef> &vtx,
             }
             else // an empty txiter should never be part of the parents
             {
-                DbgAssert("tx parents is corrupt!", ready.push(nextTx));
+                DbgAssert("tx parents is corrupt!", {
+                    links->second.parents.clear();
+                    ready.push(nextTx);
+                });
             }
         }
 

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -668,12 +668,12 @@ public:
     /** BU: Every transaction that is accepted into the mempool will call this method to update the current value*/
     void UpdateTransactionsPerSecond();
 
-    unsigned long size()
+    unsigned long size() const
     {
         READLOCK(cs);
         return mapTx.size();
     }
-    unsigned long _size() { return mapTx.size(); }
+    unsigned long _size() const { return mapTx.size(); }
     uint64_t GetTotalTxSize()
     {
         READLOCK(cs);


### PR DESCRIPTION
Fix the way transactions from committed blocks are removed from the mempool