### PR TITLE
Refactor tracking of thin type blocks in flight. (pre-req for compact blocks)

### DIFF
--- a/qa/rpc-tests/thinblocks.py
+++ b/qa/rpc-tests/thinblocks.py
@@ -22,6 +22,7 @@ class ThinBlockTest(BitcoinTestFramework):
         node_opts1 = [
             "-rpcservertimeout=0",
             "-debug=thin",
+            "-use-grapheneblocks=0",
             "-use-thinblocks=1",
             "-use-bloom-filter-targeting=0",
             "-excessiveblocksize=6000000",
@@ -33,6 +34,7 @@ class ThinBlockTest(BitcoinTestFramework):
         node_opts2 = [
             "-rpcservertimeout=0",
             "-debug=thin",
+            "-use-grapheneblocks=0",
             "-use-thinblocks=1",
             "-use-bloom-filter-targeting=0",
             "-excessiveblocksize=6000000",
@@ -44,6 +46,7 @@ class ThinBlockTest(BitcoinTestFramework):
         node_opts3 = [
             "-rpcservertimeout=0",
             "-debug=thin",
+            "-use-grapheneblocks=0",
             "-use-thinblocks=1",
             "-use-bloom-filter-targeting=1",
             "-excessiveblocksize=6000000",

--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -178,11 +178,15 @@ void ThinTypeRelay::ThinTypeBlockWasReceived(CNode *pfrom, const uint256 &hash)
     }
 }
 
-void ThinTypeRelay::AddThinTypeBlockInFlight(CNode *pfrom, const uint256 &hash, const std::string thinType)
+bool ThinTypeRelay::AddThinTypeBlockInFlight(CNode *pfrom, const uint256 &hash, const std::string thinType)
 {
     LOCK(cs_inflight);
+    if (IsThinTypeBlockInFlight(pfrom, thinType))
+        return false;
+
     mapThinTypeBlocksInFlight.insert(
         std::pair<const NodeId, CThinTypeBlockInFlight>(pfrom->GetId(), {hash, GetTime(), false, thinType}));
+    return true;
 }
 
 void ThinTypeRelay::ClearThinTypeBlockInFlight(CNode *pfrom, const uint256 &hash)

--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -3,3 +3,234 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "blockrelay/blockrelay_common.h"
+#include "net.h"
+#include "random.h"
+#include "requestManager.h"
+#include "sync.h"
+#include "util.h"
+
+bool IsThinBlockEnabled();
+bool IsGrapheneBlockEnabled();
+
+// Update the counters for how many peers we have connected.
+void ThinTypeRelay::AddThinTypePeers(CNode *pfrom, bool fCmpct)
+{
+    if (pfrom)
+    {
+        if (pfrom->nServices & NODE_XTHIN)
+            nThinBlockPeers++;
+        if (pfrom->nServices & NODE_GRAPHENE)
+            nGraphenePeers++;
+    }
+    if (fCmpct)
+    {
+        nCompactBlockPeers++;
+    }
+}
+
+void ThinTypeRelay::RemoveThinTypePeers(CNode *pfrom)
+{
+    if (pfrom)
+    {
+        if (pfrom->nServices & NODE_XTHIN)
+            nThinBlockPeers--;
+        if (pfrom->nServices & NODE_GRAPHENE)
+            nGraphenePeers--;
+        if (pfrom->fSupportsCompactBlocks)
+            nCompactBlockPeers--;
+
+        DbgAssert(nThinBlockPeers >= 0, nThinBlockPeers = 0);
+        DbgAssert(nGraphenePeers >= 0, nGraphenePeers = 0);
+        DbgAssert(nCompactBlockPeers >= 0, nCompactBlockPeers = 0);
+    }
+}
+
+// Preferential Block Relay Timer:
+// The purpose of the timer is to ensure that we more often download an XTHIN/GRAPHENE/CMPCT blocks
+// rather than full blocks.  Once a block announcement arrives the timer is started.  If there are no
+// peers that support one of the thin blocks types then timer continues until either an announcement
+// arrives from a comaptible peer, or the timer expires. If the timer expires, then and only then we
+// download a full block.
+bool ThinTypeRelay::HasBlockRelayTimerExpired(const uint256 &hash)
+{
+    // Base time used to calculate the random timeout value.
+    static uint64_t nTimeToWait = GetArg("-preferential-timer", DEFAULT_PREFERENTIAL_TIMER);
+    if (nTimeToWait == 0)
+        return false;
+
+    LOCK(cs_blockrelaytimer);
+    if (!mapBlockRelayTimer.count(hash))
+    {
+        // The timeout limit is a random number belonging to graphene-timer +/- 20%
+        // This way a node connected to this one may download the block
+        // before the other node and thus be able to serve the other with
+        // a graphene block, rather than both nodes timing out and downloading
+        // a thinblock instead. This can happen at the margins of the BU network
+        // where we receive full blocks from peers that don't support graphene.
+        //
+        // To make the timeout random we adjust the start time of the timer forward
+        // or backward by a random amount plus or minus 20% of preferential timer in milliseconds.
+        FastRandomContext insecure_rand(false);
+        uint64_t nStartInterval = nTimeToWait * 0.8;
+        uint64_t nIntervalLen = 2 * (nTimeToWait * 0.2);
+        int64_t nOffset = nTimeToWait - (nStartInterval + (insecure_rand.rand64() % nIntervalLen) + 1);
+        mapBlockRelayTimer[hash] = std::make_pair(GetTimeMillis() + nOffset, false);
+        LOG(GRAPHENE, "Starting Preferential block relay timer (%d millis)\n", nTimeToWait + nOffset);
+    }
+    else
+    {
+        // Check that we have not exceeded time limit.
+        // If we have then we want to return false so that we can
+        // proceed to download a regular block instead.
+        auto iter = mapBlockRelayTimer.find(hash);
+        if (iter != mapBlockRelayTimer.end())
+        {
+            int64_t elapsed = GetTimeMillis() - iter->second.first;
+            if (elapsed > (int64_t)nTimeToWait)
+            {
+                // Only print out the log entry once.  Because the graphene timer will be hit
+                // many times when requesting a block we don't want to fill up the log file.
+                if (!iter->second.second)
+                {
+                    iter->second.second = true;
+                    LOG(GRAPHENE | THIN, "Preferential block relay timer exceeded\n");
+                }
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool ThinTypeRelay::IsBlockRelayTimerEnabled()
+{
+    // Only engage the timer if at least one thin type relay is active.
+    if (!IsThinBlocksEnabled() && !IsGrapheneBlockEnabled())
+        return false;
+
+    // Under certain conditions the thin relay timer is not relevant.
+    bool fHaveThinBlockPeers = false;
+    bool fHaveGraphenePeers = false;
+    if (nThinBlockPeers > 0)
+        fHaveThinBlockPeers = true;
+    if (nGraphenePeers > 0)
+        fHaveGraphenePeers = true;
+
+    if (!fHaveGraphenePeers && !fHaveThinBlockPeers)
+        return false;
+    else if (IsGrapheneBlockEnabled() && !fHaveGraphenePeers && !IsThinBlocksEnabled() && fHaveThinBlockPeers)
+        return false;
+    else if (!IsGrapheneBlockEnabled() && fHaveGraphenePeers && IsThinBlocksEnabled() && !fHaveThinBlockPeers)
+        return false;
+
+    return true;
+}
+// The timer is cleared as soon as we request a block or thinblock.
+void ThinTypeRelay::ClearBlockRelayTimer(const uint256 &hash)
+{
+    LOCK(cs_blockrelaytimer);
+    if (mapBlockRelayTimer.count(hash))
+    {
+        mapBlockRelayTimer.erase(hash);
+        LOG(THIN | GRAPHENE, "Clearing Preferential BlockRelay timer\n");
+    }
+}
+
+bool ThinTypeRelay::IsThinTypeBlockInFlight(CNode *pfrom, const std::string thinType)
+{
+    LOCK(cs_inflight);
+    // first check that we are in bounds.
+    if (mapThinTypeBlocksInFlight.size() >= MAX_THINTYPE_BLOCKS_IN_FLIGHT)
+        return true;
+
+    // check if this node already has this thinType of block in flight.
+    std::pair<std::multimap<const NodeId, CThinTypeBlockInFlight>::iterator,
+        std::multimap<const NodeId, CThinTypeBlockInFlight>::iterator>
+        range = mapThinTypeBlocksInFlight.equal_range(pfrom->GetId());
+    while (range.first != range.second)
+    {
+        if (range.first->second.thinType == thinType)
+            return true;
+
+        range.first++;
+    }
+    return false;
+}
+
+unsigned int ThinTypeRelay::TotalThinTypeBlocksInFlight()
+{
+    LOCK(cs_inflight);
+    return mapThinTypeBlocksInFlight.size();
+}
+
+void ThinTypeRelay::ThinTypeBlockWasReceived(CNode *pfrom, const uint256 &hash)
+{
+    LOCK(cs_inflight);
+    std::pair<std::multimap<const NodeId, CThinTypeBlockInFlight>::iterator,
+        std::multimap<const NodeId, CThinTypeBlockInFlight>::iterator>
+        range = mapThinTypeBlocksInFlight.equal_range(pfrom->GetId());
+    while (range.first != range.second)
+    {
+        if (range.first->second.hash == hash)
+            range.first->second.fReceived = true;
+
+        range.first++;
+    }
+}
+
+void ThinTypeRelay::AddThinTypeBlockInFlight(CNode *pfrom, const uint256 &hash, const std::string thinType)
+{
+    LOCK(cs_inflight);
+    mapThinTypeBlocksInFlight.insert(
+        std::pair<const NodeId, CThinTypeBlockInFlight>(pfrom->GetId(), {hash, GetTime(), false, thinType}));
+}
+
+void ThinTypeRelay::ClearThinTypeBlockInFlight(CNode *pfrom, const uint256 &hash)
+{
+    LOCK(cs_inflight);
+    std::pair<std::multimap<const NodeId, CThinTypeBlockInFlight>::iterator,
+        std::multimap<const NodeId, CThinTypeBlockInFlight>::iterator>
+        range = mapThinTypeBlocksInFlight.equal_range(pfrom->GetId());
+    while (range.first != range.second)
+    {
+        if (range.first->second.hash == hash)
+        {
+            range.first = mapThinTypeBlocksInFlight.erase(range.first);
+        }
+        else
+        {
+            range.first++;
+        }
+    }
+}
+
+void ThinTypeRelay::CheckForThinTypeDownloadTimeout(CNode *pfrom)
+{
+    LOCK(cs_inflight);
+    if (mapThinTypeBlocksInFlight.size() == 0)
+        return;
+
+    std::pair<std::multimap<const NodeId, CThinTypeBlockInFlight>::iterator,
+        std::multimap<const NodeId, CThinTypeBlockInFlight>::iterator>
+        range = mapThinTypeBlocksInFlight.equal_range(pfrom->GetId());
+    while (range.first != range.second)
+    {
+        // Use a timeout of 6 times the retry inverval before disconnecting.  This way only a max of 6
+        // re-requested thinblocks or graphene blocks could be in memory at any one time.
+        if (!range.first->second.fReceived &&
+            (GetTime() - range.first->second.nRequestTime) >
+                (int)MAX_THINTYPE_BLOCKS_IN_FLIGHT * blkReqRetryInterval / 1000000)
+        {
+            if (!pfrom->fWhitelisted && Params().NetworkIDString() != "regtest")
+            {
+                LOG(THIN | GRAPHENE,
+                    "ERROR: Disconnecting peer %s due to thinblock download timeout exceeded (%d secs)\n",
+                    pfrom->GetLogName(), (GetTime() - range.first->second.nRequestTime));
+                pfrom->fDisconnect = true;
+                return;
+            }
+        }
+
+        range.first++;
+    }
+}

--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -13,7 +13,7 @@ bool IsThinBlockEnabled();
 bool IsGrapheneBlockEnabled();
 
 // Update the counters for how many peers we have connected.
-void ThinTypeRelay::AddThinTypePeers(CNode *pfrom, bool fCmpct)
+void ThinTypeRelay::AddThinTypePeers(CNode *pfrom)
 {
     if (pfrom)
     {
@@ -22,12 +22,12 @@ void ThinTypeRelay::AddThinTypePeers(CNode *pfrom, bool fCmpct)
         if (pfrom->nServices & NODE_GRAPHENE)
             nGraphenePeers++;
     }
-    if (fCmpct)
-    {
-        nCompactBlockPeers++;
-    }
 }
-
+void ThinTypeRelay::AddCompactBlockPeer(CNode *pfrom)
+{
+    if (pfrom && pfrom->fSupportsCompactBlocks)
+        nCompactBlockPeers++;
+}
 void ThinTypeRelay::RemoveThinTypePeers(CNode *pfrom)
 {
     if (pfrom)

--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -56,7 +56,7 @@ bool ThinTypeRelay::HasBlockRelayTimerExpired(const uint256 &hash)
     // Base time used to calculate the random timeout value.
     static uint64_t nTimeToWait = GetArg("-preferential-timer", DEFAULT_PREFERENTIAL_TIMER);
     if (nTimeToWait == 0)
-        return false;
+        return true;
 
     LOCK(cs_blockrelaytimer);
     if (!mapBlockRelayTimer.count(hash))
@@ -74,7 +74,7 @@ bool ThinTypeRelay::HasBlockRelayTimerExpired(const uint256 &hash)
         uint64_t nStartInterval = nTimeToWait * 0.8;
         uint64_t nIntervalLen = 2 * (nTimeToWait * 0.2);
         int64_t nOffset = nTimeToWait - (nStartInterval + (insecure_rand.rand64() % nIntervalLen) + 1);
-        mapBlockRelayTimer[hash] = std::make_pair(GetTimeMillis() + nOffset, false);
+        mapBlockRelayTimer.emplace(hash, std::make_pair(GetTimeMillis() + nOffset, false));
         LOG(GRAPHENE, "Starting Preferential block relay timer (%d millis)\n", nTimeToWait + nOffset);
     }
     else
@@ -95,11 +95,11 @@ bool ThinTypeRelay::HasBlockRelayTimerExpired(const uint256 &hash)
                     iter->second.second = true;
                     LOG(GRAPHENE | THIN, "Preferential block relay timer exceeded\n");
                 }
-                return false;
+                return true;
             }
         }
     }
-    return true;
+    return false;
 }
 
 bool ThinTypeRelay::IsBlockRelayTimerEnabled()

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -44,7 +44,8 @@ private:
     std::atomic<int32_t> nCompactBlockPeers{0};
 
 public:
