### PR TITLE
Create  error(ctgr, ...) that allows us to specify  a logging category

### DIFF
--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -338,8 +338,8 @@ bool CGrapheneBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string
     // Is there a previous block or header to connect with?
     if (!LookupBlockIndex(grapheneBlock.header.hashPrevBlock))
     {
-        return error("Graphene block from peer %s will not connect, unknown previous block %s", pfrom->GetLogName(),
-            grapheneBlock.header.hashPrevBlock.ToString());
+        return error(GRAPHENE, "Graphene block from peer %s will not connect, unknown previous block %s",
+            pfrom->GetLogName(), grapheneBlock.header.hashPrevBlock.ToString());
     }
 
     {

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -423,7 +423,7 @@ bool InitHTTPServer()
 #if LIBEVENT_VERSION_NUMBER >= 0x02010100
     // If -debug=libevent, set full libevent debugging.
     // Otherwise, disable all libevent debugging.
-    if (LogAcceptCategory(Logging::LIBEVENT))
+    if (Logging::LogAcceptCategory(LIBEVENT))
         event_enable_debug_logging(EVENT_DBG_ALL);
     else
         event_enable_debug_logging(EVENT_DBG_NONE);

--- a/src/qt/bitcoin.cpp
+++ b/src/qt/bitcoin.cpp
@@ -144,7 +144,7 @@ void DebugMessageHandler(QtMsgType type, const QMessageLogContext &context, cons
 {
     Q_UNUSED(context);
     // If the type is QtDebugMsg then log in the QT category, otherwise always log
-    uint64_t category = (type == QtDebugMsg) ? Logging::QT : Logging::ALL;
+    uint64_t category = (type == QtDebugMsg) ? QT : ALL;
     LOG(category, "GUI: %s\n", msg.toStdString());
 }
 

--- a/src/respend/respenddetector.cpp
+++ b/src/respend/respenddetector.cpp
@@ -23,7 +23,7 @@ std::vector<RespendActionPtr> CreateDefaultActions()
     std::vector<RespendActionPtr> actions;
 
     actions.push_back(RespendActionPtr(new RespendRelayer{}));
-    if (LogAcceptCategory(Logging::RESPEND))
+    if (Logging::LogAcceptCategory(RESPEND))
     {
         actions.push_back(RespendActionPtr(new RespendLogger{}));
     }

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -197,7 +197,7 @@ struct StartupShutdown
                 /* To enable this, add
                    -- --log_bitcoin console
                    to the end of the test_bitcoin argument list. */
-                Logging::LogToggleCategory(Logging::ALL, true);
+                Logging::LogToggleCategory(ALL, true);
                 fPrintToConsole = true;
                 fPrintToDebugLog = false;
             }

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1679,7 +1679,7 @@ UniValue setlog(const UniValue &params, bool fHelp)
     // Don't use them in other places.
 
     UniValue ret = UniValue("");
-    uint64_t catg = Logging::NONE;
+    uint64_t catg = NONE;
     int nparm = params.size();
     bool action = false;
 
@@ -1709,14 +1709,14 @@ UniValue setlog(const UniValue &params, bool fHelp)
             std::string data = params[0].get_str();
             std::transform(data.begin(), data.end(), std::back_inserter(category), ::tolower);
             catg = Logging::LogFindCategory(category);
-            if (catg == Logging::NONE)
+            if (catg == NONE)
                 return UniValue("Category not found: " + params[0].get_str()); // quit
         }
 
         switch (nparm)
         {
         case 1:
-            if (catg == Logging::ALL)
+            if (catg == ALL)
                 ret = UniValue(Logging::LogGetAllString());
             else
                 ret = UniValue(Logging::LogAcceptCategory(catg) ? "on" : "off");

--- a/src/util.h
+++ b/src/util.h
@@ -120,17 +120,6 @@ extern std::vector<std::string> splitByCommasAndRemoveSpaces(const std::vector<s
 // LOGA(...)
 // located further down.
 // (Do not use the Logging functions directly)
-namespace Logging
-{
-extern uint64_t categoriesEnabled;
-
-/*
-To add a new log category:
-1) Create a unique 1 bit category mask. (Easiest is to 2* the last enum entry.)
-   Put it at the end of enum below.
-2) Add an category/string pair to LOGLABELMAP macro below.
-*/
-
 // Log Categories:
 // 64 Bits: (Define unique bits, not 'normal' numbers)
 enum
@@ -178,6 +167,17 @@ enum
     RESPEND = 0x20000000,
     WB = 0x40000000 // weak blocks
 };
+
+namespace Logging
+{
+extern uint64_t categoriesEnabled;
+
+/*
+To add a new log category:
+1) Create a unique 1 bit category mask. (Easiest is to 2* the last enum entry.)
+   Put it at the end of enum below.
+2) Add an category/string pair to LOGLABELMAP macro below.
+*/
 
 // Add corresponding lower case string for the category:
 #define LOGLABELMAP                                                                                             \
@@ -357,12 +357,23 @@ std::string FormatStringFromLogArgs(const char *fmt, const Args &... args)
     return fmt;
 }
 
+
 template <typename... Args>
 bool error(const char *fmt, const Args &... args)
 {
     LogPrintStr("ERROR: " + tfm::format(fmt, args...) + "\n");
     return false;
 }
+
+
+template <typename... Args>
+inline bool error(uint64_t ctgr, const char *fmt, const Args &... args)
+{
+    if (Logging::LogAcceptCategory(ctgr))
+        LogPrintStr("ERROR: " + tfm::format(fmt, args...) + "\n");
+    return false;
+}
+
 
 /**
  Format an amount of bytes with a unit symbol attached, such as MB, KB, GB.
@@ -514,7 +525,7 @@ void TraceThreads(const std::string &name, Callable func)
     }
     catch (...)
     {
-        PrintExceptionContinue(NULL, name.c_str());
+        PrintExceptionContinue(nullptr, name.c_str());
         LogFlush();
         throw;
     }

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -3444,7 +3444,7 @@ bool ProcessNewBlock(CValidationState &state,
 
     int64_t end = GetTimeMicros();
 
-    if (Logging::LogAcceptCategory(Logging::BENCH))
+    if (Logging::LogAcceptCategory(BENCH))
     {
         uint64_t maxTxSizeLocal = 0;
         uint64_t maxVin = 0;


### PR DESCRIPTION
@gandrewstone Can't use a macro here so had to take the enum's for log categories out of the Logging namespace to make this work.  Not sure I really like this entirely but I didn't exactly like having to specify LOGGING::category every time we print out an error message.   I can switch back no problem but just wanted to throw this PR up for discussion.

So rather than have to say:

   error(Logging::GRAPHENE | Logging::THIN, "message ...");

it's just:

   error(GRAPHENE | THIN, "message ...");

which is consistent with the way we do LOG() messages.
