### PR TITLE
Use SipHash for cheap hashes in Graphene

### DIFF
--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -68,7 +68,7 @@ CGrapheneBlock::~CGrapheneBlock()
     }
 }
 
-void CGrapheneBlock::FillShortTxIDSelector() const
+void CGrapheneBlock::FillShortTxIDSelector()
 {
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << header << nonce;

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1509,6 +1509,11 @@ uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &t
     if (grapheneVersion < 2)
         return txhash.GetCheapHash();
 
+    // If both shorttxidk0 and shorttxidk1 are equal to 0, then it is very likely
+    // that the values have not been properly instantiated using FillShortTxIDSelector,
+    // but are instead unchanged from the default initialization value.
+    DbgAssert(!(shorttxidk0 == 0 && shorttxidk1 == 0), );
+
     static_assert(SHORTTXIDS_LENGTH == 8, "shorttxids calculation assumes 8-byte shorttxids");
     return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffffL;
 }

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -33,7 +33,8 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
     uint64_t nReceiverMemPoolTx,
     uint64_t nSenderMempoolPlusBlock,
     uint64_t _version)
-    : nonce(GetRand(std::numeric_limits<uint64_t>::max())) // Use cryptographically strong pseudorandom number because
+    : shorttxidk0(0), shorttxidk1(0),
+      nonce(GetRand(std::numeric_limits<uint64_t>::max())) // Use cryptographically strong pseudorandom number because
                                                            // we will extract SipHash secret key from this
 {
     header = pblock->GetBlockHeader();

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -160,12 +160,12 @@ bool CGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     size_t idx = 0;
     for (const CTransaction &tx : grapheneBlockTx.vMissingTx)
     {
-        pfrom->mapMissingTx[GetShortID(pfrom->shorttxidk0, pfrom->shorttxidk1, tx.GetHash(),
+        pfrom->mapMissingTx[GetShortID(pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, tx.GetHash(),
             pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED))] = MakeTransactionRef(tx);
 
         uint256 hash = tx.GetHash();
-        uint64_t cheapHash = GetShortID(
-            pfrom->shorttxidk0, pfrom->shorttxidk1, hash, pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED));
+        uint64_t cheapHash = GetShortID(pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, hash,
+            pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED));
 
         // Insert in arbitrary order if canonical ordering is enabled and xversion is recent enough
         if (enableCanonicalTxOrder.Value() && pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED) >= 1)
