### PR TITLE
Replace FORCE rule in src/Makefile.am

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -224,7 +224,7 @@ obj/build.h: FORCE
 	  $(abs_top_srcdir)
 libbitcoin_util_a-clientversion.$(OBJEXT): obj/build.h
 
-xversionkeys.h: FORCE
+xversionkeys.h: $(top_srcdir)/contrib/devtools/xversionkeys.py $(top_srcdir)/src/xversionkeys.dat
 	$(PYTHON) $(top_srcdir)/contrib/devtools/xversionkeys.py > $(abs_top_builddir)/src/xversionkeys.h < $(srcdir)/xversionkeys.dat
 
 BUILT_SOURCES= xversionkeys.h


### PR DESCRIPTION
.. for the xversionkeys.h file. Tested to build under `mingw64`/`msys2` on Windows 10.

@ptschip, @Greg-Griffith : Please test whether this works for you.