-    void AddThinTypePeers(CNode *pfrom, bool fCmpct = false);
+    void AddThinTypePeers(CNode *pfrom);
+    void AddCompactBlockPeer(CNode *pfrom);
     void RemoveThinTypePeers(CNode *pfrom);
     bool HasBlockRelayTimerExpired(const uint256 &hash);
     bool IsBlockRelayTimerEnabled();

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -5,5 +5,57 @@
 #ifndef BITCOIN_BLOCKRELAY_COMMON_H
 #define BITCOIN_BLOCKRELAY_COMMON_H
 
+#include "net.h"
+#include "utiltime.h"
+
+#include <stdint.h>
+
+class CNode;
+class uint256;
+
+struct CThinTypeBlockInFlight
+{
+    uint256 hash;
+    int64_t nRequestTime;
+    bool fReceived;
+    const std::string thinType;
+};
+
+class ThinTypeRelay
+{
+public:
+    CCriticalSection cs_inflight;
+
+private:
+    // block relay timer
+    CCriticalSection cs_blockrelaytimer;
+    std::map<uint256, std::pair<uint64_t, bool> > mapBlockRelayTimer GUARDED_BY(cs_blockrelaytimer);
+
+    // thin type blocks in flight and the time they were requested.
+    std::multimap<const NodeId, CThinTypeBlockInFlight> mapThinTypeBlocksInFlight GUARDED_BY(cs_inflight);
+
+    // put a cap on the total number of thin type blocks we can have in flight. This lowers any possible
+    // attack surface.
+    size_t MAX_THINTYPE_BLOCKS_IN_FLIGHT = 6;
+
+    // Counters for how many of each peer are currently connected.
+    std::atomic<int32_t> nThinBlockPeers{0};
+    std::atomic<int32_t> nGraphenePeers{0};
+    std::atomic<int32_t> nCompactBlockPeers{0};
+
+public:
+    void AddThinTypePeers(CNode *pfrom, bool fCmpct = false);
+    void RemoveThinTypePeers(CNode *pfrom);
+    bool HasBlockRelayTimerExpired(const uint256 &hash);
+    bool IsBlockRelayTimerEnabled();
+    void ClearBlockRelayTimer(const uint256 &hash);
+    bool IsThinTypeBlockInFlight(CNode *pfrom, const std::string thinType);
+    unsigned int TotalThinTypeBlocksInFlight();
+    void ThinTypeBlockWasReceived(CNode *pfrom, const uint256 &hash);
+    void AddThinTypeBlockInFlight(CNode *pfrom, const uint256 &hash, const std::string thinType);
+    void ClearThinTypeBlockInFlight(CNode *pfrom, const uint256 &hash);
+    void CheckForThinTypeDownloadTimeout(CNode *pfrom);
+};
+extern ThinTypeRelay thinrelay;
 
 #endif // BITCOIN_BLOCKRELAY_COMMON_H

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -52,7 +52,7 @@ public:
     bool IsThinTypeBlockInFlight(CNode *pfrom, const std::string thinType);
     unsigned int TotalThinTypeBlocksInFlight();
     void ThinTypeBlockWasReceived(CNode *pfrom, const uint256 &hash);
-    void AddThinTypeBlockInFlight(CNode *pfrom, const uint256 &hash, const std::string thinType);
+    bool AddThinTypeBlockInFlight(CNode *pfrom, const uint256 &hash, const std::string thinType);
     void ClearThinTypeBlockInFlight(CNode *pfrom, const uint256 &hash);
     void CheckForThinTypeDownloadTimeout(CNode *pfrom);
 };

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1448,7 +1448,8 @@ void RequestFailoverBlock(CNode *pfrom, uint256 blockHash)
         CBloomFilter filterMemPool;
         CInv inv2(MSG_XTHINBLOCK, blockHash);
 
