### PR TITLE
implement xversion changeable key

### DIFF
--- a/contrib/devtools/xversionkeys.py
+++ b/contrib/devtools/xversionkeys.py
@@ -101,11 +101,10 @@ namespace XVer
     print("}; // const unordered_map valtype\n\n\n", file = outfile)
 
     # set key types in enum
-    print("enum {", file = outfile)
-    valtypes = set(x["keytype"] for x in table.values())
-    for x in sorted(valtypes):
+    print("enum keyTypes {", file = outfile)
+    for x in keyTypes:
         print ("    %20s," % ("xkt_"+x), file = outfile)
-    print("}; // enum keytypes\n\n\n", file = outfile)
+    print("}; // enum keyTypes\n\n\n", file = outfile)
 
     # map keys to their expected value type
     print("const std::unordered_map<uint64_t, std::string> keytype = {", file = outfile)

--- a/contrib/devtools/xversionkeys.py
+++ b/contrib/devtools/xversionkeys.py
@@ -7,7 +7,7 @@ import time
 from sys import stdin, stdout
 import shlex
 
-keyTypes = ["i", "c"]
+keyTypes = {"i":"initial", "c":"changeable"}
 
 valueTypes = ["u64c", "vector"]
 
@@ -20,7 +20,7 @@ def readKEY(tokens):
     suffix = int(next(tokens), 0)
     valtype = next(tokens)
     if keytype not in keyTypes:
-        raise RuntimeError("Unknown key type '%s'." % keytype)
+        raise RuntimeError("Unknown key type '%s'." % type)
     if valtype not in valueTypes:
         raise RuntimeError("Unknown value type '%s'." % valtype)
     if prefix<0 or prefix>0xffff:
@@ -103,14 +103,14 @@ namespace XVer
     # set key types in enum
     print("enum keyTypes {", file = outfile)
     for x in keyTypes:
-        print ("    %20s," % ("xkt_"+x), file = outfile)
+        print ("    "+keyTypes[x]+",", file = outfile)
     print("}; // enum keyTypes\n\n\n", file = outfile)
 
     # map keys to their expected value type
     print("const std::unordered_map<uint64_t, keyTypes> keytype = {", file = outfile)
     for k in sorted(table.keys()):
         x = table[k]
