### PR TITLE
Print data directory upon initialization fail

### DIFF
--- a/src/noui.cpp
+++ b/src/noui.cpp
@@ -38,6 +38,7 @@ static bool noui_ThreadSafeMessageBox(const std::string &message, const std::str
     if (!fSecure)
         LOGA("%s: %s\n", strCaption, message);
     fprintf(stderr, "%s: %s\n", strCaption.c_str(), message.c_str());
+    fprintf(stderr, "Data directory: %s\n", GetDataDir().string().c_str());
     return false;
 }
 


### PR DESCRIPTION
This helps to figure out which process exactly is failing when
multiple RPC tests are running, for example. It adds the second line
to output like this:

Error: Unable to start HTTP server. See debug log for details.
Data directory: /home/awemany/bitcoin/building_cache/node0/regtest