-        thinrelay.AddThinTypeBlockInFlight(pfrom, inv2.hash, NetMsgType::XTHINBLOCK);
+        if (!thinrelay.AddThinTypeBlockInFlight(pfrom, inv2.hash, NetMsgType::XTHINBLOCK))
+            return;
 
         std::vector<uint256> vOrphanHashes;
         {

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -3,7 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "blockrelay/graphene.h"
-#include "blockrelay/thinblock.h"
+#include "blockrelay/blockrelay_common.h"
 #include "blockstorage/blockstorage.h"
 #include "chainparams.h"
 #include "connmgr.h"
@@ -86,8 +86,8 @@ bool CGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     LOG(GRAPHENE, "Received grblocktx for %s peer=%s\n", inv.hash.ToString(), pfrom->GetLogName());
     {
         // Do not process unrequested grblocktx unless from an expedited node.
-        LOCK(pfrom->cs_mapgrapheneblocksinflight);
-        if (!pfrom->mapGrapheneBlocksInFlight.count(inv.hash) && !connmgr->IsExpeditedUpstream(pfrom))
+        if (!thinrelay.IsThinTypeBlockInFlight(pfrom, NetMsgType::GRAPHENEBLOCK) &&
+            !connmgr->IsExpeditedUpstream(pfrom))
         {
             dosMan.Misbehaving(pfrom, 10);
             return error(
@@ -404,8 +404,7 @@ bool CGrapheneBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string
                 pfrom->GetLogName(), nSizeGrapheneBlock);
 
             // Do not process unrequested grapheneblocks.
-            LOCK(pfrom->cs_mapgrapheneblocksinflight);
-            if (!pfrom->mapGrapheneBlocksInFlight.count(inv.hash))
+            if (!thinrelay.IsThinTypeBlockInFlight(pfrom, NetMsgType::GRAPHENEBLOCK))
             {
                 dosMan.Misbehaving(pfrom, 10);
                 return error(
@@ -1173,78 +1172,12 @@ std::string CGrapheneBlockData::ReRequestedTxToString()
     return ss.str();
 }
 
-// Preferential Graphene Block Timer:
-// The purpose of the timer is to ensure that we more often download an GRAPHENEBLOCK rather than a full block.
-// The timer is started when we receive the first announcement indicating there is a new block to download.  If the
-// block inventory is from a non GRAPHENE node then we will continue to wait for block announcements until either we
-// get one from an GRAPHENE capable node or the timer is exceeded.  If the timer is exceeded before receiving an
-// announcement from an GRAPHENE node then we just download a full block instead of a graphene block.
-bool CGrapheneBlockData::CheckGrapheneBlockTimer(const uint256 &hash)
-{
-    // Base time used to calculate the random timeout value.
-    static uint64_t nTimeToWait = GetArg("-preferential-timer", DEFAULT_PREFERENTIAL_TIMER);
-    if (nTimeToWait == 0)
-        return false;
-
-    LOCK(cs_mapGrapheneBlockTimer);
-    if (!mapGrapheneBlockTimer.count(hash))
-    {
-        // The timeout limit is a random number belonging to graphene-timer +/- 20%
-        // This way a node connected to this one may download the block
-        // before the other node and thus be able to serve the other with
-        // a graphene block, rather than both nodes timing out and downloading
-        // a thinblock instead. This can happen at the margins of the BU network
-        // where we receive full blocks from peers that don't support graphene.
-        //
-        // To make the timeout random we adjust the start time of the timer forward
-        // or backward by a random amount plus or minus 20% of preferential timer in milliseconds.
-        FastRandomContext insecure_rand(false);
-        uint64_t nStartInterval = nTimeToWait * 0.8;
-        uint64_t nIntervalLen = 2 * (nTimeToWait * 0.2);
-        int64_t nOffset = nTimeToWait - (nStartInterval + (insecure_rand.rand64() % nIntervalLen) + 1);
-        mapGrapheneBlockTimer[hash] = std::make_pair(GetTimeMillis() + nOffset, false);
-        LOG(GRAPHENE, "Starting Preferential Graphene Block timer (%d millis)\n", nTimeToWait + nOffset);
-    }
-    else
-    {
-        // Check that we have not exceeded time limit.
-        // If we have then we want to return false so that we can
-        // proceed to download a regular block instead.
-        auto iter = mapGrapheneBlockTimer.find(hash);
-        if (iter != mapGrapheneBlockTimer.end())
-        {
-            int64_t elapsed = GetTimeMillis() - iter->second.first;
-            if (elapsed > (int64_t)nTimeToWait)
-            {
-                // Only print out the log entry once.  Because the graphene timer will be hit
-                // many times when requesting a block we don't want to fill up the log file.
-                if (!iter->second.second)
-                {
-                    iter->second.second = true;
-                    LOG(GRAPHENE, "Preferential Graphene Block timer exceeded\n");
-                }
-                return false;
-            }
-        }
-    }
-    return true;
-}
-
-// The timer is cleared as soon as we request a block or graphene block.
-void CGrapheneBlockData::ClearGrapheneBlockTimer(const uint256 &hash)
-{
-    LOCK(cs_mapGrapheneBlockTimer);
-    if (mapGrapheneBlockTimer.count(hash))
-    {
-        mapGrapheneBlockTimer.erase(hash);
-        LOG(GRAPHENE, "Clearing Preferential Graphene Block timer\n");
-    }
-}
-
 // After a graphene block is finished processing or if for some reason we have to pre-empt the rebuilding
 // of a graphene block then we clear out the graphene block data which can be substantial.
 void CGrapheneBlockData::ClearGrapheneBlockData(CNode *pnode)
 {
+    LOCK(pnode->cs_graphene);
+
     // Remove bytes from counter
     graphenedata.DeleteGrapheneBlockBytes(pnode->nLocalGrapheneBlockBytes, pnode);
     pnode->nLocalGrapheneBlockBytes = 0;
@@ -1264,7 +1197,7 @@ void CGrapheneBlockData::ClearGrapheneBlockData(CNode *pnode, const uint256 &has
 {
     // We must make sure to clear the graphene block data first before clearing the graphene block in flight.
     ClearGrapheneBlockData(pnode);
-    ClearGrapheneBlockInFlight(pnode, hash);
+    thinrelay.ClearThinTypeBlockInFlight(pnode, hash);
 }
 
 void CGrapheneBlockData::ClearGrapheneBlockStats()
@@ -1339,25 +1272,7 @@ void CGrapheneBlockData::FillGrapheneQuickStats(GrapheneQuickStats &stats)
     stats.nLast24hRerequestTx = mapGrapheneBlocksInBoundReRequestedTx.size();
 }
 
-bool HaveGrapheneNodes()
-{
-    LOCK(cs_vNodes);
-    for (CNode *pnode : vNodes)
-        if (pnode->GrapheneCapable())
-            return true;
-    return false;
-}
-
 bool IsGrapheneBlockEnabled() { return GetBoolArg("-use-grapheneblocks", DEFAULT_USE_GRAPHENE_BLOCKS); }
-bool CanGrapheneBlockBeDownloaded(CNode *pto)
-{
-    LOCK(pto->cs_mapgrapheneblocksinflight);
-    if (pto->mapGrapheneBlocksInFlight.size() < 1 && pto->GrapheneCapable())
-        return true;
-
-    return false;
-}
-
 bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom)
 {
     CNode *pLargest = nullptr;
@@ -1379,19 +1294,6 @@ bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom)
     }
 
     return false;
-}
-
-void ClearGrapheneBlockInFlight(CNode *pfrom, const uint256 &hash)
-{
-    LOCK(pfrom->cs_mapgrapheneblocksinflight);
-    pfrom->mapGrapheneBlocksInFlight.erase(hash);
-}
-
-void AddGrapheneBlockInFlight(CNode *pfrom, const uint256 &hash)
-{
-    LOCK(pfrom->cs_mapgrapheneblocksinflight);
-    pfrom->mapGrapheneBlocksInFlight.insert(
-        std::pair<uint256, CNode::CGrapheneBlockInFlight>(hash, CNode::CGrapheneBlockInFlight()));
 }
 
 void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CMemPoolInfo &mempoolinfo)
@@ -1538,14 +1440,15 @@ CMemPoolInfo GetGrapheneMempoolInfo()
 }
 void RequestFailoverBlock(CNode *pfrom, uint256 blockHash)
 {
-    if (IsThinBlocksEnabled() && pfrom->ThinBlockCapable())
+    if (IsThinBlocksEnabled() && pfrom->ThinBlockCapable() &&
+        !thinrelay.IsThinTypeBlockInFlight(pfrom, NetMsgType::XTHINBLOCK))
     {
         LOG(GRAPHENE, "Requesting xthin block as failover from peer %s\n", pfrom->GetLogName());
         CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
         CBloomFilter filterMemPool;
         CInv inv2(MSG_XTHINBLOCK, blockHash);
 
-        AddThinBlockInFlight(pfrom, inv2.hash);
+        thinrelay.AddThinTypeBlockInFlight(pfrom, inv2.hash, NetMsgType::XTHINBLOCK);
 
         std::vector<uint256> vOrphanHashes;
         {

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -178,9 +178,6 @@ private:
     /* The sum total of all bytes for graphene blocks currently in process of being reconstructed */
     std::atomic<uint64_t> nGrapheneBlockBytes{0};
 
-    CCriticalSection cs_mapGrapheneBlockTimer; // locks mapGrapheneBlockTimer
-    std::map<uint256, std::pair<uint64_t, bool> > mapGrapheneBlockTimer;
-
     CCriticalSection cs_graphenestats; // locks everything below this point
 
     CStatHistory<uint64_t> nOriginalSize;
@@ -285,9 +282,6 @@ public:
     std::string ValidationTimeToString();
     std::string ReRequestedTxToString();
 
-    bool CheckGrapheneBlockTimer(const uint256 &hash);
-    void ClearGrapheneBlockTimer(const uint256 &hash);
-
     void ClearGrapheneBlockData(CNode *pfrom);
     void ClearGrapheneBlockData(CNode *pfrom, const uint256 &hash);
     void ClearGrapheneBlockStats();
@@ -302,12 +296,8 @@ public:
 extern CGrapheneBlockData graphenedata; // Singleton class
 
 
-bool HaveGrapheneNodes();
 bool IsGrapheneBlockEnabled();
-bool CanGrapheneBlockBeDownloaded(CNode *pto);
 bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom);
-void ClearGrapheneBlockInFlight(CNode *pfrom, const uint256 &hash);
-void AddGrapheneBlockInFlight(CNode *pfrom, const uint256 &hash);
 void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CMemPoolInfo &mempoolinfo);
 bool IsGrapheneBlockValid(CNode *pfrom, const CBlockHeader &header);
 bool HandleGrapheneBlockRequest(CDataStream &vRecv, CNode *pfrom, const CChainParams &chainparams);

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -620,7 +620,9 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
         // If this is an expedited block then add and entry to mapThinBlocksInFlight.
         if (nHops > 0 && connmgr->IsExpeditedUpstream(pfrom))
         {
-            thinrelay.AddThinTypeBlockInFlight(pfrom, inv.hash, NetMsgType::XTHINBLOCK);
+            // If we can't add this xthin then we've already requested it
+            if (!thinrelay.AddThinTypeBlockInFlight(pfrom, inv.hash, NetMsgType::XTHINBLOCK))
+                return true;
 
             LOG(THIN, "Received new expedited %s %s from peer %s hop %d size %d bytes\n", strCommand,
                 inv.hash.ToString(), pfrom->GetLogName(), nHops, nSizeThinBlock);

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "blockrelay/blockrelay_common.h"
 #include "blockrelay/thinblock.h"
 #include "blockstorage/blockstorage.h"
 #include "chainparams.h"
@@ -95,8 +96,7 @@ bool CThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
 
     // Ban a node for sending unrequested thinblocks unless from an expedited node.
     {
-        LOCK(pfrom->cs_mapthinblocksinflight);
-        if (!pfrom->mapThinBlocksInFlight.count(inv.hash) && !connmgr->IsExpeditedUpstream(pfrom))
+        if (!thinrelay.IsThinTypeBlockInFlight(pfrom, NetMsgType::XTHINBLOCK) && !connmgr->IsExpeditedUpstream(pfrom))
         {
             dosMan.Misbehaving(pfrom, 100);
             return error("unrequested thinblock from peer %s", pfrom->GetLogName());
@@ -309,8 +309,7 @@ bool CXThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     LOG(THIN, "received xblocktx for %s peer=%s\n", inv.hash.ToString(), pfrom->GetLogName());
     {
         // Do not process unrequested xblocktx unless from an expedited node.
-        LOCK(pfrom->cs_mapthinblocksinflight);
-        if (!pfrom->mapThinBlocksInFlight.count(inv.hash) && !connmgr->IsExpeditedUpstream(pfrom))
+        if (!thinrelay.IsThinTypeBlockInFlight(pfrom, NetMsgType::XTHINBLOCK) && !connmgr->IsExpeditedUpstream(pfrom))
         {
             dosMan.Misbehaving(pfrom, 10);
             return error(
@@ -621,7 +620,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
         // If this is an expedited block then add and entry to mapThinBlocksInFlight.
         if (nHops > 0 && connmgr->IsExpeditedUpstream(pfrom))
         {
-            AddThinBlockInFlight(pfrom, inv.hash);
+            thinrelay.AddThinTypeBlockInFlight(pfrom, inv.hash, NetMsgType::XTHINBLOCK);
 
             LOG(THIN, "Received new expedited %s %s from peer %s hop %d size %d bytes\n", strCommand,
                 inv.hash.ToString(), pfrom->GetLogName(), nHops, nSizeThinBlock);
@@ -632,8 +631,8 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
                 pfrom->GetLogName(), nSizeThinBlock);
 
             // Do not process unrequested xthinblocks unless from an expedited node.
-            LOCK(pfrom->cs_mapthinblocksinflight);
-            if (!pfrom->mapThinBlocksInFlight.count(inv.hash) && !connmgr->IsExpeditedUpstream(pfrom))
+            if (!thinrelay.IsThinTypeBlockInFlight(pfrom, NetMsgType::XTHINBLOCK) &&
+                !connmgr->IsExpeditedUpstream(pfrom))
             {
                 dosMan.Misbehaving(pfrom, 10);
                 return error(
@@ -1316,78 +1315,12 @@ std::string CThinBlockData::FullTxToString()
     return ss.str();
 }
 
-// Preferential Thinblock Timer:
-// The purpose of the timer is to ensure that we more often download an XTHINBLOCK rather than a full block.
-// The timer is started when we receive the first announcement indicating there is a new block to download.  If the
-// block inventory is from a non XTHIN node then we will continue to wait for block announcements until either we
-// get one from an XTHIN capable node or the timer is exceeded.  If the timer is exceeded before receiving an
-// announcement from an XTHIN node then we just download a full block instead of an xthin.
-bool CThinBlockData::CheckThinblockTimer(const uint256 &hash)
-{
-    // Base time used to calculate the random timeout value.
-    static uint64_t nTimeToWait = GetArg("-preferential-timer", DEFAULT_PREFERENTIAL_TIMER);
-    if (nTimeToWait == 0)
-        return false;
-
-    LOCK(cs_mapThinBlockTimer);
-    if (!mapThinBlockTimer.count(hash))
-    {
-        // The timeout limit is a random number belonging to thinblock-timer +/- 20%
-        // This way a node connected to this one may download the block
-        // before the other node and thus be able to serve the other with
-        // a graphene block, rather than both nodes timing out and downloading
-        // a thinblock instead. This can happen at the margins of the BU network
-        // where we receive full blocks from peers that don't support graphene.
-        //
-        // To make the timeout random we adjust the start time of the timer forward
-        // or backward by a random amount plus or minus 20% of preferential timer in milliseconds.
-        FastRandomContext insecure_rand(false);
-        uint64_t nStartInterval = nTimeToWait * 0.8;
-        uint64_t nIntervalLen = 2 * (nTimeToWait * 0.2);
-        int64_t nOffset = nTimeToWait - (nStartInterval + (insecure_rand.rand64() % nIntervalLen) + 1);
-        mapThinBlockTimer[hash] = std::make_pair(GetTimeMillis() + nOffset, false);
-        LOG(THIN, "Starting Preferential Thinblock timer (%d millis)\n", nTimeToWait + nOffset);
-    }
-    else
-    {
-        // Check that we have not exceeded the 10 second limit.
-        // If we have then we want to return false so that we can
-        // proceed to download a regular block instead.
-        auto iter = mapThinBlockTimer.find(hash);
-        if (iter != mapThinBlockTimer.end())
-        {
-            int64_t elapsed = GetTimeMillis() - iter->second.first;
-            if (elapsed > (int64_t)nTimeToWait)
-            {
-                // Only print out the log entry once.  Because the thinblock timer will be hit
-                // many times when requesting a block we don't want to fill up the log file.
-                if (!iter->second.second)
-                {
-                    iter->second.second = true;
-                    LOG(THIN, "Preferential Thinblock timer exceeded - downloading regular block instead\n");
-                }
-                return false;
-            }
-        }
-    }
-    return true;
-}
-
-// The timer is cleared as soon as we request a block or thinblock.
-void CThinBlockData::ClearThinBlockTimer(const uint256 &hash)
-{
-    LOCK(cs_mapThinBlockTimer);
-    if (mapThinBlockTimer.count(hash))
-    {
-        mapThinBlockTimer.erase(hash);
-        LOG(THIN, "Clearing Preferential Thinblock timer\n");
-    }
-}
-
 // After a thinblock is finished processing or if for some reason we have to pre-empt the rebuilding
 // of a thinblock then we clear out the thinblock data which can be substantial.
 void CThinBlockData::ClearThinBlockData(CNode *pnode)
 {
+    LOCK(pnode->cs_xthinblock);
+
     // Remove bytes from counter
     thindata.DeleteThinBlockBytes(pnode->nLocalThinBlockBytes, pnode);
     pnode->nLocalThinBlockBytes = 0;
@@ -1407,7 +1340,7 @@ void CThinBlockData::ClearThinBlockData(CNode *pnode, const uint256 &hash)
 {
     // We must make sure to clear the thinblock data first before clearing the thinblock in flight.
     ClearThinBlockData(pnode);
-    ClearThinBlockInFlight(pnode, hash);
+    thinrelay.ClearThinTypeBlockInFlight(pnode, hash);
 }
 
 void CThinBlockData::ClearThinBlockStats()
@@ -1479,27 +1412,7 @@ void CThinBlockData::FillThinBlockQuickStats(ThinBlockQuickStats &stats)
     stats.nLast24hRerequestTx = mapThinBlocksInBoundReRequestedTx.size();
 }
 
-bool HaveThinblockNodes()
-{
-    {
-        LOCK(cs_vNodes);
-        for (CNode *pnode : vNodes)
-            if (pnode->ThinBlockCapable())
-                return true;
-    }
-    return false;
-}
-
 bool IsThinBlocksEnabled() { return GetBoolArg("-use-thinblocks", true); }
-bool CanThinBlockBeDownloaded(CNode *pto)
-{
-    LOCK(pto->cs_mapthinblocksinflight);
-    if (pto->mapThinBlocksInFlight.size() < 1 && pto->ThinBlockCapable())
-        return true;
-
-    return false;
-}
-
 bool ClearLargestThinBlockAndDisconnect(CNode *pfrom)
 {
     CNode *pLargest = nullptr;
@@ -1521,19 +1434,6 @@ bool ClearLargestThinBlockAndDisconnect(CNode *pfrom)
     }
 
     return false;
-}
-
-void ClearThinBlockInFlight(CNode *pfrom, const uint256 &hash)
-{
-    LOCK(pfrom->cs_mapthinblocksinflight);
-    pfrom->mapThinBlocksInFlight.erase(hash);
-}
-
-void AddThinBlockInFlight(CNode *pfrom, const uint256 &hash)
-{
-    LOCK(pfrom->cs_mapthinblocksinflight);
-    pfrom->mapThinBlocksInFlight.insert(
-        std::pair<uint256, CNode::CThinBlockInFlight>(hash, CNode::CThinBlockInFlight()));
 }
 
 void SendXThinBlock(ConstCBlockRef pblock, CNode *pfrom, const CInv &inv)

--- a/src/blockrelay/thinblock.h
+++ b/src/blockrelay/thinblock.h
@@ -177,9 +177,6 @@ private:
     /* The sum total of all bytes for thinblocks currently in process of being reconstructed */
     std::atomic<uint64_t> nThinBlockBytes{0};
 
-    CCriticalSection cs_mapThinBlockTimer; // locks mapThinBlockTimer
-    std::map<uint256, std::pair<uint64_t, bool> > mapThinBlockTimer;
-
     CCriticalSection cs_thinblockstats; // locks everything below this point
 
     CStatHistory<uint64_t> nOriginalSize;
@@ -273,9 +270,6 @@ public:
     std::string ThinBlockToString();
     std::string FullTxToString();
 
-    bool CheckThinblockTimer(const uint256 &hash);
-    void ClearThinBlockTimer(const uint256 &hash);
-
     void ClearThinBlockData(CNode *pfrom);
     void ClearThinBlockData(CNode *pfrom, const uint256 &hash);
     void ClearThinBlockStats();
@@ -290,12 +284,8 @@ public:
 extern CThinBlockData thindata; // Singleton class
 
 
-bool HaveThinblockNodes();
 bool IsThinBlocksEnabled();
-bool CanThinBlockBeDownloaded(CNode *pto);
 bool ClearLargestThinBlockAndDisconnect(CNode *pfrom);
-void ClearThinBlockInFlight(CNode *pfrom, const uint256 &hash);
-void AddThinBlockInFlight(CNode *pfrom, const uint256 &hash);
 void SendXThinBlock(ConstCBlockRef pblock, CNode *pfrom, const CInv &inv);
 bool IsThinBlockValid(CNode *pfrom, const std::vector<CTransaction> &vMissingTx, const CBlockHeader &header);
 void BuildSeededBloomFilter(CBloomFilter &memPoolFilter,

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -9,6 +9,7 @@
 // purposes.
 
 #include "addrman.h"
+#include "blockrelay/blockrelay_common.h"
 #include "blockrelay/graphene.h"
 #include "blockrelay/thinblock.h"
 #include "chain.h"
@@ -399,8 +400,10 @@ CStatHistory<uint64_t> nTxValidationTime("txValidationTime", STAT_OP_MAX | STAT_
 CCriticalSection cs_blockvalidationtime;
 CStatHistory<uint64_t> nBlockValidationTime("blockValidationTime", STAT_OP_MAX | STAT_INDIVIDUAL);
 
-CThinBlockData thindata; // Singleton class
-CGrapheneBlockData graphenedata; // Singleton class
+// Single classes for gather thin type block relay statistics
+CThinBlockData thindata;
+CGrapheneBlockData graphenedata;
+ThinTypeRelay thinrelay;
 
 uint256 bitcoinCashForkBlockHash = uint256S("000000000000000000651ef99cb9fcbe0dadde1d424bd9f15ff20136191a5eec");
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,6 +8,7 @@
 
 #include "addrman.h"
 #include "arith_uint256.h"
+#include "blockrelay/blockrelay_common.h"
 #include "blockrelay/graphene.h"
 #include "blockrelay/thinblock.h"
 #include "blockstorage/blockstorage.h"
@@ -144,6 +145,10 @@ void InitializeNode(const CNode *pnode)
 
 void FinalizeNode(NodeId nodeid)
 {
+    // Decrement thin type peer counters
+    thinrelay.RemoveThinTypePeers(&(*connmgr->FindNodeFromId(nodeid)));
+
+    // Update node state
     {
         CNodeStateAccessor state(nodestate, nodeid);
         DbgAssert(state != nullptr, return );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -146,7 +146,7 @@ void InitializeNode(const CNode *pnode)
 void FinalizeNode(NodeId nodeid)
 {
     // Decrement thin type peer counters
-    thinrelay.RemoveThinTypePeers(&(*connmgr->FindNodeFromId(nodeid)));
+    thinrelay.RemoveThinTypePeers(connmgr->FindNodeFromId(nodeid).get());
 
     // Update node state
     {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2937,7 +2937,6 @@ CNode::~CNode()
             pfilter = nullptr; // BU
         }
 
-        // BUIP010 - Xtreme Thinblocks - begin section
         if (pThinBlockFilter)
         {
             delete pThinBlockFilter;
@@ -2945,25 +2944,14 @@ CNode::~CNode()
         }
     }
 
-    mapThinBlocksInFlight.clear();
     thinBlockWaitingForTxns = -1;
     thinBlock.SetNull();
+    grapheneBlockWaitingForTxns = -1;
+    grapheneBlock.SetNull();
 
     // We must set this to false on disconnect otherwise we will have trouble reconnecting -addnode nodes
     // if the remote peer restarts.
     fAutoOutbound = false;
-
-    // BUIP010 - Xtreme Thinblocks - end section
-
-    // BUIPXXX - Graphene blocks - begin section
-    mapGrapheneBlocksInFlight.clear();
-    grapheneBlockWaitingForTxns = -1;
-    grapheneBlock.SetNull();
-
-    fAutoOutbound = false;
-
-    // BUIPXXX - Graphene blocks - end section
-
 
     addrFromPort = 0;
 

--- a/src/net.h
+++ b/src/net.h
@@ -355,30 +355,6 @@ class CNode
 #endif
 
 public:
-    struct CThinBlockInFlight
-    {
-        int64_t nRequestTime;
-        bool fReceived;
-
-        CThinBlockInFlight()
-        {
-            nRequestTime = GetTime();
-            fReceived = false;
-        }
-    };
-
-    struct CGrapheneBlockInFlight
-    {
-        int64_t nRequestTime;
-        bool fReceived;
-
-        CGrapheneBlockInFlight()
-        {
-            nRequestTime = GetTime();
-            fReceived = false;
-        }
-    };
-
     // This is shared-locked whenever messages are processed.
     // Take it exclusive-locked to finish all ongoing processing
     CSharedCriticalSection csMsgSerializer;
@@ -473,6 +449,7 @@ public:
     bool fShouldBan;
 
     // BUIP010 Xtreme Thinblocks: begin section
+    CCriticalSection cs_xthinblock;
     CBlock thinBlock;
     std::vector<uint256> thinBlockHashes;
     std::vector<uint64_t> xThinBlockHashes;
@@ -480,10 +457,6 @@ public:
     uint64_t nLocalThinBlockBytes; // the bytes used in creating this thinblock, updated dynamically
     int nSizeThinBlock; // Original on-wire size of the block. Just used for reporting
     int thinBlockWaitingForTxns; // if -1 then not currently waiting
-
-    // thin blocks in flight and the time they were requested.
-    CCriticalSection cs_mapthinblocksinflight;
-    std::map<uint256, CThinBlockInFlight> mapThinBlocksInFlight GUARDED_BY(cs_mapthinblocksinflight);
 
     std::atomic<double> nGetXBlockTxCount; // Count how many get_xblocktx requests are made
     std::atomic<uint64_t> nGetXBlockTxLastTime; // The last time a get_xblocktx request was made
@@ -503,10 +476,6 @@ public:
     int grapheneBlockWaitingForTxns; // if -1 then not currently waiting
     CCriticalSection cs_grapheneadditionaltxs; // lock grapheneAdditionalTxs
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
-
-    // graphene blocks in flight and the time they were requested.
-    CCriticalSection cs_mapgrapheneblocksinflight;
-    std::map<uint256, CGrapheneBlockInFlight> mapGrapheneBlocksInFlight GUARDED_BY(cs_mapgrapheneblocksinflight);
 
     std::atomic<double> nGetGrapheneBlockTxCount; // Count how many get_xblocktx requests are made
     std::atomic<uint64_t> nGetGrapheneBlockTxLastTime; // The last time a get_xblocktx request was made

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -804,7 +804,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         pfrom->fSupportsCompactBlocks = nVersion == 1;
 
         // Increment compact block peer counter.
-        thinrelay.AddThinTypePeers(nullptr, true);
+        thinrelay.AddCompactBlockPeer(pfrom);
     }
 
     else if (strCommand == NetMsgType::INV)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -7,6 +7,7 @@
 #include "net_processing.h"
 
 #include "addrman.h"
+#include "blockrelay/blockrelay_common.h"
 #include "blockrelay/graphene.h"
 #include "blockrelay/thinblock.h"
 #include "blockstorage/blockstorage.h"
@@ -379,23 +380,6 @@ static void enableSendHeaders(CNode *pfrom)
         pfrom->PushMessage(NetMsgType::SENDHEADERS);
 }
 
-static bool CheckForDownloadTimeout(CNode *pto, bool fReceived, int64_t &nRequestTime)
-{
-    // Use a timeout of 6 times the retry inverval before disconnecting.  This way only a max of 6
-    // re-requested thinblocks or graphene blocks could be in memory at any one time.
-    if (!fReceived && (GetTime() - nRequestTime) > 6 * blkReqRetryInterval / 1000000)
-    {
-        if (!pto->fWhitelisted && Params().NetworkIDString() != "regtest")
-        {
-            LOG(THIN, "ERROR: Disconnecting peer %s due to thinblock download timeout exceeded (%d secs)\n",
-                pto->GetLogName(), (GetTime() - nRequestTime));
-            pto->fDisconnect = true;
-            return true;
-        }
-    }
-    return false;
-}
-
 bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, int64_t nTimeReceived)
 {
     int64_t receiptTime = GetTime();
@@ -454,6 +438,10 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         CAddress addrMe;
         uint64_t nNonce = 1;
         vRecv >> pfrom->nVersion >> pfrom->nServices >> nTime >> addrMe;
+
+        // Update thin type peer counters. This should be at the top here before we have any
+        // potential disconnects, because on disconnect the counters will then get decremented.
+        thinrelay.AddThinTypePeers(pfrom);
 
         if (pfrom->nVersion < MIN_PEER_PROTO_VERSION)
         {
@@ -814,6 +802,9 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         // BCH network currently only supports version 1 (v2 is segwit support on BTC)
         // May need to be updated in the future if other clients deploy a new version
         pfrom->fSupportsCompactBlocks = nVersion == 1;
+
+        // Increment compact block peer counter.
+        thinrelay.AddThinTypePeers(nullptr, true);
     }
 
     else if (strCommand == NetMsgType::INV)
@@ -2028,32 +2019,11 @@ bool SendMessages(CNode *pto)
             pto->PushMessage(NetMsgType::PING, nonce);
         }
 
-        // Check to see if there are any thinblocks or graphene blocks in flight that have gone beyond the
-        // timeout interval. If so then we need to disconnect them so that the thinblock data is nullified.
+        // Check to see if there are any thin type blocks in flight that have gone beyond the
+        // timeout interval. If so then we need to disconnect them so that the thintype data is nullified.
         // We could null the associated data here but that would possibly cause a node to be banned later if
-        // the thinblock or graphene block finally did show up, so instead we just disconnect this slow node.
-        {
-            LOCK(pto->cs_mapthinblocksinflight);
-            if (!pto->mapThinBlocksInFlight.empty())
-            {
-                for (auto &item : pto->mapThinBlocksInFlight)
-                {
-                    if (CheckForDownloadTimeout(pto, item.second.fReceived, item.second.nRequestTime))
-                        break;
-                }
-            }
-        }
-        {
-            LOCK(pto->cs_mapgrapheneblocksinflight);
-            if (!pto->mapGrapheneBlocksInFlight.empty())
-            {
-                for (auto &item : pto->mapGrapheneBlocksInFlight)
-                {
-                    if (CheckForDownloadTimeout(pto, item.second.fReceived, item.second.nRequestTime))
-                        break;
-                }
-            }
-        }
+        // the thin type block finally did show up, so instead we just disconnect this slow node.
+        thinrelay.CheckForThinTypeDownloadTimeout(pto);
 
         // Check for block download timeout and disconnect node if necessary. Does not require cs_main.
         int64_t nNow = GetTimeMicros();

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -3,6 +3,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "requestManager.h"
+#include "blockrelay/blockrelay_common.h"
 #include "blockrelay/graphene.h"
 #include "blockrelay/thinblock.h"
 #include "chain.h"
@@ -485,14 +486,16 @@ bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
     CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
     CBloomFilter filterMemPool;
 
-    // Ask for Graphene blocks
-    if (IsChainNearlySyncd() && IsGrapheneBlockEnabled() && HaveGrapheneNodes())
+    if (IsChainNearlySyncd() &&
+        (!thinrelay.HasBlockRelayTimerExpired(obj.hash) || !thinrelay.IsBlockRelayTimerEnabled()))
     {
-        if (graphenedata.CheckGrapheneBlockTimer(obj.hash))
+        // Ask for Graphene blocks
+        // Must download a graphene block from a graphene enabled peer.
+        if (IsGrapheneBlockEnabled() && pfrom->GrapheneCapable())
         {
-            // Must download a graphene block from a graphene enabled peer.
-            // We can only request one graphene block per peer at a time.
-            if (CanGrapheneBlockBeDownloaded(pfrom))
+            // We can only request one thin type block per peer at a time.
+            LOCK(thinrelay.cs_inflight);
+            if (!thinrelay.IsThinTypeBlockInFlight(pfrom, NetMsgType::GRAPHENEBLOCK))
             {
                 // Instead of building a bloom filter here as we would for an xthin, we actually
                 // just need to fill in CMempoolInfo
@@ -504,120 +507,44 @@ bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
                     ::GetSerializeSize(receiverMemPoolInfo, SER_NETWORK, PROTOCOL_VERSION));
 
                 MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
-                AddGrapheneBlockInFlight(pfrom, inv2.hash);
+                thinrelay.AddThinTypeBlockInFlight(pfrom, inv2.hash, NetMsgType::GRAPHENEBLOCK);
                 pfrom->PushMessage(NetMsgType::GET_GRAPHENE, ss);
                 LOG(GRAPHENE, "Requesting graphene block %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
                 return true;
             }
         }
-        else
+
+
+        // Ask for an xthin if Graphene is not possible.
+        // Must download an xthinblock from a xthin peer.
+        if (IsThinBlocksEnabled() && pfrom->ThinBlockCapable())
         {
-            // Try to download a graphene block if possible otherwise just download a regular block.
-            // We can only request one graphene block per peer at a time.
-            if (CanGrapheneBlockBeDownloaded(pfrom))
+            // We can only request one thin type block per peer at a time.
+            LOCK(thinrelay.cs_inflight);
+            if (!thinrelay.IsThinTypeBlockInFlight(pfrom, NetMsgType::XTHINBLOCK))
             {
-                // Instead of building a bloom filter here as we would for an xthin, we actually
-                // just need to fill in CMempoolInfo.
-                inv2.type = MSG_GRAPHENEBLOCK;
+                inv2.type = MSG_XTHINBLOCK;
+                std::vector<uint256> vOrphanHashes;
+                {
+                    READLOCK(orphanpool.cs);
+                    for (auto &mi : orphanpool.mapOrphanTransactions)
+                        vOrphanHashes.emplace_back(mi.first);
+                }
+                BuildSeededBloomFilter(filterMemPool, vOrphanHashes, inv2.hash, pfrom);
                 ss << inv2;
-                ss << GetGrapheneMempoolInfo();
+                ss << filterMemPool;
 
                 MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
-                AddGrapheneBlockInFlight(pfrom, inv2.hash);
-                pfrom->PushMessage(NetMsgType::GET_GRAPHENE, ss);
-                LOG(GRAPHENE, "Requesting graphene block %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
-                return true;
-            }
-            else if (!IsThinBlocksEnabled())
-            {
-                LOG(GRAPHENE, "Requesting regular block %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
-                std::vector<CInv> vToFetch;
-                inv2.type = MSG_BLOCK;
-                vToFetch.push_back(inv2);
-
-                MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
-                pfrom->PushMessage(NetMsgType::GETDATA, vToFetch);
+                thinrelay.AddThinTypeBlockInFlight(pfrom, inv2.hash, NetMsgType::XTHINBLOCK);
+                pfrom->PushMessage(NetMsgType::GET_XTHIN, ss);
+                LOG(THIN, "Requesting xthinblock %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
                 return true;
             }
         }
     }
 
-
-    // Ask for XTHIN's if Graphene is not enabled, or, ask for XTHIN's if graphene is enabled
-    // but the grapheneblock timer has lapsed.
-    if (IsChainNearlySyncd() && IsThinBlocksEnabled() && HaveThinblockNodes())
-    {
-        if (!IsGrapheneBlockEnabled() || !graphenedata.CheckGrapheneBlockTimer(obj.hash))
-        {
-            if (thindata.CheckThinblockTimer(obj.hash))
-            {
-                // Must download an xthinblock from a XTHIN peer.
-                // We can only request one xthinblock per peer at a time.
-                if (CanThinBlockBeDownloaded(pfrom))
-                {
-                    inv2.type = MSG_XTHINBLOCK;
-                    std::vector<uint256> vOrphanHashes;
-                    {
-                        READLOCK(orphanpool.cs);
-                        for (auto &mi : orphanpool.mapOrphanTransactions)
-                            vOrphanHashes.emplace_back(mi.first);
-                    }
-                    BuildSeededBloomFilter(filterMemPool, vOrphanHashes, inv2.hash, pfrom);
-                    ss << inv2;
-                    ss << filterMemPool;
-
-                    MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
-                    AddThinBlockInFlight(pfrom, inv2.hash);
-                    pfrom->PushMessage(NetMsgType::GET_XTHIN, ss);
-                    LOG(THIN, "Requesting xthinblock %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
-                    return true;
-                }
-            }
-            else
-            {
-                // Try to download a thinblock if possible otherwise just download a regular block.
-                // We can only request one xthinblock per peer at a time.
-                if (CanThinBlockBeDownloaded(pfrom))
-                {
-                    inv2.type = MSG_XTHINBLOCK;
-                    std::vector<uint256> vOrphanHashes;
-                    {
-                        READLOCK(orphanpool.cs);
-                        for (auto &mi : orphanpool.mapOrphanTransactions)
-                            vOrphanHashes.emplace_back(mi.first);
-                    }
-                    BuildSeededBloomFilter(filterMemPool, vOrphanHashes, inv2.hash, pfrom);
-                    ss << inv2;
-                    ss << filterMemPool;
-
-                    MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
-                    AddThinBlockInFlight(pfrom, inv2.hash);
-                    pfrom->PushMessage(NetMsgType::GET_XTHIN, ss);
-                    LOG(THIN, "Requesting xthinblock %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
-                    return true;
-                }
-                else
-                {
-                    std::vector<CInv> vToFetch;
-                    inv2.type = MSG_BLOCK;
-                    vToFetch.push_back(inv2);
-
-                    MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
-                    pfrom->PushMessage(NetMsgType::GETDATA, vToFetch);
-                    LOG(THIN, "Requesting Regular Block %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
-                    return true;
-                }
-            }
-        }
-    }
-
-    // Request a full block if graphene and thinblocks is turned off.  Also we must request a full block
-    // if we've fallen behind from the state of being fully syncd, furthermore, this is crucial for initial
-    // sync to function as this is the only way we request full blocks near the end of the initial sync process.
-    if (!IsChainNearlySyncd() || (!IsGrapheneBlockEnabled() && !IsThinBlocksEnabled()) ||
-        (!HaveThinblockNodes() && !HaveGrapheneNodes()) ||
-        (!IsGrapheneBlockEnabled() && HaveGrapheneNodes() && IsThinBlocksEnabled() && !HaveThinblockNodes()) ||
-        (IsGrapheneBlockEnabled() && !HaveGrapheneNodes() && !IsThinBlocksEnabled() && HaveThinblockNodes()))
+    // Request a full block if the BlockRelayTimer has expired.
+    if (!IsChainNearlySyncd() || thinrelay.HasBlockRelayTimerExpired(obj.hash) || !thinrelay.IsBlockRelayTimerEnabled())
     {
         std::vector<CInv> vToFetch;
         inv2.type = MSG_BLOCK;
@@ -625,7 +552,8 @@ bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
 
         MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
         pfrom->PushMessage(NetMsgType::GETDATA, vToFetch);
-        LOG(THIN | GRAPHENE, "Requesting Regular Block %s from peer %s\n", inv2.hash.ToString(), pfrom->GetLogName());
+        LOG(THIN | GRAPHENE, "Requesting Regular Block %s from peer %s\n", inv2.hash.ToString(),
+            pfrom->GetLogName());
         return true;
     }
     return false; // no block was requested
@@ -1149,8 +1077,7 @@ void CRequestManager::FindNextBlocksToDownload(CNode *node, unsigned int count, 
 void CRequestManager::MarkBlockAsInFlight(NodeId nodeid, const uint256 &hash)
 {
     // If started then clear the timers used for preferential downloading
-    thindata.ClearThinBlockTimer(hash);
-    graphenedata.ClearGrapheneBlockTimer(hash);
+    thinrelay.ClearBlockRelayTimer(hash);
 
     // Add to inflight, if it hasn't already been marked inflight for this node id.
     LOCK(cs_objDownloader);
@@ -1309,33 +1236,18 @@ bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
         LOG(THIN | BLK, "BLOCK_DOWNLOAD_WINDOW is %d nMaxBlocksInTransit is %d\n", BLOCK_DOWNLOAD_WINDOW.load(),
             pnode->nMaxBlocksInTransit.load());
 
+        // Update the appropriate response time based on the type of block received.
         if (IsChainNearlySyncd())
         {
-            // Update the appropriate response time based on the type of block received.
-            LOCK(cs_vNodes);
-            for (CNode *_pnode : vNodes)
+            // Update Thinblock stats
+            if (thinrelay.IsThinTypeBlockInFlight(pnode, NetMsgType::XTHINBLOCK))
             {
-                // Update Thinblock stats
-                if (IsThinBlocksEnabled())
-                {
-                    LOCK(_pnode->cs_mapthinblocksinflight);
-                    if (_pnode->mapThinBlocksInFlight.count(hash))
-                    {
-                        thindata.UpdateResponseTime(nResponseTime);
-                        break;
-                    }
-                }
-
-                // Update Graphene stats
-                if (IsGrapheneBlockEnabled())
-                {
-                    LOCK(_pnode->cs_mapgrapheneblocksinflight);
-                    if (_pnode->mapGrapheneBlocksInFlight.count(hash))
-                    {
-                        graphenedata.UpdateResponseTime(nResponseTime);
-                        break;
-                    }
-                }
+                thindata.UpdateResponseTime(nResponseTime);
+            }
+            // Update Graphene stats
+            if (thinrelay.IsThinTypeBlockInFlight(pnode, NetMsgType::GRAPHENEBLOCK))
+            {
+                graphenedata.UpdateResponseTime(nResponseTime);
             }
         }
 

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "blockrelay/blockrelay_common.h"
 #include "blockrelay/thinblock.h"
 #include "bloom.h"
 #include "chainparams.h"
@@ -892,11 +893,8 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             excessiveBlockSize = (nSizeTxInBlock * 158) / (nSharedTxSize * 16); // 88
 
             // Add the node to vNodes and also we need a thinblockinflight entry
-            {
-                LOCK(dummyNode6.cs_mapthinblocksinflight);
-                dummyNode6.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
-                vNodes.push_back(&dummyNode6);
-            }
+            thinrelay.AddThinTypeBlockInFlight(&dummyNode6, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
+            vNodes.push_back(&dummyNode6);
 
             // Process an xthinblock which causes a disconnect
             dummyNode6.fDisconnect = false;
@@ -913,11 +911,8 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             thindata.ClearThinBlockData(&dummyNode6, TestBlock1().GetHash());
 
             // Add the node to vNodes and also we need a thinblockinflight entry
-            {
-                LOCK(dummyNode6.cs_mapthinblocksinflight);
-                dummyNode6.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
-                vNodes.push_back(&dummyNode6);
-            }
+            thinrelay.AddThinTypeBlockInFlight(&dummyNode6, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
+            vNodes.push_back(&dummyNode6);
 
             // Process a regular thinblock
             dummyNode6.fDisconnect = false;
@@ -961,17 +956,12 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // Add the node to vNodes and also we need a thinblockinflight entry
             {
-                LOCK(dummyNode6.cs_mapthinblocksinflight);
-                LOCK(dummyNode7.cs_mapthinblocksinflight);
-                LOCK(dummyNode8.cs_mapthinblocksinflight);
-                LOCK(dummyNode9.cs_mapthinblocksinflight);
-                dummyNode6.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
                 vNodes.push_back(&dummyNode6);
-                dummyNode7.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
+                thinrelay.AddThinTypeBlockInFlight(&dummyNode7, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
                 vNodes.push_back(&dummyNode7);
-                dummyNode8.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
+                thinrelay.AddThinTypeBlockInFlight(&dummyNode8, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
                 vNodes.push_back(&dummyNode8);
-                dummyNode9.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
+                thinrelay.AddThinTypeBlockInFlight(&dummyNode9, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
                 vNodes.push_back(&dummyNode9);
             }
 
@@ -1035,17 +1025,13 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // Add the node to vNodes and also we need a thinblockinflight entry
             {
-                LOCK(dummyNode6.cs_mapthinblocksinflight);
-                LOCK(dummyNode7.cs_mapthinblocksinflight);
-                LOCK(dummyNode8.cs_mapthinblocksinflight);
-                LOCK(dummyNode9.cs_mapthinblocksinflight);
-                dummyNode6.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
+                thinrelay.AddThinTypeBlockInFlight(&dummyNode6, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
                 vNodes.push_back(&dummyNode6);
-                dummyNode7.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
+                thinrelay.AddThinTypeBlockInFlight(&dummyNode7, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
                 vNodes.push_back(&dummyNode7);
-                dummyNode8.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
+                thinrelay.AddThinTypeBlockInFlight(&dummyNode8, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
                 vNodes.push_back(&dummyNode8);
-                dummyNode9.mapThinBlocksInFlight[TestBlock1().GetHash()].nRequestTime = GetTime();
+                thinrelay.AddThinTypeBlockInFlight(&dummyNode9, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
                 vNodes.push_back(&dummyNode9);
             }
 
@@ -1118,11 +1104,11 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             dummyNode2.state_outgoing = ConnectionStateOutgoing::READY;
 
             SetMockTime(nStartTime);
-            AddThinBlockInFlight(&dummyNode1, hash1);
+            thinrelay.AddThinTypeBlockInFlight(&dummyNode1, hash1, NetMsgType::XTHINBLOCK);
             SetMockTime(nStartTime + 1);
-            AddThinBlockInFlight(&dummyNode1, hash2);
+            thinrelay.AddThinTypeBlockInFlight(&dummyNode1, hash2, NetMsgType::XTHINBLOCK);
             SetMockTime(nStartTime + 1);
-            AddThinBlockInFlight(&dummyNode2, hash1);
+            thinrelay.AddThinTypeBlockInFlight(&dummyNode2, hash1, NetMsgType::XTHINBLOCK);
 
             // Move clock forward to the boundary of the timeout interval
             // No nodes should be disconnected.

--- a/src/test/requestmanager_tests.cpp
+++ b/src/test/requestmanager_tests.cpp
@@ -48,11 +48,7 @@ static std::string NetMessage(std::deque<CSerializeData> &_vSendMsg)
     return ss.str();
 }
 
-static void ClearThinBlocksInFlight(CNode &node, CInv &inv)
-{
-    thinrelay.ClearThinTypeBlockInFlight(&node, inv.hash);
-}
-
+static void ClearThinBlocksInFlight(CNode &node, CInv &inv) { thinrelay.ClearThinTypeBlockInFlight(&node, inv.hash); }
 BOOST_FIXTURE_TEST_SUITE(requestmanager_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(blockrequest_tests)

--- a/src/test/requestmanager_tests.cpp
+++ b/src/test/requestmanager_tests.cpp
@@ -2,6 +2,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "blockrelay/blockrelay_common.h"
 #include "blockrelay/graphene.h"
 #include "blockrelay/thinblock.h"
 #include "bloom.h"
@@ -47,10 +48,9 @@ static std::string NetMessage(std::deque<CSerializeData> &_vSendMsg)
     return ss.str();
 }
 
-static void ClearBlocksInFlight(CNode &node)
+static void ClearThinBlocksInFlight(CNode &node, CInv &inv)
 {
-    node.mapGrapheneBlocksInFlight.clear();
-    node.mapThinBlocksInFlight.clear();
+    thinrelay.ClearThinTypeBlockInFlight(&node, inv.hash);
 }
 
 BOOST_FIXTURE_TEST_SUITE(requestmanager_tests, TestingSetup)
@@ -102,12 +102,10 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     IsChainNearlySyncdSet(false);
     SetBoolArg("-use-grapheneblocks", true);
     SetBoolArg("-use-thinblocks", true);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeXthin);
-        vNodes.push_back(&dummyNodeGraphene);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeGraphene);
+    thinrelay.AddThinTypePeers(&dummyNodeXthin);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
+
     requester.RequestBlock(&dummyNodeXthin, inv);
     BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("getdata") != 0);
 
@@ -117,253 +115,192 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     requester.RequestBlock(&dummyNodeNone, inv);
     BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeGraphene);
-    ClearBlocksInFlight(dummyNodeNone);
-    ClearBlocksInFlight(dummyNodeXthin);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
+    ClearThinBlocksInFlight(dummyNodeXthin, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeGraphene);
+    thinrelay.RemoveThinTypePeers(&dummyNodeXthin);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
+
     // Chains IS sync'd,  No graphene nodes, No Thinblock nodes, Thinblocks OFF, Graphene OFF
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", false);
     SetBoolArg("-use-thinblocks", false);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
+
     requester.RequestBlock(&dummyNodeNone, inv);
     BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeNone);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
+
     // Chains IS sync'd,  HAVE graphene nodes, NO Thinblock nodes, Thinblocks OFF, Graphene OFF
     IsChainNearlySyncdSet(true);
     SetBoolArg("use-grapheneblocks", false);
     SetBoolArg("-use-thinblocks", false);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeGraphene);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeGraphene);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
+
     requester.RequestBlock(&dummyNodeNone, inv);
     BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeGraphene);
-    ClearBlocksInFlight(dummyNodeNone);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeGraphene);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
+
     // Chains IS sync'd,  NO graphene nodes, NO Thinblock nodes, Thinblocks ON, Graphene OFF
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", false);
     SetBoolArg("-use-thinblocks", true);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
+
     requester.RequestBlock(&dummyNodeNone, inv);
     BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeNone);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
+
     // Chains IS sync'd,  HAVE graphene nodes, NO Thinblock nodes, Thinblocks ON, Graphene OFF
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", false);
     SetBoolArg("-use-thinblocks", true);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeGraphene);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeGraphene);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
+
     requester.RequestBlock(&dummyNodeNone, inv);
     BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeGraphene);
-    ClearBlocksInFlight(dummyNodeNone);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeGraphene);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
+
     // Chains IS sync'd,  NO graphene nodes, HAVE Thinblock nodes, Thinblocks OFF, Graphene ON
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", true);
     SetBoolArg("-use-thinblocks", false);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeXthin);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeXthin);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
+
     requester.RequestBlock(&dummyNodeNone, inv);
     BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeNone);
-    ClearBlocksInFlight(dummyNodeXthin);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
+    ClearThinBlocksInFlight(dummyNodeXthin, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeXthin);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
+
     // Chains IS sync'd,  NO graphene nodes, NO Thinblock nodes, Thinblocks OFF, Graphene ON
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", true);
     SetBoolArg("-use-thinblocks", false);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
+
     requester.RequestBlock(&dummyNodeNone, inv);
     BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeNone);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
+
     // Chains IS sync'd,  NO graphene nodes, NO Thinblock nodes, Thinblocks ON, Graphene ON
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", true);
     SetBoolArg("-use-thinblocks", true);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
+
     requester.RequestBlock(&dummyNodeNone, inv);
     BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeNone);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
 
     // Chains IS sync'd,  HAVE graphene nodes, NO Thinblock nodes, Thinblocks ON, Graphene ON
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", true);
     SetBoolArg("-use-thinblocks", true);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeGraphene);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeGraphene);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
+
     requester.RequestBlock(&dummyNodeGraphene, inv);
     BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("get_graphene") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeGraphene);
-    ClearBlocksInFlight(dummyNodeNone);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeGraphene);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
+
     // Chains IS sync'd,  HAVE graphene nodes, NO Thinblock nodes, Thinblocks OFF, Graphene ON
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", true);
     SetBoolArg("-use-thinblocks", false);
     BOOST_CHECK(IsThinBlocksEnabled() == false);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeGraphene);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeGraphene);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