-        print ("    {%40s, %42s }," % (x["name"], x["keytype"]), file = outfile)
+        print ("    {%40s, %42s }," % (x["name"], keyTypes[x["keytype"]]), file = outfile)
     print("}; // const unordered_map keytype\n\n\n", file = outfile)
 
     print(

--- a/contrib/devtools/xversionkeys.py
+++ b/contrib/devtools/xversionkeys.py
@@ -107,10 +107,10 @@ namespace XVer
     print("}; // enum keyTypes\n\n\n", file = outfile)
 
     # map keys to their expected value type
-    print("const std::unordered_map<uint64_t, std::string> keytype = {", file = outfile)
+    print("const std::unordered_map<uint64_t, keyTypes> keytype = {", file = outfile)
     for k in sorted(table.keys()):
         x = table[k]
-        print ("    {%40s, %42s }," % (x["name"], '"'+x["keytype"]+'"'), file = outfile)
+        print ("    {%40s, %42s }," % (x["name"], x["keytype"]), file = outfile)
     print("}; // const unordered_map keytype\n\n\n", file = outfile)
 
     print(

--- a/contrib/devtools/xversionkeys.py
+++ b/contrib/devtools/xversionkeys.py
@@ -101,13 +101,13 @@ namespace XVer
     print("}; // const unordered_map valtype\n\n\n", file = outfile)
 
     # set key types in enum
-    print("enum keyTypes {", file = outfile)
+    print("enum keyType {", file = outfile)
     for x in keyTypes:
         print ("    "+keyTypes[x]+",", file = outfile)
-    print("}; // enum keyTypes\n\n\n", file = outfile)
+    print("}; // enum keyType\n\n\n", file = outfile)
 
     # map keys to their expected value type
-    print("const std::unordered_map<uint64_t, keyTypes> keytype = {", file = outfile)
+    print("const std::unordered_map<uint64_t, keyType> mapKeyType = {", file = outfile)
     for k in sorted(table.keys()):
         x = table[k]
         print ("    {%40s, %42s }," % (x["name"], keyTypes[x["keytype"]]), file = outfile)

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -237,7 +237,8 @@ class NodeConn(asyncore.dispatcher):
         b"mempool": msg_mempool,
         b"sendheaders": msg_sendheaders,
         b"xversion" : msg_xversion,
-        b"xverack" : msg_xverack
+        b"xverack" : msg_xverack,
+        b"xupdate" : msg_xupdate
     }, bumessagemap)
 
     BTC_MAGIC_BYTES = {

--- a/qa/rpc-tests/test_framework/nodemessages.py
+++ b/qa/rpc-tests/test_framework/nodemessages.py
@@ -930,6 +930,34 @@ class msg_xverack(object):
     def __repr__(self):
         return "msg_xverack()"
 
+class msg_xupdate(object):
+    command = b"xupdate"
+
+    def __init__(self, xver = {}):
+        self.xver = xver
+
+    def deserialize(self, f):
+        map_size = CompactSize().deserialize(f)
+        self.xver = {}
+        for i in range(map_size):
+            key = CompactSize().deserialize(f)
+            val_size = CompactSize().deserialize(f)
+            value = f.read(val_size)
+            self.xver[key] = value
+
+    def serialize(self):
+        res = CompactSize(len(self.xver)).serialize()
+        for k, v in self.xver.items():
+            res += CompactSize(k).serialize()
+            if type(v) is int:  # serialize integers in compact format inside the vector
+                v = CompactSize(v).serialize()
+            res += CompactSize(len(v)).serialize()
+            res += v
+        return res
+
+    def __repr__(self):
+        return "msg_xupdate(%s)" % repr(self.xver)
+
 
 class msg_addr(object):
     command = b"addr"

--- a/qa/rpc-tests/xversion.py
+++ b/qa/rpc-tests/xversion.py
@@ -145,6 +145,18 @@ class XVersionTest(BitcoinTestFramework):
         assert len(xv_map) == 1
         assert unhexlify(list(xv_map.values())[0]) == b"test string"
 
+        # send xupdate to test what would happen if someone tries to update a non-existant key
+        conn.send_message(msg_xupdate({1111 : b"bad string"}))
+        # some arbitrary sleep time
+        time.sleep(3);
+        # nothing should have changed, 1111 is not listed as a known key
+        node = self.nodes[0]
+        peer_info = node.getpeerinfo()
+        assert len(peer_info) == 1
+        assert "xversion_map" in peer_info[0]
+        xv_map = peer_info[0]["xversion_map"]
+        assert len(xv_map) == 1
+
         # TODO appent to this test to test a changeable key once one has been implemented in the node
 
         conn.connection.disconnect_node()

--- a/qa/rpc-tests/xversion.py
+++ b/qa/rpc-tests/xversion.py
@@ -131,6 +131,22 @@ class XVersionTest(BitcoinTestFramework):
         assert len(xv_map) == 1
         assert unhexlify(list(xv_map.values())[0]) == b"test string"
 
+        # send xupdate to test what would happen if someone tries to update non-chaneable key
+        conn.send_message(msg_xupdate({1000 : b"test string changed"}))
+        # some arbitrary sleep time
+        time.sleep(3);
+
+        # nothing should have changed, 1000 is not listed as a changeable key
+        node = self.nodes[0]
+        peer_info = node.getpeerinfo()
+        assert len(peer_info) == 1
+        assert "xversion_map" in peer_info[0]
+        xv_map = peer_info[0]["xversion_map"]
+        assert len(xv_map) == 1
+        assert unhexlify(list(xv_map.values())[0]) == b"test string"
+
+        # TODO appent to this test to test a changeable key once one has been implemented in the node
+
         conn.connection.disconnect_node()
         nt.join()
 

--- a/src/net.h
+++ b/src/net.h
@@ -432,9 +432,6 @@ public:
     //! the intial xversion message sent in the handshake
     CXVersionMessage xVersion;
 
-    //! seperate xmap for changing the value of changeable keys
-    XVersionMap xState;
-
     // strSubVer is whatever byte array we read from the wire. However, this field is intended
     // to be printed out, displayed to humans in various forms and so on. So we sanitize it and
     // store the sanitized version in cleanSubVer. The original should be used when dealing with

--- a/src/net.h
+++ b/src/net.h
@@ -430,6 +430,7 @@ public:
     CCriticalSection csSerialPhase;
 
     //! the intial xversion message sent in the handshake
+    CCriticalSection cs_xversion;
     CXVersionMessage xVersion;
 
     // strSubVer is whatever byte array we read from the wire. However, this field is intended

--- a/src/net.h
+++ b/src/net.h
@@ -429,7 +429,11 @@ public:
     //! used to make processing serial when version handshake is taking place
     CCriticalSection csSerialPhase;
 
+    //! the intial xversion message sent in the handshake
     CXVersionMessage xVersion;
+
+    //! seperate xmap for changing the value of changeable keys
+    XVersionMap xState;
 
     // strSubVer is whatever byte array we read from the wire. However, this field is intended
     // to be printed out, displayed to humans in various forms and so on. So we sanitize it and

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -653,7 +653,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         for (auto entry : pfrom->xVersion.xmap)
         {
             auto iter = XVer::keytype.find(entry.first);
-            if (iter != XVer::keytype.end() && iter->second == "c")
+            if (iter != XVer::keytype.end() && iter->second == XVer::keyTypes::changeable)
             {
                 pfrom->xState.emplace(entry);
             }
@@ -686,7 +686,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                     pfrom->GetLogName());
                 return false;
             }
