### PR TITLE
[Windows Build Scripts] - Update toolchain and dependencies versions.

### DIFF
--- a/build-aux/mingw/SET_ENV_VARS.bat
+++ b/build-aux/mingw/SET_ENV_VARS.bat
@@ -35,7 +35,7 @@ REM If you have installed the GitHub Desktop app this includes a copy of git.exe
 REM 
 REM   example git install path from GitHub Desktop:
 REM C:\Users\username\AppData\Local\GitHub\PortableGit_d7effa1a4a322478cd29c826b52a0c118ad3db11\mingw32\bin\git.exe
-REM set GIT_EXE="C:\Users\Justaphf\AppData\Local\GitHub\PortableGit_d7effa1a4a322478cd29c826b52a0c118ad3db11\mingw32\bin\git.exe"
+REM set GIT_EXE="C:\Program Files\Git\cmd\git.exe"
 
 REM Set Python installation path(s) (optional)
 REM If python has been installed and this path is provided, a wrapper script will be "installed" for

--- a/build-aux/mingw/clean-bitcoin.sh
+++ b/build-aux/mingw/clean-bitcoin.sh
@@ -14,7 +14,7 @@ cd "$BITCOIN_GIT_ROOT"
 
 #define and export BOOST_ROOT prior to any calls that require
 #executing ./configure (this may include `make clean`) depending on current system state
-export BOOST_ROOT="$PATH_DEPS/boost_1_61_0"
+export BOOST_ROOT="$PATH_DEPS/boost_1_68_0"
 
 #if the clean parameter was passed call clean prior to make
 echo 'Cleaning build...'

