### PR TITLE
Initialize templates during startup rather than at first use

### DIFF
--- a/src/script/standard.h
+++ b/src/script/standard.h
@@ -92,5 +92,6 @@ CScript GetScriptForMultisig(int nRequired, const std::vector<CPubKey> &keys);
 CScript GetScriptForFreeze(CScriptNum nLockTime, const CPubKey &pubKey);
 CScript GetScriptLabelPublic(const std::string &labelPublic);
 
+void InitTemplates();
 
 #endif // BITCOIN_SCRIPT_STANDARD_H

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -40,6 +40,7 @@ extern void noui_connect();
 
 BasicTestingSetup::BasicTestingSetup(const std::string &chainName)
 {
+    InitTemplates();
     SHA256AutoDetect();
     ECC_Start();
     SetupEnvironment();

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -585,6 +585,9 @@ void UnlimitedSetup(void)
             checkpoints.fTransactionsPerDay = 280000.0;
         }
     }
+
+    // Initialize templates used in validating transactions
+    InitTemplates();
 }
 
 FILE *blockReceiptLog = nullptr;


### PR DESCRIPTION
Fixes a reported crash bug in dev...

We no longer rely on cs_main for locking and since transaction handling
is now multithreaded we can end up having two threads initializing the
template map. By moving the init phase to startup we no longer have
the conflict and futherore don't have to make the check every time
we process a transaction. Also added a mutes, although it's not really
necessary, just in case the InitTemplactes() function get's moved
somewhere else in the future.