-            else if (iter->second != "c")
+            else if (iter->second != XVer::keyTypes::changeable)
             {
                 pfrom->fDisconnect = true;
                 LOG(NET, "ERROR: disconnecting - peer=%s attempting to update non-changeable xversion value\n",

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -650,14 +650,6 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                      "setting. peer=%s version=%s\n",
                 pfrom->GetLogName(), pfrom->cleanSubVer);
         }
-        for (auto entry : pfrom->xVersion.xmap)
-        {
-            auto iter = XVer::keytype.find(entry.first);
-            if (iter != XVer::keytype.end() && iter->second == XVer::keyTypes::changeable)
-            {
-                pfrom->xState.emplace(entry);
-            }
-        }
         pfrom->PushMessage(NetMsgType::XVERACK);
         pfrom->state_incoming = ConnectionStateIncoming::READY;
         handleAddressAfterInit(pfrom);
@@ -681,23 +673,12 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             auto iter = XVer::keytype.find(entry.first);
             if (iter == XVer::keytype.end())
             {
-                pfrom->fDisconnect = true;
-                LOG(NET, "ERROR: disconnecting - peer=%s attempting to update non-existing xversion value\n",
-                    pfrom->GetLogName());
-                return false;
+                continue;
             }
-            else if (iter->second != XVer::keyTypes::changeable)
+            else if (iter->second == XVer::keyTypes::changeable)
             {
-                pfrom->fDisconnect = true;
-                LOG(NET, "ERROR: disconnecting - peer=%s attempting to update non-changeable xversion value\n",
-                    pfrom->GetLogName());
-                return false;
+                pfrom->xVersion.xmap[entry.first] = xUpdate.xmap[entry.first];
             }
-        }
-        // no issues? continue and actually update
-        for (auto entry : xUpdate.xmap)
-        {
-            pfrom->xState[entry.first] = xUpdate.xmap[entry.first];
         }
     }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -677,6 +677,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             }
             else if (iter->second == XVer::keyType::changeable)
             {
+                LOCK(pfrom->cs_xversion);
                 pfrom->xVersion.xmap[entry.first] = xUpdate.xmap[entry.first];
             }
         }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -670,12 +670,12 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         // check for peer trying to change non-changeable key
         for (auto entry : xUpdate.xmap)
         {
-            auto iter = XVer::keytype.find(entry.first);
-            if (iter == XVer::keytype.end())
+            auto iter = XVer::mapKeyType.find(entry.first);
+            if (iter == XVer::mapKeyType.end())
             {
                 continue;
             }
-            else if (iter->second == XVer::keyTypes::changeable)
+            else if (iter->second == XVer::keyType::changeable)
             {
                 pfrom->xVersion.xmap[entry.first] = xUpdate.xmap[entry.first];
             }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -650,6 +650,14 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
                      "setting. peer=%s version=%s\n",
                 pfrom->GetLogName(), pfrom->cleanSubVer);
         }
