### PR TITLE
XVERSION integration test improvement

### DIFF
--- a/contrib/devtools/xversionkeys.py
+++ b/contrib/devtools/xversionkeys.py
@@ -6,6 +6,8 @@
 import time
 from sys import stdin, stdout
 import shlex
+import argparse
+import pickle
 
 valueTypes = ["u64c", "vector"]
 
@@ -105,5 +107,18 @@ namespace XVer
 
 
 if __name__ == "__main__":
-    table = readTable(stdin)
-    writeTableCPPH(stdout, table)
+    parser = argparse.ArgumentParser(description='Process the xversion descriptor file')
+    parser.add_argument('infile', help='Input file (usually xversionkeys.dat)')
+    parser.add_argument('--headerfile', help='Output header file (usually xversionkeys.h)')
+    parser.add_argument('--picklefile', help='Output pickle file with the data from xversionkeys.dat')
+    args = parser.parse_args()
+
+    table = readTable(open(args.infile, "r"))
+
+    if args.headerfile is not None:
+        with open(args.headerfile, "w") as outf:
+            writeTableCPPH(outf, table)
+
+    if args.picklefile is not None:
+        with open(args.picklefile, "wb") as outf:
+            pickle.dump(table, outf)

--- a/qa/rpc-tests/test_framework/.gitignore
+++ b/qa/rpc-tests/test_framework/.gitignore
@@ -1,0 +1,1 @@
+xversion.pickle

--- a/qa/rpc-tests/test_framework/xversion.py
+++ b/qa/rpc-tests/test_framework/xversion.py
@@ -1,0 +1,21 @@
+import pickle
+from os.path import dirname, join
+
+pickle_file = "xversion.pickle"
+
+table = pickle.load(open(join(
+    dirname(__file__), pickle_file),
+                         "rb"))
+
+def assert_in_table(s):
+    if s not in table:
+        raise RuntimeError("Xversion key '%s' is unknown." % s)
+
+def key(s):
+    assert_in_table(s)
+    return ((table[s]['prefix']<<16) +
+            table[s]['suffix'])
+
+def valtype(s):
+    assert_in_table(s)
+    return table[s]['valtype']

--- a/qa/rpc-tests/xversion.py
+++ b/qa/rpc-tests/xversion.py
@@ -17,6 +17,7 @@ from test_framework.mininode import NetworkThread
 from test_framework.nodemessages import *
 from test_framework.bumessages import *
 from test_framework.bunode import BasicBUCashNode, BUProtocolHandler
+from test_framework import xversion
 
 class XVersionTestProtoHandler(BUProtocolHandler):
     def __init__(self):
@@ -118,7 +119,7 @@ class XVersionTest(BitcoinTestFramework):
 
         # test that it contains the BU_LISTEN_PORT (replacement for buversion message)
         # FIXME: use proper constant
-        assert 1<<17 in conn.remote_xversion.xver.keys()
+        assert xversion.key("BU_LISTEN_PORT") in conn.remote_xversion.xver.keys()
 
         # Likewise, check that the remote end got our message
         node = self.nodes[0]

--- a/qa/rpc-tests/zerochecksum.py
+++ b/qa/rpc-tests/zerochecksum.py
@@ -17,6 +17,7 @@ from test_framework.mininode import NetworkThread
 from test_framework.nodemessages import *
 from test_framework.bumessages import *
 from test_framework.bunode import BasicBUCashNode, BUProtocolHandler
+from test_framework import xversion
 
 class NodeProtoHandler(BUProtocolHandler):
     def __init__(self):
@@ -99,7 +100,7 @@ class MyTest(BitcoinTestFramework):
         conn.send_message(msg_verack())
 
         # now it is time for xversion
-        conn.send_message(msg_xversion({0x00020002 : 1}))
+        conn.send_message(msg_xversion({xversion.key("BU_MSG_IGNORE_CHECKSUM") : 1}))
 
         # send extra buversion and buverack, shouldn't harm
         conn.send_message(msg_buversion(addrFromPort = 12345))

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -225,7 +225,12 @@ obj/build.h: FORCE
 libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
 
 xversionkeys.h: FORCE
-	$(PYTHON) $(top_srcdir)/contrib/devtools/xversionkeys.py > $(abs_top_builddir)/src/xversionkeys.h < $(srcdir)/xversionkeys.dat
+	$(PYTHON) $(top_srcdir)/contrib/devtools/xversionkeys.py $(srcdir)/xversionkeys.dat --headerfile $@
+
+$(XVERSION_PICKLE): $(srcdir)/xversionkeys.dat $(abs_top_builddir)/src/xversionkeys.h
+	$(PYTHON) $(top_srcdir)/contrib/devtools/xversionkeys.py $(srcdir)/xversionkeys.dat --picklefile $@
+
+all-local: $(XVERSION_PICKLE)
 
 BUILT_SOURCES= xversionkeys.h
 
@@ -622,7 +627,9 @@ CLEANFILES += wallet/*.gcda wallet/*.gcno
 CLEANFILES += wallet/test/*.gcda wallet/test/*.gcno
 CLEANFILES += zmq/*.gcda zmq/*.gcno
 
-DISTCLEANFILES = obj/build.h xversionkeys.h
+XVERSION_PICKLE = $(top_srcdir)/qa/rpc-tests/test_framework/xversion.pickle
+
+DISTCLEANFILES = obj/build.h xversionkeys.h $(XVERSION_PICKLE)
 
 EXTRA_DIST = leveldb $(CTAES_DIST) $(srcdir)/xversionkeys.dat $(top_srcdir)/contrib/devtools/xversionkeys.py
 


### PR DESCRIPTION
This is to preempt loads of ugly, hardcoded `xversion` values becoming part of the integration test suite.