### PR TITLE
Allow early pings and include a functional test for that

### DIFF
--- a/qa/rpc-tests/pingearly.py
+++ b/qa/rpc-tests/pingearly.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2018 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+import test_framework.loginit
+import os
+import os.path
+import time
+import sys
+if sys.version_info[0] < 3:
+    raise "Use Python 3"
+import logging
+from binascii import unhexlify
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+from test_framework.mininode import NetworkThread
+from test_framework.nodemessages import *
+from test_framework.bumessages import *
+from test_framework.bunode import BasicBUCashNode,  VersionlessProtoHandler
+
+class PingEarlyTest(BitcoinTestFramework):
+    def __init__(self):
+        self.nodes = []
+        BitcoinTestFramework.__init__(self)
+
+    def setup_chain(self):
+        pass
+
+    def setup_network(self, split=False):
+        pass
+
+    def restart_node(self, send_initial_version = True):
+        # remove any potential banlist
+        banlist_fn = os.path.join(
+            node_regtest_dir(self.options.tmpdir, 0),
+            "banlist.dat")
+        print("Banlist file name:", banlist_fn)
+        try:
+            os.remove(banlist_fn)
+            print("Removed old banlist %s.")
+        except:
+                pass
+        stop_nodes(self.nodes)
+        wait_bitcoinds()
+        print("Initializing test directory " + self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 1)
+        self.nodes = [ start_node(0, self.options.tmpdir, ["-debug"]) ]
+        self.pynode = pynode = BasicBUCashNode()
+
+        pynode.connect(0, '127.0.0.1', p2p_port(0), self.nodes[0],
+                       protohandler = VersionlessProtoHandler(),
+                       send_initial_version = send_initial_version)
+        return pynode.cnxns[0]
+
+    def run_test(self):
+        logging.info("Testing early ping replies")
+
+        conn = self.restart_node(send_initial_version = False)
+        conn.send_message(msg_ping(), pushbuf=True)
+        nt = NetworkThread()
+        nt.start()
+        conn.wait_for(lambda : conn.pong_counter)
+        conn.connection.disconnect_node()
+        nt.join()
+
+if __name__ == '__main__':
+    xvt = PingEarlyTest()
+    xvt.main()

--- a/qa/rpc-tests/test_framework/bunode.py
+++ b/qa/rpc-tests/test_framework/bunode.py
@@ -287,6 +287,21 @@ class BUProtocolHandler(NodeConnCB):
         getblocks_message.locator.vHave = locator
         self.send_message(getblocks_message)
 
+
+class VersionlessProtoHandler(BUProtocolHandler):
+    """ Variant of the BUProtocolHandler that avoids auto-sending and reacting to
+version messages. Useful for testing that part of the P2P handshake. """
+    def __init__(self):
+        BUProtocolHandler.__init__(self)
+
+    def on_version(self, conn, message):
+        self.show_debug_msg("version received\n")
+        self.remoteVersion = message.nVersion
+
+    def on_verack(self, conn, message):
+        self.show_debug_msg("verack received\n")
+        self.verack_received = True
+
 class BasicBUCashNode():
     def __init__(self):
         self.cnxns = {}

--- a/qa/rpc-tests/test_framework/bunode.py
+++ b/qa/rpc-tests/test_framework/bunode.py
@@ -25,6 +25,7 @@ class BUProtocolHandler(NodeConnCB):
         self.last_headers = None
         self.last_block = None
         self.ping_counter = 1
+        self.pong_counter = 0
         self.last_pong = msg_pong(0)
         self.last_getdata = []
         self.sleep_time = 0.05
@@ -150,6 +151,7 @@ class BUProtocolHandler(NodeConnCB):
 
     def on_pong(self, conn, message):
         self.last_pong = message
+        self.pong_counter += 1
         if self.parent and hasattr(self.parent, "on_pong"):
             self.parent.on_pong(self,message)
 

--- a/qa/rpc-tests/test_framework/bunode.py
+++ b/qa/rpc-tests/test_framework/bunode.py
@@ -33,6 +33,7 @@ class BUProtocolHandler(NodeConnCB):
         self.last_getheaders = None
         self.disconnected = False
         self.remoteVersion = 0
+        self.remote_xversion = None
         self.buverack_received = False
         self.parent = None
         self.requestOnInv = 0
@@ -77,6 +78,14 @@ class BUProtocolHandler(NodeConnCB):
     def on_buverack(self, conn, message):
         self.show_debug_msg("BU version ACK\n")
         self.buverack_received = True
+
+    def on_xverack(self, conn, message):
+        self.show_debug_msg("xverack received\n")
+        self.xverack_received = True
+
+    def on_xversion(self, conn, message):
+        self.show_debug_msg("xversion received\n")
+        self.remote_xversion = message
 
     def add_connection(self, conn):
         self.connection = conn

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -81,13 +81,14 @@ class NodeConnCB(object):
     # This can be called from the testing thread, so it needs to acquire the
     # global lock.
     def wait_for(self, test_function):