@@ -295,7 +295,7 @@ bool CRequestGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
         {
             for (auto &tx : block.vtx)
             {
-                uint64_t cheapHash = GetShortID(pfrom->shorttxidk0, pfrom->shorttxidk1, tx->GetHash(),
+                uint64_t cheapHash = GetShortID(pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, tx->GetHash(),
                     pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED));
 
                 if (grapheneRequestBlockTx.setCheapHashesToRequest.count(cheapHash))
@@ -446,8 +446,8 @@ bool CGrapheneBlock::process(CNode *pfrom,
     pfrom->grapheneBlock.nTime = header.nTime;
     pfrom->grapheneBlock.hashMerkleRoot = header.hashMerkleRoot;
     pfrom->grapheneBlock.hashPrevBlock = header.hashPrevBlock;
-    pfrom->shorttxidk0 = shorttxidk0;
-    pfrom->shorttxidk1 = shorttxidk1;
+    pfrom->gr_shorttxidk0 = shorttxidk0;
+    pfrom->gr_shorttxidk1 = shorttxidk1;
 
     {
         LOCK(pfrom->cs_grapheneadditionaltxs);
@@ -750,7 +750,7 @@ static bool ReconstructBlock(CNode *pfrom, int &missingCount, int &unnecessaryCo
                     inMemPool = true;
             }
 
-            bool inMissingTx = pfrom->mapMissingTx.count(GetShortID(pfrom->shorttxidk0, pfrom->shorttxidk1, hash,
+            bool inMissingTx = pfrom->mapMissingTx.count(GetShortID(pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, hash,
                                    pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED))) > 0;
             bool inAdditionalTxs = mapAdditionalTxs.count(hash) > 0;
             bool inOrphanCache = orphanpool.mapOrphanTransactions.count(hash) > 0;
@@ -770,7 +770,7 @@ static bool ReconstructBlock(CNode *pfrom, int &missingCount, int &unnecessaryCo
             }
             else if (inMissingTx)
             {
-                ptx = pfrom->mapMissingTx[GetShortID(pfrom->shorttxidk0, pfrom->shorttxidk1, hash,
+                ptx = pfrom->mapMissingTx[GetShortID(pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, hash,
                     pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED))];
                 pfrom->grapheneBlock.setUnVerifiedTxns.insert(hash);
             }
@@ -1353,8 +1353,8 @@ void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CM
 
             CGrapheneBlock grapheneBlock(MakeBlockRef(*pblock), mempoolinfo.nTx, nSenderMempoolPlusBlock,
                 pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED));
-            pfrom->shorttxidk0 = grapheneBlock.shorttxidk0;
-            pfrom->shorttxidk1 = grapheneBlock.shorttxidk1;
+            pfrom->gr_shorttxidk0 = grapheneBlock.shorttxidk0;
+            pfrom->gr_shorttxidk1 = grapheneBlock.shorttxidk1;
             int nSizeBlock = pblock->GetBlockSize();
             int nSizeGrapheneBlock = ::GetSerializeSize(grapheneBlock, SER_NETWORK, PROTOCOL_VERSION);
 

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -34,8 +34,9 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
     uint64_t nSenderMempoolPlusBlock,
     uint64_t _version)
     : shorttxidk0(0), shorttxidk1(0),
-      nonce(GetRand(std::numeric_limits<uint64_t>::max())) // Use cryptographically strong pseudorandom number because
-                                                           // we will extract SipHash secret key from this
+      sipHashNonce(
+          GetRand(std::numeric_limits<uint64_t>::max())) // Use cryptographically strong pseudorandom number because
+// we will extract SipHash secret key from this
 {
     header = pblock->GetBlockHeader();
     nBlockTxs = pblock->vtx.size();
@@ -77,7 +78,7 @@ CGrapheneBlock::~CGrapheneBlock()
 void CGrapheneBlock::FillShortTxIDSelector()
 {
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
-    stream << header << nonce;
+    stream << header << sipHashNonce;
     CSHA256 hasher;
     hasher.Write((unsigned char *)&(*stream.begin()), stream.end() - stream.begin());
     uint256 shorttxidhash;

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -29,8 +29,11 @@ static bool ReconstructBlock(CNode *pfrom, int &missingCount, int &unnecessaryCo
 
 CMemPoolInfo::CMemPoolInfo(uint64_t _nTx) : nTx(_nTx) {}
 CMemPoolInfo::CMemPoolInfo() { this->nTx = 0; }
-CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock, uint64_t nReceiverMemPoolTx, uint64_t nSenderMempoolPlusBlock, bool _useSipHash) :
-    nonce(GetRand(std::numeric_limits<uint64_t>::max()))
+CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
+    uint64_t nReceiverMemPoolTx,
+    uint64_t nSenderMempoolPlusBlock,
+    bool _useSipHash)
+    : nonce(GetRand(std::numeric_limits<uint64_t>::max()))
 {
     header = pblock->GetBlockHeader();
     nBlockTxs = pblock->vtx.size();
@@ -49,9 +52,11 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock, uint64_t nReceiverMemPool
     }
 
     if (enableCanonicalTxOrder.Value())
-        pGrapheneSet = new CGrapheneSet(nReceiverMemPoolTx, nSenderMempoolPlusBlock, blockHashes, shorttxidk0, shorttxidk1, useSipHash, false);
+        pGrapheneSet = new CGrapheneSet(
+            nReceiverMemPoolTx, nSenderMempoolPlusBlock, blockHashes, shorttxidk0, shorttxidk1, useSipHash, false);
     else
-        pGrapheneSet = new CGrapheneSet(nReceiverMemPoolTx, nSenderMempoolPlusBlock, blockHashes, shorttxidk0, shorttxidk1, useSipHash, true);
+        pGrapheneSet = new CGrapheneSet(
+            nReceiverMemPoolTx, nSenderMempoolPlusBlock, blockHashes, shorttxidk0, shorttxidk1, useSipHash, true);
 }
 
 CGrapheneBlock::~CGrapheneBlock()
@@ -63,11 +68,12 @@ CGrapheneBlock::~CGrapheneBlock()
     }
 }
 
-void CGrapheneBlock::FillShortTxIDSelector() const {
+void CGrapheneBlock::FillShortTxIDSelector() const
+{
     CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
     stream << header << nonce;
     CSHA256 hasher;
-    hasher.Write((unsigned char*)&(*stream.begin()), stream.end() - stream.begin());
+    hasher.Write((unsigned char *)&(*stream.begin()), stream.end() - stream.begin());
     uint256 shorttxidhash;
     hasher.Finalize(shorttxidhash.begin());
     shorttxidk0 = shorttxidhash.GetUint64(0);
@@ -150,7 +156,8 @@ bool CGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     size_t idx = 0;
     for (const CTransaction &tx : grapheneBlockTx.vMissingTx)
     {
-        pfrom->mapMissingTx[GetShortID(pfrom->shorttxidk0, pfrom->shorttxidk1, tx.GetHash(), pfrom->useSipHash)] = MakeTransactionRef(tx);
+        pfrom->mapMissingTx[GetShortID(pfrom->shorttxidk0, pfrom->shorttxidk1, tx.GetHash(), pfrom->useSipHash)] =
+            MakeTransactionRef(tx);
 
         uint256 hash = tx.GetHash();
         uint64_t cheapHash = GetShortID(pfrom->shorttxidk0, pfrom->shorttxidk1, hash, pfrom->useSipHash);
@@ -283,7 +290,8 @@ bool CRequestGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
         {
             for (auto &tx : block.vtx)
             {
-                uint64_t cheapHash = GetShortID(pfrom->shorttxidk0, pfrom->shorttxidk1, tx->GetHash(), pfrom->useSipHash);
+                uint64_t cheapHash =
+                    GetShortID(pfrom->shorttxidk0, pfrom->shorttxidk1, tx->GetHash(), pfrom->useSipHash);
 
                 if (grapheneRequestBlockTx.setCheapHashesToRequest.count(cheapHash))
                     vTx.push_back(*tx);
@@ -518,8 +526,8 @@ bool CGrapheneBlock::process(CNode *pfrom,
                 // Ensure coinbase is first
                 if (blockCheapHashes[0] != GetShortID(shorttxidk0, shorttxidk1, coinbase->GetHash(), useSipHash))
                 {
-                    auto it =
-                        std::find(blockCheapHashes.begin(), blockCheapHashes.end(), GetShortID(shorttxidk0, shorttxidk1, coinbase->GetHash(), useSipHash));
+                    auto it = std::find(blockCheapHashes.begin(), blockCheapHashes.end(),
+                        GetShortID(shorttxidk0, shorttxidk1, coinbase->GetHash(), useSipHash));
 
                     if (it == blockCheapHashes.end())
                     {
@@ -738,7 +746,8 @@ static bool ReconstructBlock(CNode *pfrom, int &missingCount, int &unnecessaryCo
                     inMemPool = true;
             }
 
-            bool inMissingTx = pfrom->mapMissingTx.count(GetShortID(pfrom->shorttxidk0, pfrom->shorttxidk1, hash, pfrom->useSipHash)) > 0;
+            bool inMissingTx = pfrom->mapMissingTx.count(
+                                   GetShortID(pfrom->shorttxidk0, pfrom->shorttxidk1, hash, pfrom->useSipHash)) > 0;
             bool inAdditionalTxs = mapAdditionalTxs.count(hash) > 0;
             bool inOrphanCache = orphanpool.mapOrphanTransactions.count(hash) > 0;
 
@@ -1339,7 +1348,8 @@ void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CM
             uint64_t nSenderMempoolPlusBlock =
                 GetGrapheneMempoolInfo().nTx + pblock->vtx.size() - 1; // exclude coinbase
 
-            CGrapheneBlock grapheneBlock(MakeBlockRef(*pblock), mempoolinfo.nTx, nSenderMempoolPlusBlock, pfrom->useSipHash);
+            CGrapheneBlock grapheneBlock(
+                MakeBlockRef(*pblock), mempoolinfo.nTx, nSenderMempoolPlusBlock, pfrom->useSipHash);
             pfrom->shorttxidk0 = grapheneBlock.shorttxidk0;
             pfrom->shorttxidk1 = grapheneBlock.shorttxidk1;
             int nSizeBlock = pblock->GetBlockSize();
@@ -1488,7 +1498,8 @@ void RequestFailoverBlock(CNode *pfrom, const uint256 &blockhash)
 }
 
 // Generate cheap hash from seeds using SipHash
-uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256& txhash, bool useSipHash) {
+uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &txhash, bool useSipHash)
+{
     if (!useSipHash)
         return txhash.GetCheapHash();
 

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -33,7 +33,8 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
     uint64_t nReceiverMemPoolTx,
     uint64_t nSenderMempoolPlusBlock,
     uint64_t _version)
-    : nonce(GetRand(std::numeric_limits<uint64_t>::max()))
+    : nonce(GetRand(std::numeric_limits<uint64_t>::max())) // Use cryptographically strong pseudorandom number because
+                                                           // we will extract SipHash secret key from this
 {
     header = pblock->GetBlockHeader();
     nBlockTxs = pblock->vtx.size();

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -66,8 +66,8 @@ public:
         uint64_t nReceiverMemPoolTx,
         uint64_t nSenderMempoolPlusBlock,
         uint64_t _version);
-    CGrapheneBlock() : pGrapheneSet(nullptr), version(2) {}
-    CGrapheneBlock(uint64_t _version) : pGrapheneSet(nullptr) { version = _version; }
+    CGrapheneBlock() : shorttxidk0(0), shorttxidk1(0), pGrapheneSet(nullptr), version(2) {}
+    CGrapheneBlock(uint64_t _version) : shorttxidk0(0), shorttxidk1(0), pGrapheneSet(nullptr) { version = _version; }
     ~CGrapheneBlock();
     // Create seeds for SipHash using the nonce generated in the constructor
     // Note that this must be called any time members header or nonce are changed

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -48,18 +48,20 @@ public:
 class CGrapheneBlock
 {
 private:
-    mutable uint64_t shorttxidk0, shorttxidk1;
     uint64_t nonce;
 
 public:
+    mutable uint64_t shorttxidk0, shorttxidk1;
     CBlockHeader header;
     std::vector<CTransactionRef> vAdditionalTxs; // vector of transactions receiver probably does not have
     uint64_t nBlockTxs;
     CGrapheneSet *pGrapheneSet;
+    bool useSipHash;
 
 public:
-    CGrapheneBlock(const CBlockRef pblock, uint64_t nReceiverMemPoolTx, uint64_t nSenderMempoolPlusBlock);
-    CGrapheneBlock() : pGrapheneSet(nullptr) {}
+    CGrapheneBlock(const CBlockRef pblock, uint64_t nReceiverMemPoolTx, uint64_t nSenderMempoolPlusBlock, bool _useSipHash);
+    CGrapheneBlock() : pGrapheneSet(nullptr), useSipHash(true) {}
+    CGrapheneBlock(bool _useSipHash) : pGrapheneSet(nullptr) { useSipHash = _useSipHash; }
     ~CGrapheneBlock();
     // Create seeds for SipHash using the nonce generated in the constructor
     void FillShortTxIDSelector() const;
@@ -79,9 +81,11 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
-        READWRITE(shorttxidk0);
-        READWRITE(shorttxidk1);
-        READWRITE(nonce);
+        if (useSipHash) {
+            READWRITE(shorttxidk0);
+            READWRITE(shorttxidk1);
+            READWRITE(nonce);
+        }
         READWRITE(header);
         READWRITE(vAdditionalTxs);
         READWRITE(nBlockTxs);
@@ -90,7 +94,7 @@ public:
         if (nBlockTxs > (excessiveBlockSize * maxMessageSizeMultiplier / 100))
             throw std::runtime_error("nBlockTxs exceeds threshold for excessive block txs");
         if (!pGrapheneSet)
-            pGrapheneSet = new CGrapheneSet();
+            pGrapheneSet = new CGrapheneSet(useSipHash);
         READWRITE(*pGrapheneSet);
     }
     uint64_t GetAdditionalTxSerializationSize()
@@ -314,6 +318,6 @@ bool HandleGrapheneBlockRequest(CDataStream &vRecv, CNode *pfrom, const CChainPa
 CMemPoolInfo GetGrapheneMempoolInfo();
 void RequestFailoverBlock(CNode *pfrom, const uint256 &blockhash);
 // Generate cheap hash from seeds using SipHash
-uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256& txhash);
+uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256& txhash, bool useSipHash);
 
 #endif // BITCOIN_GRAPHENE_H

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -51,7 +51,7 @@ private:
     uint64_t nonce;
 
 public:
-    mutable uint64_t shorttxidk0, shorttxidk1;
+    uint64_t shorttxidk0, shorttxidk1;
     CBlockHeader header;
     std::vector<CTransactionRef> vAdditionalTxs; // vector of transactions receiver probably does not have
     uint64_t nBlockTxs;
@@ -67,7 +67,7 @@ public:
     CGrapheneBlock(bool _useSipHash) : pGrapheneSet(nullptr) { useSipHash = _useSipHash; }
     ~CGrapheneBlock();
     // Create seeds for SipHash using the nonce generated in the constructor
-    void FillShortTxIDSelector() const;
+    void FillShortTxIDSelector();
     /**
      * Handle an incoming Graphene block
      * Once the block is validated apart from the Merkle root, forward the Xpedited block with a hop count of nHops.

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -49,11 +49,11 @@ class CGrapheneBlock
 {
 private:
     // Entropy used for SipHash secret key; this is distinct from the block nonce
-    uint64_t nonce;
+    uint64_t sipHashNonce;
 
 public:
     // These describe, in two parts, the 128-bit secret key used for SipHash
-    // Note that they are populated by FillShortTxIDSelector, which uses header and nonce
+    // Note that they are populated by FillShortTxIDSelector, which uses header and sipHashNonce
     uint64_t shorttxidk0, shorttxidk1;
     CBlockHeader header;
     std::vector<CTransactionRef> vAdditionalTxs; // vector of transactions receiver probably does not have
@@ -69,8 +69,8 @@ public:
     CGrapheneBlock() : shorttxidk0(0), shorttxidk1(0), pGrapheneSet(nullptr), version(2) {}
     CGrapheneBlock(uint64_t _version) : shorttxidk0(0), shorttxidk1(0), pGrapheneSet(nullptr) { version = _version; }
     ~CGrapheneBlock();
-    // Create seeds for SipHash using the nonce generated in the constructor
-    // Note that this must be called any time members header or nonce are changed
+    // Create seeds for SipHash using the sipHashNonce generated in the constructor
+    // Note that this must be called any time members header or sipHashNonce are changed
     void FillShortTxIDSelector();
     /**
      * Handle an incoming Graphene block
@@ -92,7 +92,7 @@ public:
         {
             READWRITE(shorttxidk0);
             READWRITE(shorttxidk1);
-            READWRITE(nonce);
+            READWRITE(sipHashNonce);
         }
         READWRITE(header);
         READWRITE(vAdditionalTxs);

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -59,7 +59,10 @@ public:
     bool useSipHash;
 
 public:
-    CGrapheneBlock(const CBlockRef pblock, uint64_t nReceiverMemPoolTx, uint64_t nSenderMempoolPlusBlock, bool _useSipHash);
+    CGrapheneBlock(const CBlockRef pblock,
+        uint64_t nReceiverMemPoolTx,
+        uint64_t nSenderMempoolPlusBlock,
+        bool _useSipHash);
     CGrapheneBlock() : pGrapheneSet(nullptr), useSipHash(true) {}
     CGrapheneBlock(bool _useSipHash) : pGrapheneSet(nullptr) { useSipHash = _useSipHash; }
     ~CGrapheneBlock();
@@ -81,7 +84,8 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
-        if (useSipHash) {
+        if (useSipHash)
+        {
             READWRITE(shorttxidk0);
             READWRITE(shorttxidk1);
             READWRITE(nonce);
@@ -318,6 +322,6 @@ bool HandleGrapheneBlockRequest(CDataStream &vRecv, CNode *pfrom, const CChainPa
 CMemPoolInfo GetGrapheneMempoolInfo();
 void RequestFailoverBlock(CNode *pfrom, const uint256 &blockhash);
 // Generate cheap hash from seeds using SipHash
-uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256& txhash, bool useSipHash);
+uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &txhash, bool useSipHash);
 
 #endif // BITCOIN_GRAPHENE_H

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -48,9 +48,12 @@ public:
 class CGrapheneBlock
 {
 private:
+    // Entropy used for SipHash secret key; this is distinct from the block nonce
     uint64_t nonce;
 
 public:
+    // These describe, in two parts, the 128-bit secret key used for SipHash
+    // Note that they are populated by FillShortTxIDSelector, which uses header and nonce
     uint64_t shorttxidk0, shorttxidk1;
     CBlockHeader header;
     std::vector<CTransactionRef> vAdditionalTxs; // vector of transactions receiver probably does not have
@@ -67,6 +70,7 @@ public:
     CGrapheneBlock(uint64_t _version) : pGrapheneSet(nullptr) { version = _version; }
     ~CGrapheneBlock();
     // Create seeds for SipHash using the nonce generated in the constructor
+    // Note that this must be called any time members header or nonce are changed
     void FillShortTxIDSelector();
     /**
      * Handle an incoming Graphene block

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -118,7 +118,8 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
 }
 
 
-uint64_t CGrapheneSet::GetShortID(const uint256& txhash) const {
+uint64_t CGrapheneSet::GetShortID(const uint256 &txhash) const
+{
     if (!useSipHash)
         return txhash.GetCheapHash();
 

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -19,6 +19,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
     const std::vector<uint256> &_itemHashes,
     uint64_t _shorttxidk0,
     uint64_t _shorttxidk1,
+    bool _useSipHash,
     bool _ordered,
     bool fDeterministic)
 {
@@ -29,6 +30,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
 
     shorttxidk0 = _shorttxidk0;
     shorttxidk1 = _shorttxidk1;
+    useSipHash = _useSipHash;
 
     // Below is the parameter "n" from the graphene paper
     uint64_t nItems = _itemHashes.size();
@@ -117,7 +119,9 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
 
 
 uint64_t CGrapheneSet::GetShortID(const uint256& txhash) const {
-    //return txhash.GetCheapHash();
+    if (!useSipHash)
+        return txhash.GetCheapHash();
+
     static_assert(SHORTTXIDS_LENGTH == 8, "shorttxids calculation assumes 8-byte shorttxids");
     return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffffL;
 }

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -17,6 +17,8 @@
 CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
     uint64_t nSenderUniverseItems,
     const std::vector<uint256> &_itemHashes,
+    uint64_t _shorttxidk0,
+    uint64_t _shorttxidk1,
     bool _ordered,
     bool fDeterministic)
 {
@@ -24,6 +26,9 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
 
     // Below is the parameter "m" from the graphene paper
     nReceiverUniverseItems = _nReceiverUniverseItems;
+
+    shorttxidk0 = _shorttxidk0;
+    shorttxidk1 = _shorttxidk1;
 
     // Below is the parameter "n" from the graphene paper
     uint64_t nItems = _itemHashes.size();
@@ -108,6 +113,13 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
 
         encodedRank = CGrapheneSet::EncodeRank(sortedIdxs, nBits);
     }
+}
+
+
+uint64_t CGrapheneSet::GetShortID(const uint256& txhash) const {
+    //return txhash.GetCheapHash();
+    static_assert(SHORTTXIDS_LENGTH == 8, "shorttxids calculation assumes 8-byte shorttxids");
+    return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffffL;
 }
 
 

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -84,7 +84,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
 
     for (const uint256 &itemHash : _itemHashes)
     {
-        uint64_t cheapHash = itemHash.GetCheapHash();
+        uint64_t cheapHash = GetShortID(itemHash);
 
         pSetFilter->insert(itemHash);
 
@@ -227,7 +227,7 @@ std::vector<uint64_t> CGrapheneSet::Reconcile(const std::vector<uint256> &receiv
     int passedFilter = 0;
     for (const uint256 &itemHash : receiverItemHashes)
     {
-        uint64_t cheapHash = itemHash.GetCheapHash();
+        uint64_t cheapHash = GetShortID(itemHash);
 
         auto ir = mapCheapHashes.insert(std::make_pair(cheapHash, itemHash));
         if (!ir.second)

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -19,7 +19,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
     const std::vector<uint256> &_itemHashes,
     uint64_t _shorttxidk0,
     uint64_t _shorttxidk1,
-    bool _useSipHash,
+    uint64_t _version,
     bool _ordered,
     bool fDeterministic)
 {
@@ -30,7 +30,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
 
     shorttxidk0 = _shorttxidk0;
     shorttxidk1 = _shorttxidk1;
-    useSipHash = _useSipHash;
+    version = _version;
 
     // Below is the parameter "n" from the graphene paper
     uint64_t nItems = _itemHashes.size();
@@ -120,7 +120,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
 
 uint64_t CGrapheneSet::GetShortID(const uint256 &txhash) const
 {
-    if (!useSipHash)
+    if (version == 0)
         return txhash.GetCheapHash();
 
     static_assert(SHORTTXIDS_LENGTH == 8, "shorttxids calculation assumes 8-byte shorttxids");

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -55,8 +55,17 @@ private:
 
 public:
     // The default constructor is for 2-phase construction via deserialization
-    CGrapheneSet() : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), useSipHash(true), pSetFilter(nullptr), pSetIblt(nullptr) {}
-    CGrapheneSet(bool _useSipHash) : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), pSetFilter(nullptr), pSetIblt(nullptr) { useSipHash = _useSipHash; }
+    CGrapheneSet()
+        : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), useSipHash(true),
+          pSetFilter(nullptr), pSetIblt(nullptr)
+    {
+    }
+    CGrapheneSet(bool _useSipHash)
+        : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), pSetFilter(nullptr),
+          pSetIblt(nullptr)
+    {
+        useSipHash = _useSipHash;
+    }
     CGrapheneSet(size_t _nReceiverUniverseItems,
         uint64_t nSenderUniverseItems,
         const std::vector<uint256> &_itemHashes,
@@ -67,7 +76,7 @@ public:
         bool fDeterministic = false);
 
     // Generate cheap hash from seeds using SipHash
-    uint64_t GetShortID(const uint256& txhash) const;
+    uint64_t GetShortID(const uint256 &txhash) const;
 
     /* Optimal symmetric difference between block txs and receiver mempool txs passing
      * though filter to use for IBLT.
@@ -142,7 +151,8 @@ public:
     {
         READWRITE(ordered);
         READWRITE(nReceiverUniverseItems);
-        if (useSipHash) {
+        if (useSipHash)
+        {
             READWRITE(shorttxidk0);
             READWRITE(shorttxidk1);
         }

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -36,6 +36,7 @@ private:
     bool ordered;
     uint64_t nReceiverUniverseItems;
     mutable uint64_t shorttxidk0, shorttxidk1;
+    bool useSipHash;
     std::vector<unsigned char> encodedRank;
     CBloomFilter *pSetFilter;
     CIblt *pSetIblt;
@@ -54,12 +55,14 @@ private:
 
 public:
     // The default constructor is for 2-phase construction via deserialization
-    CGrapheneSet() : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), pSetFilter(nullptr), pSetIblt(nullptr) {}
+    CGrapheneSet() : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), useSipHash(true), pSetFilter(nullptr), pSetIblt(nullptr) {}
+    CGrapheneSet(bool _useSipHash) : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), pSetFilter(nullptr), pSetIblt(nullptr) { useSipHash = _useSipHash; }
     CGrapheneSet(size_t _nReceiverUniverseItems,
         uint64_t nSenderUniverseItems,
         const std::vector<uint256> &_itemHashes,
         uint64_t _shorttxidk0,
         uint64_t _shorttxidk1,
+        bool _useSipHash,
         bool _ordered = false,
         bool fDeterministic = false);
 
@@ -139,8 +142,10 @@ public:
     {
         READWRITE(ordered);
         READWRITE(nReceiverUniverseItems);
-        READWRITE(shorttxidk0);
-        READWRITE(shorttxidk1);
+        if (useSipHash) {
+            READWRITE(shorttxidk0);
+            READWRITE(shorttxidk1);
+        }
         if (nReceiverUniverseItems > LARGE_MEM_POOL_SIZE)
             throw std::runtime_error("nReceiverUniverseItems exceeds threshold for excessive mempool size");
         READWRITE(encodedRank);

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -60,7 +60,7 @@ public:
           pSetIblt(nullptr)
     {
     }
-    CGrapheneSet(bool _version)
+    CGrapheneSet(uint64_t _version)
         : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), pSetFilter(nullptr),
           pSetIblt(nullptr)
     {

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -36,7 +36,7 @@ private:
     bool ordered;
     uint64_t nReceiverUniverseItems;
     mutable uint64_t shorttxidk0, shorttxidk1;
-    bool useSipHash;
+    uint64_t version;
     std::vector<unsigned char> encodedRank;
     CBloomFilter *pSetFilter;
     CIblt *pSetIblt;
@@ -56,22 +56,22 @@ private:
 public:
     // The default constructor is for 2-phase construction via deserialization
     CGrapheneSet()
-        : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), useSipHash(true),
-          pSetFilter(nullptr), pSetIblt(nullptr)
+        : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), version(1), pSetFilter(nullptr),
+          pSetIblt(nullptr)
     {
     }
-    CGrapheneSet(bool _useSipHash)
+    CGrapheneSet(bool _version)
         : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), pSetFilter(nullptr),
           pSetIblt(nullptr)
     {
-        useSipHash = _useSipHash;
+        version = _version;
     }
     CGrapheneSet(size_t _nReceiverUniverseItems,
         uint64_t nSenderUniverseItems,
         const std::vector<uint256> &_itemHashes,
         uint64_t _shorttxidk0,
         uint64_t _shorttxidk1,
-        bool _useSipHash,
+        uint64_t _version,
         bool _ordered = false,
         bool fDeterministic = false);
 
@@ -151,7 +151,7 @@ public:
     {
         READWRITE(ordered);
         READWRITE(nReceiverUniverseItems);
-        if (useSipHash)
+        if (version > 0)
         {
             READWRITE(shorttxidk0);
             READWRITE(shorttxidk1);

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -33,9 +33,9 @@ const float IBLT_DEFAULT_OVERHEAD = 1.5;
 class CGrapheneSet
 {
 private:
-    mutable uint64_t shorttxidk0, shorttxidk1;
     bool ordered;
     uint64_t nReceiverUniverseItems;
+    mutable uint64_t shorttxidk0, shorttxidk1;
     std::vector<unsigned char> encodedRank;
     CBloomFilter *pSetFilter;
     CIblt *pSetIblt;
@@ -139,10 +139,10 @@ public:
     {
         READWRITE(ordered);
         READWRITE(nReceiverUniverseItems);
-        if (nReceiverUniverseItems > LARGE_MEM_POOL_SIZE)
-            throw std::runtime_error("nReceiverUniverseItems exceeds threshold for excessive mempool size");
         READWRITE(shorttxidk0);
         READWRITE(shorttxidk1);
+        if (nReceiverUniverseItems > LARGE_MEM_POOL_SIZE)
+            throw std::runtime_error("nReceiverUniverseItems exceeds threshold for excessive mempool size");
         READWRITE(encodedRank);
         if (!pSetFilter)
             pSetFilter = new CBloomFilter();

--- a/src/net.h
+++ b/src/net.h
@@ -478,6 +478,7 @@ public:
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
     uint64_t shorttxidk0; // Used for generating cheap hash from SipHash
     uint64_t shorttxidk1;
+    bool useSipHash;
 
     std::atomic<double> nGetGrapheneBlockTxCount; // Count how many get_xblocktx requests are made
     std::atomic<uint64_t> nGetGrapheneBlockTxLastTime; // The last time a get_xblocktx request was made

--- a/src/net.h
+++ b/src/net.h
@@ -478,7 +478,6 @@ public:
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
     uint64_t shorttxidk0; // Used for generating cheap hash from SipHash
     uint64_t shorttxidk1;
-    bool useSipHash;
 
     std::atomic<double> nGetGrapheneBlockTxCount; // Count how many get_xblocktx requests are made
     std::atomic<uint64_t> nGetGrapheneBlockTxLastTime; // The last time a get_xblocktx request was made

--- a/src/net.h
+++ b/src/net.h
@@ -476,13 +476,6 @@ public:
     int grapheneBlockWaitingForTxns; // if -1 then not currently waiting
     CCriticalSection cs_grapheneadditionaltxs; // lock grapheneAdditionalTxs
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
-    uint64_t shorttxidk0; // Used for generating cheap hash from SipHash
-    uint64_t shorttxidk1;
-
-    std::atomic<double> nGetGrapheneBlockTxCount; // Count how many get_xblocktx requests are made
-    std::atomic<uint64_t> nGetGrapheneBlockTxLastTime; // The last time a get_xblocktx request was made
-    std::atomic<double> nGetGrapheneCount; // Count how many get_graphene requests are made
-    std::atomic<uint64_t> nGetGrapheneLastTime; // The last time a get_graphene request was made
     uint32_t nGrapheneBloomfilterSize; // The maximum graphene bloom filter size (in bytes) that our peer will accept.
     // BUIPXXX Graphene blocks: end section
 

--- a/src/net.h
+++ b/src/net.h
@@ -476,6 +476,13 @@ public:
     int grapheneBlockWaitingForTxns; // if -1 then not currently waiting
     CCriticalSection cs_grapheneadditionaltxs; // lock grapheneAdditionalTxs
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
+    uint64_t shorttxidk0; // Used for generating cheap hash from SipHash
+    uint64_t shorttxidk1;
+
+    std::atomic<double> nGetGrapheneBlockTxCount; // Count how many get_xblocktx requests are made
+    std::atomic<uint64_t> nGetGrapheneBlockTxLastTime; // The last time a get_xblocktx request was made
+    std::atomic<double> nGetGrapheneCount; // Count how many get_graphene requests are made
+    std::atomic<uint64_t> nGetGrapheneLastTime; // The last time a get_graphene request was made
     uint32_t nGrapheneBloomfilterSize; // The maximum graphene bloom filter size (in bytes) that our peer will accept.
     // BUIPXXX Graphene blocks: end section
 

--- a/src/net.h
+++ b/src/net.h
@@ -477,6 +477,8 @@ public:
     CCriticalSection cs_grapheneadditionaltxs; // lock grapheneAdditionalTxs
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
     uint32_t nGrapheneBloomfilterSize; // The maximum graphene bloom filter size (in bytes) that our peer will accept.
+    uint64_t gr_shorttxidk0;
+    uint64_t gr_shorttxidk1;
     // BUIPXXX Graphene blocks: end section
 
     // Compact Blocks : begin

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -532,7 +532,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         CXVersionMessage xver;
         xver.set_u64c(XVer::BU_LISTEN_PORT, GetListenPort());
         xver.set_u64c(XVer::BU_MSG_IGNORE_CHECKSUM, 1); // we will ignore 0 value msg checksums
-        xver.set_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED, 1);
+        xver.set_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED, 2);
         xver.set_u64c(XVer::BU_XTHIN_VERSION, 2); // xthin version
         pfrom->PushMessage(NetMsgType::XVERSION, xver);
 

--- a/src/test/graphene_tests.cpp
+++ b/src/test/graphene_tests.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_encodes_and_decodes)
 
     // unordered graphene sets
     {
-        CGrapheneSet senderGrapheneSet(6, 6, senderItems, 0, 0, false, true);
+        CGrapheneSet senderGrapheneSet(6, 6, senderItems, 0, 0, false, false, true);
         std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
         std::vector<uint64_t> senderCheapHashes;
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_encodes_and_decodes)
 
     // ordered graphene sets
     {
-        CGrapheneSet senderGrapheneSet(6, 6, senderItems, 0, 0, true, true);
+        CGrapheneSet senderGrapheneSet(6, 6, senderItems, 0, 0, false, true, true);
         std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
         std::vector<uint64_t> senderCheapHashes;
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_multiple_sizes)
                 receiverItems.push_back(SerializeHash(GetHash(nNumHashes)));
             }
 
-            CGrapheneSet senderGrapheneSet(receiverItems.size(), receiverItems.size(), senderItems, 0, 0, true, true);
+            CGrapheneSet senderGrapheneSet(receiverItems.size(), receiverItems.size(), senderItems, 0, 0, false, true, true);
             std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
             BOOST_CHECK_EQUAL_COLLECTIONS(reconciledCheapHashes.begin(), reconciledCheapHashes.end(),
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_multiple_sizes)
                 receiverItems.push_back(SerializeHash(GetHash(nNumHashes)));
             }
 
-            CGrapheneSet senderGrapheneSet(receiverItems.size(), receiverItems.size(), senderItems, 0, 0, true, true);
+            CGrapheneSet senderGrapheneSet(receiverItems.size(), receiverItems.size(), senderItems, 0, 0, false, true, true);
             std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
             BOOST_CHECK_EQUAL_COLLECTIONS(reconciledCheapHashes.begin(), reconciledCheapHashes.end(),
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_multiple_sizes)
 
 BOOST_AUTO_TEST_CASE(graphene_set_finds_brute_force_opt_for_small_blocks)
 {
-    CGrapheneSet grapheneSet;
+    CGrapheneSet grapheneSet(false);
 
     int n = (int)std::floor(APPROX_ITEMS_THRESH / 2);
     int mu = 100;
@@ -159,7 +159,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_finds_approx_opt_for_large_blocks)
     int n = 4 * APPROX_ITEMS_THRESH;
     int mu = 1000;
     int m = APPROX_ITEMS_THRESH + mu;
-    CGrapheneSet grapheneSet;
+    CGrapheneSet grapheneSet(false);
     auto approxSymDiff = [n]() {
         return std::max(
             1.0, std::round(FILTER_CELL_SIZE * n / (8 * IBLT_CELL_SIZE * IBLT_DEFAULT_OVERHEAD * LN2SQUARED)));
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_approx_opt_close_to_optimal)
     int n = APPROX_ITEMS_THRESH;
     int mu = 100;
     int m = (int)std::ceil(n / APPROX_EXCESS_RATE) + mu;
-    CGrapheneSet grapheneSet;
+    CGrapheneSet grapheneSet(false);
 
     float totalBytesApprox = (float)ProjectedGrapheneSizeBytes(n, m - mu, grapheneSet.ApproxOptimalSymDiff(n));
     float totalBytesBrute =
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_empty_intersection)
         SerializeHash(-5), SerializeHash(-11)};
     std::vector<uint256> receiverItems(receiverArr, receiverArr + sizeof(receiverArr) / sizeof(uint256));
 
-    CGrapheneSet senderGrapheneSet(6, 12, senderItems, 0, 0, true, true);
+    CGrapheneSet senderGrapheneSet(6, 12, senderItems, 0, 0, false, true, true);
     std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
     std::vector<uint64_t> senderCheapHashes;
@@ -211,8 +211,8 @@ BOOST_AUTO_TEST_CASE(graphene_set_can_serde)
     CDataStream ss(SER_DISK, 0);
 
     senderItems.push_back(SerializeHash(3));
-    CGrapheneSet sentGrapheneSet(1, 1, senderItems, 0, 0, true);
-    CGrapheneSet receivedGrapheneSet;
+    CGrapheneSet sentGrapheneSet(1, 1, senderItems, 0, 0, false, true);
+    CGrapheneSet receivedGrapheneSet(false);
 
     ss << sentGrapheneSet;
     ss >> receivedGrapheneSet;

--- a/src/test/graphene_tests.cpp
+++ b/src/test/graphene_tests.cpp
@@ -48,7 +48,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_encodes_and_decodes)
 
     // unordered graphene sets
     {
-        CGrapheneSet senderGrapheneSet(6, 6, senderItems, false, true);
+        CGrapheneSet senderGrapheneSet(6, 6, senderItems, 0, 0, false, true);
         std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
         std::vector<uint64_t> senderCheapHashes;
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_encodes_and_decodes)
 
     // ordered graphene sets
     {
-        CGrapheneSet senderGrapheneSet(6, 6, senderItems, true, true);
+        CGrapheneSet senderGrapheneSet(6, 6, senderItems, 0, 0, true, true);
         std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
         std::vector<uint64_t> senderCheapHashes;
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_multiple_sizes)
                 receiverItems.push_back(SerializeHash(GetHash(nNumHashes)));
             }
 
-            CGrapheneSet senderGrapheneSet(receiverItems.size(), receiverItems.size(), senderItems, true, true);
+            CGrapheneSet senderGrapheneSet(receiverItems.size(), receiverItems.size(), senderItems, 0, 0, true, true);
             std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
             BOOST_CHECK_EQUAL_COLLECTIONS(reconciledCheapHashes.begin(), reconciledCheapHashes.end(),
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_multiple_sizes)
                 receiverItems.push_back(SerializeHash(GetHash(nNumHashes)));
             }
 
-            CGrapheneSet senderGrapheneSet(receiverItems.size(), receiverItems.size(), senderItems, true, true);
+            CGrapheneSet senderGrapheneSet(receiverItems.size(), receiverItems.size(), senderItems, 0, 0, true, true);
             std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
             BOOST_CHECK_EQUAL_COLLECTIONS(reconciledCheapHashes.begin(), reconciledCheapHashes.end(),
@@ -194,7 +194,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_empty_intersection)
         SerializeHash(-5), SerializeHash(-11)};
     std::vector<uint256> receiverItems(receiverArr, receiverArr + sizeof(receiverArr) / sizeof(uint256));
 
-    CGrapheneSet senderGrapheneSet(6, 12, senderItems, true, true);
+    CGrapheneSet senderGrapheneSet(6, 12, senderItems, 0, 0, true, true);
     std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
     std::vector<uint64_t> senderCheapHashes;
@@ -211,7 +211,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_can_serde)
     CDataStream ss(SER_DISK, 0);
 
     senderItems.push_back(SerializeHash(3));
-    CGrapheneSet sentGrapheneSet(1, 1, senderItems, true);
+    CGrapheneSet sentGrapheneSet(1, 1, senderItems, 0, 0, true);
     CGrapheneSet receivedGrapheneSet;
 
     ss << sentGrapheneSet;

--- a/src/test/graphene_tests.cpp
+++ b/src/test/graphene_tests.cpp
@@ -104,7 +104,8 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_multiple_sizes)
                 receiverItems.push_back(SerializeHash(GetHash(nNumHashes)));
             }
 
-            CGrapheneSet senderGrapheneSet(receiverItems.size(), receiverItems.size(), senderItems, 0, 0, false, true, true);
+            CGrapheneSet senderGrapheneSet(
+                receiverItems.size(), receiverItems.size(), senderItems, 0, 0, false, true, true);
             std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
             BOOST_CHECK_EQUAL_COLLECTIONS(reconciledCheapHashes.begin(), reconciledCheapHashes.end(),
@@ -120,7 +121,8 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_multiple_sizes)
                 receiverItems.push_back(SerializeHash(GetHash(nNumHashes)));
             }
 
-            CGrapheneSet senderGrapheneSet(receiverItems.size(), receiverItems.size(), senderItems, 0, 0, false, true, true);
+            CGrapheneSet senderGrapheneSet(
+                receiverItems.size(), receiverItems.size(), senderItems, 0, 0, false, true, true);
             std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
             BOOST_CHECK_EQUAL_COLLECTIONS(reconciledCheapHashes.begin(), reconciledCheapHashes.end(),

--- a/src/test/test_bitcoin_fuzzy.cpp
+++ b/src/test/test_bitcoin_fuzzy.cpp
@@ -529,7 +529,7 @@ protected:
         try
         {
             gs = std::make_shared<CGrapheneSet>(
-                nReceiverUniverseItems, nReceiverUniverseItems, itemHashes, ordered, fDeterministic);
+                nReceiverUniverseItems, nReceiverUniverseItems, itemHashes, 0, 0, true, ordered, fDeterministic);
 
             while (!ds->empty())
             {


### PR DESCRIPTION
This PR replaces all calls to GetCheapHash with a 64 bit SipHash. Some of the SipHash setup was taken from work that was done on Compact Blocks by @TheBlueMatt. SipHashes are used only when graphene sender and receiver versions are both greater than or equal to 2.