### PR TITLE
Add missing lock in FindNextBlocksToDownload()

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2388,6 +2388,8 @@ bool SendMessages(CNode *pto)
             }
         }
 
+        // If the chain is not entirely sync'd then look for new blocks to download.
+        if (!IsChainSyncd())
         {
             TRY_LOCK(cs_main, locked);
             if (locked)

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -939,7 +939,13 @@ void CRequestManager::UpdateBlockAvailability(NodeId nodeid, const uint256 &hash
 
 void CRequestManager::RequestNextBlocksToDownload(CNode *pto)
 {
-    int nBlocksInFlight = mapRequestManagerNodeState[pto->GetId()].nBlocksInFlight;
+    AssertLockHeld(cs_main);
+
+    int nBlocksInFlight = 0;
+    {
+        LOCK(cs_objDownloader);
+        nBlocksInFlight = mapRequestManagerNodeState[pto->GetId()].nBlocksInFlight;
+    }
     if (!pto->fDisconnectRequest && !pto->fDisconnect && !pto->fClient &&
         nBlocksInFlight < (int)pto->nMaxBlocksInTransit)
     {

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -47,9 +47,9 @@ double GetDifficulty(const CBlockIndex *blockindex)
 {
     // Floating point number that is a multiple of the minimum difficulty,
     // minimum difficulty = 1.0.
-    if (blockindex == NULL)
+    if (blockindex == nullptr)
     {
-        if (chainActive.Tip() == NULL)
+        if (chainActive.Tip() == nullptr)
             return 1.0;
         else
             blockindex = chainActive.Tip();
@@ -161,7 +161,6 @@ UniValue getblockcount(const UniValue &params, bool fHelp)
                             "n    (numeric) The current block count\n"
                             "\nExamples:\n" +
                             HelpExampleCli("getblockcount", "") + HelpExampleRpc("getblockcount", ""));
-    LOCK(cs_main);
     return chainActive.Height();
 }
 
@@ -175,7 +174,6 @@ UniValue getbestblockhash(const UniValue &params, bool fHelp)
                             "\nExamples\n" +
                             HelpExampleCli("getbestblockhash", "") + HelpExampleRpc("getbestblockhash", ""));
 
-    LOCK(cs_main);
     return chainActive.Tip()->GetBlockHash().GetHex();
 }
 
@@ -190,7 +188,6 @@ UniValue getdifficulty(const UniValue &params, bool fHelp)
             "\nExamples:\n" +
             HelpExampleCli("getdifficulty", "") + HelpExampleRpc("getdifficulty", ""));
 
-    LOCK(cs_main);
     return GetDifficulty();
 }
 


### PR DESCRIPTION
Also, only check find next blocks if the chain is not synced entirely.