-        while True:
+        for i in range(200):
             if self.disconnected:
                 raise DisconnectedError()
             with mininode_lock:
                 if test_function():
                     return
             time.sleep(0.05)
+        raise TimeoutError("Waiting for %s timed out." % repr(test_function))
 
     def wait_for_verack(self):
         self.wait_for(lambda : self.verack_received)

--- a/qa/rpc-tests/xversion.py
+++ b/qa/rpc-tests/xversion.py
@@ -20,7 +20,6 @@ from test_framework.bunode import BasicBUCashNode, BUProtocolHandler
 
 class XVersionTestProtoHandler(BUProtocolHandler):
     def __init__(self):
-        self.remote_xversion = None
         BUProtocolHandler.__init__(self)
 
     def on_version(self, conn, message):
@@ -30,14 +29,6 @@ class XVersionTestProtoHandler(BUProtocolHandler):
     def on_verack(self, conn, message):
         self.show_debug_msg("verack received\n")
         self.verack_received = True
-
-    def on_xverack(self, conn, message):
-        self.show_debug_msg("xverack received\n")
-        self.xverack_received = True
-
-    def on_xversion(self, conn, message):
-        self.show_debug_msg("xversion received\n")
-        self.remote_xversion = message
 
 class XVersionTest(BitcoinTestFramework):
     def __init__(self):

--- a/qa/rpc-tests/xversion.py
+++ b/qa/rpc-tests/xversion.py
@@ -16,19 +16,7 @@ from test_framework.util import *
 from test_framework.mininode import NetworkThread
 from test_framework.nodemessages import *
 from test_framework.bumessages import *
-from test_framework.bunode import BasicBUCashNode, BUProtocolHandler
-
-class XVersionTestProtoHandler(BUProtocolHandler):
-    def __init__(self):
-        BUProtocolHandler.__init__(self)
-
-    def on_version(self, conn, message):
-        self.show_debug_msg("version received\n")
-        self.remoteVersion = message.nVersion
-
-    def on_verack(self, conn, message):
-        self.show_debug_msg("verack received\n")
-        self.verack_received = True
+from test_framework.bunode import BasicBUCashNode,  VersionlessProtoHandler
 
 class XVersionTest(BitcoinTestFramework):
     def __init__(self):
@@ -60,7 +48,7 @@ class XVersionTest(BitcoinTestFramework):
         self.pynode = pynode = BasicBUCashNode()
 
         pynode.connect(0, '127.0.0.1', p2p_port(0), self.nodes[0],
-                       protohandler = XVersionTestProtoHandler(),
+                       protohandler = VersionlessProtoHandler(),
                        send_initial_version = send_initial_version)
         return pynode.cnxns[0]
 

--- a/qa/rpc-tests/zerochecksum.py
+++ b/qa/rpc-tests/zerochecksum.py
@@ -21,7 +21,6 @@ from test_framework.bunode import BasicBUCashNode, BUProtocolHandler
 class NodeProtoHandler(BUProtocolHandler):
     def __init__(self):
         self.remote_xversion = None
-        self.pong_received = 0
         BUProtocolHandler.__init__(self)
 
     def on_version(self, conn, message):
@@ -31,14 +30,6 @@ class NodeProtoHandler(BUProtocolHandler):
     def on_verack(self, conn, message):
         self.show_debug_msg("verack received\n")
         self.verack_received = True
-
-    def on_xverack(self, conn, message):
-        self.show_debug_msg("xverack received\n")
-        self.xverack_received = True
-
-    def on_xversion(self, conn, message):
-        self.show_debug_msg("xversion received\n")
-        self.remote_xversion = message
 
 
 class MyTest(BitcoinTestFramework):

--- a/qa/rpc-tests/zerochecksum.py
+++ b/qa/rpc-tests/zerochecksum.py
@@ -40,10 +40,6 @@ class NodeProtoHandler(BUProtocolHandler):
         self.show_debug_msg("xversion received\n")
         self.remote_xversion = message
 
-    def on_pong(self, conn, message):
-        self.show_debug_msg("pong received\n")
-        self.pong_received += 1
-
 
 class MyTest(BitcoinTestFramework):
     def __init__(self):
@@ -107,7 +103,7 @@ class MyTest(BitcoinTestFramework):
         conn.wait_for(lambda : conn.remote_xversion)
 
         conn.send_message(msg_ping())
-        conn.wait_for(lambda : conn.pong_received)
+        conn.wait_for(lambda : conn.pong_counter)
         # check that we are getting 0-value checksums from the BU node
         assert(self.hndlr.num0Checksums > 0)
 

