### PR TITLE
Don't disconnect slow -addnode or -connect peers during IBD

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2849,6 +2849,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
     fInbound = fInboundIn;
     fAutoOutbound = false;
     fNetworkNode = false;
+    fCanRequestBlocksDuringIBD = true;
     tVersionSent = -1;
     fDisconnect = false;
     fDisconnectRequest = false;

--- a/src/net.h
+++ b/src/net.h
@@ -441,8 +441,14 @@ public:
     bool fOneShot;
     bool fClient;
     bool fInbound;
-    bool fAutoOutbound; // any outbound node not connected with -addnode, connect-thinblock or -connect
+    bool fAutoOutbound; // any outbound node not connected with -addnode or -connect
     bool fNetworkNode; // any outbound node
+
+    // During IBD -addnode or -connect peers may be slow, however we can not auto-disconnect
+    // them because we will only try to reconnect again. By setting this flag to false, a slow
+    //  -addnode or -connect node will not cause issues with IBD.
+    std::atomic<bool> fCanRequestBlocksDuringIBD;
+
     int64_t tVersionSent;
 
     bool successfullyConnected() const


### PR DESCRIPTION
This has the effect of causing disruption in IBD because once we
diconnect, we then reconnect, ask for more blocks, which are then
slow and then disconnect again.  Rather than do that, here we
set a flag which indicates this peer is not to be requested from
during the IDB period.