### PR TITLE
Improve optimization

### DIFF
--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -119,7 +119,7 @@ double CGrapheneSet::OptimalSymDiff(uint64_t nBlockTxs,
     /* Optimal symmetric difference between block txs and receiver mempool txs passing
      * though filter to use for IBLT.
      */
-    if (nBlockTxs >= APPROX_NITEMS_THRESH && nReceiverExcessTxs >= nBlockTxs / APPROX_NEXCESS_RATE)
+    if (nBlockTxs >= APPROX_ITEMS_THRESH && nReceiverExcessTxs >= nBlockTxs / APPROX_EXCESS_RATE)
         return ApproxOptimalSymDiff(nBlockTxs);
     else
         return BruteForceSymDiff(nBlockTxs, nReceiverPoolTx, nReceiverExcessTxs, nReceiverMissingTxs);
@@ -132,13 +132,13 @@ double CGrapheneSet::ApproxOptimalSymDiff(uint64_t nBlockTxs)
      * mempool txs passing through filter to use for IBLT.
      *
      * This method is called by OptimalSymDiff provided that:
-     * 1) nBlockTxs >= APPROX_NITEMS_THRESH
-     * 2) nReceiverExcessTxs >= nBlockTxs / APPROX_NEXCESS_RATE
+     * 1) nBlockTxs >= APPROX_ITEMS_THRESH
+     * 2) nReceiverExcessTxs >= nBlockTxs / APPROX_EXCESS_RATE
      *
      * For details see
      * https://github.com/bissias/graphene-experiments/blob/master/jupyter/graphene_size_optimization.ipynb
      */
-    assert(nBlockTxs >= APPROX_NITEMS_THRESH);
+    assert(nBlockTxs >= APPROX_ITEMS_THRESH);
 
     return std::max(
         1.0, std::round(FILTER_CELL_SIZE * nBlockTxs / (8 * IBLT_CELL_SIZE * IBLT_DEFAULT_OVERHEAD * LN2SQUARED)));

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -25,6 +25,9 @@ const float FILTER_FPR_MAX = 0.999;
 const uint8_t IBLT_CELL_MINIMUM = 2;
 const std::vector<uint8_t> IBLT_NULL_VALUE = {};
 const unsigned char WORD_BITS = 8;
+const uint16_t APPROX_NITEMS_THRESH = 600;
+const uint8_t APPROX_NEXCESS_RATE = 4;
+const float IBLT_DEFAULT_OVERHEAD = 1.5;
 
 
 class CGrapheneSet
@@ -57,6 +60,26 @@ public:
 
     /* Optimal symmetric difference between block txs and receiver mempool txs passing
      * though filter to use for IBLT.
+     */
+    double OptimalSymDiff(uint64_t nBlockTxs,
+        uint64_t nReceiverPoolTx,
+        uint64_t nReceiverExcessTxs = 0,
+        uint64_t nReceiverMissingTxs = 1);
+
+    /* Approximation to the optimal symmetric difference between block txs and receiver
+     * mempool txs passing through filter to use for IBLT.
+     *
+     * This method is called by OptimalSymDiff provided that:
+     * 1) nBlockTxs >= APPROX_NITEMS_THRESH
+     * 2) nReceiverExcessTxs >= nBlockTxs / APPROX_NEXCESS_RATE
+     *
+     * For details see
+     * https://github.com/bissias/graphene-experiments/blob/master/jupyter/graphene_size_optimization.ipynb
+     */
+    double ApproxOptimalSymDiff(uint64_t nBlockTxs);
+
+    /* Brute force search for optimal symmetric difference between block txs and receiver
+     * mempool txs passing though filter to use for IBLT.
      *
      * Let a be defined as the size of the symmetric difference between items in the
      * sender and receiver IBLTs.
@@ -64,10 +87,10 @@ public:
      * The total size in bytes of a graphene block is given by T(a) = F(a) + L(a) as defined
      * in the code below. (Note that meta parameters for the Bloom Filter and IBLT are ignored).
      */
