### PR TITLE
add a few batch rpc calls

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -239,7 +239,8 @@ testScripts = [ RpcTest(t) for t in [
     'checkdatasig_activation',
     'xversion',
     'sighashmatch',
-    'getlogcategories'
+    'getlogcategories',
+    'getrawtransaction'
 ] ]
 
 testScriptsExt = [ RpcTest(t) for t in [

--- a/qa/rpc-tests/getrawtransaction.py
+++ b/qa/rpc-tests/getrawtransaction.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2018 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+import test_framework.loginit
+# This is a template to make creating new QA tests easy.
+# You can also use this template to quickly start and connect a few regtest nodes.
+
+import time
+import sys
+if sys.version_info[0] < 3:
+    raise "Use Python 3"
+import logging
+
+import json
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+class GetRawTransactionTest (BitcoinTestFramework):
+
+    def setup_chain(self,bitcoinConfDict=None, wallets=None):
+        print("Initializing test directory "+self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 2, bitcoinConfDict, wallets)
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(2, self.options.tmpdir)
+        connect_nodes_full(self.nodes)
+        self.is_network_split=False
+        self.sync_blocks()
+
+    def run_test (self):
+
+        # generate enough blocks so that nodes[0] has a balance
+        self.sync_blocks()
+        self.nodes[0].generate(105)
+        self.sync_blocks()
+
+        startinghash = self.nodes[0].generate(1)
+
+        blockTxids = {}
+
+        blocks = 0
+        while blocks < 5:
+            txids = []
+            txids.append(self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1))
+            txids.append(self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1))
+            txids.append(self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1))
+            blockhash = self.nodes[0].generate(1)[0]
+            blockTxids[blockhash] = txids
+            blocks = blocks + 1
+
+        self.sync_blocks()
+
+        # intentionally ask for more blocks than can be returned for testing
+        rawtransactionssince = self.nodes[1].getrawtransactionssince(startinghash[0], 0, 10)
+        for hash ,txs in blockTxids.items():
+            assert_not_equal(rawtransactionssince.get(hash, False), False)
+            for txid in txs:
+                assert_not_equal(rawtransactionssince[hash].get(txid, False), False)
+        assert_equal(rawtransactionssince.get("notarealhash", False), False)
+
+        for hash ,txs in blockTxids.items():
+            assert_equal(self.nodes[0].getrawblocktransactions(hash, 0), rawtransactionssince[hash])
+
+
+if __name__ == '__main__':
+    GetRawTransactionTest ().main ()
+
+# Create a convenient function for an interactive python debugging session
+def GetRawTransactionTest():
+    t = GetRawTransactionTest()
+    bitcoinConf = {
+        "debug": ["net", "blk", "thin", "mempool", "req", "bench", "evict"],
+        "blockprioritysize": 2000000  # we don't want any transactions rejected due to insufficient fees...
+    }
+
+
+    flags = standardFlags()
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/getrawtransaction.py
+++ b/qa/rpc-tests/getrawtransaction.py
@@ -53,7 +53,7 @@ class GetRawTransactionTest (BitcoinTestFramework):
         self.sync_blocks()
 
         # intentionally ask for more blocks than can be returned for testing
-        rawtransactionssince = self.nodes[1].getrawtransactionssince(startinghash[0], 0, 10)
+        rawtransactionssince = self.nodes[1].getrawtransactionssince(startinghash[0], 10)
         for hash ,txs in blockTxids.items():
             assert_not_equal(rawtransactionssince.get(hash, False), False)
             for txid in txs:
@@ -61,7 +61,7 @@ class GetRawTransactionTest (BitcoinTestFramework):
         assert_equal(rawtransactionssince.get("notarealhash", False), False)
 
         for hash ,txs in blockTxids.items():
-            assert_equal(self.nodes[0].getrawblocktransactions(hash, 0), rawtransactionssince[hash])
+            assert_equal(self.nodes[0].getrawblocktransactions(hash), rawtransactionssince[hash])
 
 
 if __name__ == '__main__':

