### PR TITLE
[Windows Build Scripts] - Update cleanup script to remove previous build outputs

### DIFF
--- a/build-aux/mingw/clean-bitcoin.bat
+++ b/build-aux/mingw/clean-bitcoin.bat
@@ -64,6 +64,13 @@ set "PATH=%TOOLCHAIN_BIN%;%OLD_PATH%"
 
 %MSYS_SH% "%INST_DIR%\clean-bitcoin.sh"
 
+REM Remove previously built executable outputs that were copied to non-standard location
+del /F /Q "%BUILD_OUTPUT%\bitcoin-tx.exe"
+del /F /Q "%BUILD_OUTPUT%\bitcoin-cli.exe"
+del /F /Q "%BUILD_OUTPUT%\bitcoind.exe"
+del /F /Q "%BUILD_OUTPUT%\bitcoin-miner.exe"
+del /F /Q "%BUILD_OUTPUT%\bitcoin-qt.exe"
+
 REM Go to the 64-bit build section (in case we are building both 32 and 64 bit)
 GOTO BUILD_START_64
 


### PR DESCRIPTION
The native Windows MinGW build script copies the final executable files to a final output location, but the clean-up script did not remove those files.  This corrects that oversight.