--- a/build-aux/mingw/config-mingw.bat
+++ b/build-aux/mingw/config-mingw.bat
@@ -213,8 +213,8 @@ if %errorlevel% neq 0 (
 REM Qt 5
 echo Building Qt 5.3.2...
 cd "%PATH_DEPS%\Qt\5.3.2"
-set "INCLUDE=%PATH_DEPS%\libpng-1.6.16;%PATH_DEPS%\openssl-1.0.1k\include"
-set "LIB=%PATH_DEPS%\libpng-1.6.16\.libs;%PATH_DEPS%\openssl-1.0.1k"
+set "INCLUDE=%PATH_DEPS%\libpng-1.6.16;%PATH_DEPS%\openssl-1.0.2o\include"
+set "LIB=%PATH_DEPS%\libpng-1.6.16\.libs;%PATH_DEPS%\openssl-1.0.2o"
 call configure.bat -release -opensource -confirm-license -static -make libs -no-sql-sqlite -no-opengl -system-zlib -qt-pcre -no-icu -no-gif -system-libpng -no-libjpeg -no-freetype -no-angle -no-vcproj -openssl -no-dbus -no-audio-backend -no-wmf-backend -no-qml-debug
 REM Check to see if configure.bat failed
 if %errorlevel% neq 0 (

--- a/build-aux/mingw/config-mingw.bat
+++ b/build-aux/mingw/config-mingw.bat
@@ -93,6 +93,8 @@ REM Install required msys base package (provide access to msys sh shell)
 echo Updating base MinGW
 %MINGW_GET% update
 %MINGW_GET% install msys-base-bin
+REM Install patch utility so we can apply code patches where necessary
+%MINGW_GET% install msys-patch
 
 REM Verify that MSYS was correctly installed and updated by previous steps
 if not exist "%MSYS_SH%" (

--- a/build-aux/mingw/config-mingw.bat
+++ b/build-aux/mingw/config-mingw.bat
@@ -276,6 +276,7 @@ cd "%BITCOIN_GIT_ROOT%\src"
 copy bitcoin-tx.exe "%BUILD_OUTPUT%\bitcoin-tx.exe"
 copy bitcoin-cli.exe "%BUILD_OUTPUT%\bitcoin-cli.exe"
 copy bitcoind.exe "%BUILD_OUTPUT%\bitcoind.exe"
+copy bitcoin-miner.exe "%BUILD_OUTPUT%\bitcoin-miner.exe"
 
 REM cd to src\qt to copy bitcoin-qt.exe
 cd qt

--- a/build-aux/mingw/config-mingw.bat
+++ b/build-aux/mingw/config-mingw.bat
@@ -215,11 +215,11 @@ if %errorlevel% neq 0 (
 )
 
 REM Qt 5
-echo Building Qt 5.3.2...
-cd "%PATH_DEPS%\Qt\5.3.2"
+echo Building Qt 5.7.1...
+cd "%PATH_DEPS%\Qt\5.7.1"
 set "INCLUDE=%PATH_DEPS%\libpng-1.6.36;%PATH_DEPS%\openssl-1.0.2o\include"
 set "LIB=%PATH_DEPS%\libpng-1.6.36\.libs;%PATH_DEPS%\openssl-1.0.2o"
-call configure.bat -release -opensource -confirm-license -static -make libs -no-sql-sqlite -no-opengl -system-zlib -qt-pcre -no-icu -no-gif -system-libpng -no-libjpeg -no-freetype -no-angle -no-vcproj -openssl -no-dbus -no-audio-backend -no-wmf-backend -no-qml-debug
+call configure.bat -release -opensource -confirm-license -static -make libs -nomake tests -nomake examples -no-sql-sqlite -no-opengl -qt-zlib -qt-pcre -no-icu -no-gif -qt-libpng -qt-libjpeg -no-freetype -no-angle -openssl -no-dbus -no-audio-backend -no-wmf-backend -no-qml-debug -I "%PATH_DEPS%\openssl-1.0.2o\include" -L "%PATH_DEPS%\openssl-1.0.2o"
 REM Check to see if configure.bat failed
 if %errorlevel% neq 0 (
 	echo ERROR: Configuring Qt failed!
@@ -235,9 +235,9 @@ if %errorlevel% neq 0 (
 )
 
 echo Building Qt Tools...
-set "PATH=%PATH%;%PATH_DEPS%\Qt\5.3.2\bin"
-set "PATH=%PATH%;%PATH_DEPS%\Qt\qttools-opensource-src-5.3.2"
-cd "%PATH_DEPS%\Qt\qttools-opensource-src-5.3.2"
+set "PATH=%PATH%;%PATH_DEPS%\Qt\5.7.1\bin"
+set "PATH=%PATH%;%PATH_DEPS%\Qt\qttools-opensource-src-5.7.1"
+cd "%PATH_DEPS%\Qt\qttools-opensource-src-5.7.1"
 qmake qttools.pro
 REM Check to see if qmake failed
 if %errorlevel% neq 0 (

--- a/build-aux/mingw/config-mingw.bat
+++ b/build-aux/mingw/config-mingw.bat
@@ -213,8 +213,8 @@ if %errorlevel% neq 0 (
 REM Qt 5
 echo Building Qt 5.3.2...
 cd "%PATH_DEPS%\Qt\5.3.2"
-set "INCLUDE=%PATH_DEPS%\libpng-1.6.16;%PATH_DEPS%\openssl-1.0.2o\include"
-set "LIB=%PATH_DEPS%\libpng-1.6.16\.libs;%PATH_DEPS%\openssl-1.0.2o"
+set "INCLUDE=%PATH_DEPS%\libpng-1.6.36;%PATH_DEPS%\openssl-1.0.2o\include"
+set "LIB=%PATH_DEPS%\libpng-1.6.36\.libs;%PATH_DEPS%\openssl-1.0.2o"
 call configure.bat -release -opensource -confirm-license -static -make libs -no-sql-sqlite -no-opengl -system-zlib -qt-pcre -no-icu -no-gif -system-libpng -no-libjpeg -no-freetype -no-angle -no-vcproj -openssl -no-dbus -no-audio-backend -no-wmf-backend -no-qml-debug
 REM Check to see if configure.bat failed
 if %errorlevel% neq 0 (

--- a/build-aux/mingw/config-mingw.bat
+++ b/build-aux/mingw/config-mingw.bat
@@ -128,6 +128,8 @@ if "%BUILD_32_BIT%" NEQ "" (
 	set "TOOLCHAIN_BIN=%TOOL_CHAIN_ROOT%\mingw32\bin"
 	set "PATH_DEPS=%DEPS_ROOT%\x86"
 	set "BUILD_OUTPUT=%BITCOIN_GIT_ROOT%\build-output\x86"
+	REM For 32-bit builds Boost 1.68 errors if we don't limit address model to 32
+	set "BOOST_BITS=address-model=32"
 	
 	GOTO BUILD_START
 )
@@ -142,6 +144,8 @@ if "%BUILD_64_BIT%" NEQ "" (
 	set "TOOLCHAIN_BIN=%TOOL_CHAIN_ROOT%\mingw64\bin"
 	set "PATH_DEPS=%DEPS_ROOT%\x64"
 	set "BUILD_OUTPUT=%BITCOIN_GIT_ROOT%\build-output\x64"
+	REM For 64-bit builds Boost 1.68 is fine with default address model settings
+	set "BOOST_BITS=address-model=64"
 	
 	set HAS_BUILT_64_BIT=TRUE
 	
@@ -178,7 +182,7 @@ set "PATH=%TOOLCHAIN_BIN%;%BASE_PATH%"
 
 REM Boost
 echo Building Boost...
-cd "%PATH_DEPS%\boost_1_61_0"
+cd "%PATH_DEPS%\boost_1_68_0"
 call bootstrap.bat gcc
 REM Check to see if bootstrap.bat failed
 if %errorlevel% neq 0 (
@@ -186,7 +190,7 @@ if %errorlevel% neq 0 (
 	pause
 	exit /b %errorlevel%
 )
-b2 --build-type=complete --with-chrono --with-filesystem --with-program_options --with-system --with-thread %BOOST_ENABLE_TESTS% toolset=gcc variant=release link=static threading=multi runtime-link=static stage
+b2 --build-type=complete %BOOST_BITS% --with-chrono --with-filesystem --with-program_options --with-system --with-thread %BOOST_ENABLE_TESTS% toolset=gcc variant=release link=static threading=multi runtime-link=static stage
 REM Check to see if b2 failed
 if %errorlevel% neq 0 (
 	echo ERROR: Building Boost failed!

--- a/build-aux/mingw/install-deps.sh
+++ b/build-aux/mingw/install-deps.sh
@@ -116,21 +116,23 @@ make $MAKE_CORES
 # Boost (Download and unpack - build requires Windows CMD)
 cd "$DEPS_ROOT"
 # don't download if already downloaded
-if [ ! -e boost_1_61_0.zip ]
+if [ ! -e boost_1_68_0.zip ]
 then
-	wget --no-check-certificate https://sourceforge.net/projects/boost/files/boost/1.61.0/boost_1_61_0.zip/download -O "$DEPS_ROOT/boost_1_61_0.zip"
+	wget --no-check-certificate https://sourceforge.net/projects/boost/files/boost/1.68.0/boost_1_68_0.zip/download -O "$DEPS_ROOT/boost_1_68_0.zip"
 	# Verify downloaded file's hash
-	# sha1=f56f449a203e5009cf6ea16691a022d4928e37f7
+	# v1.61.0 sha1=f56f449a203e5009cf6ea16691a022d4928e37f7
+	# v1.68.0 sha1=c4cd90922d22ca17d9b8330441637397395e5812
 	# NOTE: The sha256 has was self computed, but the sha1 provided by the publisher was verified first
 	# v1.61.0 sha256=02d420e6908016d4ac74dfc712eec7d9616a7fc0da78b0a1b5b937536b2e01e8
-	check_hash 02d420e6908016d4ac74dfc712eec7d9616a7fc0da78b0a1b5b937536b2e01e8 "$DEPS_ROOT/boost_1_61_0.zip"
+	# v1.68.0 sha256=3B1DB0B67079266C40B98329D85916E910BBADFC3DB3E860C049056788D4D5CD
+	check_hash 3B1DB0B67079266C40B98329D85916E910BBADFC3DB3E860C049056788D4D5CD "$DEPS_ROOT/boost_1_68_0.zip"
 fi
 # don't extract if already extracted
 cd "$PATH_DEPS"
-if [ ! -d boost_1_61_0 ]
+if [ ! -d boost_1_68_0 ]
 then
 	cd "$DEPS_ROOT"
-	"$CMD_7ZIP" x boost_1_61_0.zip -aoa -o"$PATH_DEPS"
+	"$CMD_7ZIP" x boost_1_68_0.zip -aoa -o"$PATH_DEPS"
 fi
 
 

--- a/build-aux/mingw/install-deps.sh
+++ b/build-aux/mingw/install-deps.sh
@@ -245,23 +245,25 @@ cp .libs/libpng16.a .libs/libpng.a
 # Qrencode (Download, unpack, and build)
 cd "$DEPS_ROOT"
 # don't download if already downloaded
-if [ ! -e qrencode-3.4.4.tar.gz ]
+if [ ! -e qrencode-4.0.2.tar.gz ]
 then
-	wget --no-check-certificate http://fukuchi.org/works/qrencode/qrencode-3.4.4.tar.gz -O "$DEPS_ROOT/qrencode-3.4.4.tar.gz"
+	wget --no-check-certificate http://fukuchi.org/works/qrencode/qrencode-4.0.2.tar.gz -O "$DEPS_ROOT/qrencode-4.0.2.tar.gz"
 	# Verify downloaded file's hash
-	# sha512=2c7a5bb6a51993a4d44a8e4ef30a3d3e43c55dc726fb7d702cde306a5bfcea1faa5a1bd851aa57c7550c81dadb4cc1cf6ea8afa7b5fa4e9b9c5ed7d9bb6b68cc
+	# v3.4.4 sha512=2c7a5bb6a51993a4d44a8e4ef30a3d3e43c55dc726fb7d702cde306a5bfcea1faa5a1bd851aa57c7550c81dadb4cc1cf6ea8afa7b5fa4e9b9c5ed7d9bb6b68cc
+	# v4.0.2 sha512=c3e3834574ec059a4b571427b29d6f5f26bd806fd7498b9bba778f4eceab6ebe5733eef0f3c4f6af91eb3f2e9310f93f6d7b337c28e85c72db7e59bd79be77a9
 	# NOTE: The sha256 has was self computed, but the sha512 provided by the publisher was verified first
 	# v3.4.4 sha256=e794e26a96019013c0e3665cb06b18992668f352c5553d0a553f5d144f7f2a72
-	check_hash e794e26a96019013c0e3665cb06b18992668f352c5553d0a553f5d144f7f2a72 "$DEPS_ROOT/qrencode-3.4.4.tar.gz"
+	# v4.0.2 sha256=DBABE79C07614625D1F74D8C0AE2EE5358C4E27EAB8FD8FE31F9365F821A3B1D
+	check_hash DBABE79C07614625D1F74D8C0AE2EE5358C4E27EAB8FD8FE31F9365F821A3B1D "$DEPS_ROOT/qrencode-4.0.2.tar.gz"
 fi
 # don't extract if already extracted
 cd "$PATH_DEPS"
-if [ ! -d qrencode-3.4.4 ]
+if [ ! -d qrencode-4.0.2 ]
 then
 	cd "$DEPS_ROOT"
-	tar -xvf qrencode-3.4.4.tar.gz -C "$PATH_DEPS"
+	tar -xvf qrencode-4.0.2.tar.gz -C "$PATH_DEPS"
 fi
-cd "$PATH_DEPS/qrencode-3.4.4"
+cd "$PATH_DEPS/qrencode-4.0.2"
 LIBS="../libpng-1.6.36/.libs/libpng.a $LIBZ_STATIC_LIB" \
 png_CFLAGS="-I../libpng-1.6.36" \
 png_LIBS="-L../libpng-1.6.36/.libs" \

--- a/build-aux/mingw/install-deps.sh
+++ b/build-aux/mingw/install-deps.sh
@@ -45,20 +45,21 @@ cd "$DEPS_ROOT"
 # don't download if already downloaded
 if [ ! -e hexdump.zip ]
 then
-	wget --no-check-certificate https://github.com/wahern/hexdump/archive/rel-20160408.zip -O "$DEPS_ROOT/hexdump.zip"
+	wget --no-check-certificate https://github.com/wahern/hexdump/archive/67157e987d04fba9e4df733a97b410fffb8dfbdf.zip -O "$DEPS_ROOT/hexdump.zip"
 	# Verify downloaded file's hash
 	# NOTE: This hash was self computed as it was not provided by the author
 	# v2016.04.08 sha256=ad2bf521260826e57b8268c8f12810935fcb5a0616137643b6b260ee43034632
-	check_hash ad2bf521260826e57b8268c8f12810935fcb5a0616137643b6b260ee43034632 "$DEPS_ROOT/hexdump.zip"
+	# v2018.12.21 sha256=B582A18D70C51EFE49B482D08FDFAFD35DC4CB0C31DF1DA4F8777DC649893D78
+	check_hash B582A18D70C51EFE49B482D08FDFAFD35DC4CB0C31DF1DA4F8777DC649893D78 "$DEPS_ROOT/hexdump.zip"
 fi
 # don't extract if already extracted
 cd "$PATH_DEPS"
-if [ ! -d hexdump-master ]
+if [ ! -d hexdump-67157e987d04fba9e4df733a97b410fffb8dfbdf ]
 then
 	cd "$DEPS_ROOT"
 	"$CMD_7ZIP" x hexdump.zip -aoa -o"$PATH_DEPS"
 fi
-cd "$PATH_DEPS/hexdump-master"
+cd "$PATH_DEPS/hexdump-67157e987d04fba9e4df733a97b410fffb8dfbdf"
 gcc -std=gnu99 -g -O2 -Wall -Wextra -Werror -Wno-unused-variable -Wno-unused-parameter hexdump.c -DHEXDUMP_MAIN -o "$MSYS_BIN/hexdump.exe"
 
 

--- a/build-aux/mingw/install-deps.sh
+++ b/build-aux/mingw/install-deps.sh
@@ -16,11 +16,11 @@ TOOLCHAIN_ROOT=${TOOLCHAIN_BIN%/*}
 if [ "$(basename $TOOLCHAIN_ROOT)" = "mingw32" ]
 then
 	LIBZ_STATIC_LIB="$TOOLCHAIN_ROOT/i686-w64-mingw32/lib/libz.a"
-	# OpenSSL 1.0.1 requires correctly specifying the version of MinGW
+	# OpenSSL 1.0.2 requires correctly specifying the version of MinGW
 	LIB_SSL_MINGW=mingw
 else
 	LIBZ_STATIC_LIB="$TOOLCHAIN_ROOT/x86_64-w64-mingw32/lib/libz.a"
-	# OpenSSL 1.0.1 requires correctly specifying the version of MinGW
+	# OpenSSL 1.0.2 requires correctly specifying the version of MinGW
 	LIB_SSL_MINGW=mingw64
 fi
 
@@ -66,22 +66,24 @@ gcc -std=gnu99 -g -O2 -Wall -Wextra -Werror -Wno-unused-variable -Wno-unused-par
 # Open SSL (Download, unpack, and build)
 cd "$DEPS_ROOT"
 # don't download if already downloaded
-if [ ! -e openssl-1.0.1k.tar.gz ]
+if [ ! -e openssl-1.0.2o.tar.gz ]
 then
-	wget --no-check-certificate https://www.openssl.org/source/openssl-1.0.1k.tar.gz -O "$DEPS_ROOT/openssl-1.0.1k.tar.gz"
-	# Verify downloaded file's hash (from depends packages)
+	wget --no-check-certificate https://www.openssl.org/source/openssl-1.0.2o.tar.gz -O "$DEPS_ROOT/openssl-1.0.2o.tar.gz"
+	# Verify downloaded file's hash (v1.0.1k from depends packages, v1.0.2o from OpenSSL website)
 	# v1.0.1k sha256=8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c
-	check_hash 8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c "$DEPS_ROOT/openssl-1.0.1k.tar.gz"
+	# v1.0.2o sha256=ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d
+	check_hash ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d "$DEPS_ROOT/openssl-1.0.2o.tar.gz"
 fi
 # don't extract if already extracted
 cd "$PATH_DEPS"
-if [ ! -d openssl-1.0.1k ]
+if [ ! -d openssl-1.0.2o ]
 then
 	cd "$DEPS_ROOT"
-	tar xvfz openssl-1.0.1k.tar.gz -C "$PATH_DEPS"
+	tar xvfz openssl-1.0.2o.tar.gz -C "$PATH_DEPS"
 fi
-cd "$PATH_DEPS/openssl-1.0.1k"
+cd "$PATH_DEPS/openssl-1.0.2o"
 ./Configure no-zlib no-shared no-dso no-krb5 no-camellia no-capieng no-cast no-cms no-dtls1 no-gost no-gmp no-heartbeats no-idea no-jpake no-md2 no-mdc2 no-rc5 no-rdrand no-rfc3779 no-rsax no-sctp no-seed no-sha0 no-static_engine no-whirlpool no-rc2 no-rc4 no-ssl2 no-ssl3 $LIB_SSL_MINGW
+make $MAKE_CORES depend
 make $MAKE_CORES
 #pause for debugging purposes
 #read -rsp $'Press any key to continue...\n' -n 1 key

--- a/build-aux/mingw/install-deps.sh
+++ b/build-aux/mingw/install-deps.sh
@@ -212,23 +212,29 @@ make $MAKE_CORES
 # Libpng (Download, unpack, build, and rename-copy)
 cd "$DEPS_ROOT"
 # don't download if already downloaded
-if [ ! -e libpng-1.6.16.tar.gz ]
+if [ ! -e libpng-1.6.36.tar.gz ]
 then
-	wget --no-check-certificate http://download.sourceforge.net/libpng/libpng-1.6.16.tar.gz -O "$DEPS_ROOT/libpng-1.6.16.tar.gz"
+	wget --no-check-certificate http://download.sourceforge.net/libpng/libpng-1.6.36.tar.gz -O "$DEPS_ROOT/libpng-1.6.36.tar.gz"
 	# Verify downloaded file's hash
-	# sha1=50f3b31d013a31e2cac70db177094f6a7618b8be
+	# v1.6.16 sha1=50f3b31d013a31e2cac70db177094f6a7618b8be
+	# v1.6.36 sha1=65184fe3b20d5dd1a132f271b1b76a0a2dd79447
 	# NOTE: The sha256 has was self computed, but the sha1 provided by the publisher was verified first
-	# v1.61.0 sha256=02f96b6bad5a381d36d7ba7a5d9be3b06f7fe6c274da00707509c23592a073ad
-	check_hash 02f96b6bad5a381d36d7ba7a5d9be3b06f7fe6c274da00707509c23592a073ad "$DEPS_ROOT/libpng-1.6.16.tar.gz"
+	# v1.6.16 sha256=02f96b6bad5a381d36d7ba7a5d9be3b06f7fe6c274da00707509c23592a073ad
+	# v1.6.36 sha256=CA13C548BDE5FB6FF7117CC0BDAB38808ACB699C0ECCB613F0E4697826E1FD7D
+	check_hash CA13C548BDE5FB6FF7117CC0BDAB38808ACB699C0ECCB613F0E4697826E1FD7D "$DEPS_ROOT/libpng-1.6.36.tar.gz"
 fi
 # don't extract if already extracted
 cd "$PATH_DEPS"
-if [ ! -d libpng-1.6.16 ]
+if [ ! -d libpng-1.6.36 ]
 then
 	cd "$DEPS_ROOT"
-	tar -xvf libpng-1.6.16.tar.gz -C "$PATH_DEPS"
+	tar -xvf libpng-1.6.36.tar.gz -C "$PATH_DEPS"
 fi
-cd "$PATH_DEPS/libpng-1.6.16"
+cd "$PATH_DEPS/libpng-1.6.36"
+# Apply patch to fix handling of carriage returns in scripts/dfn.awk
+# otherwise MinGW builds on Windows systems will fail
+patch -p1 --forward scripts/dfn.awk "$BITCOIN_GIT_ROOT/depends/patches/libpng/mingw-line-ending-fix.patch"
+
 ./configure --disable-shared
 make $MAKE_CORES
 cp .libs/libpng16.a .libs/libpng.a
@@ -256,9 +262,9 @@ then
 	tar -xvf qrencode-3.4.4.tar.gz -C "$PATH_DEPS"
 fi
 cd "$PATH_DEPS/qrencode-3.4.4"
-LIBS="../libpng-1.6.16/.libs/libpng.a $LIBZ_STATIC_LIB" \
-png_CFLAGS="-I../libpng-1.6.16" \
-png_LIBS="-L../libpng-1.6.16/.libs" \
+LIBS="../libpng-1.6.36/.libs/libpng.a $LIBZ_STATIC_LIB" \
+png_CFLAGS="-I../libpng-1.6.36" \
+png_LIBS="-L../libpng-1.6.36/.libs" \
 ./configure --enable-static --disable-shared --without-tools
 make $MAKE_CORES
 #pause for debugging purposes

--- a/build-aux/mingw/install-deps.sh
+++ b/build-aux/mingw/install-deps.sh
@@ -278,36 +278,44 @@ make $MAKE_CORES
 # Qt (Download, unpack, and rename - build requires Windows CMD)
 cd "$DEPS_ROOT"
 # don't download if already downloaded
-if [ ! -e qttools-opensource-src-5.3.2.7z ]
+if [ ! -e qttools-opensource-src-5.7.1.7z ]
 then
-	wget --no-check-certificate http://download.qt-project.org/archive/qt/5.3/5.3.2/submodules/qttools-opensource-src-5.3.2.7z -O "$DEPS_ROOT/qttools-opensource-src-5.3.2.7z"
+	wget --no-check-certificate http://download.qt-project.org/archive/qt/5.7/5.7.1/submodules/qttools-opensource-src-5.7.1.7z -O "$DEPS_ROOT/qttools-opensource-src-5.7.1.7z"
 	# Verify downloaded file's hash (provided on Qt site)
 	# v5.3.2 sha256=e3d026c8bd48ad41c3eec8e45ee4a3b9e39475438ce45dde90dc010164fc95c9
-	check_hash e3d026c8bd48ad41c3eec8e45ee4a3b9e39475438ce45dde90dc010164fc95c9 "$DEPS_ROOT/qttools-opensource-src-5.3.2.7z"
+	# v5.7.1 sha256=904b1fb861c5b4923c0db1f1c1a06528a7c45c2170e13ca3eafbe10a54c366b4
+	check_hash 904b1fb861c5b4923c0db1f1c1a06528a7c45c2170e13ca3eafbe10a54c366b4 "$DEPS_ROOT/qttools-opensource-src-5.7.1.7z"
 fi
 # don't extract if already extracted
 cd "$PATH_DEPS/Qt"
-if [ ! -d "qttools-opensource-src-5.3.2" ]
+if [ ! -d "qttools-opensource-src-5.7.1" ]
 then
 	cd "$DEPS_ROOT"
-	"$CMD_7ZIP" x qttools-opensource-src-5.3.2.7z -aoa -o"$PATH_DEPS/Qt"
+	"$CMD_7ZIP" x qttools-opensource-src-5.7.1.7z -aoa -o"$PATH_DEPS/Qt"
 fi
 
 cd "$DEPS_ROOT"
 # don't download if already downloaded
-if [ ! -e qtbase-opensource-src-5.3.2.7z ]
+if [ ! -e qtbase-opensource-src-5.7.1.7z ]
 then
-	wget --no-check-certificate http://download.qt-project.org/archive/qt/5.3/5.3.2/submodules/qtbase-opensource-src-5.3.2.7z -O "$DEPS_ROOT/qtbase-opensource-src-5.3.2.7z"
+	wget --no-check-certificate http://download.qt-project.org/archive/qt/5.7/5.7.1/submodules/qtbase-opensource-src-5.7.1.7z -O "$DEPS_ROOT/qtbase-opensource-src-5.7.1.7z"
 	# Verify downloaded file's hash (provided on Qt site)
 	# v5.3.2 sha256=e7898f6a3f1b1ae19df120cbb1bf811b9699e441162c67ede0e97118093e6a7e
-	check_hash e7898f6a3f1b1ae19df120cbb1bf811b9699e441162c67ede0e97118093e6a7e "$DEPS_ROOT/qtbase-opensource-src-5.3.2.7z"
+	# v5.7.1 sha256=a160e9c1403204f6a5c3a921de8530c3ff2e64f6608f259716f35f830e77f4d0
+	check_hash a160e9c1403204f6a5c3a921de8530c3ff2e64f6608f259716f35f830e77f4d0 "$DEPS_ROOT/qtbase-opensource-src-5.7.1.7z"
 fi
 # don't extract if already extracted
 cd "$PATH_DEPS/Qt"
-if [ ! -d "5.3.2" ]
+if [ ! -d "5.7.1" ]
 then
 	cd "$DEPS_ROOT"
-	"$CMD_7ZIP" x qtbase-opensource-src-5.3.2.7z -aoa -o"$PATH_DEPS/Qt"
+	"$CMD_7ZIP" x qtbase-opensource-src-5.7.1.7z -aoa -o"$PATH_DEPS/Qt"
 	cd "$PATH_DEPS/Qt"
-	mv qtbase-opensource-src-5.3.2 5.3.2
+	mv qtbase-opensource-src-5.7.1 5.7.1
 fi
+
+# Qt 5.7.1 needs a configuration change for static library builds
+cd "$PATH_DEPS/Qt/5.7.1/mkspecs/features"
+patch --forward ./default_post.prf "$BITCOIN_GIT_ROOT/depends/patches/qt/fix_qt571_win32_qmake.patch"
+cd "$DEPS_ROOT"
+

--- a/build-aux/mingw/install-toolchain.sh
+++ b/build-aux/mingw/install-toolchain.sh
@@ -67,12 +67,14 @@ then
 	DOWNLOAD_32="$DEPS_ROOT/toolchain_x86.7z"
 	if [ ! -e "$DOWNLOAD_32" ]
 	then
-		wget --no-check-certificate http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/4.9.2/threads-posix/dwarf/i686-4.9.2-release-posix-dwarf-rt_v3-rev1.7z/download --output-document="$DOWNLOAD_32"
+		wget --no-check-certificate https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win32/Personal%20Builds/mingw-builds/7.3.0/threads-posix/dwarf/i686-7.3.0-release-posix-dwarf-rt_v5-rev0.7z/download --output-document="$DOWNLOAD_32"
 		# Verify downloaded file's hash
-		# sha1=a315254e0e85cfa170939e8c6890a7df1dc6bd20
+		# v4.9.2 v3 rev1 sha1=a315254e0e85cfa170939e8c6890a7df1dc6bd20
+		# v7.3.0 v5 rev0 sha1=96e11c754b379c093e1cb3133f71db5b9f3e0532
 		# NOTE: The sha256 has was self computed, but the sha1 provided by the publisher was verified first
 		# v4.9.2 v3 rev1 sha256=f6de32350a28f4b6c30eec26dbfee65f112300d51e37e4d2007b0598bef9bb79
-		check_hash f6de32350a28f4b6c30eec26dbfee65f112300d51e37e4d2007b0598bef9bb79 "$DOWNLOAD_32"
+		# v7.3.0 v5 rev0 sha256=0475B097AD645AE25438AE3470AF7E16E218EC1BD617B73E50B6A6C9622589A7
+		check_hash 0475B097AD645AE25438AE3470AF7E16E218EC1BD617B73E50B6A6C9622589A7 "$DOWNLOAD_32"
 	fi
 	# don't extract if already extracted
 	cd "$TOOLCHAIN_ROOT"
@@ -91,12 +93,14 @@ then
 	DOWNLOAD_64="$DEPS_ROOT/toolchain_x64.7z"
 	if [ ! -e "$DOWNLOAD_64" ]
 	then
-		wget --no-check-certificate http://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/4.9.2/threads-posix/seh/x86_64-4.9.2-release-posix-seh-rt_v3-rev1.7z/download --output-document="$DOWNLOAD_64"
+		wget --no-check-certificate https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/7.3.0/threads-posix/seh/x86_64-7.3.0-release-posix-seh-rt_v5-rev0.7z/download --output-document="$DOWNLOAD_64"
 		# Verify downloaded file's hash
-		# sha1=c160858ddba88110077c9f853a38b254ca0bdb1b
+		# v4.9.2 v3 rev1 sha1=c160858ddba88110077c9f853a38b254ca0bdb1b
+		# v7.3.0 v5 rev0 sha1=0fce15036400568babd10d65b247e9576515da2c
 		# NOTE: The sha256 has was self computed, but the sha1 provided by the publisher was verified first
 		# v4.9.2 v3 rev1 sha256=58626ce6d93199784ef7fe73790ebbdbf5a157be8d30ae396d437748e69c0cf3
-		check_hash 58626ce6d93199784ef7fe73790ebbdbf5a157be8d30ae396d437748e69c0cf3 "$DOWNLOAD_64"
+		# v7.3.0 v5 rev0 sha256=784D25B00E7CF27AA64ABE2363B315400C27526BFCE672FDEE97137F71823D03
+		check_hash 784D25B00E7CF27AA64ABE2363B315400C27526BFCE672FDEE97137F71823D03 "$DOWNLOAD_64"
 	fi
 	# don't extract if already extracted
 	cd "$TOOLCHAIN_ROOT"

--- a/build-aux/mingw/make-bitcoin.sh
+++ b/build-aux/mingw/make-bitcoin.sh
@@ -10,7 +10,7 @@ BITCOIN_GIT_ROOT=$(echo "/$BITCOIN_GIT_ROOT" | sed -e 's/\\/\//g' -e 's/://' -e 
 PATH="$TOOLCHAIN_BIN:$MSYS_BIN:$PATH"
 
 # Verify that required dependencies have been built
-CHECK_PATH="$PATH_DEPS/openssl-1.0.1k/libssl.a"
+CHECK_PATH="$PATH_DEPS/openssl-1.0.2o/libssl.a"
 if [ ! -e "$CHECK_PATH" ]
 then
 	echo OpenSSL dependency is missing.  Please run config-mingw.bat.
@@ -104,14 +104,14 @@ if [ -z "$SKIP_CONFIGURE" ]; then
 	#ENABLE_DEBUG="--enable-debug"
 
 	CPPFLAGS="-I$PATH_DEPS/db-4.8.30.NC/build_unix \
-	-I$PATH_DEPS/openssl-1.0.1k/include \
+	-I$PATH_DEPS/openssl-1.0.2o/include \
 	-I$PATH_DEPS/libevent-2.0.22/include \
 	-I$PATH_DEPS \
 	-I$PATH_DEPS/protobuf-2.6.1/src \
 	-I$PATH_DEPS/libpng-1.6.16 \
 	-I$PATH_DEPS/qrencode-3.4.4" \
 	LDFLAGS="-L$PATH_DEPS/db-4.8.30.NC/build_unix \
-	-L$PATH_DEPS/openssl-1.0.1k \
+	-L$PATH_DEPS/openssl-1.0.2o \
 	-L$PATH_DEPS/libevent-2.0.22/.libs \
 	-L$PATH_DEPS/miniupnpc \
 	-L$PATH_DEPS/protobuf-2.6.1/src/.libs \

--- a/build-aux/mingw/make-bitcoin.sh
+++ b/build-aux/mingw/make-bitcoin.sh
@@ -34,7 +34,7 @@ then
 	echo Protobuf dependency is missing.  Please run config-mingw.bat.
 	exit -1
 fi
-CHECK_PATH="$PATH_DEPS/libpng-1.6.16/.libs/libpng.a"
+CHECK_PATH="$PATH_DEPS/libpng-1.6.36/.libs/libpng.a"
 if [ ! -e "$CHECK_PATH" ]
 then
 	echo LibPNG dependency is missing.  Please run config-mingw.bat.
@@ -108,14 +108,14 @@ if [ -z "$SKIP_CONFIGURE" ]; then
 	-I$PATH_DEPS/libevent-2.0.22/include \
 	-I$PATH_DEPS \
 	-I$PATH_DEPS/protobuf-2.6.1/src \
-	-I$PATH_DEPS/libpng-1.6.16 \
+	-I$PATH_DEPS/libpng-1.6.36 \
 	-I$PATH_DEPS/qrencode-3.4.4" \
 	LDFLAGS="-L$PATH_DEPS/db-4.8.30.NC/build_unix \
 	-L$PATH_DEPS/openssl-1.0.2o \
 	-L$PATH_DEPS/libevent-2.0.22/.libs \
 	-L$PATH_DEPS/miniupnpc \
 	-L$PATH_DEPS/protobuf-2.6.1/src/.libs \
-	-L$PATH_DEPS/libpng-1.6.16/.libs \
+	-L$PATH_DEPS/libpng-1.6.36/.libs \
 	-L$PATH_DEPS/qrencode-3.4.4/.libs" \
 	BOOST_ROOT="$PATH_DEPS/boost_1_61_0" \
 	./configure \

--- a/build-aux/mingw/make-bitcoin.sh
+++ b/build-aux/mingw/make-bitcoin.sh
@@ -66,7 +66,7 @@ then
 		exit -1
 	fi
 fi
-CHECK_PATH="$PATH_DEPS/Qt/5.3.2/lib/libQt5Core.a"
+CHECK_PATH="$PATH_DEPS/Qt/5.7.1/lib/libQt5Core.a"
 if [ ! -e "$CHECK_PATH" ]
 then
 	echo Qt dependency is missing.  Please run config-mingw.bat.
@@ -130,16 +130,17 @@ if [ -z "$SKIP_CONFIGURE" ]; then
 	-L$PATH_DEPS/miniupnpc \
 	-L$PATH_DEPS/protobuf-2.6.1/src/.libs \
 	-L$PATH_DEPS/libpng-1.6.36/.libs \
+	-L$PATH_DEPS/QT/5.7.1/lib \
 	-L$PATH_DEPS/qrencode-4.0.2/.libs" \
 	BOOST_ROOT="$PATH_DEPS/boost_1_68_0" \
 	./configure \
 	$ENABLE_DEBUG \
 	--disable-upnp-default \
 	$DISABLE_TESTS \
-	--with-qt-incdir="$PATH_DEPS/Qt/5.3.2/include" \
-	--with-qt-libdir="$PATH_DEPS/Qt/5.3.2/lib" \
-	--with-qt-plugindir="$PATH_DEPS/Qt/5.3.2/plugins" \
-	--with-qt-bindir="$PATH_DEPS/Qt/5.3.2/bin" \
+	--with-qt-incdir="$PATH_DEPS/Qt/5.7.1/include" \
+	--with-qt-libdir="$PATH_DEPS/Qt/5.7.1/lib" \
+	--with-qt-plugindir="$PATH_DEPS/Qt/5.7.1/plugins" \
+	--with-qt-bindir="$PATH_DEPS/Qt/5.7.1/bin" \
 	--with-protoc-bindir="$PATH_DEPS/protobuf-2.6.1/src"
 fi
 

--- a/build-aux/mingw/make-bitcoin.sh
+++ b/build-aux/mingw/make-bitcoin.sh
@@ -163,6 +163,7 @@ if [ -n "$STRIP" ]; then
 	echo 'Stripping exeutables'
 	strip src/bitcoin-tx.exe
 	strip src/bitcoin-cli.exe
+	strip src/bitcoin-miner.exe
 	strip src/bitcoind.exe
 	strip src/qt/bitcoin-qt.exe
 fi

--- a/build-aux/mingw/make-bitcoin.sh
+++ b/build-aux/mingw/make-bitcoin.sh
@@ -40,7 +40,7 @@ then
 	echo LibPNG dependency is missing.  Please run config-mingw.bat.
 	exit -1
 fi
-CHECK_PATH="$PATH_DEPS/qrencode-3.4.4/.libs/libqrencode.a"
+CHECK_PATH="$PATH_DEPS/qrencode-4.0.2/.libs/libqrencode.a"
 if [ ! -e "$CHECK_PATH" ]
 then
 	echo LibQREncode dependency is missing.  Please run config-mingw.bat.
@@ -109,14 +109,14 @@ if [ -z "$SKIP_CONFIGURE" ]; then
 	-I$PATH_DEPS \
 	-I$PATH_DEPS/protobuf-2.6.1/src \
 	-I$PATH_DEPS/libpng-1.6.36 \
-	-I$PATH_DEPS/qrencode-3.4.4" \
+	-I$PATH_DEPS/qrencode-4.0.2" \
 	LDFLAGS="-L$PATH_DEPS/db-4.8.30.NC/build_unix \
 	-L$PATH_DEPS/openssl-1.0.2o \
 	-L$PATH_DEPS/libevent-2.0.22/.libs \
 	-L$PATH_DEPS/miniupnpc \
 	-L$PATH_DEPS/protobuf-2.6.1/src/.libs \
 	-L$PATH_DEPS/libpng-1.6.36/.libs \
-	-L$PATH_DEPS/qrencode-3.4.4/.libs" \
+	-L$PATH_DEPS/qrencode-4.0.2/.libs" \
 	BOOST_ROOT="$PATH_DEPS/boost_1_61_0" \
 	./configure \
 	$ENABLE_DEBUG \

--- a/build-aux/mingw/make-bitcoin.sh
+++ b/build-aux/mingw/make-bitcoin.sh
@@ -5,6 +5,7 @@ MSYS_BIN=$(echo "/$MSYS_BIN" | sed -e 's/\\/\//g' -e 's/://' -e 's/\"//g')
 PATH_DEPS=$(echo "/$PATH_DEPS" | sed -e 's/\\/\//g' -e 's/://' -e 's/\"//g')
 TOOLCHAIN_BIN=$(echo "/$TOOLCHAIN_BIN" | sed -e 's/\\/\//g' -e 's/://' -e 's/\"//g')
 BITCOIN_GIT_ROOT=$(echo "/$BITCOIN_GIT_ROOT" | sed -e 's/\\/\//g' -e 's/://' -e 's/\"//g')
+BUILD_TYPE=$(basename $PATH_DEPS)
 
 # Set PATH using POSIX style paths
 PATH="$TOOLCHAIN_BIN:$MSYS_BIN:$PATH"
@@ -46,11 +47,24 @@ then
 	echo LibQREncode dependency is missing.  Please run config-mingw.bat.
 	exit -1
 fi
-CHECK_PATH="$PATH_DEPS/boost_1_61_0/bin.v2/libs/chrono/build/gcc-mingw-4.9.2/release/link-static/runtime-link-static/threading-multi/libboost_chrono-mgw49-mt-s-1_61.a"
-if [ ! -e "$CHECK_PATH" ]
+# In Boost 1.68, the output libraries have different names depending on 32 or 64 bit so check both
+if [ "$BUILD_TYPE" = "x86" ]
 then
-	echo Boost dependency is missing.  Please run config-mingw.bat.
-	exit -1
+	CHECK_PATH="$PATH_DEPS/boost_1_68_0/bin.v2/libs/chrono/build/gcc-7.3.0/release/link-static/threading-multi/libboost_chrono-mgw73-mt-s-x32-1_68.a"
+	if [ ! -e "$CHECK_PATH" ]
+	then
+		echo Boost 32-bit dependency is missing.  Please run config-mingw.bat.
+		exit -1
+	fi
+fi
+if [ "$BUILD_TYPE" = "x64" ]
+then
+	CHECK_PATH="$PATH_DEPS/boost_1_68_0/bin.v2/libs/chrono/build/gcc-7.3.0/release/link-static/threading-multi/libboost_chrono-mgw73-mt-s-x64-1_68.a"
+	if [ ! -e "$CHECK_PATH" ]
+	then
+		echo Boost 64-bit dependency is missing.  Please run config-mingw.bat.
+		exit -1
+	fi
 fi
 CHECK_PATH="$PATH_DEPS/Qt/5.3.2/lib/libQt5Core.a"
 if [ ! -e "$CHECK_PATH" ]
@@ -69,7 +83,7 @@ cd "$BITCOIN_GIT_ROOT"
 
 #define and export BOOST_ROOT prior to any calls that require
 #executing ./configure (this may include `make clean`) depending on current system state
-export BOOST_ROOT="$PATH_DEPS/boost_1_61_0"
+export BOOST_ROOT="$PATH_DEPS/boost_1_68_0"
 
 #if the clean parameter was passed call clean prior to make
 if [ -n "$CLEAN_BUILD" ]; then
@@ -117,7 +131,7 @@ if [ -z "$SKIP_CONFIGURE" ]; then
 	-L$PATH_DEPS/protobuf-2.6.1/src/.libs \
 	-L$PATH_DEPS/libpng-1.6.36/.libs \
 	-L$PATH_DEPS/qrencode-4.0.2/.libs" \
-	BOOST_ROOT="$PATH_DEPS/boost_1_61_0" \
+	BOOST_ROOT="$PATH_DEPS/boost_1_68_0" \
 	./configure \
 	$ENABLE_DEBUG \
 	--disable-upnp-default \

--- a/build-aux/mingw/rebuild-bitcoin.bat
+++ b/build-aux/mingw/rebuild-bitcoin.bat
@@ -87,6 +87,12 @@ set "PATH=%MSYS_BIN%;%MINGW_BIN%;%BASE_PATH%"
 REM Remember the path without the toolchain prepended so we can easily switch toolchains
 set "OLD_PATH=%PATH%"
 
+REM Updates utilities executable wrappers aliasing git and python in case the user changed
+REM the paths in SET_ENV_VARS.bat.  This way the full config-mingw-bat script doesn't need
+REM to be re-run just to update these utility alias paths.
+echo Updating utilities...
+%MSYS_SH% "%INST_DIR%\install-utils.sh"
+
 REM Since the build procedure is the same for x86 and x64 except for the toolchain and deps path
 REM Just set the variable for these paths here based on build mode
 REM This allows building both 32-bit and 64-bit in a single run

--- a/depends/patches/libpng/mingw-line-ending-fix.patch
+++ b/depends/patches/libpng/mingw-line-ending-fix.patch
@@ -1,0 +1,23 @@
+--- scripts/dfn.awk.orig
++++ scripts/dfn.awk
+@@ -106,6 +106,10 @@ $1 ~ /^PNG_DFN_END_SORT/{
+    #	#define name "John Smith"
+    #
+    while (1) {
++      # Remove trailing CR
++   sub(/$/, "", line)
++
++   
+       # While there is an @" remove it and the next "@
+       if (line ~ /@"/) {
+          if (line ~ /@".*"@/) {
+@@ -172,9 +176,6 @@ $1 ~ /^PNG_DFN_END_SORT/{
+    # editorial consistency
+    sub(/ *$/, "", line)
+ 
+-   # Remove trailing CR
+-   sub(/$/, "", line)
+-
+    if (sort) {
+       if (split(line, parts) < sort) {
+          print "line", lineno ": missing sort field:", line

--- a/depends/patches/qt/fix_qt571_win32_qmake.patch
+++ b/depends/patches/qt/fix_qt571_win32_qmake.patch
@@ -1,0 +1,10 @@
+--- old/qtbase/mkspecs/features/default_post.prf
++++ new/qtbase/mkspecs/features/default_post.prf
+@@ -67,6 +67,7 @@
+
+ dll:win32: QMAKE_LFLAGS += $$QMAKE_LFLAGS_DLL
+ static:mac: QMAKE_LFLAGS += $$QMAKE_LFLAGS_STATIC_LIB
++static:win32: QMAKE_LFLAGS += $$QMAKE_LFLAGS_STATIC_LIB
+ staticlib:unix {
+     QMAKE_CFLAGS += $$QMAKE_CFLAGS_STATIC_LIB
+     QMAKE_CXXFLAGS += $$QMAKE_CXXFLAGS_STATIC_LIB


### PR DESCRIPTION
This updates the native Windows MinGW build scripts based on the work done by @CCGLLC-knc in #1219 to update the mingw build instructions.  Does not exactly follow the updated steps as there were some typos and I ran into trouble with the 32-bit Boost build of v1.66 so updated to v1.68 instead.

Summary of version updates and configuration changes necessary:
* Tool chain (both 32 & 64 bit) updated to 7.3.0, v5, rev0
* Update hexdump utility to latest master build (only used if building in tests)
* Update OpenSSL to v1.0.2o
  * Configuration needed to be changed to call `make depend` before calling `make`
* Update libpng to v1.6.36
  * Required applying a patch to fix line ending handling prior to building
* Update qrencode to v4.0.2
* Update Boost to v1.68.0
  * Configuration now requires specifying `address-model` when building for 32-bit.  Not sure if this is because of the toolchain or because of Boost itself (v1.61 with the v4.9.2 toolchain didn't require this)
* Update QT to v5.7.1
  * Required applying a patch for static library builds
  * Configuration required changing to use `qt-zlib`, `qt-libpng`, and `qt-libjpeg`.  Previously the v5.3.2 Qt configuration used `system-zlib`, `system-libpng` and `no-libjpeg`.
  * Configuration also now requires explicit specification of include and lib folders for the OpenSSL path
  * Bitcoin configuration required additionally specifying the Qt libs location in addition to the existing `with-qt-libdir`

I have tested full download and build from scratch of all dependencies and bitcoin binaries in both 32-bit and 64-bit modes.  Ran each of the 32-bit and 64-bit builds for about a day each without seeing issues with normal operations.