### PR TITLE
[Net] Reduce preferential Graphene/Xthin timers to 1 second each

### DIFF
--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1182,12 +1182,12 @@ std::string CGrapheneBlockData::ReRequestedTxToString()
 bool CGrapheneBlockData::CheckGrapheneBlockTimer(const uint256 &hash)
 {
     // Base time used to calculate the random timeout value.
-    static int64_t nTimeToWait = 10000;
+    static int64_t nTimeToWait = 1000;
 
     LOCK(cs_mapGrapheneBlockTimer);
     if (!mapGrapheneBlockTimer.count(hash))
     {
-        // The timeout limit is a random number betwee 8 and 12 seconds.
+        // The timeout limit is a random number between 0.8 and 1.2 seconds.
         // This way a node connected to this one may download the block
         // before the other node and thus be able to serve the other with
         // a graphene block, rather than both nodes timing out and downloading
@@ -1195,9 +1195,9 @@ bool CGrapheneBlockData::CheckGrapheneBlockTimer(const uint256 &hash)
         // where we receive full blocks from peers that don't support graphene.
         //
         // To make the timeout random we adjust the start time of the timer forward
-        // or backward by a random amount plus or minus 2 seconds.
+        // or backward by a random amount plus or minus 0.2 seconds.
         FastRandomContext insecure_rand(false);
-        uint64_t nOffset = nTimeToWait - (8000 + (insecure_rand.rand64() % 4000) + 1);
+        uint64_t nOffset = nTimeToWait - (800 + (insecure_rand.rand64() % 400) + 1);
         mapGrapheneBlockTimer[hash] = std::make_pair(GetTimeMillis() + nOffset, false);
         LOG(GRAPHENE, "Starting Preferential Graphene Block timer (%d millis)\n", nTimeToWait + nOffset);
     }

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -1325,12 +1325,12 @@ std::string CThinBlockData::FullTxToString()
 bool CThinBlockData::CheckThinblockTimer(const uint256 &hash)
 {
     // Base time used to calculate the random timeout value.
-    static uint64_t nTimeToWait = 10000;
+    static uint64_t nTimeToWait = 1000;
 
     LOCK(cs_mapThinBlockTimer);
     if (!mapThinBlockTimer.count(hash))
     {
-        // The timeout limit is a random number betwee 8 and 12 seconds.
+        // The timeout limit is a random number between 0.8 and 1.2 seconds.
         // This way a node connected to this one may download the block
         // before the other node and thus be able to serve the other with
         // a graphene block, rather than both nodes timing out and downloading
@@ -1338,9 +1338,9 @@ bool CThinBlockData::CheckThinblockTimer(const uint256 &hash)
         // where we receive full blocks from peers that don't support graphene.
         //
         // To make the timeout random we adjust the start time of the timer forward
-        // or backward by a random amount plus or minus 2 seconds.
+        // or backward by a random amount plus or minus 0.2 seconds.
         FastRandomContext insecure_rand(false);
-        uint64_t nOffset = nTimeToWait - (8000 + (insecure_rand.rand64() % 4000) + 1);
+        uint64_t nOffset = nTimeToWait - (800 + (insecure_rand.rand64() % 400) + 1);
         mapThinBlockTimer[hash] = std::make_pair(GetTimeMillis() + nOffset, false);
         LOG(THIN, "Starting Preferential Thinblock timer (%d millis)\n", nTimeToWait + nOffset);
     }


### PR DESCRIPTION
Recently, the consecutive 10 second preferential download timers for Xthin/Graphene caused an orphan race on BCH mainnet:

https://www.reddit.com/r/btc/comments/a1bp0b/please_send_me_your_debuglog_files_from_the_bsv/eb2ogw0/?context=3

These 10 second timers often result in BU not downloading a block (even a tiny, 20 kB one!) from peers until 20 seconds have elapsed. Since no BU nodes support Compact Blocks, and almost no other nodes (except XT) supports both CB and Xthin, this means that any time a block is mined by BSV or ABC, no BU nodes on the network will receive it for at least 10 seconds, and when XT network bridging doesn't work (e.g. on BSV) all BU nodes will be delayed by 20 seconds. This causes a 3.27% higher orphan rate than necessary for any miners using BU.

This preferential download mechanism should probably be completely redesigned and replaced. I proposed one such idea in the reddit thread above. However, as a short-term fix, I suggest lowering the timers to 1 second instead of 10 seconds. This is long enough that a node that sees an Xthin or Graphene peer with the block will usually be able to download it in time, but short enough that orphan rates will not increase very much for BU miners. This PR implements this 1 second timer.

Based on my test results from mainnet, it seems to work as intended. My test node is probably already effectively bridging the BU and ABC subsets of the BCH network:

2018-12-04 19:48:25 AskFor block via headers direct fetch 0000000000000000001ffe762dbd324320a4112a43cac97ef7ebb0c18ba304c7 (559418) peer=19
2018-12-04 19:48:26 Preferential Graphene Block timer exceeded
2018-12-04 19:48:26 Starting Preferential Thinblock timer (1169 millis)
2018-12-04 19:48:27 Preferential Thinblock timer exceeded - downloading regular block instead
2018-12-04 19:48:27 Clearing Preferential Thinblock timer
2018-12-04 19:48:27 Clearing Preferential Graphene Block timer
2018-12-04 19:48:27 sending msg: getdata (37 bytes) peer=39
2018-12-04 19:48:27 Requesting Regular Block 0000000000000000001ffe762dbd324320a4112a43cac97ef7ebb0c18ba304c7 from peer 47.95.32.37:8333 (39)

This PR is identical to https://github.com/BitcoinUnlimited/BitcoinUnlimited/pull/1510, but rebased on the dev branch instead of release.