+
     requester.RequestBlock(&dummyNodeGraphene, inv);
     BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("get_graphene") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeGraphene);
-    ClearBlocksInFlight(dummyNodeNone);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeGraphene);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
+
     // Chains IS sync'd,  HAVE graphene nodes, HAVE Thinblock nodes, Thinblocks ON, Graphene ON
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", true);
     SetBoolArg("-use-thinblocks", true);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeGraphene);
-        vNodes.push_back(&dummyNodeXthin);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeGraphene);
+    thinrelay.AddThinTypePeers(&dummyNodeXthin);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
 
     requester.RequestBlock(&dummyNodeGraphene, inv);
     BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("get_graphene") != 0);
 
-    ClearBlocksInFlight(dummyNodeGraphene);
-    ClearBlocksInFlight(dummyNodeNone);
-    ClearBlocksInFlight(dummyNodeXthin);
+    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
+    ClearThinBlocksInFlight(dummyNodeXthin, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeGraphene);
+    thinrelay.RemoveThinTypePeers(&dummyNodeXthin);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
 
     // Chains IS sync'd,  NO graphene nodes, HAVE Thinblock nodes, Thinblocks ON, Graphene OFF
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", false);
     SetBoolArg("-use-thinblocks", true);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeXthin);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeXthin);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