-    double OptimalSymDiff(uint64_t nBlockTxs,
+    double BruteForceSymDiff(uint64_t nBlockTxs,
         uint64_t nReceiverPoolTx,
-        uint64_t nReceiverExcessTxs = 0,
-        uint64_t nReceiverMissingTxs = 1);
+        uint64_t nReceiverExcessTxs,
+        uint64_t nReceiverMissingTxs);
 
     // Pass the transaction hashes that the local machine has to reconcile with the remote and return a list
     // of cheap hashes in the block in the correct order

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -25,8 +25,8 @@ const float FILTER_FPR_MAX = 0.999;
 const uint8_t IBLT_CELL_MINIMUM = 2;
 const std::vector<uint8_t> IBLT_NULL_VALUE = {};
 const unsigned char WORD_BITS = 8;
-const uint16_t APPROX_NITEMS_THRESH = 600;
-const uint8_t APPROX_NEXCESS_RATE = 4;
+const uint16_t APPROX_ITEMS_THRESH = 600;
+const uint8_t APPROX_EXCESS_RATE = 4;
 const float IBLT_DEFAULT_OVERHEAD = 1.5;
 
 
@@ -70,8 +70,8 @@ public:
      * mempool txs passing through filter to use for IBLT.
      *
      * This method is called by OptimalSymDiff provided that:
-     * 1) nBlockTxs >= APPROX_NITEMS_THRESH
-     * 2) nReceiverExcessTxs >= nBlockTxs / APPROX_NEXCESS_RATE
+     * 1) nBlockTxs >= APPROX_ITEMS_THRESH
+     * 2) nReceiverExcessTxs >= nBlockTxs / APPROX_EXCESS_RATE
      *
      * For details see
      * https://github.com/bissias/graphene-experiments/blob/master/jupyter/graphene_size_optimization.ipynb

--- a/src/test/graphene_tests.cpp
+++ b/src/test/graphene_tests.cpp
@@ -132,7 +132,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_finds_brute_force_opt_for_small_blocks)
 {
     CGrapheneSet grapheneSet;
 
-    int n = (int)std::floor(APPROX_NITEMS_THRESH / 2);
+    int n = (int)std::floor(APPROX_ITEMS_THRESH / 2);
     int mu = 100;
     int m = (int)std::floor(n / 8) + mu;
 
@@ -155,9 +155,9 @@ BOOST_AUTO_TEST_CASE(graphene_set_finds_brute_force_opt_for_small_blocks)
 
 BOOST_AUTO_TEST_CASE(graphene_set_finds_approx_opt_for_large_blocks)
 {
-    int n = 4 * APPROX_NITEMS_THRESH;
+    int n = 4 * APPROX_ITEMS_THRESH;
     int mu = 1000;
-    int m = APPROX_NITEMS_THRESH + mu;
+    int m = APPROX_ITEMS_THRESH + mu;
     CGrapheneSet grapheneSet;
     auto approxSymDiff = [n]() {
         return std::max(
@@ -169,9 +169,9 @@ BOOST_AUTO_TEST_CASE(graphene_set_finds_approx_opt_for_large_blocks)
 
 BOOST_AUTO_TEST_CASE(graphene_set_approx_opt_close_to_optimal)
 {
-    int n = APPROX_NITEMS_THRESH;
+    int n = APPROX_ITEMS_THRESH;
     int mu = 100;
-    int m = (int)std::ceil(n / APPROX_NEXCESS_RATE) + mu;
+    int m = (int)std::ceil(n / APPROX_EXCESS_RATE) + mu;
     CGrapheneSet grapheneSet;
 
     float totalBytesApprox = (float)ProjectedGrapheneSizeBytes(n, m - mu, grapheneSet.ApproxOptimalSymDiff(n));


### PR DESCRIPTION
In Graphene currently, brute force search is used to determine the optimal size for the IBLT relative to the Bloom filter. This is a reasonable choice for small blocks, but as block sizes grow it will become too inefficient. The [original Graphene](https://people.cs.umass.edu/~gbiss/graphene.pdf) paper derived a formula for a nearly optimal choice. I have performed some [followup work](https://github.com/bissias/graphene-experiments/blob/master/jupyter/graphene_size_optimization.ipynb) that shows where the formula is most accurate. It turns out that for most blocks with more than 600 txs, the formula is off by no more than 10%. So this PR introduces code that simply delegates to using the formula over brute force search when the proper conditions arise.