--- a/qa/rpc-tests/zerochecksum.py
+++ b/qa/rpc-tests/zerochecksum.py
@@ -16,20 +16,7 @@ from test_framework.util import *
 from test_framework.mininode import NetworkThread
 from test_framework.nodemessages import *
 from test_framework.bumessages import *
-from test_framework.bunode import BasicBUCashNode, BUProtocolHandler
-
-class NodeProtoHandler(BUProtocolHandler):
-    def __init__(self):
-        self.remote_xversion = None
-        BUProtocolHandler.__init__(self)
-
-    def on_version(self, conn, message):
-        self.show_debug_msg("version received\n")
-        self.remoteVersion = message.nVersion
-
-    def on_verack(self, conn, message):
-        self.show_debug_msg("verack received\n")
-        self.verack_received = True
+from test_framework.bunode import BasicBUCashNode, VersionlessProtoHandler
 
 
 class MyTest(BitcoinTestFramework):
@@ -62,7 +49,7 @@ class MyTest(BitcoinTestFramework):
         self.pynode = pynode = BasicBUCashNode()
 
         self.hndlr = pynode.connect(0, '127.0.0.1', p2p_port(0), self.nodes[0],
-                       protohandler =NodeProtoHandler(),
+                       protohandler =VersionlessProtoHandler(),
                        send_initial_version = send_initial_version)
         self.hndlr.allow0Checksum = True
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2979,7 +2979,7 @@ void CNode::BeginMessage(const char *pszCommand) EXCLUSIVE_LOCK_FUNCTION(cs_vSen
     ENTER_CRITICAL_SECTION(cs_vSend);
     assert(ssSend.size() == 0);
     ssSend << CMessageHeader(GetMagic(Params()), pszCommand, 0);
-    LOG(NET, "sending msg: %s ", SanitizeString(pszCommand));
+    LOG(NET, "sending msg: %s to %s\n", SanitizeString(pszCommand), GetLogName());
     currentCommand = pszCommand;
 }
 

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -254,7 +254,10 @@ BOOST_AUTO_TEST_CASE(verack_tests)
     dummyNode4.tVersionSent = nStartTime;
     SetMockTime(nStartTime + VERACK_TIMEOUT); // should not disconnect if timeout not exceeded and no VERACK
     vRecv1 << (uint64_t)12345; // ping nonce
-    ProcessMessage(&dummyNode4, NetMsgType::PING, vRecv1, GetTime());
+    {
+        READLOCK(dummyNode4.csMsgSerializer);
+        ProcessMessage(&dummyNode4, NetMsgType::PING, vRecv1, GetTime());
+    }
     BOOST_CHECK(!dummyNode4.fDisconnect);
 
     vRecv1.clear();
@@ -264,7 +267,10 @@ BOOST_AUTO_TEST_CASE(verack_tests)
     dummyNode4a.tVersionSent = nStartTime;
     SetMockTime(nStartTime + VERACK_TIMEOUT + 1); // should disconnect if timeout exceeded and no VERACK
     vRecv1 << (uint64_t)12345; // ping nonce
-    ProcessMessage(&dummyNode4a, NetMsgType::PING, vRecv1, GetTime());
+    {
+        READLOCK(dummyNode4.csMsgSerializer);
+        ProcessMessage(&dummyNode4a, NetMsgType::PING, vRecv1, GetTime());
+    }
     BOOST_CHECK(dummyNode4a.fDisconnect);
 }
 

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -253,6 +253,7 @@ BOOST_AUTO_TEST_CASE(verack_tests)
     dummyNode4.nVersion = 1;
     dummyNode4.tVersionSent = nStartTime;
     SetMockTime(nStartTime + VERACK_TIMEOUT); // should not disconnect if timeout not exceeded and no VERACK
+    vRecv1 << (uint64_t)12345; // ping nonce
     ProcessMessage(&dummyNode4, NetMsgType::PING, vRecv1, GetTime());
     BOOST_CHECK(!dummyNode4.fDisconnect);
 
@@ -262,6 +263,7 @@ BOOST_AUTO_TEST_CASE(verack_tests)
     dummyNode4a.nVersion = 1;
     dummyNode4a.tVersionSent = nStartTime;
     SetMockTime(nStartTime + VERACK_TIMEOUT + 1); // should disconnect if timeout exceeded and no VERACK
+    vRecv1 << (uint64_t)12345; // ping nonce
     ProcessMessage(&dummyNode4a, NetMsgType::PING, vRecv1, GetTime());
     BOOST_CHECK(dummyNode4a.fDisconnect);
 }


### PR DESCRIPTION
To test that this additional change is necessary, run the `pingearly.py` integration test with and without the previous "Allow ping replies in the initial handshake" commit applied (E.g. use `git revert` to testing).

This cherry-picks from #1516 as well as from #1505.