--- a/qa/rpc-tests/merkle_blocks.py
+++ b/qa/rpc-tests/merkle_blocks.py
@@ -84,5 +84,10 @@ class MerkleBlockTest(BitcoinTestFramework):
         # ...or if we have a -txindex
         assert_equal(self.nodes[2].verifytxoutproof(self.nodes[3].gettxoutproof([txid_spent])), [txid_spent])
 
+        # ensure we get the same data for fetching multiple proofs at a time that we get for each one individually
+        proofsresult = self.nodes[2].gettxoutproofs([txid1, txid2], blockhash)
+        assert_equal(proofsresult[txid1], self.nodes[2].gettxoutproof([txid1], blockhash))
+        assert_equal(proofsresult[txid2], self.nodes[2].gettxoutproof([txid2], blockhash))
+
 if __name__ == '__main__':
     MerkleBlockTest().main()

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -163,7 +163,7 @@ size_t CTransaction::GetTxSize() const
 }
 
 
-bool CTransaction::HasData()
+bool CTransaction::HasData() const
 {
     for (auto &out : vout)
     {
@@ -173,7 +173,7 @@ bool CTransaction::HasData()
     return false;
 }
 
-bool CTransaction::HasData(uint32_t dataID)
+bool CTransaction::HasData(uint32_t dataID) const
 {
     for (auto &out : vout)
     {

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -233,10 +233,10 @@ public:
     bool IsEquivalentTo(const CTransaction &tx) const;
 
     //* Return true if this transaction contains at least one OP_RETURN output.
-    bool HasData();
+    bool HasData() const;
     //* Return true if this transaction contains at least one OP_RETURN output, with the specified data ID
     // the data ID is defined as a 4 byte pushdata containing a little endian 4 byte integer.
-    bool HasData(uint32_t dataID);
+    bool HasData(uint32_t dataID) const;
 
     // Return sum of txouts.
     CAmount GetValueOut() const;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -222,7 +222,7 @@ UniValue getrawblocktransactions(const UniValue &params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
-            "getrawtransactions \"blockhash\" ( verbose )\n"
+            "getrawblocktransactions \"blockhash\" ( verbose )\n"
             "\nReturn the raw transaction data for a given block.\n"
             "\nIf verbose=0, each tx is a string that is serialized, hex-encoded data.\n"
             "If verbose is non-zero, returns an array of Objects with information about each tx in the block.\n"
@@ -285,9 +285,9 @@ UniValue getrawblocktransactions(const UniValue &params, bool fHelp)
             "  ...\n"
             "}\n"
             "\nExamples:\n" +
-            HelpExampleCli("getrawtransactions", "\"hashblock\"") +
-            HelpExampleCli("getrawtransactions", "\"hashblock\" 1") +
-            HelpExampleRpc("getrawtransactions", "\"hashblock\", 1"));
+            HelpExampleCli("getrawblocktransactions", "\"hashblock\"") +
+            HelpExampleCli("getrawblocktransactions", "\"hashblock\" 1") +
+            HelpExampleRpc("getrawblocktransactions", "\"hashblock\", 1"));
 
     uint256 hashBlock = ParseHashV(params[0], "parameter 1");
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -328,7 +328,8 @@ UniValue getrawtransactionssince(const UniValue &params, bool fHelp)
     if (fHelp || params.size() < 1 || params.size() > 3)
         throw runtime_error(
             "getrawtransactionssince \"blockhash\" ( verbose ) ( count )\n"
-            "\nReturn the raw transaction data for a <count> blocks starting with blockhash and moving towards the tip.\n"
+            "\nReturn the raw transaction data for a <count> blocks starting with blockhash and moving towards the "
+            "tip.\n"
             "\nIf verbose=0, each tx is a string that is serialized, hex-encoded data.\n"
             "If verbose is non-zero, returns an array of Objects with information about each tx in the block.\n"
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -241,7 +241,7 @@ void getRawTransactionsBlock(UniValue &arrayObject, const CBlock &block, bool fV
     }
 }
 
-UniValue getrawtransactions(const UniValue &params, bool fHelp)
+UniValue getrawblocktransactions(const UniValue &params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 2)
         throw runtime_error(
@@ -441,7 +441,7 @@ UniValue getrawtransactionssince(const UniValue &params, bool fHelp)
     UniValue resultSet(UniValue::VARR);
     int64_t fetched = 0;
     bool foundOne = false;
-    int64_t limit = acestorcount + 1;
+    int64_t limit = ancestorcount + 1;
     while (fetched < limit)
     {
         pblockindex = LookupBlockIndex(hashBlock);
@@ -1323,7 +1323,7 @@ static const CRPCCommand commands[] = {
     //  category              name                      actor (function)         okSafeMode
     //  --------------------- ------------------------  -----------------------  ----------
     {"rawtransactions", "getrawtransaction", &getrawtransaction, true},
-    {"rawtransactions", "getrawtransactions", &getrawtransactions, true},
+    {"rawtransactions", "getrawblocktransactions", &getrawblocktransactions, true},
     {"rawtransactions", "getrawtransactionssince", &getrawtransactionssince, true},
     {"rawtransactions", "createrawtransaction", &createrawtransaction, true},
     {"rawtransactions", "decoderawtransaction", &decoderawtransaction, true},

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -220,7 +220,6 @@ UniValue getrawtransaction(const UniValue &params, bool fHelp)
 
 UniValue getrawblocktransactions(const UniValue &params, bool fHelp)
 {
-
     bool fVerbose = false;
 
     // check for param  --verbose or -v
@@ -239,7 +238,8 @@ UniValue getrawblocktransactions(const UniValue &params, bool fHelp)
             "If verbose is non-zero, returns an array of Objects with information about each tx in the block.\n"
 
             "\nArguments:\n"
-            "1. \"-v\" or \"--verbose\" (string, optional, default=false) return an array of txid:hexstring, other return an "
+            "1. \"-v\" or \"--verbose\" (string, optional, default=false) return an array of txid:hexstring, other "
+            "return an "
             "array of tx json object\n"
             "2. \"hashblock\" (string, required) The block hash\n"
 
@@ -351,7 +351,8 @@ UniValue getrawtransactionssince(const UniValue &params, bool fHelp)
             "If verbose is non-zero, returns an array of Objects with information about each tx in the block.\n"
 
             "\nArguments:\n"
-            "1. \"-v\" or \"--verbose\" (string, optional, default=false) return an array of txid:hexstring, other return an "
+            "1. \"-v\" or \"--verbose\" (string, optional, default=false) return an array of txid:hexstring, other "
+            "return an "
             "array of tx json object\n"
             "2. \"hashblock\" (string, required) The block hash\n"
             "3. count    (numeric, optional, default=1) Fetch information for <count> blocks "

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -328,7 +328,7 @@ UniValue getrawtransactionssince(const UniValue &params, bool fHelp)
     if (fHelp || params.size() < 1 || params.size() > 3)
         throw runtime_error(
             "getrawtransactionssince \"blockhash\" ( verbose ) ( count )\n"
-            "\nReturn the raw transaction data for a <count> blocks starting with blockhash and moving towards the "
+            "\nReturn the raw transaction data for <count> blocks starting with blockhash and moving towards the "
             "tip.\n"
             "\nIf verbose=0, each tx is a string that is serialized, hex-encoded data.\n"
             "If verbose is non-zero, returns an array of Objects with information about each tx in the block.\n"

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -312,8 +312,6 @@ UniValue getrawblocktransactions(const UniValue &params, bool fHelp)
             HelpExampleCli("getrawtransactions", "\"hashblock\" 1") +
             HelpExampleRpc("getrawtransactions", "\"hashblock\", 1"));
 
-    LOCK(cs_main);
-
     uint256 hashBlock = ParseHashV(params[0], "parameter 1");
 
     bool fVerbose = false;
@@ -418,8 +416,6 @@ UniValue getrawtransactionssince(const UniValue &params, bool fHelp)
             HelpExampleCli("getrawtransactionssince", "\"hashblock\" 1") +
             HelpExampleCli("getrawtransactionssince", "\"hashblock\" 1 10") +
             HelpExampleRpc("getrawtransactionssince", "\"hashblock\", 1 10"));
-
-    LOCK(cs_main);
 
     uint256 hashBlock = ParseHashV(params[0], "parameter 1");
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -220,17 +220,28 @@ UniValue getrawtransaction(const UniValue &params, bool fHelp)
 
 UniValue getrawblocktransactions(const UniValue &params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 2)
+
+    bool fVerbose = false;
+
+    // check for param  --verbose or -v
+    string::size_type params_offset = 0;
+    if (params[0].isStr() && (params[0].get_str() == "--verbose" || params[0].get_str() == "-v"))
+    {
+        fVerbose = true;
+        ++params_offset;
+    }
+
+    if (fHelp || params.size() != 1 + params_offset)
         throw runtime_error(
-            "getrawblocktransactions \"blockhash\" ( verbose )\n"
+            "getrawblocktransactions\n"
             "\nReturn the raw transaction data for a given block.\n"
             "\nIf verbose=0, each tx is a string that is serialized, hex-encoded data.\n"
             "If verbose is non-zero, returns an array of Objects with information about each tx in the block.\n"
 
             "\nArguments:\n"
-            "1. \"hashblock\" (string, required) The block hash\n"
-            "2. verbose       (numeric, optional, default=0) If 0, return an array of txid:hexstring, other return an "
+            "1. \"-v\" or \"--verbose\" (string, optional, default=false) return an array of txid:hexstring, other return an "
             "array of tx json object\n"
+            "2. \"hashblock\" (string, required) The block hash\n"
 
             "\nResult (if verbose is not set or set to 0):\n"
             "{\n"
@@ -289,11 +300,7 @@ UniValue getrawblocktransactions(const UniValue &params, bool fHelp)
             HelpExampleCli("getrawblocktransactions", "\"hashblock\" 1") +
             HelpExampleRpc("getrawblocktransactions", "\"hashblock\", 1"));
 
-    uint256 hashBlock = ParseHashV(params[0], "parameter 1");
-
-    bool fVerbose = false;
-    if (params.size() > 1)
-        fVerbose = (params[1].get_int() != 0);
+    uint256 hashBlock = ParseHashV(params[0 + params_offset], "parameter 1");
 
     CBlockIndex *pblockindex = nullptr;
     pblockindex = LookupBlockIndex(hashBlock);
@@ -325,18 +332,28 @@ UniValue getrawblocktransactions(const UniValue &params, bool fHelp)
 
 UniValue getrawtransactionssince(const UniValue &params, bool fHelp)
 {
-    if (fHelp || params.size() < 1 || params.size() > 3)
+    bool fVerbose = false;
+
+    // check for param  --verbose or -v
+    string::size_type params_offset = 0;
+    if (params[0].isStr() && (params[0].get_str() == "--verbose" || params[0].get_str() == "-v"))
+    {
+        fVerbose = true;
+        ++params_offset;
+    }
+
+    if (fHelp || params.size() < (1 + params_offset) || params.size() > (2 + params_offset))
         throw runtime_error(
-            "getrawtransactionssince \"blockhash\" ( verbose ) ( count )\n"
+            "getrawtransactionssince\n"
             "\nReturn the raw transaction data for <count> blocks starting with blockhash and moving towards the "
             "tip.\n"
             "\nIf verbose=0, each tx is a string that is serialized, hex-encoded data.\n"
             "If verbose is non-zero, returns an array of Objects with information about each tx in the block.\n"
 
             "\nArguments:\n"
-            "1. \"hashblock\" (string, required) The block hash\n"
-            "2. verbose       (numeric, optional, default=0) If 0, return an array of txid:hexstring, other return an "
+            "1. \"-v\" or \"--verbose\" (string, optional, default=false) return an array of txid:hexstring, other return an "
             "array of tx json object\n"
+            "2. \"hashblock\" (string, required) The block hash\n"
             "3. count    (numeric, optional, default=1) Fetch information for <count> blocks "
             "starting with <hashblock> and moving towards the chain tip\n"
 
@@ -400,22 +417,18 @@ UniValue getrawtransactionssince(const UniValue &params, bool fHelp)
             "}\n"
             "\nExamples:\n" +
             HelpExampleCli("getrawtransactionssince", "\"hashblock\"") +
-            HelpExampleCli("getrawtransactionssince", "\"hashblock\" 1") +
-            HelpExampleCli("getrawtransactionssince", "\"hashblock\" 1 10") +
-            HelpExampleRpc("getrawtransactionssince", "\"hashblock\", 1 10"));
+            HelpExampleCli("getrawtransactionssince", "-v \"hashblock\"") +
+            HelpExampleCli("getrawtransactionssince", "-v \"hashblock\" 10") +
+            HelpExampleRpc("getrawtransactionssince", "-v \"hashblock\", 10"));
 
     LOCK(cs_main);
 
-    uint256 hashBlock = ParseHashV(params[0], "parameter 1");
-
-    bool fVerbose = false;
-    if (params.size() > 1)
-        fVerbose = (params[1].get_int() != 0);
+    uint256 hashBlock = ParseHashV(params[0 + params_offset], "parameter 1");
 
     int64_t limit = 1;
-    if (params.size() > 2)
+    if (params.size() > 1 + params_offset)
     {
-        int64_t arg = params[2].get_int64();
+        int64_t arg = params[1 + params_offset].get_int64();
         if (arg > 1)
         {
             limit = arg;

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -247,7 +247,9 @@ UniValue getrawblocktransactions(const UniValue &params, bool fHelp)
             "return an "
             "array of tx json object\n"
             "2. \"hashblock\"  (string, required) The block hash\n"
-            "3. \"protocol_id\" (string, optional) The protocol id to search OP_RETURN for. Use * as a wildcard for any id. If this param is entered we will not return any transactions that do not meet the protocol id criteria\n"
+            "3. \"protocol_id\" (string, optional) The protocol id to search OP_RETURN for. Use * as a wildcard for "
+            "any id. If this param is entered we will not return any transactions that do not meet the protocol id "
+            "criteria\n"
 
             "\nResult (if verbose is not set):\n"
             "{\n"
@@ -314,7 +316,7 @@ UniValue getrawblocktransactions(const UniValue &params, bool fHelp)
     bool has_protocol = params.size() > (1 + params_offset);
     if (has_protocol)
     {
-        str_protocol_id = params[1+ params_offset].get_str();
+        str_protocol_id = params[1 + params_offset].get_str();
         fAll = (str_protocol_id == "*");
         if (!fAll)
         {
@@ -360,7 +362,7 @@ UniValue getrawblocktransactions(const UniValue &params, bool fHelp)
         UniValue result(UniValue::VOBJ);
         result.pushKV("hex", strHex);
         TxToJSON(*tx, block.GetHash(), result);
-        resultSet.pushKV(tx->GetHash().ToString(),result);
+        resultSet.pushKV(tx->GetHash().ToString(), result);
     }
     return resultSet;
 }
@@ -392,7 +394,9 @@ UniValue getrawtransactionssince(const UniValue &params, bool fHelp)
             "2. \"hashblock\" (string, required) The block hash\n"
             "3. count    (numeric, optional, default=1) Fetch information for <count> blocks "
             "starting with <hashblock> and moving towards the chain tip\n"
-            "4. \"protocol_id\" (string, optional) The protocol id to search OP_RETURN for. Use * as a wildcard for any id. If this param is entered we will not return any transactions that do not meet the protocol id criteria\n"
+            "4. \"protocol_id\" (string, optional) The protocol id to search OP_RETURN for. Use * as a wildcard for "
+            "any id. If this param is entered we will not return any transactions that do not meet the protocol id "
+            "criteria\n"
 
 
             "\nResult (if verbose is not set or set to 0):\n"

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -222,7 +222,7 @@ void getRawTransactionsBlock(UniValue &arrayObject, const CBlock &block, bool fV
 {
     if (includeBlockHash)
     {
-        arrayObject.push_back(Pair("block_hash", block.GetHash().GetHex()));
+        arrayObject.pushKV("block_hash", block.GetHash().GetHex());
     }
     for (auto tx : block.vtx)
     {
@@ -230,12 +230,12 @@ void getRawTransactionsBlock(UniValue &arrayObject, const CBlock &block, bool fV
 
         if (!fVerbose)
         {
-            arrayObject.push_back(Pair(tx->GetHash().GetHex(), strHex));
+            arrayObject.pushKV(tx->GetHash().GetHex(), strHex);
             continue;
         }
 
         UniValue result(UniValue::VOBJ);
-        result.push_back(Pair("hex", strHex));
+        result.pushKV("hex", strHex);
         TxToJSON(*tx, block.GetHash(), result);
         arrayObject.push_back(result);
     }
@@ -637,7 +637,7 @@ UniValue gettxoutproofs(const UniValue &params, bool fHelp)
         CMerkleBlock mb(block, setTxid);
         ssMB << mb;
         std::string strHex = HexStr(ssMB.begin(), ssMB.end());
-        resultSet.push_back(Pair(txid.ToString(), strHex));
+        resultSet.pushKV(txid.ToString(), strHex);
     }
     return resultSet;
 }

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -629,7 +629,7 @@ UniValue gettxoutproofs(const UniValue &params, bool fHelp)
                 ntxFound++;
             }
         }
-        if(ntxFound != 1)
+        if (ntxFound != 1)
         {
             continue;
         }
@@ -637,7 +637,7 @@ UniValue gettxoutproofs(const UniValue &params, bool fHelp)
         CMerkleBlock mb(block, setTxid);
         ssMB << mb;
         std::string strHex = HexStr(ssMB.begin(), ssMB.end());
-        resultSet.push_back(Pair(txid.ToString(),strHex));
+        resultSet.push_back(Pair(txid.ToString(), strHex));
     }
     return resultSet;
 }
@@ -1410,8 +1410,7 @@ static const CRPCCommand commands[] = {
     {"rawtransactions", "enqueuerawtransaction", &enqueuerawtransaction, false},
     {"rawtransactions", "signrawtransaction", &signrawtransaction, false}, /* uses wallet if enabled */
 
-    {"blockchain", "gettxoutproof", &gettxoutproof, true},
-    {"blockchain", "gettxoutproofs", &gettxoutproofs, true},
+    {"blockchain", "gettxoutproof", &gettxoutproof, true}, {"blockchain", "gettxoutproofs", &gettxoutproofs, true},
     {"blockchain", "verifytxoutproof", &verifytxoutproof, true},
 };
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -619,20 +619,21 @@ UniValue gettxoutproofs(const UniValue &params, bool fHelp)
 
     for (auto txid : setTxids)
     {
-        std::set<uint256> setTxid;
-        setTxid.insert(txid);
-        unsigned int ntxFound = 0;
+        bool ntxFound = false;
         for (const auto &tx : block.vtx)
         {
-            if (setTxids.count(tx->GetHash()))
+            if (txid == tx->GetHash())
             {
-                ntxFound++;
+                ntxFound = true;
+                break;
             }
         }
-        if (ntxFound != 1)
+        if (!ntxFound)
         {
             continue;
         }
+        std::set<uint256> setTxid;
+        setTxid.insert(txid);
         CDataStream ssMB(SER_NETWORK, PROTOCOL_VERSION);
         CMerkleBlock mb(block, setTxid);
         ssMB << mb;


### PR DESCRIPTION
Batch RPC calls added by this PR:
- getrawtransactions : get raw transaction data for every tx in a block
- getrawtransactionssince : getrawtransactions for a block and specified amount of its ancestors
- gettxoutproofs : provides a proof for each txid passed in instead of one proof for the entire set