+        for (auto entry : pfrom->xVersion.xmap)
+        {
+            auto iter = XVer::keytype.find(entry.first);
+            if (iter != XVer::keytype.end() && iter->second == "c")
+            {
+                pfrom->xState.emplace(entry);
+            }
+        }
         pfrom->PushMessage(NetMsgType::XVERACK);
         pfrom->state_incoming = ConnectionStateIncoming::READY;
         handleAddressAfterInit(pfrom);
@@ -662,6 +670,35 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
 
         // This step done after final handshake
         CheckAndRequestExpeditedBlocks(pfrom);
+    }
+    else if (strCommand == NetMsgType::XUPDATE)
+    {
+        CXVersionMessage xUpdate;
+        vRecv >> xUpdate;
+        // check for peer trying to change non-changeable key
+        for (auto entry : xUpdate.xmap)
+        {
+            auto iter = XVer::keytype.find(entry.first);
+            if (iter == XVer::keytype.end())
+            {
+                pfrom->fDisconnect = true;
+                LOG(NET, "ERROR: disconnecting - peer=%s attempting to update non-existing xversion value\n",
+                    pfrom->GetLogName());
+                return false;
+            }
+            else if (iter->second != "c")
+            {
+                pfrom->fDisconnect = true;
+                LOG(NET, "ERROR: disconnecting - peer=%s attempting to update non-changeable xversion value\n",
+                    pfrom->GetLogName());
+                return false;
+            }
+        }
+        // no issues? continue and actually update
+        for (auto entry : xUpdate.xmap)
+        {
+            pfrom->xState[entry.first] = xUpdate.xmap[entry.first];
+        }
     }
 
     // ------------------------- END INITIAL COMMAND SET PROCESSING

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -54,9 +54,10 @@ const char *XPEDITEDREQUEST = "req_xpedited";
 const char *XPEDITEDBLK = "Xb";
 const char *XPEDITEDTxn = "Xt";
 const char *BUVERSION = "buversion";
+const char *BUVERACK = "buverack";
 const char *XVERSION = "xversion";
 const char *XVERACK = "xverack";
-const char *BUVERACK = "buverack";
+const char *XUPDATE = "xupdate";
 const char *SENDCMPCT = "sendcmpct";
 };
 
@@ -79,7 +80,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::XTHINBLOCK, NetMsgType::XBLOCKTX, NetMsgType::GET_XBLOCKTX, NetMsgType::GET_XTHIN,
     NetMsgType::GRAPHENEBLOCK, NetMsgType::GRAPHENETX, NetMsgType::GET_GRAPHENETX, NetMsgType::GET_GRAPHENE,
     NetMsgType::XPEDITEDREQUEST, NetMsgType::XPEDITEDBLK, NetMsgType::XPEDITEDTxn, NetMsgType::BUVERSION,
-    NetMsgType::BUVERACK, NetMsgType::SENDCMPCT,
+    NetMsgType::BUVERACK, NetMsgType::XVERSION, NetMsgType::XVERACK, NetMsgType::XUPDATE, NetMsgType::SENDCMPCT,
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes,
     allNetMessageTypes + ARRAYLEN(allNetMessageTypes));

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -309,6 +309,9 @@ extern const char *XVERSION;
  * @since protocol version FIXME.
  */
 extern const char *XVERACK;
+
+
+extern const char *XUPDATE;
 };
 
 

--- a/src/xversionkeys.dat
+++ b/src/xversionkeys.dat
@@ -14,7 +14,7 @@
 
 #parsing marker (KEY for now)
 #   key name
-#    type of key ('i'nitial or 'c'hangeable?) (only i supported for now)
+#    type of key ('i'nitial or 'c'hangeable)
 #                                             16 bit prefix (currently)
 #                                                                      16 bit suffix  <value type>
 


### PR DESCRIPTION
implement some logic for the c key type (changeable). all changeable keys sent with the xversion message are added to a separate xmap called xstate which is a data member of CNode. a new message XUPDATE is added which updates the values only of values inside xstate, if it tries to update something not in xstate the peer sending the XUPDATE message gets banned. 