### PR TITLE
Making xversion more permissive

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -359,6 +359,11 @@ ConnectionStateIncoming operator|(const ConnectionStateIncoming &a, const Connec
     return (ConnectionStateIncoming)((uint64_t)a | (uint64_t)b);
 }
 
+ConnectionStateOutgoing operator|(const ConnectionStateOutgoing &a, const ConnectionStateOutgoing &b)
+{
+    return (ConnectionStateOutgoing)((uint64_t)a | (uint64_t)b);
+}
+
 std::string toString(const ConnectionStateIncoming &state) { return toString((uint64_t)state, bitMeaningsCSI); }
 std::ostream &operator<<(std::ostream &os, const ConnectionStateIncoming &state) { return (os << toString(state)); }
 std::string toString(const ConnectionStateOutgoing &state) { return toString((uint64_t)state, bitMeaningsCSO); }

--- a/src/net.h
+++ b/src/net.h
@@ -336,6 +336,7 @@ enum class ConnectionStateOutgoing : uint8_t {
     //! placeholder value to allow any when checking for a particular state
     ANY           = 0xff
 };
+ConnectionStateOutgoing operator|(const ConnectionStateOutgoing& a, const ConnectionStateOutgoing& b);
 // clang-format on
 
 //! ConnectionStateIncoming enum to string

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -604,7 +604,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
     {
         if (!ensureConnectionState(strCommand,
                 ConnectionStateIncoming::SENT_VERACK_READY_FOR_POTENTIAL_XVERSION | ConnectionStateIncoming::READY,
-                ConnectionStateOutgoing::READY, pfrom))
+                ConnectionStateOutgoing::READY | ConnectionStateOutgoing::SENT_VERSION, pfrom))
             return false;
 
         // Each connection can only send one version message


### PR DESCRIPTION
As per the commit messages. For compatibility with current BUCash releases 1.5.0.x that do parallelized message processing.