+
     requester.RequestBlock(&dummyNodeXthin, inv);
     BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("get_xthin") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeNone);
-    ClearBlocksInFlight(dummyNodeXthin);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
+    ClearThinBlocksInFlight(dummyNodeXthin, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeXthin);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
 
     /******************************
      * Check full blocks are downloaded when no block announcements come from a graphene or thinblock peer
@@ -374,12 +311,10 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", true);
     SetBoolArg("-use-thinblocks", true);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeGraphene);
-        vNodes.push_back(&dummyNodeXthin);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeGraphene);
+    thinrelay.AddThinTypePeers(&dummyNodeXthin);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
+
     // Set mocktime
     nTime = GetTime();
     SetMockTime(nTime);
@@ -387,30 +322,20 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     // The first request should fail but the timers should be triggered for graphene
     BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == false);
 
-    // Now move the clock ahead so that the graphene timer is exceeded
+    // Now move the clock ahead so that the timer is exceeded
     SetMockTime(nTime + 20);
-
-    // The second request should fail because but the thinblock timer will be tripped
-    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == false);
-
-    // Now move the clock ahead so that the thinblock timer is exceeded
-    SetMockTime(nTime + 40);
 
     requester.RequestBlock(&dummyNodeNone, inv);
     BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeGraphene);
-    ClearBlocksInFlight(dummyNodeNone);
-    ClearBlocksInFlight(dummyNodeXthin);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
+    ClearThinBlocksInFlight(dummyNodeXthin, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeGraphene);
+    thinrelay.RemoveThinTypePeers(&dummyNodeXthin);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
 
     /******************************
      * Check full blocks are downloaded when graphene is off but thinblock timer is exceeded
@@ -420,12 +345,9 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", false);
     SetBoolArg("-use-thinblocks", true);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeGraphene);
-        vNodes.push_back(&dummyNodeXthin);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeGraphene);
+    thinrelay.AddThinTypePeers(&dummyNodeXthin);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
 
     // Set mocktime
     nTime = GetTime();
@@ -440,18 +362,14 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     requester.RequestBlock(&dummyNodeNone, inv);
     BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeGraphene);
-    ClearBlocksInFlight(dummyNodeNone);
-    ClearBlocksInFlight(dummyNodeXthin);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
+    ClearThinBlocksInFlight(dummyNodeXthin, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeGraphene);
+    thinrelay.RemoveThinTypePeers(&dummyNodeXthin);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
 
     /******************************
      * Check Xthin is downloaded when graphene timer is exceeded and we have a block available from an
@@ -462,12 +380,9 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", true);
     SetBoolArg("-use-thinblocks", true);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeGraphene);
-        vNodes.push_back(&dummyNodeXthin);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeGraphene);
+    thinrelay.AddThinTypePeers(&dummyNodeXthin);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
 
     // Set mocktime
     nTime = GetTime();
@@ -482,18 +397,14 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     requester.RequestBlock(&dummyNodeXthin, inv);
     BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("get_xthin") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeGraphene);
-    ClearBlocksInFlight(dummyNodeNone);
-    ClearBlocksInFlight(dummyNodeXthin);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
+    ClearThinBlocksInFlight(dummyNodeXthin, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeGraphene);
+    thinrelay.RemoveThinTypePeers(&dummyNodeXthin);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
 
     /******************************
      * Check a Graphene block is downloaded when Graphene timer is exceeded but then we get an announcement
@@ -504,12 +415,9 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", true);
     SetBoolArg("-use-thinblocks", true);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeGraphene);
-        vNodes.push_back(&dummyNodeXthin);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeGraphene);
+    thinrelay.AddThinTypePeers(&dummyNodeXthin);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
 
     // Set mocktime
     nTime = GetTime();
@@ -524,18 +432,14 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     requester.RequestBlock(&dummyNodeGraphene, inv);
     BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("get_graphene") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeGraphene);
-    ClearBlocksInFlight(dummyNodeNone);
-    ClearBlocksInFlight(dummyNodeXthin);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
+    ClearThinBlocksInFlight(dummyNodeXthin, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeGraphene);
+    thinrelay.RemoveThinTypePeers(&dummyNodeXthin);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
 
     /******************************
      * Check a full block is downloaded when Graphene timer is exceeded but then we get an announcement
@@ -548,12 +452,9 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", true);
     SetBoolArg("-use-thinblocks", false);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeGraphene);
-        vNodes.push_back(&dummyNodeXthin);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeGraphene);
+    thinrelay.AddThinTypePeers(&dummyNodeXthin);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
 
     // Set mocktime
     nTime = GetTime();
@@ -566,23 +467,19 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     // download a full block
     SetMockTime(nTime + 20);
     randhash = GetRandHash();
-    AddGrapheneBlockInFlight(&dummyNodeGraphene, randhash);
+    thinrelay.AddThinTypeBlockInFlight(&dummyNodeGraphene, randhash, NetMsgType::GRAPHENEBLOCK);
     requester.RequestBlock(&dummyNodeGraphene, inv);
     BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("getdata") != 0);
-    ClearGrapheneBlockInFlight(&dummyNodeGraphene, randhash);
+    thinrelay.ClearThinTypeBlockInFlight(&dummyNodeGraphene, randhash);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeGraphene);
-    ClearBlocksInFlight(dummyNodeNone);
-    ClearBlocksInFlight(dummyNodeXthin);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
+    ClearThinBlocksInFlight(dummyNodeXthin, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeGraphene);
+    thinrelay.RemoveThinTypePeers(&dummyNodeXthin);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
 
     /******************************
      * Check an Xthin is downloaded when Graphene timer is exceeded but then we get an announcement
@@ -595,19 +492,17 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", true);
     SetBoolArg("-use-thinblocks", true);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeGraphene);
-        vNodes.push_back(&dummyNodeXthin);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeGraphene);
+    thinrelay.AddThinTypePeers(&dummyNodeXthin);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
+
     // Set mocktime
     nTime = GetTime();
     SetMockTime(nTime);
 
     // The first request should fail but the timers should be triggered for both xthin and graphene
     randhash = GetRandHash();
-    AddGrapheneBlockInFlight(&dummyNodeGraphene, randhash);
+    thinrelay.AddThinTypeBlockInFlight(&dummyNodeGraphene, randhash, NetMsgType::GRAPHENEBLOCK);
     BOOST_CHECK(requester.RequestBlock(&dummyNodeGraphene, inv) == false);
 
     // Now move the clock ahead so that the timers are exceeded and we should now
@@ -615,20 +510,16 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     SetMockTime(nTime + 20);
     requester.RequestBlock(&dummyNodeXthin, inv);
     BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("get_xthin") != 0);
-    ClearGrapheneBlockInFlight(&dummyNodeGraphene, randhash);
+    thinrelay.ClearThinTypeBlockInFlight(&dummyNodeGraphene, randhash);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeGraphene);
-    ClearBlocksInFlight(dummyNodeNone);
-    ClearBlocksInFlight(dummyNodeXthin);
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
+    ClearThinBlocksInFlight(dummyNodeXthin, inv);
     requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.RemoveThinTypePeers(&dummyNodeGraphene);
+    thinrelay.RemoveThinTypePeers(&dummyNodeXthin);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
 
 
     /******************************
@@ -640,12 +531,10 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", false);
     SetBoolArg("-use-thinblocks", true);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeGraphene);
-        vNodes.push_back(&dummyNodeXthin);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeGraphene);
+    thinrelay.AddThinTypePeers(&dummyNodeXthin);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
+
     // Set mocktime
     nTime = GetTime();
     SetMockTime(nTime);
@@ -659,18 +548,14 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     requester.RequestBlock(&dummyNodeXthin, inv);
     BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("get_xthin") != 0);
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeGraphene);
-    ClearBlocksInFlight(dummyNodeNone);
-    ClearBlocksInFlight(dummyNodeXthin);
-    requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
+    ClearThinBlocksInFlight(dummyNodeXthin, inv);
+    thinrelay.RemoveThinTypePeers(&dummyNodeGraphene);
+    thinrelay.RemoveThinTypePeers(&dummyNodeXthin);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
+
     /******************************
      * Check a Xthin is is downloaded when thinblock timer is exceeded but then we get an announcement
      * from a thinblock peer, and then request from that thinblock peer before we request from any others.
@@ -681,12 +566,9 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     IsChainNearlySyncdSet(true);
     SetBoolArg("-use-grapheneblocks", false);
     SetBoolArg("-use-thinblocks", true);
-    {
-        LOCK(cs_vNodes);
-        vNodes.push_back(&dummyNodeGraphene);
-        vNodes.push_back(&dummyNodeXthin);
-        vNodes.push_back(&dummyNodeNone);
-    }
+    thinrelay.AddThinTypePeers(&dummyNodeGraphene);
+    thinrelay.AddThinTypePeers(&dummyNodeXthin);
+    thinrelay.AddThinTypePeers(&dummyNodeNone);
 
     // Set mocktime
     nTime = GetTime();
@@ -699,23 +581,18 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     // download a full block
     SetMockTime(nTime + 20);
     randhash = GetRandHash();
-    AddThinBlockInFlight(&dummyNodeXthin, randhash);
+    thinrelay.AddThinTypeBlockInFlight(&dummyNodeXthin, randhash, NetMsgType::XTHINBLOCK);
     requester.RequestBlock(&dummyNodeXthin, inv);
     BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("getdata") != 0);
 
 
-    thindata.ClearThinBlockTimer(inv.hash);
-    graphenedata.ClearGrapheneBlockTimer(inv.hash);
-    ClearBlocksInFlight(dummyNodeGraphene);
-    ClearBlocksInFlight(dummyNodeNone);
-    ClearBlocksInFlight(dummyNodeXthin);
-    requester.MapBlocksInFlightClear();
-    {
-        LOCK(cs_vNodes);
-        vNodes.pop_back();
-        vNodes.pop_back();
-        vNodes.pop_back();
-    }
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
+    ClearThinBlocksInFlight(dummyNodeNone, inv);
+    ClearThinBlocksInFlight(dummyNodeXthin, inv);
+    thinrelay.RemoveThinTypePeers(&dummyNodeGraphene);
+    thinrelay.RemoveThinTypePeers(&dummyNodeXthin);
+    thinrelay.RemoveThinTypePeers(&dummyNodeNone);
 
     // Final cleanup: Unset mocktime
     SetMockTime(0);


### PR DESCRIPTION
Move tracking of thin type block out of CNode and into a new "thintype" singleton
class. This removes a great deal of redundant code from thinblock.cpp and graphene.cpp
and makes the code much easier to maintain particularly in RequestBlock() in the
requestManager.cpp.

Consolidate the thinblock/grapheneblock timers and put them in the thintype
singleton class. This helps to further cleanup the logic  in RequestBlock().

put a cap on inflight thin type

use multimap for thintype tracking which will eventually allow us to handle
multiple thin type blocks in flight for a single peer.

Use a system of atomic counters to determine how many of each type of peer
is currently connected.