### PR TITLE
Ditch boost scoped_ptr and use C++11 std::unique_ptr instead

### DIFF
--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -591,7 +591,7 @@ public:
 
 static void MutateTx(CMutableTransaction &tx, const string &command, const string &commandVal)
 {
-    boost::scoped_ptr<Secp256k1Init> ecc;
+    std::unique_ptr<Secp256k1Init> ecc;
 
     if (command == "nversion")
         MutateTxVersion(tx, commandVal);

--- a/src/bitnodes.cpp
+++ b/src/bitnodes.cpp
@@ -238,7 +238,7 @@ private:
     boost::asio::ssl::stream<boost::asio::ip::tcp::socket> socket_;
     boost::asio::streambuf response_;
     std::string content_;
-    boost::scoped_ptr<boost::asio::deadline_timer> timer_;
+    std::unique_ptr<boost::asio::deadline_timer> timer_;
     std::string url_path_;
     std::string url_host_;
     std::string cert_hostname_;

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -174,7 +174,7 @@ std::vector<unsigned char> CDBWrapper::CreateObfuscateKey() const
 
 bool CDBWrapper::IsEmpty()
 {
-    boost::scoped_ptr<CDBIterator> it(NewIterator());
+    std::unique_ptr<CDBIterator> it(NewIterator());
     it->SeekToFirst();
     return !(it->Valid());
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -166,7 +166,7 @@ public:
 };
 
 static CCoinsViewErrorCatcher *pcoinscatcher = NULL;
-static boost::scoped_ptr<ECCVerifyHandle> globalVerifyHandle;
+static std::unique_ptr<ECCVerifyHandle> globalVerifyHandle;
 
 void Interrupt(boost::thread_group &threadGroup)
 {

--- a/src/test/dbwrapper_tests.cpp
+++ b/src/test/dbwrapper_tests.cpp
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(dbwrapper_iterator)
         uint256 in2 = GetRandHash();
         BOOST_CHECK(dbw.Write(key2, in2));
 
-        boost::scoped_ptr<CDBIterator> it(const_cast<CDBWrapper *>(&dbw)->NewIterator());
+        std::unique_ptr<CDBIterator> it(const_cast<CDBWrapper *>(&dbw)->NewIterator());
 
         // Be sure to seek past the obfuscation key (if it exists)
         it->Seek(key);
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(iterator_ordering)
         BOOST_CHECK(dbw.Write(key, value));
     }
 
-    boost::scoped_ptr<CDBIterator> it(const_cast<CDBWrapper *>(&dbw)->NewIterator());
+    std::unique_ptr<CDBIterator> it(const_cast<CDBWrapper *>(&dbw)->NewIterator());
     for (int c = 0; c < 2; ++c)
     {
         int seek_start;
@@ -308,7 +308,7 @@ BOOST_AUTO_TEST_CASE(iterator_string_ordering)
         }
     }
 
-    boost::scoped_ptr<CDBIterator> it(const_cast<CDBWrapper *>(&dbw)->NewIterator());
+    std::unique_ptr<CDBIterator> it(const_cast<CDBWrapper *>(&dbw)->NewIterator());
     for (int c = 0; c < 2; ++c)
     {
         int seek_start;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -376,7 +376,7 @@ bool CBlockTreeDB::ReadFlag(const std::string &name, bool &fValue)
 
 bool CBlockTreeDB::FindBlockIndex(uint256 blockhash, CDiskBlockIndex *pindex)
 {
-    boost::scoped_ptr<CDBIterator> pcursor(NewIterator());
+    std::unique_ptr<CDBIterator> pcursor(NewIterator());
     pcursor->Seek(make_pair(DB_BLOCK_INDEX, uint256()));
     // Load mapBlockIndex
     while (pcursor->Valid())
@@ -415,7 +415,7 @@ bool CBlockTreeDB::FindBlockIndex(uint256 blockhash, CDiskBlockIndex *pindex)
 
 bool CBlockTreeDB::LoadBlockIndexGuts()
 {
-    boost::scoped_ptr<CDBIterator> pcursor(NewIterator());
+    std::unique_ptr<CDBIterator> pcursor(NewIterator());
 
     pcursor->Seek(make_pair(DB_BLOCK_INDEX, uint256()));
 
@@ -464,7 +464,7 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
 
 bool CBlockTreeDB::GetSortedHashIndex(std::vector<std::pair<int, CDiskBlockIndex> > &hashesByHeight)
 {
-    boost::scoped_ptr<CDBIterator> pcursor(NewIterator());
+    std::unique_ptr<CDBIterator> pcursor(NewIterator());
     pcursor->Seek(make_pair(DB_BLOCK_INDEX, uint256()));
     // Load mapBlockIndex
     while (pcursor->Valid())

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -1057,7 +1057,7 @@ bool CWalletDB::Recover(CDBEnv &dbenv, const std::string &filename, bool fOnlyKe
     }
     LOGA("Salvage(aggressive) found %u records\n", salvagedData.size());
 
-    boost::scoped_ptr<Db> pdbCopy(new Db(dbenv.dbenv, 0));
+    std::unique_ptr<Db> pdbCopy(new Db(dbenv.dbenv, 0));
     int ret = pdbCopy->open(nullptr, // Txn pointer
         filename.c_str(), // Filename
         "main", // Logical db name


### PR DESCRIPTION
Since we are using C++11 standard since a long time this should
have been done a while ago. What the commit is basically a scripted
string substitution s/boost::scoped_ptr/std::unique_ptr/