### PR TITLE
[UI] - Re-enable word wrap in peer details header

### DIFF
--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1123,11 +1123,17 @@
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
+         <property name="textFormat">
+          <enum>Qt::RichText</enum>
+         </property>
          <property name="text">
           <string>Select a peer to view detailed information.</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignHCenter|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>


### PR DESCRIPTION
In #1303 I disabled word wrap in the peers details tab for the peer header due to some odd formatting behavior for wrapped text when a peer was selected.  This turns out to have been unnecessary provided the text format was also set to `Qt::RichText`.  With word wrap turned off, if no peer is selected, the details column is much wider than the normal width, which causes a lot of width resizing when going between having a peer selected or not.

The end result of this change is that "Select a peer to view detailed information." title text now wraps "information." to a second line.  This prevents a lot of column width jumping and makes the behavior more consistent/"smoother".