### PR TITLE
Remove a useless assert in PruneBlockIndexCandidates()

### DIFF
--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -248,8 +248,6 @@ void PruneBlockIndexCandidates()
     {
         setBlockIndexCandidates.erase(it++);
     }
-    // Either the current tip or a successor of it we're working towards is left in setBlockIndexCandidates.
-    assert(!setBlockIndexCandidates.empty());
 }
 
 CBlockIndex *AddToBlockIndex(const CBlockHeader &block)


### PR DESCRIPTION
The assert at the end PruneBlockIndexCandidates() was put there
to make sure that the setBlockIndexCandidates was not empty or
abort the program otherwise.

Fact is that the code at the top of `PruneBlockIndexCandidates()`
already deal with the case of setBlockIndexCandidates being empty
by returning without raising an error. This imply that the assert
cannot be triggered.