### PR TITLE
Add a new parameter to define the duration of Graphene and Thinblock preferential timer.

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -649,9 +649,6 @@ static void addNodeRelayOptions(AllowedArgs &allowedArgs)
                         "but the data rate will not exceed this parameter (default: %u)"),
                     DEFAULT_MAX_SEND_BURST))
         .addArg("use-thinblocks", optionalBool, _("Enable thin blocks to speed up the relay of blocks (default: 1)"))
-        .addArg("thinblock-timer=<millisec>", requiredInt,
-            strprintf(_("Set thinblock preferential timer duration (default: %u). Use 0 to disable it."),
-                    DEFAULT_THINBLOCK_TIMER))
         .addArg("xthinbloomfiltersize=<n>", requiredInt,
             strprintf(_("The maximum xthin bloom filter size that our node will accept in Bytes (default: %u)"),
                     SMALLEST_MAX_BLOOM_FILTER_SIZE))
@@ -660,9 +657,9 @@ static void addNodeRelayOptions(AllowedArgs &allowedArgs)
               "although it can impact performance. (default: 0)"))
         .addArg("use-grapheneblocks", optionalBool,
             strprintf(_("Enable graphene to speed up the relay of blocks (default: %d)"), DEFAULT_USE_GRAPHENE_BLOCKS))
-        .addArg("graphene-timer=<millisec>", requiredInt,
-            strprintf(_("Set graphene preferential timer duration (default: %u). Use 0 to disable it."),
-                    DEFAULT_GRAPHENE_TIMER));
+        .addArg("preferential-timer=<millisec>", requiredInt,
+            strprintf(_("Set graphene and thinblock preferential timer duration (default: %u). Use 0 to disable it."),
+                    DEFAULT_PREFERENTIAL_TIMER));
 }
 
 static void addBlockCreationOptions(AllowedArgs &allowedArgs)

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -649,6 +649,9 @@ static void addNodeRelayOptions(AllowedArgs &allowedArgs)
                         "but the data rate will not exceed this parameter (default: %u)"),
                     DEFAULT_MAX_SEND_BURST))
         .addArg("use-thinblocks", optionalBool, _("Enable thin blocks to speed up the relay of blocks (default: 1)"))
+        .addArg("thinblock-timer=<millisec>", requiredInt,
+            strprintf(_("Set thinblock preferential timer duration (default: %u). Use 0 to disable it."),
+                    DEFAULT_THINBLOCK_TIMER))
         .addArg("xthinbloomfiltersize=<n>", requiredInt,
             strprintf(_("The maximum xthin bloom filter size that our node will accept in Bytes (default: %u)"),
                     SMALLEST_MAX_BLOOM_FILTER_SIZE))
@@ -656,7 +659,10 @@ static void addNodeRelayOptions(AllowedArgs &allowedArgs)
             _("Enable thin block bloom filter targeting which helps to keep the size of bloom filters to a minumum "
               "although it can impact performance. (default: 0)"))
         .addArg("use-grapheneblocks", optionalBool,
-            strprintf(_("Enable graphene to speed up the relay of blocks (default: %d)"), DEFAULT_USE_GRAPHENE_BLOCKS));
+            strprintf(_("Enable graphene to speed up the relay of blocks (default: %d)"), DEFAULT_USE_GRAPHENE_BLOCKS))
+        .addArg("graphene-timer=<millisec>", requiredInt,
+            strprintf(_("Set graphene preferential timer duration (default: %u). Use 0 to disable it."),
+                    DEFAULT_GRAPHENE_TIMER));
 }
 
 static void addBlockCreationOptions(AllowedArgs &allowedArgs)

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1184,10 +1184,7 @@ bool CGrapheneBlockData::CheckGrapheneBlockTimer(const uint256 &hash)
     // Base time used to calculate the random timeout value.
     static uint64_t nTimeToWait = GetArg("-preferential-timer", DEFAULT_PREFERENTIAL_TIMER);
     if (nTimeToWait == 0)
