### PR TITLE
Use canonical ordering in graphene

### DIFF
--- a/qa/rpc-tests/ctor.py
+++ b/qa/rpc-tests/ctor.py
@@ -212,7 +212,10 @@ class MyTest (BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MyTest ().main (bitcoinConfDict={"limitdescendantsize": 50,FORK_CFG: 0})
+    MyTest ().main (bitcoinConfDict={"limitdescendantsize": 50,
+                                     FORK_CFG: 0,
+                                     "use-thinblocks": 1, 
+                                     "use-grapheneblocks": 0})
 
 # Create a convenient function for an interactive python debugging session
 def Test():

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -544,7 +544,10 @@ bool CGrapheneBlock::process(CNode *pfrom,
         }
 
         if (coinbase == NULL)
-            throw std::runtime_error("No coinbase transaction found in graphene block");
+        {
+            LOG(GRAPHENE, "Error: No coinbase transaction found in graphene block, peer=%s", pfrom->GetLogName());
+            return false;
+        }
 
         if (!collision)
         {
@@ -559,7 +562,11 @@ bool CGrapheneBlock::process(CNode *pfrom,
                         std::find(blockCheapHashes.begin(), blockCheapHashes.end(), coinbase->GetHash().GetCheapHash());
 
                     if (it == blockCheapHashes.end())
-                        throw std::runtime_error("No coinbase transaction found in graphene block");
+                    {
+                        LOG(GRAPHENE, "Error: No coinbase transaction found in graphene block, peer=%s",
+                            pfrom->GetLogName());
+                        return false;
+                    }
 
                     auto idx = std::distance(blockCheapHashes.begin(), it);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -546,6 +546,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         CXVersionMessage xver;
         xver.set_u64c(XVer::BU_LISTEN_PORT, GetListenPort());
         xver.set_u64c(XVer::BU_MSG_IGNORE_CHECKSUM, 1); // we will ignore 0 value msg checksums
+        xver.set_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED, 1);
         pfrom->PushMessage(NetMsgType::XVERSION, xver);
 
 


### PR DESCRIPTION
This commit uses the canonical transaction order instead of sending ordering information provided that canonical ordering has been enabled and the graphene version is at least 1.