### PR TITLE
switch from a scoped_lock to a lock_guard in UpdateTransactionsPerSec…

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1438,7 +1438,7 @@ void CTxMemPool::TrimToSize(size_t sizelimit, std::vector<COutPoint> *pvNoSpends
 
 void CTxMemPool::UpdateTransactionsPerSecond()
 {
-    boost::mutex::scoped_lock lock(cs_txPerSec);
+    std::lock_guard<std::mutex> lock(cs_txPerSec);
 
     static int64_t nLastTime = GetTime();
     double nSecondsToAverage = 60; // Length of time in seconds to smooth the tx rate over

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -462,7 +462,7 @@ private:
 
     void trackPackageRemoved(const CFeeRate &rate);
 
-    boost::mutex cs_txPerSec;
+    std::mutex cs_txPerSec;
     double nTxPerSec; // BU: tx's per second accepted into the mempool
 
 public:
@@ -688,7 +688,7 @@ public:
     bool _exists(const uint256 &hash) const { return (mapTx.count(hash) != 0); }
     double TransactionsPerSecond()
     {
-        boost::mutex::scoped_lock lock(cs_txPerSec);
+        std::lock_guard<std::mutex> lock(cs_txPerSec);
         return nTxPerSec;
     }
 


### PR DESCRIPTION
lock_guard() has slightly less overhead than a scoped_lock and also we can get away from using boost here at the same time.