-    {
-        LOG(GRAPHENE, "Graphene preferential times is disabled\n");
         return false;
-    }
 
     LOCK(cs_mapGrapheneBlockTimer);
     if (!mapGrapheneBlockTimer.count(hash))

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1182,7 +1182,7 @@ std::string CGrapheneBlockData::ReRequestedTxToString()
 bool CGrapheneBlockData::CheckGrapheneBlockTimer(const uint256 &hash)
 {
     // Base time used to calculate the random timeout value.
-    static uint64_t nTimeToWait = GetArg("-graphene-timer", DEFAULT_GRAPHENE_TIMER);
+    static uint64_t nTimeToWait = GetArg("-preferential-timer", DEFAULT_PREFERENTIAL_TIMER);
     if (nTimeToWait == 0)
     {
         LOG(GRAPHENE, "Graphene preferential times is disabled\n");
@@ -1200,7 +1200,7 @@ bool CGrapheneBlockData::CheckGrapheneBlockTimer(const uint256 &hash)
         // where we receive full blocks from peers that don't support graphene.
         //
         // To make the timeout random we adjust the start time of the timer forward
-        // or backward by a random amount plus or minus 0.2 seconds.
+        // or backward by a random amount plus or minus 20% of preferential timer in milliseconds.
         FastRandomContext insecure_rand(false);
         uint64_t nStartInterval = nTimeToWait * 0.8;
         uint64_t nIntervalLen = 2 * (nTimeToWait * 0.2);

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1201,7 +1201,7 @@ bool CGrapheneBlockData::CheckGrapheneBlockTimer(const uint256 &hash)
         FastRandomContext insecure_rand(false);
         uint64_t nStartInterval = nTimeToWait * 0.8;
         uint64_t nIntervalLen = 2 * (nTimeToWait * 0.2);
-        uint64_t nOffset = nTimeToWait - (nStartInterval + (insecure_rand.rand64() % nIntervalLen) + 1);
+        int64_t nOffset = nTimeToWait - (nStartInterval + (insecure_rand.rand64() % nIntervalLen) + 1);
         mapGrapheneBlockTimer[hash] = std::make_pair(GetTimeMillis() + nOffset, false);
         LOG(GRAPHENE, "Starting Preferential Graphene Block timer (%d millis)\n", nTimeToWait + nOffset);
     }

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1182,12 +1182,17 @@ std::string CGrapheneBlockData::ReRequestedTxToString()
 bool CGrapheneBlockData::CheckGrapheneBlockTimer(const uint256 &hash)
 {
     // Base time used to calculate the random timeout value.
-    static int64_t nTimeToWait = 1000;
+    static uint64_t nTimeToWait = GetArg("-graphene-timer", DEFAULT_GRAPHENE_TIMER);
+    if (nTimeToWait == 0)
+    {
+        LOG(GRAPHENE, "Graphene preferential times is disabled\n");
+        return false;
+    }
 
     LOCK(cs_mapGrapheneBlockTimer);
     if (!mapGrapheneBlockTimer.count(hash))
     {
-        // The timeout limit is a random number between 0.8 and 1.2 seconds.
+        // The timeout limit is a random number belonging to graphene-timer +/- 20%
         // This way a node connected to this one may download the block
         // before the other node and thus be able to serve the other with
         // a graphene block, rather than both nodes timing out and downloading
@@ -1197,7 +1202,9 @@ bool CGrapheneBlockData::CheckGrapheneBlockTimer(const uint256 &hash)
         // To make the timeout random we adjust the start time of the timer forward
         // or backward by a random amount plus or minus 0.2 seconds.
         FastRandomContext insecure_rand(false);
-        uint64_t nOffset = nTimeToWait - (800 + (insecure_rand.rand64() % 400) + 1);
+        uint64_t nStartInterval = nTimeToWait * 0.8;
+        uint64_t nIntervalLen = 2 * (nTimeToWait * 0.2);
+        uint64_t nOffset = nTimeToWait - (nStartInterval + (insecure_rand.rand64() % nIntervalLen) + 1);
         mapGrapheneBlockTimer[hash] = std::make_pair(GetTimeMillis() + nOffset, false);
         LOG(GRAPHENE, "Starting Preferential Graphene Block timer (%d millis)\n", nTimeToWait + nOffset);
     }
@@ -1210,7 +1217,7 @@ bool CGrapheneBlockData::CheckGrapheneBlockTimer(const uint256 &hash)
         if (iter != mapGrapheneBlockTimer.end())
         {
             int64_t elapsed = GetTimeMillis() - iter->second.first;
-            if (elapsed > nTimeToWait)
+            if (elapsed > (int64_t)nTimeToWait)
             {
                 // Only print out the log entry once.  Because the graphene timer will be hit
                 // many times when requesting a block we don't want to fill up the log file.

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -1344,7 +1344,7 @@ bool CThinBlockData::CheckThinblockTimer(const uint256 &hash)
         FastRandomContext insecure_rand(false);
         uint64_t nStartInterval = nTimeToWait * 0.8;
         uint64_t nIntervalLen = 2 * (nTimeToWait * 0.2);
-        uint64_t nOffset = nTimeToWait - (nStartInterval + (insecure_rand.rand64() % nIntervalLen) + 1);
+        int64_t nOffset = nTimeToWait - (nStartInterval + (insecure_rand.rand64() % nIntervalLen) + 1);
         mapThinBlockTimer[hash] = std::make_pair(GetTimeMillis() + nOffset, false);
         LOG(THIN, "Starting Preferential Thinblock timer (%d millis)\n", nTimeToWait + nOffset);
     }

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -1327,10 +1327,7 @@ bool CThinBlockData::CheckThinblockTimer(const uint256 &hash)
     // Base time used to calculate the random timeout value.
     static uint64_t nTimeToWait = GetArg("-preferential-timer", DEFAULT_PREFERENTIAL_TIMER);
     if (nTimeToWait == 0)
-    {
-        LOG(THIN, "Thinblock preferential times is disabled\n");
         return false;
-    }
 
     LOCK(cs_mapThinBlockTimer);
     if (!mapThinBlockTimer.count(hash))

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -1325,12 +1325,17 @@ std::string CThinBlockData::FullTxToString()
 bool CThinBlockData::CheckThinblockTimer(const uint256 &hash)
 {
     // Base time used to calculate the random timeout value.
-    static uint64_t nTimeToWait = 1000;
+    static uint64_t nTimeToWait = GetArg("-thinblock-timer", DEFAULT_THINBLOCK_TIMER);
+    if (nTimeToWait == 0)
+    {
+        LOG(THIN, "Thinblock preferential times is disabled\n");
+        return false;
+    }
 
     LOCK(cs_mapThinBlockTimer);
     if (!mapThinBlockTimer.count(hash))
     {
-        // The timeout limit is a random number between 0.8 and 1.2 seconds.
+        // The timeout limit is a random number belonging to thinblock-timer +/- 20%
         // This way a node connected to this one may download the block
         // before the other node and thus be able to serve the other with
         // a graphene block, rather than both nodes timing out and downloading
@@ -1338,9 +1343,11 @@ bool CThinBlockData::CheckThinblockTimer(const uint256 &hash)
         // where we receive full blocks from peers that don't support graphene.
         //
         // To make the timeout random we adjust the start time of the timer forward
-        // or backward by a random amount plus or minus 0.2 seconds.
+        // or backward by a random amount plus or minus 20% of thinblock-timer in seconds.
         FastRandomContext insecure_rand(false);
-        uint64_t nOffset = nTimeToWait - (800 + (insecure_rand.rand64() % 400) + 1);
+        uint64_t nStartInterval = nTimeToWait * 0.8;
+        uint64_t nIntervalLen = 2 * (nTimeToWait * 0.2);
+        uint64_t nOffset = nTimeToWait - (nStartInterval + (insecure_rand.rand64() % nIntervalLen) + 1);
         mapThinBlockTimer[hash] = std::make_pair(GetTimeMillis() + nOffset, false);
         LOG(THIN, "Starting Preferential Thinblock timer (%d millis)\n", nTimeToWait + nOffset);
     }

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -1325,7 +1325,7 @@ std::string CThinBlockData::FullTxToString()
 bool CThinBlockData::CheckThinblockTimer(const uint256 &hash)
 {
     // Base time used to calculate the random timeout value.
-    static uint64_t nTimeToWait = GetArg("-thinblock-timer", DEFAULT_THINBLOCK_TIMER);
+    static uint64_t nTimeToWait = GetArg("-preferential-timer", DEFAULT_PREFERENTIAL_TIMER);
     if (nTimeToWait == 0)
     {
         LOG(THIN, "Thinblock preferential times is disabled\n");
@@ -1343,7 +1343,7 @@ bool CThinBlockData::CheckThinblockTimer(const uint256 &hash)
         // where we receive full blocks from peers that don't support graphene.
         //
         // To make the timeout random we adjust the start time of the timer forward
-        // or backward by a random amount plus or minus 20% of thinblock-timer in seconds.
+        // or backward by a random amount plus or minus 20% of preferential timer in milliseconds.
         FastRandomContext insecure_rand(false);
         uint64_t nStartInterval = nTimeToWait * 0.8;
         uint64_t nIntervalLen = 2 * (nTimeToWait * 0.2);

--- a/src/main.h
+++ b/src/main.h
@@ -152,8 +152,7 @@ static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 8;
 
 static const bool DEFAULT_PEERBLOOMFILTERS = true;
 static const bool DEFAULT_USE_THINBLOCKS = true;
-static const int64_t DEFAULT_THINBLOCK_TIMER = 1000;
-static const int64_t DEFAULT_GRAPHENE_TIMER = 1000;
+static const uint64_t DEFAULT_PREFERENTIAL_TIMER = 1000;
 static const bool DEFAULT_USE_GRAPHENE_BLOCKS = true;
 
 static const bool DEFAULT_REINDEX = false;

--- a/src/main.h
+++ b/src/main.h
@@ -152,6 +152,8 @@ static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 8;
 
 static const bool DEFAULT_PEERBLOOMFILTERS = true;
 static const bool DEFAULT_USE_THINBLOCKS = true;
+static const int64_t DEFAULT_THINBLOCK_TIMER = 1000;
+static const int64_t DEFAULT_GRAPHENE_TIMER = 1000;
 static const bool DEFAULT_USE_GRAPHENE_BLOCKS = true;
 
 static const bool DEFAULT_REINDEX = false;


### PR DESCRIPTION
New param:

```
preferential-timer=<millisec>
```

The value is expressed in milliseconds. Default value is 1000. To disable the timers set those parameters to 0.