### PR TITLE
 Use UniValue.pushKV rather than push_back(Pair())

### DIFF
--- a/src/bitcoin-miner.cpp
+++ b/src/bitcoin-miner.cpp
@@ -280,11 +280,11 @@ static UniValue CpuMineBlock(unsigned int searchDuration, const UniValue &params
     printf("Solution! Checked %d possibilities\n", header.nNonce - startNonce);
 
     tmpstr = HexStr(coinbaseBytes.begin(), coinbaseBytes.end());
-    tmp.push_back(Pair("coinbase", tmpstr));
-    tmp.push_back(Pair("id", params["id"]));
-    tmp.push_back(Pair("time", UniValue(header.nTime))); // Optional. We have changed so must send.
-    tmp.push_back(Pair("nonce", UniValue(header.nNonce)));
-    tmp.push_back(Pair("version", UniValue(header.nVersion))); // Optional. We may have changed so sending.
+    tmp.pushKV("coinbase", tmpstr);
+    tmp.pushKV("id", params["id"]);
+    tmp.pushKV("time", UniValue(header.nTime)); // Optional. We have changed so must send.
+    tmp.pushKV("nonce", UniValue(header.nNonce));
+    tmp.pushKV("version", UniValue(header.nVersion)); // Optional. We may have changed so sending.
     ret.push_back(tmp);
 
     return ret;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -604,24 +604,24 @@ static bool rest_getutxos(HTTPRequest *req, const std::string &strURIPart)
 
         // pack in some essentials
         // use more or less the same output as mentioned in Bip64
-        objGetUTXOResponse.push_back(Pair("chainHeight", chainActive.Height()));
-        objGetUTXOResponse.push_back(Pair("chaintipHash", chainActive.Tip()->GetBlockHash().GetHex()));
-        objGetUTXOResponse.push_back(Pair("bitmap", bitmapStringRepresentation));
+        objGetUTXOResponse.pushKV("chainHeight", chainActive.Height());
+        objGetUTXOResponse.pushKV("chaintipHash", chainActive.Tip()->GetBlockHash().GetHex());
+        objGetUTXOResponse.pushKV("bitmap", bitmapStringRepresentation);
 
         UniValue utxos(UniValue::VARR);
         for (const CCoin &coin : outs)
         {
             UniValue utxo(UniValue::VOBJ);
-            utxo.push_back(Pair("height", (int32_t)coin.nHeight));
-            utxo.push_back(Pair("value", ValueFromAmount(coin.out.nValue)));
+            utxo.pushKV("height", (int32_t)coin.nHeight);
+            utxo.pushKV("value", ValueFromAmount(coin.out.nValue));
 
             // include the script in a json output
             UniValue o(UniValue::VOBJ);
             ScriptPubKeyToJSON(coin.out.scriptPubKey, o, true);
-            utxo.push_back(Pair("scriptPubKey", o));
+            utxo.pushKV("scriptPubKey", o);
             utxos.push_back(utxo);
         }
-        objGetUTXOResponse.push_back(Pair("utxos", utxos));
+        objGetUTXOResponse.pushKV("utxos", utxos);
 
         // return json string
         string strJSON = objGetUTXOResponse.write() + "\n";

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -76,45 +76,45 @@ double GetDifficulty(const CBlockIndex *blockindex)
 UniValue blockheaderToJSON(const CBlockIndex *blockindex)
 {
     UniValue result(UniValue::VOBJ);
-    result.push_back(Pair("hash", blockindex->GetBlockHash().GetHex()));
+    result.pushKV("hash", blockindex->GetBlockHash().GetHex());
     int confirmations = -1;
     // Only report confirmations if the block is on the main chain
     if (chainActive.Contains(blockindex))
         confirmations = chainActive.Height() - blockindex->nHeight + 1;
-    result.push_back(Pair("confirmations", confirmations));
-    result.push_back(Pair("height", blockindex->nHeight));
-    result.push_back(Pair("version", blockindex->nVersion));
-    result.push_back(Pair("versionHex", strprintf("%08x", blockindex->nVersion)));
-    result.push_back(Pair("merkleroot", blockindex->hashMerkleRoot.GetHex()));
-    result.push_back(Pair("time", (int64_t)blockindex->nTime));
-    result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
-    result.push_back(Pair("nonce", (uint64_t)blockindex->nNonce));
-    result.push_back(Pair("bits", strprintf("%08x", blockindex->nBits)));
-    result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
-    result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
+    result.pushKV("confirmations", confirmations);
+    result.pushKV("height", blockindex->nHeight);
+    result.pushKV("version", blockindex->nVersion);
+    result.pushKV("versionHex", strprintf("%08x", blockindex->nVersion));
+    result.pushKV("merkleroot", blockindex->hashMerkleRoot.GetHex());
+    result.pushKV("time", (int64_t)blockindex->nTime);
+    result.pushKV("mediantime", (int64_t)blockindex->GetMedianTimePast());
+    result.pushKV("nonce", (uint64_t)blockindex->nNonce);
+    result.pushKV("bits", strprintf("%08x", blockindex->nBits));
+    result.pushKV("difficulty", GetDifficulty(blockindex));
+    result.pushKV("chainwork", blockindex->nChainWork.GetHex());
 
     if (blockindex->pprev)
-        result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
+        result.pushKV("previousblockhash", blockindex->pprev->GetBlockHash().GetHex());
     CBlockIndex *pnext = chainActive.Next(blockindex);
     if (pnext)
-        result.push_back(Pair("nextblockhash", pnext->GetBlockHash().GetHex()));
+        result.pushKV("nextblockhash", pnext->GetBlockHash().GetHex());
     return result;
 }
 
 UniValue blockToJSON(const CBlock &block, const CBlockIndex *blockindex, bool txDetails = false, bool listTxns = true)
 {
     UniValue result(UniValue::VOBJ);
-    result.push_back(Pair("hash", blockindex->GetBlockHash().GetHex()));
+    result.pushKV("hash", blockindex->GetBlockHash().GetHex());
     int confirmations = -1;
     // Only report confirmations if the block is on the main chain
     if (chainActive.Contains(blockindex))
         confirmations = chainActive.Height() - blockindex->nHeight + 1;
-    result.push_back(Pair("confirmations", confirmations));
-    result.push_back(Pair("size", (int)::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION)));
-    result.push_back(Pair("height", blockindex->nHeight));
-    result.push_back(Pair("version", block.nVersion));
-    result.push_back(Pair("versionHex", strprintf("%08x", block.nVersion)));
-    result.push_back(Pair("merkleroot", block.hashMerkleRoot.GetHex()));
+    result.pushKV("confirmations", confirmations);
+    result.pushKV("size", (int)::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION));
+    result.pushKV("height", blockindex->nHeight);
+    result.pushKV("version", block.nVersion);
+    result.pushKV("versionHex", strprintf("%08x", block.nVersion));
+    result.pushKV("merkleroot", block.hashMerkleRoot.GetHex());
     UniValue txs(UniValue::VARR);
     if (listTxns)
     {
@@ -131,24 +131,24 @@ UniValue blockToJSON(const CBlock &block, const CBlockIndex *blockindex, bool tx
                 txs.push_back(tx->GetHash().GetHex());
             }
         }
-        result.push_back(Pair("tx", txs));
+        result.pushKV("tx", txs);
     }
     else
     {
-        result.push_back(Pair("txcount", (uint64_t)block.vtx.size()));
+        result.pushKV("txcount", (uint64_t)block.vtx.size());
     }
-    result.push_back(Pair("time", block.GetBlockTime()));
-    result.push_back(Pair("mediantime", (int64_t)blockindex->GetMedianTimePast()));
-    result.push_back(Pair("nonce", (uint64_t)block.nNonce));
-    result.push_back(Pair("bits", strprintf("%08x", block.nBits)));
-    result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
-    result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
+    result.pushKV("time", block.GetBlockTime());
+    result.pushKV("mediantime", (int64_t)blockindex->GetMedianTimePast());
+    result.pushKV("nonce", (uint64_t)block.nNonce);
+    result.pushKV("bits", strprintf("%08x", block.nBits));
+    result.pushKV("difficulty", GetDifficulty(blockindex));
+    result.pushKV("chainwork", blockindex->nChainWork.GetHex());
 
     if (blockindex->pprev)
-        result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
+        result.pushKV("previousblockhash", blockindex->pprev->GetBlockHash().GetHex());
     CBlockIndex *pnext = chainActive.Next(blockindex);
     if (pnext)
-        result.push_back(Pair("nextblockhash", pnext->GetBlockHash().GetHex()));
+        result.pushKV("nextblockhash", pnext->GetBlockHash().GetHex());
     return result;
 }
 
@@ -227,19 +227,19 @@ void entryToJSON(UniValue &info, const CTxMemPoolEntry &e)
 {
     AssertLockHeld(mempool.cs);
 
-    info.push_back(Pair("size", (int)e.GetTxSize()));
-    info.push_back(Pair("fee", ValueFromAmount(e.GetFee())));
-    info.push_back(Pair("modifiedfee", ValueFromAmount(e.GetModifiedFee())));
-    info.push_back(Pair("time", e.GetTime()));
-    info.push_back(Pair("height", (int)e.GetHeight()));
-    info.push_back(Pair("startingpriority", e.GetPriority(e.GetHeight())));
-    info.push_back(Pair("currentpriority", e.GetPriority(chainActive.Height())));
-    info.push_back(Pair("descendantcount", e.GetCountWithDescendants()));
-    info.push_back(Pair("descendantsize", e.GetSizeWithDescendants()));
-    info.push_back(Pair("descendantfees", e.GetModFeesWithDescendants()));
-    info.push_back(Pair("ancestorcount", e.GetCountWithAncestors()));
-    info.push_back(Pair("ancestorsize", e.GetSizeWithAncestors()));
-    info.push_back(Pair("ancestorfees", e.GetModFeesWithAncestors()));
+    info.pushKV("size", (int)e.GetTxSize());
+    info.pushKV("fee", ValueFromAmount(e.GetFee()));
+    info.pushKV("modifiedfee", ValueFromAmount(e.GetModifiedFee()));
+    info.pushKV("time", e.GetTime());
+    info.pushKV("height", (int)e.GetHeight());
+    info.pushKV("startingpriority", e.GetPriority(e.GetHeight()));
+    info.pushKV("currentpriority", e.GetPriority(chainActive.Height()));
+    info.pushKV("descendantcount", e.GetCountWithDescendants());
+    info.pushKV("descendantsize", e.GetSizeWithDescendants());
+    info.pushKV("descendantfees", e.GetModFeesWithDescendants());
+    info.pushKV("ancestorcount", e.GetCountWithAncestors());
+    info.pushKV("ancestorsize", e.GetSizeWithAncestors());
+    info.pushKV("ancestorfees", e.GetModFeesWithAncestors());
     const CTransaction &tx = e.GetTx();
     set<string> setDepends;
     for (const CTxIn &txin : tx.vin)
@@ -253,7 +253,7 @@ void entryToJSON(UniValue &info, const CTxMemPoolEntry &e)
     {
         depends.push_back(dep);
     }
-    info.push_back(Pair("depends", depends));
+    info.pushKV("depends", depends);
 
     UniValue spent(UniValue::VARR);
     const CTxMemPool::txiter &it = mempool.mapTx.find(tx.GetHash());
@@ -262,7 +262,7 @@ void entryToJSON(UniValue &info, const CTxMemPoolEntry &e)
     {
         spent.push_back(childiter->GetTx().GetHash().ToString());
     }
-    info.push_back(Pair("spentby", spent));
+    info.pushKV("spentby", spent);
 }
 
 UniValue mempoolToJSON(bool fVerbose = false)
@@ -276,7 +276,7 @@ UniValue mempoolToJSON(bool fVerbose = false)
             const uint256 &hash = e.GetTx().GetHash();
             UniValue info(UniValue::VOBJ);
             entryToJSON(info, e);
-            o.push_back(Pair(hash.ToString(), info));
+            o.pushKV(hash.ToString(), info);
         }
         return o;
     }
@@ -414,7 +414,7 @@ UniValue getmempoolancestors(const UniValue &params, bool fHelp)
             const uint256 &hash = e.GetTx().GetHash();
             UniValue info(UniValue::VOBJ);
             entryToJSON(info, e);
-            o.push_back(Pair(hash.ToString(), info));
+            o.pushKV(hash.ToString(), info);
         }
         return o;
     }
@@ -484,7 +484,7 @@ UniValue getmempooldescendants(const UniValue &params, bool fHelp)
             const uint256 &hash = e.GetTx().GetHash();
             UniValue info(UniValue::VOBJ);
             entryToJSON(info, e);
-            o.push_back(Pair(hash.ToString(), info));
+            o.pushKV(hash.ToString(), info);
         }
         return o;
     }
@@ -783,13 +783,13 @@ UniValue gettxoutsetinfo(const UniValue &params, bool fHelp)
     FlushStateToDisk();
     if (GetUTXOStats(pcoinsdbview, stats))
     {
-        ret.push_back(Pair("height", (int64_t)stats.nHeight));
-        ret.push_back(Pair("bestblock", stats.hashBlock.GetHex()));
-        ret.push_back(Pair("transactions", (int64_t)stats.nTransactions));
-        ret.push_back(Pair("txouts", (int64_t)stats.nTransactionOutputs));
-        ret.push_back(Pair("hash_serialized_2", stats.hashSerialized.GetHex()));
-        ret.push_back(Pair("disk_size", stats.nDiskSize));
-        ret.push_back(Pair("total_amount", ValueFromAmount(stats.nTotalAmount)));
+        ret.pushKV("height", (int64_t)stats.nHeight);
+        ret.pushKV("bestblock", stats.hashBlock.GetHex());
+        ret.pushKV("transactions", (int64_t)stats.nTransactions);
+        ret.pushKV("txouts", (int64_t)stats.nTransactionOutputs);
+        ret.pushKV("hash_serialized_2", stats.hashSerialized.GetHex());
+        ret.pushKV("disk_size", stats.nDiskSize);
+        ret.pushKV("total_amount", ValueFromAmount(stats.nTotalAmount));
     }
     return ret;
 }
@@ -861,20 +861,20 @@ UniValue gettxout(const UniValue &params, bool fHelp)
     }
 
     CBlockIndex *pindex = LookupBlockIndex(pcoinsTip->GetBestBlock());
-    ret.push_back(Pair("bestblock", pindex->GetBlockHash().GetHex()));
+    ret.pushKV("bestblock", pindex->GetBlockHash().GetHex());
     if (coin.nHeight == MEMPOOL_HEIGHT)
     {
-        ret.push_back(Pair("confirmations", 0));
+        ret.pushKV("confirmations", 0);
     }
     else
     {
-        ret.push_back(Pair("confirmations", (int64_t)(pindex->nHeight - coin.nHeight + 1)));
+        ret.pushKV("confirmations", (int64_t)(pindex->nHeight - coin.nHeight + 1));
     }
-    ret.push_back(Pair("value", ValueFromAmount(coin.out.nValue)));
+    ret.pushKV("value", ValueFromAmount(coin.out.nValue));
     UniValue o(UniValue::VOBJ);
     ScriptPubKeyToJSON(coin.out.scriptPubKey, o, true);
-    ret.push_back(Pair("scriptPubKey", o));
-    ret.push_back(Pair("coinbase", (bool)coin.fCoinBase));
+    ret.pushKV("scriptPubKey", o);
+    ret.pushKV("coinbase", (bool)coin.fCoinBase);
 
     return ret;
 }
@@ -923,7 +923,7 @@ static UniValue SoftForkMajorityDesc(int version, CBlockIndex *pindex, const Con
         activated = pindex->nHeight >= consensusParams.BIP65Height;
         break;
     }
-    rv.push_back(Pair("status", activated));
+    rv.pushKV("status", activated);
     return rv;
 }
 
@@ -933,9 +933,9 @@ static UniValue SoftForkDesc(const std::string &name,
     const Consensus::Params &consensusParams)
 {
     UniValue rv(UniValue::VOBJ);
-    rv.push_back(Pair("id", name));
-    rv.push_back(Pair("version", version));
-    rv.push_back(Pair("reject", SoftForkMajorityDesc(version, pindex, consensusParams)));
+    rv.pushKV("id", name);
+    rv.pushKV("version", version);
+    rv.pushKV("reject", SoftForkMajorityDesc(version, pindex, consensusParams));
     return rv;
 }
 
@@ -946,27 +946,27 @@ static UniValue BIP9SoftForkDesc(const Consensus::Params &consensusParams, Conse
     switch (thresholdState)
     {
     case THRESHOLD_DEFINED:
-        rv.push_back(Pair("status", "defined"));
+        rv.pushKV("status", "defined");
         break;
     case THRESHOLD_STARTED:
-        rv.push_back(Pair("status", "started"));
+        rv.pushKV("status", "started");
         break;
     case THRESHOLD_LOCKED_IN:
-        rv.push_back(Pair("status", "locked_in"));
+        rv.pushKV("status", "locked_in");
         break;
     case THRESHOLD_ACTIVE:
-        rv.push_back(Pair("status", "active"));
+        rv.pushKV("status", "active");
         break;
     case THRESHOLD_FAILED:
-        rv.push_back(Pair("status", "failed"));
+        rv.pushKV("status", "failed");
         break;
     }
     if (THRESHOLD_STARTED == thresholdState)
     {
-        rv.push_back(Pair("bit", consensusParams.vDeployments[id].bit));
+        rv.pushKV("bit", consensusParams.vDeployments[id].bit);
     }
-    rv.push_back(Pair("startTime", consensusParams.vDeployments[id].nStartTime));
-    rv.push_back(Pair("timeout", consensusParams.vDeployments[id].nTimeout));
+    rv.pushKV("startTime", consensusParams.vDeployments[id].nStartTime);
+    rv.pushKV("timeout", consensusParams.vDeployments[id].nTimeout);
     return rv;
 }
 
@@ -974,32 +974,32 @@ static UniValue BIP9SoftForkDesc(const Consensus::Params &consensusParams, Conse
 static UniValue BIP135ForkDesc(const Consensus::Params &consensusParams, Consensus::DeploymentPos id)
 {
     UniValue rv(UniValue::VOBJ);
-    rv.push_back(Pair("bit", (int)id));
+    rv.pushKV("bit", (int)id);
     const ThresholdState thresholdState = VersionBitsTipState(consensusParams, id);
     switch (thresholdState)
     {
     case THRESHOLD_DEFINED:
-        rv.push_back(Pair("status", "defined"));
+        rv.pushKV("status", "defined");
         break;
     case THRESHOLD_STARTED:
-        rv.push_back(Pair("status", "started"));
+        rv.pushKV("status", "started");
         break;
     case THRESHOLD_LOCKED_IN:
-        rv.push_back(Pair("status", "locked_in"));
+        rv.pushKV("status", "locked_in");
         break;
     case THRESHOLD_ACTIVE:
-        rv.push_back(Pair("status", "active"));
+        rv.pushKV("status", "active");
         break;
     case THRESHOLD_FAILED:
-        rv.push_back(Pair("status", "failed"));
+        rv.pushKV("status", "failed");
         break;
     }
-    rv.push_back(Pair("startTime", consensusParams.vDeployments[id].nStartTime));
-    rv.push_back(Pair("timeout", consensusParams.vDeployments[id].nTimeout));
-    rv.push_back(Pair("windowsize", consensusParams.vDeployments[id].windowsize));
-    rv.push_back(Pair("threshold", consensusParams.vDeployments[id].threshold));
-    rv.push_back(Pair("minlockedblocks", consensusParams.vDeployments[id].minlockedblocks));
-    rv.push_back(Pair("minlockedtime", consensusParams.vDeployments[id].minlockedtime));
+    rv.pushKV("startTime", consensusParams.vDeployments[id].nStartTime);
+    rv.pushKV("timeout", consensusParams.vDeployments[id].nTimeout);
+    rv.pushKV("windowsize", consensusParams.vDeployments[id].windowsize);
+    rv.pushKV("threshold", consensusParams.vDeployments[id].threshold);
+    rv.pushKV("minlockedblocks", consensusParams.vDeployments[id].minlockedblocks);
+    rv.pushKV("minlockedtime", consensusParams.vDeployments[id].minlockedtime);
     return rv;
 }
 // bip135 end
@@ -1069,16 +1069,16 @@ UniValue getblockchaininfo(const UniValue &params, bool fHelp)
     LOCK(cs_main);
 
     UniValue obj(UniValue::VOBJ);
-    obj.push_back(Pair("chain", Params().NetworkIDString()));
-    obj.push_back(Pair("blocks", (int)chainActive.Height()));
-    obj.push_back(Pair("headers", pindexBestHeader ? pindexBestHeader.load()->nHeight : -1));
-    obj.push_back(Pair("bestblockhash", chainActive.Tip()->GetBlockHash().GetHex()));
-    obj.push_back(Pair("difficulty", (double)GetDifficulty()));
-    obj.push_back(Pair("mediantime", (int64_t)chainActive.Tip()->GetMedianTimePast()));
-    obj.push_back(Pair(
-        "verificationprogress", Checkpoints::GuessVerificationProgress(Params().Checkpoints(), chainActive.Tip())));
-    obj.push_back(Pair("chainwork", chainActive.Tip()->nChainWork.GetHex()));
-    obj.push_back(Pair("pruned", fPruneMode));
+    obj.pushKV("chain", Params().NetworkIDString());
+    obj.pushKV("blocks", (int)chainActive.Height());
+    obj.pushKV("headers", pindexBestHeader ? pindexBestHeader.load()->nHeight : -1);
+    obj.pushKV("bestblockhash", chainActive.Tip()->GetBlockHash().GetHex());
+    obj.pushKV("difficulty", (double)GetDifficulty());
+    obj.pushKV("mediantime", (int64_t)chainActive.Tip()->GetMedianTimePast());
+    obj.pushKV(
+        "verificationprogress", Checkpoints::GuessVerificationProgress(Params().Checkpoints(), chainActive.Tip()));
+    obj.pushKV("chainwork", chainActive.Tip()->nChainWork.GetHex());
+    obj.pushKV("pruned", fPruneMode);
 
     const Consensus::Params &consensusParams = Params().GetConsensus();
     CBlockIndex *tip = chainActive.Tip();
@@ -1095,15 +1095,15 @@ UniValue getblockchaininfo(const UniValue &params, bool fHelp)
         const struct ForkDeploymentInfo &vbinfo = VersionBitsDeploymentInfo[bit];
         if (IsConfiguredDeployment(consensusParams, bit))
         {
-            bip9_softforks.push_back(Pair(vbinfo.name, BIP9SoftForkDesc(consensusParams, bit)));
-            bip135_forks.push_back(Pair(vbinfo.name, BIP135ForkDesc(consensusParams, bit)));
+            bip9_softforks.pushKV(vbinfo.name, BIP9SoftForkDesc(consensusParams, bit));
+            bip135_forks.pushKV(vbinfo.name, BIP135ForkDesc(consensusParams, bit));
         }
     }
 
-    obj.push_back(Pair("softforks", softforks));
-    obj.push_back(Pair("bip9_softforks", bip9_softforks));
+    obj.pushKV("softforks", softforks);
+    obj.pushKV("bip9_softforks", bip9_softforks);
     // to maintain backward compat initially, we introduce a new list for the full BIP135 data
-    obj.push_back(Pair("bip135_forks", bip135_forks));
+    obj.pushKV("bip135_forks", bip135_forks);
     // bip135 end
 
     if (fPruneMode)
@@ -1113,7 +1113,7 @@ UniValue getblockchaininfo(const UniValue &params, bool fHelp)
             block = block->pprev;
 
         if (block != nullptr)
-            obj.push_back(Pair("pruneheight", block->nHeight));
+            obj.pushKV("pruneheight", block->nHeight);
     }
     return obj;
 }
@@ -1214,12 +1214,12 @@ UniValue getchaintips(const UniValue &params, bool fHelp)
     for (const CBlockIndex *block : setTips)
     {
         UniValue obj(UniValue::VOBJ);
-        obj.push_back(Pair("height", block->nHeight));
-        obj.push_back(Pair("chainwork", block->nChainWork.GetHex()));
-        obj.push_back(Pair("hash", block->phashBlock->GetHex()));
+        obj.pushKV("height", block->nHeight);
+        obj.pushKV("chainwork", block->nChainWork.GetHex());
+        obj.pushKV("hash", block->phashBlock->GetHex());
 
         const int branchLen = block->nHeight - chainActive.FindFork(block)->nHeight;
-        obj.push_back(Pair("branchlen", branchLen));
+        obj.pushKV("branchlen", branchLen);
 
         string status;
         if (chainActive.Contains(block))
@@ -1254,7 +1254,7 @@ UniValue getchaintips(const UniValue &params, bool fHelp)
             // No clue.
             status = "unknown";
         }
-        obj.push_back(Pair("status", status));
+        obj.pushKV("status", status);
 
         res.push_back(obj);
     }
@@ -1265,19 +1265,19 @@ UniValue getchaintips(const UniValue &params, bool fHelp)
 UniValue mempoolInfoToJSON()
 {
     UniValue ret(UniValue::VOBJ);
-    ret.push_back(Pair("size", (int64_t)mempool.size()));
-    ret.push_back(Pair("bytes", (int64_t)mempool.GetTotalTxSize()));
-    ret.push_back(Pair("usage", (int64_t)mempool.DynamicMemoryUsage()));
+    ret.pushKV("size", (int64_t)mempool.size());
+    ret.pushKV("bytes", (int64_t)mempool.GetTotalTxSize());
+    ret.pushKV("usage", (int64_t)mempool.DynamicMemoryUsage());
     size_t maxmempool = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
-    ret.push_back(Pair("maxmempool", (int64_t)maxmempool));
-    ret.push_back(Pair("mempoolminfee", ValueFromAmount(mempool.GetMinFee(maxmempool).GetFeePerK())));
+    ret.pushKV("maxmempool", (int64_t)maxmempool);
+    ret.pushKV("mempoolminfee", ValueFromAmount(mempool.GetMinFee(maxmempool).GetFeePerK()));
     try
     {
-        ret.push_back(Pair("tps", boost::lexical_cast<double>(strprintf("%.2f", mempool.TransactionsPerSecond()))));
+        ret.pushKV("tps", boost::lexical_cast<double>(strprintf("%.2f", mempool.TransactionsPerSecond())));
     }
     catch (boost::bad_lexical_cast &)
     {
-        ret.push_back(Pair("tps", "N/A"));
+        ret.pushKV("tps", "N/A");
     }
 
     return ret;
@@ -1306,8 +1306,8 @@ UniValue getmempoolinfo(const UniValue &params, bool fHelp)
 UniValue orphanpoolInfoToJSON()
 {
     UniValue ret(UniValue::VOBJ);
-    ret.push_back(Pair("size", (int64_t)orphanpool.GetOrphanPoolSize()));
-    ret.push_back(Pair("bytes", (int64_t)orphanpool.GetOrphanPoolBytes()));
+    ret.pushKV("size", (int64_t)orphanpool.GetOrphanPoolSize());
+    ret.pushKV("bytes", (int64_t)orphanpool.GetOrphanPoolBytes());
 
     return ret;
 }

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -275,17 +275,17 @@ UniValue getmininginfo(const UniValue &params, bool fHelp)
     LOCK(cs_main);
 
     UniValue obj(UniValue::VOBJ);
-    obj.push_back(Pair("blocks", (int)chainActive.Height()));
-    obj.push_back(Pair("currentblocksize", (uint64_t)nLastBlockSize));
-    obj.push_back(Pair("currentblocktx", (uint64_t)nLastBlockTx));
-    obj.push_back(Pair("difficulty", (double)GetDifficulty()));
-    obj.push_back(Pair("errors", GetWarnings("statusbar")));
-    obj.push_back(Pair("genproclimit", (int)GetArg("-genproclimit", DEFAULT_GENERATE_THREADS)));
-    obj.push_back(Pair("networkhashps", getnetworkhashps(params, false)));
-    obj.push_back(Pair("pooledtx", (uint64_t)mempool.size()));
-    obj.push_back(Pair("testnet", Params().TestnetToBeDeprecatedFieldRPC()));
-    obj.push_back(Pair("chain", Params().NetworkIDString()));
-    obj.push_back(Pair("generate", getgenerate(params, false)));
+    obj.pushKV("blocks", (int)chainActive.Height());
+    obj.pushKV("currentblocksize", (uint64_t)nLastBlockSize);
+    obj.pushKV("currentblocktx", (uint64_t)nLastBlockTx);
+    obj.pushKV("difficulty", (double)GetDifficulty());
+    obj.pushKV("errors", GetWarnings("statusbar"));
+    obj.pushKV("genproclimit", (int)GetArg("-genproclimit", DEFAULT_GENERATE_THREADS));
+    obj.pushKV("networkhashps", getnetworkhashps(params, false));
+    obj.pushKV("pooledtx", (uint64_t)mempool.size());
+    obj.pushKV("testnet", Params().TestnetToBeDeprecatedFieldRPC());
+    obj.pushKV("chain", Params().NetworkIDString());
+    obj.pushKV("generate", getgenerate(params, false));
     return obj;
 }
 
@@ -382,7 +382,7 @@ static int32_t UtilMkBlockTmplVersionBits(int32_t version,
             const struct ForkDeploymentInfo &vbinfo = VersionBitsDeploymentInfo[pos];
             if (pvbavailable != nullptr)
             {
-                pvbavailable->push_back(Pair(gbt_vb_name(pos), consensusParams.vDeployments[pos].bit));
+                pvbavailable->pushKV(gbt_vb_name(pos), consensusParams.vDeployments[pos].bit);
             }
             if (setClientRules.find(vbinfo.name) == setClientRules.end())
             {
@@ -448,9 +448,9 @@ static UniValue MkFullMiningCandidateJson(std::set<std::string> setClientRules,
 
         UniValue entry(UniValue::VOBJ);
 
-        entry.push_back(Pair("data", EncodeHexTx(tx)));
+        entry.pushKV("data", EncodeHexTx(tx));
 
-        entry.push_back(Pair("hash", txHash.GetHex()));
+        entry.pushKV("hash", txHash.GetHex());
 
         UniValue deps(UniValue::VARR);
         for (const CTxIn &in : tx.vin)
@@ -458,11 +458,11 @@ static UniValue MkFullMiningCandidateJson(std::set<std::string> setClientRules,
             if (setTxIndex.count(in.prevout.hash))
                 deps.push_back(setTxIndex[in.prevout.hash]);
         }
-        entry.push_back(Pair("depends", deps));
+        entry.pushKV("depends", deps);
 
         int index_in_template = i - 1;
-        entry.push_back(Pair("fee", pblocktemplate->vTxFees[index_in_template]));
-        entry.push_back(Pair("sigops", pblocktemplate->vTxSigOps[index_in_template]));
+        entry.pushKV("fee", pblocktemplate->vTxFees[index_in_template]);
+        entry.pushKV("sigops", pblocktemplate->vTxSigOps[index_in_template]);
 
         transactions.push_back(entry);
     }
@@ -474,7 +474,7 @@ static UniValue MkFullMiningCandidateJson(std::set<std::string> setClientRules,
 
     UniValue aux(UniValue::VOBJ);
     // COINBASE_FLAGS were assigned in CreateNewBlock() in the steps above.  Now we can use it here.
-    aux.push_back(Pair("flags", HexStr(COINBASE_FLAGS.begin(), COINBASE_FLAGS.end())));
+    aux.pushKV("flags", HexStr(COINBASE_FLAGS.begin(), COINBASE_FLAGS.end()));
 
     arith_uint256 hashTarget = arith_uint256().SetCompact(pblock->nBits);
 
@@ -484,11 +484,11 @@ static UniValue MkFullMiningCandidateJson(std::set<std::string> setClientRules,
     aMutable.push_back("prevblock");
 
     UniValue result(UniValue::VOBJ);
-    result.push_back(Pair("capabilities", aCaps));
-    result.push_back(Pair("version", pblock->nVersion));
-    result.push_back(Pair("rules", aRules));
-    result.push_back(Pair("vbavailable", vbavailable));
-    result.push_back(Pair("vbrequired", int(0)));
+    result.pushKV("capabilities", aCaps);
+    result.pushKV("version", pblock->nVersion);
+    result.pushKV("rules", aRules);
+    result.pushKV("vbavailable", vbavailable);
+    result.pushKV("vbrequired", int(0));
 
     if (nMaxVersionPreVB >= 2)
     {
@@ -502,22 +502,21 @@ static UniValue MkFullMiningCandidateJson(std::set<std::string> setClientRules,
         aMutable.push_back("version/force");
     }
 
-    result.push_back(Pair("previousblockhash", pblock->hashPrevBlock.GetHex()));
-    result.push_back(Pair("transactions", transactions));
-    result.push_back(Pair("coinbaseaux", aux));
-    result.push_back(Pair("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue));
-    result.push_back(
-        Pair("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast)));
-    result.push_back(Pair("target", hashTarget.GetHex()));
-    result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast() + 1));
-    result.push_back(Pair("mutable", aMutable));
-    result.push_back(Pair("noncerange", "00000000ffffffff"));
-    result.push_back(Pair("sigoplimit", (int64_t)BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS));
-    result.push_back(Pair("sizelimit", (int64_t)maxGeneratedBlock));
-    result.push_back(Pair("curtime", pblock->GetBlockTime()));
-    result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
+    result.pushKV("previousblockhash", pblock->hashPrevBlock.GetHex());
+    result.pushKV("transactions", transactions);
+    result.pushKV("coinbaseaux", aux);
+    result.pushKV("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue);
+    result.pushKV("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast));
+    result.pushKV("target", hashTarget.GetHex());
+    result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast() + 1);
+    result.pushKV("mutable", aMutable);
+    result.pushKV("noncerange", "00000000ffffffff");
+    result.pushKV("sigoplimit", (int64_t)BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS);
+    result.pushKV("sizelimit", (int64_t)maxGeneratedBlock);
+    result.pushKV("curtime", pblock->GetBlockTime());
+    result.pushKV("bits", strprintf("%08x", pblock->nBits));
     // BU get the height directly from the block because pindexPrev could change if another block has come in.
-    result.push_back(Pair("height", (int64_t)(pblock->GetHeight())));
+    result.pushKV("height", (int64_t)(pblock->GetHeight()));
 
     return result;
 }
@@ -999,8 +998,8 @@ UniValue estimatesmartfee(const UniValue &params, bool fHelp)
     UniValue result(UniValue::VOBJ);
     int answerFound;
     CFeeRate feeRate = mempool.estimateSmartFee(nBlocks, &answerFound);
-    result.push_back(Pair("feerate", feeRate == CFeeRate(0) ? -1.0 : ValueFromAmount(feeRate.GetFeePerK())));
-    result.push_back(Pair("blocks", answerFound));
+    result.pushKV("feerate", feeRate == CFeeRate(0) ? -1.0 : ValueFromAmount(feeRate.GetFeePerK()));
+    result.pushKV("blocks", answerFound);
     return result;
 }
 
@@ -1033,8 +1032,8 @@ UniValue estimatesmartpriority(const UniValue &params, bool fHelp)
     UniValue result(UniValue::VOBJ);
     int answerFound;
     double priority = mempool.estimateSmartPriority(nBlocks, &answerFound);
-    result.push_back(Pair("priority", priority));
-    result.push_back(Pair("blocks", answerFound));
+    result.pushKV("priority", priority);
+    result.pushKV("blocks", answerFound);
     return result;
 }
 

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -94,35 +94,35 @@ UniValue getinfo(const UniValue &params, bool fHelp)
     GetProxy(NET_IPV4, proxy);
 
     UniValue obj(UniValue::VOBJ);
-    obj.push_back(Pair("version", CLIENT_VERSION));
-    obj.push_back(Pair("protocolversion", PROTOCOL_VERSION));
+    obj.pushKV("version", CLIENT_VERSION);
+    obj.pushKV("protocolversion", PROTOCOL_VERSION);
 #ifdef ENABLE_WALLET
     if (pwalletMain)
     {
-        obj.push_back(Pair("walletversion", pwalletMain->GetVersion()));
-        obj.push_back(Pair("balance", ValueFromAmount(pwalletMain->GetBalance())));
+        obj.pushKV("walletversion", pwalletMain->GetVersion());
+        obj.pushKV("balance", ValueFromAmount(pwalletMain->GetBalance()));
     }
 #endif
-    obj.push_back(Pair("blocks", (int)chainActive.Height()));
-    obj.push_back(Pair("timeoffset", GetTimeOffset()));
-    obj.push_back(Pair("connections", nNodes));
-    obj.push_back(Pair("proxy", (proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string())));
-    obj.push_back(Pair("difficulty", (double)GetDifficulty()));
-    obj.push_back(Pair("testnet", Params().TestnetToBeDeprecatedFieldRPC()));
+    obj.pushKV("blocks", (int)chainActive.Height());
+    obj.pushKV("timeoffset", GetTimeOffset());
+    obj.pushKV("connections", nNodes);
+    obj.pushKV("proxy", (proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string()));
+    obj.pushKV("difficulty", (double)GetDifficulty());
+    obj.pushKV("testnet", Params().TestnetToBeDeprecatedFieldRPC());
 #ifdef ENABLE_WALLET
     if (pwalletMain)
     {
-        obj.push_back(Pair("keypoololdest", pwalletMain->GetOldestKeyPoolTime()));
-        obj.push_back(Pair("keypoolsize", (int)pwalletMain->GetKeyPoolSize()));
+        obj.pushKV("keypoololdest", pwalletMain->GetOldestKeyPoolTime());
+        obj.pushKV("keypoolsize", (int)pwalletMain->GetKeyPoolSize());
     }
     if (pwalletMain && pwalletMain->IsCrypted())
-        obj.push_back(Pair("unlocked_until", nWalletUnlockTime));
-    obj.push_back(Pair("paytxfee", ValueFromAmount(payTxFee.GetFeePerK())));
+        obj.pushKV("unlocked_until", nWalletUnlockTime);
+    obj.pushKV("paytxfee", ValueFromAmount(payTxFee.GetFeePerK()));
 #endif
-    obj.push_back(Pair("relayfee", ValueFromAmount(::minRelayTxFee.GetFeePerK())));
-    obj.push_back(Pair("status", statusStrings.GetPrintable()));
-    obj.push_back(Pair("errors", GetWarnings("statusbar")));
-    obj.push_back(Pair("fork", "Bitcoin Cash"));
+    obj.pushKV("relayfee", ValueFromAmount(::minRelayTxFee.GetFeePerK()));
+    obj.pushKV("status", statusStrings.GetPrintable());
+    obj.pushKV("errors", GetWarnings("statusbar"));
+    obj.pushKV("fork", "Bitcoin Cash");
 
     return obj;
 }
@@ -146,11 +146,11 @@ public:
     {
         UniValue obj(UniValue::VOBJ);
         CPubKey vchPubKey;
-        obj.push_back(Pair("isscript", false));
+        obj.pushKV("isscript", false);
         if (pwalletMain && pwalletMain->GetPubKey(keyID, vchPubKey))
         {
-            obj.push_back(Pair("pubkey", HexStr(vchPubKey)));
-            obj.push_back(Pair("iscompressed", vchPubKey.IsCompressed()));
+            obj.pushKV("pubkey", HexStr(vchPubKey));
+            obj.pushKV("iscompressed", vchPubKey.IsCompressed());
         }
         return obj;
     }
@@ -159,23 +159,23 @@ public:
     {
         UniValue obj(UniValue::VOBJ);
         CScript subscript;
-        obj.push_back(Pair("isscript", true));
+        obj.pushKV("isscript", true);
         if (pwalletMain && pwalletMain->GetCScript(scriptID, subscript))
         {
             std::vector<CTxDestination> addresses;
             txnouttype whichType;
             int nRequired;
             ExtractDestinations(subscript, whichType, addresses, nRequired);
-            obj.push_back(Pair("script", GetTxnOutputType(whichType)));
-            obj.push_back(Pair("hex", HexStr(subscript.begin(), subscript.end())));
+            obj.pushKV("script", GetTxnOutputType(whichType));
+            obj.pushKV("hex", HexStr(subscript.begin(), subscript.end()));
             UniValue a(UniValue::VARR);
             for (const CTxDestination &addr : addresses)
             {
                 a.push_back(EncodeDestination(addr));
             }
-            obj.push_back(Pair("addresses", a));
+            obj.pushKV("addresses", a);
             if (whichType == TX_MULTISIG)
-                obj.push_back(Pair("sigsrequired", nRequired));
+                obj.pushKV("sigsrequired", nRequired);
         }
         return obj;
     }
@@ -220,31 +220,31 @@ UniValue validateaddress(const UniValue &params, bool fHelp)
     bool isValid = IsValidDestination(dest);
 
     UniValue ret(UniValue::VOBJ);
-    ret.push_back(Pair("isvalid", isValid));
+    ret.pushKV("isvalid", isValid);
     if (isValid)
     {
         std::string currentAddress = EncodeDestination(dest);
-        ret.push_back(Pair("address", currentAddress));
+        ret.pushKV("address", currentAddress);
 
         CScript scriptPubKey = GetScriptForDestination(dest);
-        ret.push_back(Pair("scriptPubKey", HexStr(scriptPubKey.begin(), scriptPubKey.end())));
+        ret.pushKV("scriptPubKey", HexStr(scriptPubKey.begin(), scriptPubKey.end()));
 
 #ifdef ENABLE_WALLET
         isminetype mine = pwalletMain ? IsMine(*pwalletMain, dest, chainActive.Tip()) : ISMINE_NO;
-        ret.push_back(Pair("ismine", (mine & ISMINE_SPENDABLE) ? true : false));
-        ret.push_back(Pair("iswatchonly", (mine & ISMINE_WATCH_ONLY) ? true : false));
+        ret.pushKV("ismine", (mine & ISMINE_SPENDABLE) ? true : false);
+        ret.pushKV("iswatchonly", (mine & ISMINE_WATCH_ONLY) ? true : false);
         UniValue detail = boost::apply_visitor(DescribeAddressVisitor(), dest);
         ret.pushKVs(detail);
         if (pwalletMain && pwalletMain->mapAddressBook.count(dest))
-            ret.push_back(Pair("account", pwalletMain->mapAddressBook[dest].name));
+            ret.pushKV("account", pwalletMain->mapAddressBook[dest].name);
         const CKeyID *keyID = boost::get<CKeyID>(&dest);
         if (keyID)
         {
             if (pwalletMain && pwalletMain->mapKeyMetadata.count(*keyID) &&
                 !pwalletMain->mapKeyMetadata[*keyID].hdKeypath.empty())
             {
-                ret.push_back(Pair("hdkeypath", pwalletMain->mapKeyMetadata[*keyID].hdKeypath));
-                ret.push_back(Pair("hdmasterkeyid", pwalletMain->mapKeyMetadata[*keyID].hdMasterKeyID.GetHex()));
+                ret.pushKV("hdkeypath", pwalletMain->mapKeyMetadata[*keyID].hdKeypath);
+                ret.pushKV("hdmasterkeyid", pwalletMain->mapKeyMetadata[*keyID].hdMasterKeyID.GetHex());
             }
         }
 #endif
@@ -358,8 +358,8 @@ UniValue createmultisig(const UniValue &params, bool fHelp)
     CScriptID innerID(inner);
 
     UniValue result(UniValue::VOBJ);
-    result.push_back(Pair("address", EncodeDestination(innerID)));
-    result.push_back(Pair("redeemScript", HexStr(inner.begin(), inner.end())));
+    result.pushKV("address", EncodeDestination(innerID));
+    result.pushKV("redeemScript", HexStr(inner.begin(), inner.end()));
 
     return result;
 }

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -151,42 +151,42 @@ UniValue getpeerinfo(const UniValue &params, bool fHelp)
             UniValue obj(UniValue::VOBJ);
             CNodeStateStats statestats;
             bool fStateStats = GetNodeStateStats(stats.nodeid, statestats);
-            obj.push_back(Pair("id", stats.nodeid));
-            obj.push_back(Pair("addr", stats.addrName));
+            obj.pushKV("id", stats.nodeid);
+            obj.pushKV("addr", stats.addrName);
             if (!(stats.addrLocal.empty()))
-                obj.push_back(Pair("addrlocal", stats.addrLocal));
-            obj.push_back(Pair("services", strprintf("%016x", stats.nServices)));
-            obj.push_back(Pair("relaytxes", stats.fRelayTxes));
-            obj.push_back(Pair("lastsend", stats.nLastSend));
-            obj.push_back(Pair("lastrecv", stats.nLastRecv));
-            obj.push_back(Pair("bytessent", stats.nSendBytes));
-            obj.push_back(Pair("bytesrecv", stats.nRecvBytes));
-            obj.push_back(Pair("conntime", stats.nTimeConnected));
-            obj.push_back(Pair("timeoffset", stats.nTimeOffset));
-            obj.push_back(Pair("pingtime", stats.dPingTime));
-            obj.push_back(Pair("minping", stats.dPingMin));
+                obj.pushKV("addrlocal", stats.addrLocal);
+            obj.pushKV("services", strprintf("%016x", stats.nServices));
+            obj.pushKV("relaytxes", stats.fRelayTxes);
+            obj.pushKV("lastsend", stats.nLastSend);
+            obj.pushKV("lastrecv", stats.nLastRecv);
+            obj.pushKV("bytessent", stats.nSendBytes);
+            obj.pushKV("bytesrecv", stats.nRecvBytes);
+            obj.pushKV("conntime", stats.nTimeConnected);
+            obj.pushKV("timeoffset", stats.nTimeOffset);
+            obj.pushKV("pingtime", stats.dPingTime);
+            obj.pushKV("minping", stats.dPingMin);
             if (stats.dPingWait > 0.0)
-                obj.push_back(Pair("pingwait", stats.dPingWait));
-            obj.push_back(Pair("version", stats.nVersion));
+                obj.pushKV("pingwait", stats.dPingWait);
+            obj.pushKV("version", stats.nVersion);
             // Use the sanitized form of subver here, to avoid tricksy remote peers from
             // corrupting or modifiying the JSON output by putting special characters in
             // their ver message.
-            obj.push_back(Pair("subver", stats.cleanSubVer));
-            obj.push_back(Pair("inbound", stats.fInbound));
-            obj.push_back(Pair("startingheight", stats.nStartingHeight));
+            obj.pushKV("subver", stats.cleanSubVer);
+            obj.pushKV("inbound", stats.fInbound);
+            obj.pushKV("startingheight", stats.nStartingHeight);
             if (fStateStats)
             {
-                obj.push_back(Pair("banscore", statestats.nMisbehavior));
-                obj.push_back(Pair("synced_headers", statestats.nSyncHeight));
-                obj.push_back(Pair("synced_blocks", statestats.nCommonHeight));
+                obj.pushKV("banscore", statestats.nMisbehavior);
+                obj.pushKV("synced_headers", statestats.nSyncHeight);
+                obj.pushKV("synced_blocks", statestats.nCommonHeight);
                 UniValue heights(UniValue::VARR);
                 for (int height : statestats.vHeightInFlight)
                 {
                     heights.push_back(height);
                 }
-                obj.push_back(Pair("inflight", heights));
+                obj.pushKV("inflight", heights);
             }
-            obj.push_back(Pair("whitelisted", stats.fWhitelisted));
+            obj.pushKV("whitelisted", stats.fWhitelisted);
 
             CNodeRef snode = FindLikelyNode(stats.addrName);
 
@@ -195,9 +195,9 @@ UniValue getpeerinfo(const UniValue &params, bool fHelp)
                 UniValue xmap_enc(UniValue::VOBJ);
                 for (auto kv : snode->xVersion.xmap)
                 {
-                    xmap_enc.push_back(Pair(strprintf("%016llx", kv.first), HexStr(kv.second).c_str()));
+                    xmap_enc.pushKV(strprintf("%016llx", kv.first), HexStr(kv.second).c_str());
                 }
-                obj.push_back(Pair("xversion_map", xmap_enc));
+                obj.pushKV("xversion_map", xmap_enc);
             }
             ret.push_back(obj);
         }
@@ -340,7 +340,7 @@ UniValue getaddednodeinfo(const UniValue &params, bool fHelp)
         for (const std::string &strAddNode : laddedNodes)
         {
             UniValue obj(UniValue::VOBJ);
-            obj.push_back(Pair("addednode", strAddNode));
+            obj.pushKV("addednode", strAddNode);
             ret.push_back(obj);
         }
         return ret;
@@ -355,10 +355,10 @@ UniValue getaddednodeinfo(const UniValue &params, bool fHelp)
         else
         {
             UniValue obj(UniValue::VOBJ);
-            obj.push_back(Pair("addednode", strAddNode));
-            obj.push_back(Pair("connected", false));
+            obj.pushKV("addednode", strAddNode);
+            obj.pushKV("connected", false);
             UniValue addresses(UniValue::VARR);
-            obj.push_back(Pair("addresses", addresses));
+            obj.pushKV("addresses", addresses);
         }
     }
 
@@ -366,7 +366,7 @@ UniValue getaddednodeinfo(const UniValue &params, bool fHelp)
     for (list<pair<string, vector<CService> > >::iterator it = laddedAddreses.begin(); it != laddedAddreses.end(); it++)
     {
         UniValue obj(UniValue::VOBJ);
-        obj.push_back(Pair("addednode", it->first));
+        obj.pushKV("addednode", it->first);
 
         UniValue addresses(UniValue::VARR);
         bool fConnected = false;
@@ -374,23 +374,23 @@ UniValue getaddednodeinfo(const UniValue &params, bool fHelp)
         {
             bool fFound = false;
             UniValue node(UniValue::VOBJ);
-            node.push_back(Pair("address", addrNode.ToString()));
+            node.pushKV("address", addrNode.ToString());
             for (CNode *pnode : vNodes)
             {
                 if (pnode->addr == addrNode)
                 {
                     fFound = true;
                     fConnected = true;
-                    node.push_back(Pair("connected", pnode->fInbound ? "inbound" : "outbound"));
+                    node.pushKV("connected", pnode->fInbound ? "inbound" : "outbound");
                     break;
                 }
             }
             if (!fFound)
-                node.push_back(Pair("connected", "false"));
+                node.pushKV("connected", "false");
             addresses.push_back(node);
         }
-        obj.push_back(Pair("connected", fConnected));
-        obj.push_back(Pair("addresses", addresses));
+        obj.pushKV("connected", fConnected);
+        obj.pushKV("addresses", addresses);
         ret.push_back(obj);
     }
 
@@ -422,18 +422,18 @@ UniValue getnettotals(const UniValue &params, bool fHelp)
             HelpExampleCli("getnettotals", "") + HelpExampleRpc("getnettotals", ""));
 
     UniValue obj(UniValue::VOBJ);
-    obj.push_back(Pair("totalbytesrecv", CNode::GetTotalBytesRecv()));
-    obj.push_back(Pair("totalbytessent", CNode::GetTotalBytesSent()));
-    obj.push_back(Pair("timemillis", GetTimeMillis()));
+    obj.pushKV("totalbytesrecv", CNode::GetTotalBytesRecv());
+    obj.pushKV("totalbytessent", CNode::GetTotalBytesSent());
+    obj.pushKV("timemillis", GetTimeMillis());
 
     UniValue outboundLimit(UniValue::VOBJ);
-    outboundLimit.push_back(Pair("timeframe", CNode::GetMaxOutboundTimeframe()));
-    outboundLimit.push_back(Pair("target", CNode::GetMaxOutboundTarget()));
-    outboundLimit.push_back(Pair("target_reached", CNode::OutboundTargetReached(false)));
-    outboundLimit.push_back(Pair("serve_historical_blocks", !CNode::OutboundTargetReached(true)));
-    outboundLimit.push_back(Pair("bytes_left_in_cycle", CNode::GetOutboundTargetBytesLeft()));
-    outboundLimit.push_back(Pair("time_left_in_cycle", CNode::GetMaxOutboundTimeLeftInCycle()));
-    obj.push_back(Pair("uploadtarget", outboundLimit));
+    outboundLimit.pushKV("timeframe", CNode::GetMaxOutboundTimeframe());
+    outboundLimit.pushKV("target", CNode::GetMaxOutboundTarget());
+    outboundLimit.pushKV("target_reached", CNode::OutboundTargetReached(false));
+    outboundLimit.pushKV("serve_historical_blocks", !CNode::OutboundTargetReached(true));
+    outboundLimit.pushKV("bytes_left_in_cycle", CNode::GetOutboundTargetBytesLeft());
+    outboundLimit.pushKV("time_left_in_cycle", CNode::GetMaxOutboundTimeLeftInCycle());
+    obj.pushKV("uploadtarget", outboundLimit);
     return obj;
 }
 
@@ -448,11 +448,11 @@ static UniValue GetNetworksInfo()
         proxyType proxy;
         UniValue obj(UniValue::VOBJ);
         GetProxy(network, proxy);
-        obj.push_back(Pair("name", GetNetworkName(network)));
-        obj.push_back(Pair("limited", IsLimited(network)));
-        obj.push_back(Pair("reachable", IsReachable(network)));
-        obj.push_back(Pair("proxy", proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string()));
-        obj.push_back(Pair("proxy_randomize_credentials", proxy.randomize_credentials));
+        obj.pushKV("name", GetNetworkName(network));
+        obj.pushKV("limited", IsLimited(network));
+        obj.pushKV("reachable", IsReachable(network));
+        obj.pushKV("proxy", proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string());
+        obj.pushKV("proxy_randomize_credentials", proxy.randomize_credentials);
         networks.push_back(obj);
     }
     return networks;
@@ -463,20 +463,20 @@ static UniValue GetThinBlockStats()
 {
     UniValue obj(UniValue::VOBJ);
     bool enabled = IsThinBlocksEnabled();
-    obj.push_back(Pair("enabled", enabled));
+    obj.pushKV("enabled", enabled);
     if (enabled)
     {
-        obj.push_back(Pair("summary", thindata.ToString()));
-        obj.push_back(Pair("mempool_limiter", thindata.MempoolLimiterBytesSavedToString()));
-        obj.push_back(Pair("inbound_percent", thindata.InBoundPercentToString()));
-        obj.push_back(Pair("outbound_percent", thindata.OutBoundPercentToString()));
-        obj.push_back(Pair("response_time", thindata.ResponseTimeToString()));
-        obj.push_back(Pair("validation_time", thindata.ValidationTimeToString()));
-        obj.push_back(Pair("outbound_bloom_filters", thindata.OutBoundBloomFiltersToString()));
-        obj.push_back(Pair("inbound_bloom_filters", thindata.InBoundBloomFiltersToString()));
-        obj.push_back(Pair("thin_block_size", thindata.ThinBlockToString()));
-        obj.push_back(Pair("thin_full_tx", thindata.FullTxToString()));
-        obj.push_back(Pair("rerequested", thindata.ReRequestedTxToString()));
+        obj.pushKV("summary", thindata.ToString());
+        obj.pushKV("mempool_limiter", thindata.MempoolLimiterBytesSavedToString());
+        obj.pushKV("inbound_percent", thindata.InBoundPercentToString());
+        obj.pushKV("outbound_percent", thindata.OutBoundPercentToString());
+        obj.pushKV("response_time", thindata.ResponseTimeToString());
+        obj.pushKV("validation_time", thindata.ValidationTimeToString());
+        obj.pushKV("outbound_bloom_filters", thindata.OutBoundBloomFiltersToString());
+        obj.pushKV("inbound_bloom_filters", thindata.InBoundBloomFiltersToString());
+        obj.pushKV("thin_block_size", thindata.ThinBlockToString());
+        obj.pushKV("thin_full_tx", thindata.FullTxToString());
+        obj.pushKV("rerequested", thindata.ReRequestedTxToString());
     }
     return obj;
 }
@@ -487,20 +487,20 @@ static UniValue GetGrapheneStats()
 {
     UniValue obj(UniValue::VOBJ);
     bool enabled = IsGrapheneBlockEnabled();
-    obj.push_back(Pair("enabled", enabled));
+    obj.pushKV("enabled", enabled);
     if (enabled)
     {
-        obj.push_back(Pair("summary", graphenedata.ToString()));
-        obj.push_back(Pair("inbound_percent", graphenedata.InBoundPercentToString()));
-        obj.push_back(Pair("outbound_percent", graphenedata.OutBoundPercentToString()));
-        obj.push_back(Pair("response_time", graphenedata.ResponseTimeToString()));
-        obj.push_back(Pair("validation_time", graphenedata.ValidationTimeToString()));
-        obj.push_back(Pair("filter", graphenedata.FilterToString()));
-        obj.push_back(Pair("iblt", graphenedata.IbltToString()));
-        obj.push_back(Pair("rank", graphenedata.RankToString()));
-        obj.push_back(Pair("graphene_block_size", graphenedata.GrapheneBlockToString()));
-        obj.push_back(Pair("graphene_additional_tx_size", graphenedata.AdditionalTxToString()));
-        obj.push_back(Pair("rerequested", graphenedata.ReRequestedTxToString()));
+        obj.pushKV("summary", graphenedata.ToString());
+        obj.pushKV("inbound_percent", graphenedata.InBoundPercentToString());
+        obj.pushKV("outbound_percent", graphenedata.OutBoundPercentToString());
+        obj.pushKV("response_time", graphenedata.ResponseTimeToString());
+        obj.pushKV("validation_time", graphenedata.ValidationTimeToString());
+        obj.pushKV("filter", graphenedata.FilterToString());
+        obj.pushKV("iblt", graphenedata.IbltToString());
+        obj.pushKV("rank", graphenedata.RankToString());
+        obj.pushKV("graphene_block_size", graphenedata.GrapheneBlockToString());
+        obj.pushKV("graphene_additional_tx_size", graphenedata.AdditionalTxToString());
+        obj.pushKV("rerequested", graphenedata.ReRequestedTxToString());
     }
     return obj;
 }
@@ -552,37 +552,37 @@ UniValue getnetworkinfo(const UniValue &params, bool fHelp)
     LOCK(cs_main);
 
     UniValue obj(UniValue::VOBJ);
-    obj.push_back(Pair("version", CLIENT_VERSION));
+    obj.pushKV("version", CLIENT_VERSION);
     // BUIP005: special subversion
-    obj.push_back(Pair("subversion", FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, BUComments)));
-    obj.push_back(Pair("protocolversion", PROTOCOL_VERSION));
-    obj.push_back(Pair("localservices", strprintf("%016x", nLocalServices)));
-    obj.push_back(Pair("timeoffset", GetTimeOffset()));
-    obj.push_back(Pair("connections", (int)vNodes.size()));
-    obj.push_back(Pair("networks", GetNetworksInfo()));
-    obj.push_back(Pair("relayfee", ValueFromAmount(::minRelayTxFee.GetFeePerK())));
-    obj.push_back(Pair("minlimitertxfee", strprintf("%.4f", dMinLimiterTxFee.Value())));
-    obj.push_back(Pair("maxlimitertxfee", strprintf("%.4f", dMaxLimiterTxFee.Value())));
+    obj.pushKV("subversion", FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, BUComments));
+    obj.pushKV("protocolversion", PROTOCOL_VERSION);
+    obj.pushKV("localservices", strprintf("%016x", nLocalServices));
+    obj.pushKV("timeoffset", GetTimeOffset());
+    obj.pushKV("connections", (int)vNodes.size());
+    obj.pushKV("networks", GetNetworksInfo());
+    obj.pushKV("relayfee", ValueFromAmount(::minRelayTxFee.GetFeePerK()));
+    obj.pushKV("minlimitertxfee", strprintf("%.4f", dMinLimiterTxFee.Value()));
+    obj.pushKV("maxlimitertxfee", strprintf("%.4f", dMaxLimiterTxFee.Value()));
     UniValue localAddresses(UniValue::VARR);
     {
         LOCK(cs_mapLocalHost);
         for (const PAIRTYPE(CNetAddr, LocalServiceInfo) & item : mapLocalHost)
         {
             UniValue rec(UniValue::VOBJ);
-            rec.push_back(Pair("address", item.first.ToString()));
-            rec.push_back(Pair("port", item.second.nPort));
-            rec.push_back(Pair("score", item.second.nScore));
+            rec.pushKV("address", item.first.ToString());
+            rec.pushKV("port", item.second.nPort);
+            rec.pushKV("score", item.second.nScore);
             localAddresses.push_back(rec);
         }
     }
-    obj.push_back(Pair("localaddresses", localAddresses));
+    obj.pushKV("localaddresses", localAddresses);
     // BitcoinUnlimited BUIP010: Start
-    obj.push_back(Pair("thinblockstats", GetThinBlockStats()));
+    obj.pushKV("thinblockstats", GetThinBlockStats());
     // BitcoinUnlimited BUIP010: End
     //// BitcoinUnlimited BUIPXXX: Start
-    obj.push_back(Pair("grapheneblockstats", GetGrapheneStats()));
+    obj.pushKV("grapheneblockstats", GetGrapheneStats());
     // BitcoinUnlimited BUIPXXX: End
-    obj.push_back(Pair("warnings", GetWarnings("statusbar")));
+    obj.pushKV("warnings", GetWarnings("statusbar"));
     return obj;
 }
 
@@ -703,10 +703,10 @@ UniValue listbanned(const UniValue &params, bool fHelp)
     {
         CBanEntry banEntry = (*it).second;
         UniValue rec(UniValue::VOBJ);
-        rec.push_back(Pair("address", (*it).first.ToString()));
-        rec.push_back(Pair("banned_until", banEntry.nBanUntil));
-        rec.push_back(Pair("ban_created", banEntry.nCreateTime));
-        rec.push_back(Pair("ban_reason", banEntry.banReasonToString()));
+        rec.pushKV("address", (*it).first.ToString());
+        rec.pushKV("banned_until", banEntry.nBanUntil);
+        rec.pushKV("ban_created", banEntry.nCreateTime);
+        rec.pushKV("ban_reason", banEntry.banReasonToString());
 
         bannedAddresses.push_back(rec);
     }

--- a/src/rpc/protocol.cpp
+++ b/src/rpc/protocol.cpp
@@ -30,9 +30,9 @@ using namespace std;
 string JSONRPCRequest(const string &strMethod, const UniValue &params, const UniValue &id)
 {
     UniValue request(UniValue::VOBJ);
-    request.push_back(Pair("method", strMethod));
-    request.push_back(Pair("params", params));
-    request.push_back(Pair("id", id));
+    request.pushKV("method", strMethod);
+    request.pushKV("params", params);
+    request.pushKV("id", id);
     return request.write() + "\n";
 }
 
@@ -40,11 +40,11 @@ UniValue JSONRPCReplyObj(const UniValue &result, const UniValue &error, const Un
 {
     UniValue reply(UniValue::VOBJ);
     if (!error.isNull())
-        reply.push_back(Pair("result", NullUniValue));
+        reply.pushKV("result", NullUniValue);
     else
-        reply.push_back(Pair("result", result));
-    reply.push_back(Pair("error", error));
-    reply.push_back(Pair("id", id));
+        reply.pushKV("result", result);
+    reply.pushKV("error", error);
+    reply.pushKV("id", id);
     return reply;
 }
 
@@ -57,8 +57,8 @@ string JSONRPCReply(const UniValue &result, const UniValue &error, const UniValu
 UniValue JSONRPCError(int code, const string &message)
 {
     UniValue error(UniValue::VOBJ);
-    error.push_back(Pair("code", code));
-    error.push_back(Pair("message", message));
+    error.pushKV("code", code);
+    error.pushKV("message", message);
     return error;
 }
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -48,18 +48,18 @@ void ScriptPubKeyToJSON(const CScript &scriptPubKey, UniValue &out, bool fInclud
     vector<CTxDestination> addresses;
     int nRequired;
 
-    out.push_back(Pair("asm", ScriptToAsmStr(scriptPubKey)));
+    out.pushKV("asm", ScriptToAsmStr(scriptPubKey));
     if (fIncludeHex)
-        out.push_back(Pair("hex", HexStr(scriptPubKey.begin(), scriptPubKey.end())));
+        out.pushKV("hex", HexStr(scriptPubKey.begin(), scriptPubKey.end()));
 
     if (!ExtractDestinations(scriptPubKey, type, addresses, nRequired))
     {
-        out.push_back(Pair("type", GetTxnOutputType(type)));
+        out.pushKV("type", GetTxnOutputType(type));
         return;
     }
 
-    out.push_back(Pair("reqSigs", nRequired));
-    out.push_back(Pair("type", GetTxnOutputType(type)));
+    out.pushKV("reqSigs", nRequired);
+    out.pushKV("type", GetTxnOutputType(type));
 
     UniValue a(UniValue::VARR);
     for (const CTxDestination &addr : addresses)
@@ -67,62 +67,62 @@ void ScriptPubKeyToJSON(const CScript &scriptPubKey, UniValue &out, bool fInclud
         a.push_back(EncodeDestination(addr));
     }
 
-    out.push_back(Pair("addresses", a));
+    out.pushKV("addresses", a);
 }
 
 void TxToJSON(const CTransaction &tx, const uint256 hashBlock, UniValue &entry)
 {
-    entry.push_back(Pair("txid", tx.GetHash().GetHex()));
-    entry.push_back(Pair("size", (int)tx.GetTxSize()));
-    entry.push_back(Pair("version", tx.nVersion));
-    entry.push_back(Pair("locktime", (int64_t)tx.nLockTime));
+    entry.pushKV("txid", tx.GetHash().GetHex());
+    entry.pushKV("size", (int)tx.GetTxSize());
+    entry.pushKV("version", tx.nVersion);
+    entry.pushKV("locktime", (int64_t)tx.nLockTime);
     UniValue vin(UniValue::VARR);
     for (const CTxIn &txin : tx.vin)
     {
         UniValue in(UniValue::VOBJ);
         if (tx.IsCoinBase())
-            in.push_back(Pair("coinbase", HexStr(txin.scriptSig.begin(), txin.scriptSig.end())));
+            in.pushKV("coinbase", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));
         else
         {
-            in.push_back(Pair("txid", txin.prevout.hash.GetHex()));
-            in.push_back(Pair("vout", (int64_t)txin.prevout.n));
+            in.pushKV("txid", txin.prevout.hash.GetHex());
+            in.pushKV("vout", (int64_t)txin.prevout.n);
             UniValue o(UniValue::VOBJ);
-            o.push_back(Pair("asm", ScriptToAsmStr(txin.scriptSig, true)));
-            o.push_back(Pair("hex", HexStr(txin.scriptSig.begin(), txin.scriptSig.end())));
-            in.push_back(Pair("scriptSig", o));
+            o.pushKV("asm", ScriptToAsmStr(txin.scriptSig, true));
+            o.pushKV("hex", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));
+            in.pushKV("scriptSig", o);
         }
-        in.push_back(Pair("sequence", (int64_t)txin.nSequence));
+        in.pushKV("sequence", (int64_t)txin.nSequence);
         vin.push_back(in);
     }
-    entry.push_back(Pair("vin", vin));
+    entry.pushKV("vin", vin);
     UniValue vout(UniValue::VARR);
     for (unsigned int i = 0; i < tx.vout.size(); i++)
     {
         const CTxOut &txout = tx.vout[i];
         UniValue out(UniValue::VOBJ);
-        out.push_back(Pair("value", ValueFromAmount(txout.nValue)));
-        out.push_back(Pair("n", (int64_t)i));
+        out.pushKV("value", ValueFromAmount(txout.nValue));
+        out.pushKV("n", (int64_t)i);
         UniValue o(UniValue::VOBJ);
         ScriptPubKeyToJSON(txout.scriptPubKey, o, true);
-        out.push_back(Pair("scriptPubKey", o));
+        out.pushKV("scriptPubKey", o);
         vout.push_back(out);
     }
-    entry.push_back(Pair("vout", vout));
+    entry.pushKV("vout", vout);
 
     if (!hashBlock.IsNull())
     {
-        entry.push_back(Pair("blockhash", hashBlock.GetHex()));
+        entry.pushKV("blockhash", hashBlock.GetHex());
         CBlockIndex *pindex = LookupBlockIndex(hashBlock);
         if (pindex)
         {
             if (chainActive.Contains(pindex))
             {
-                entry.push_back(Pair("confirmations", 1 + chainActive.Height() - pindex->nHeight));
-                entry.push_back(Pair("time", pindex->GetBlockTime()));
-                entry.push_back(Pair("blocktime", pindex->GetBlockTime()));
+                entry.pushKV("confirmations", 1 + chainActive.Height() - pindex->nHeight);
+                entry.pushKV("time", pindex->GetBlockTime());
+                entry.pushKV("blocktime", pindex->GetBlockTime());
             }
             else
-                entry.push_back(Pair("confirmations", 0));
+                entry.pushKV("confirmations", 0);
         }
     }
 }
@@ -213,7 +213,7 @@ UniValue getrawtransaction(const UniValue &params, bool fHelp)
         return strHex;
 
     UniValue result(UniValue::VOBJ);
-    result.push_back(Pair("hex", strHex));
+    result.pushKV("hex", strHex);
     TxToJSON(*tx, hashBlock, result);
     return result;
 }
@@ -588,7 +588,7 @@ UniValue decodescript(const UniValue &params, bool fHelp)
     {
         // P2SH cannot be wrapped in a P2SH. If this script is already a P2SH,
         // don't return the address for a P2SH of the P2SH.
-        r.push_back(Pair("p2sh", EncodeDestination(CScriptID(script))));
+        r.pushKV("p2sh", EncodeDestination(CScriptID(script)));
     }
 
     return r;
@@ -598,11 +598,11 @@ UniValue decodescript(const UniValue &params, bool fHelp)
 static void TxInErrorToJSON(const CTxIn &txin, UniValue &vErrorsRet, const std::string &strMessage)
 {
     UniValue entry(UniValue::VOBJ);
-    entry.push_back(Pair("txid", txin.prevout.hash.ToString()));
-    entry.push_back(Pair("vout", (uint64_t)txin.prevout.n));
-    entry.push_back(Pair("scriptSig", HexStr(txin.scriptSig.begin(), txin.scriptSig.end())));
-    entry.push_back(Pair("sequence", (uint64_t)txin.nSequence));
-    entry.push_back(Pair("error", strMessage));
+    entry.pushKV("txid", txin.prevout.hash.ToString());
+    entry.pushKV("vout", (uint64_t)txin.prevout.n);
+    entry.pushKV("scriptSig", HexStr(txin.scriptSig.begin(), txin.scriptSig.end()));
+    entry.pushKV("sequence", (uint64_t)txin.nSequence);
+    entry.pushKV("error", strMessage);
     vErrorsRet.push_back(entry);
 }
 
@@ -910,11 +910,11 @@ UniValue signrawtransaction(const UniValue &params, bool fHelp)
     bool fComplete = vErrors.empty();
 
     UniValue result(UniValue::VOBJ);
-    result.push_back(Pair("hex", EncodeHexTx(mergedTx)));
-    result.push_back(Pair("complete", fComplete));
+    result.pushKV("hex", EncodeHexTx(mergedTx));
+    result.pushKV("complete", fComplete);
     if (!vErrors.empty())
     {
-        result.push_back(Pair("errors", vErrors));
+        result.pushKV("errors", vErrors);
     }
 
     return result;

--- a/src/stat.h
+++ b/src/stat.h
@@ -632,9 +632,9 @@ public:
     operator UniValue() const
     {
         UniValue ret(UniValue::VOBJ);
-        ret.push_back(Pair("min", (UniValue)min));
-        ret.push_back(Pair("val", (UniValue)val));
-        ret.push_back(Pair("max", (UniValue)max));
+        ret.pushKV("min", (UniValue)min);
+        ret.pushKV("val", (UniValue)val);
+        ret.pushKV("max", (UniValue)max);
         return ret;
     }
 };

--- a/src/tweak.cpp
+++ b/src/tweak.cpp
@@ -53,7 +53,7 @@ UniValue gettweak(const UniValue &params, bool fHelp)
     {
         for (CTweakMap::iterator item = tweaks.begin(); item != tweaks.end(); ++item)
         {
-            ret.push_back(Pair(item->second->GetName(), item->second->Get()));
+            ret.pushKV(item->second->GetName(), item->second->Get());
         }
     }
 
@@ -74,9 +74,9 @@ UniValue gettweak(const UniValue &params, bool fHelp)
             if (wildmatch(match_str, item->first))
             {
                 if (help)
-                    ret.push_back(Pair(item->second->GetName(), item->second->GetHelp()));
+                    ret.pushKV(item->second->GetName(), item->second->GetHelp());
                 else
-                    ret.push_back(Pair(item->second->GetName(), item->second->Get()));
+                    ret.pushKV(item->second->GetName(), item->second->Get());
             }
         }
     }

--- a/src/univalue/gen/gen.cpp
+++ b/src/univalue/gen/gen.cpp
@@ -12,8 +12,6 @@
 #include <string.h>
 #include "univalue.h"
 
-using namespace std;
-
 static bool initEscapes;
 static std::string escapes[256];
 

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -135,6 +135,10 @@ public:
         UniValue tmpVal(val_);
         return pushKV(key, tmpVal);
     }
+    bool pushKV(const std::string& key, bool val_) {
+        UniValue tmpVal((bool)val_);
+        return pushKV(key, tmpVal);
+    }
     bool pushKV(const std::string& key, int val_) {
         UniValue tmpVal((int64_t)val_);
         return pushKV(key, tmpVal);

--- a/src/univalue/include/univalue.h
+++ b/src/univalue/include/univalue.h
@@ -15,7 +15,6 @@
 #include <cassert>
 
 #include <sstream>        // .get_int64()
-#include <utility>        // std::pair
 
 class UniValue {
 public:
@@ -179,82 +178,8 @@ public:
     const UniValue& get_array() const;
 
     enum VType type() const { return getType(); }
-    bool push_back(std::pair<std::string,UniValue> pear) {
-        return pushKV(pear.first, pear.second);
-    }
     friend const UniValue& find_value( const UniValue& obj, const std::string& name);
 };
-
-//
-// The following were added for compatibility with json_spirit.
-// Most duplicate other methods, and should be removed.
-//
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, const char *cVal)
-{
-    std::string key(cKey);
-    UniValue uVal(cVal);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, std::string strVal)
-{
-    std::string key(cKey);
-    UniValue uVal(strVal);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, unsigned long ulVal)
-{
-    std::string key(cKey);
-    UniValue uVal(ulVal);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, unsigned long long ullVal)
-{
-    std::string key(cKey);
-    UniValue uVal(ullVal);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, int64_t i64Val)
-{
-    std::string key(cKey);
-    UniValue uVal(i64Val);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, bool iVal)
-{
-    std::string key(cKey);
-    UniValue uVal(iVal);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, int iVal)
-{
-    std::string key(cKey);
-    UniValue uVal(iVal);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, double dVal)
-{
-    std::string key(cKey);
-    UniValue uVal(dVal);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(const char *cKey, const UniValue& uVal)
-{
-    std::string key(cKey);
-    return std::make_pair(key, uVal);
-}
-
-static inline std::pair<std::string,UniValue> Pair(std::string key, const UniValue& uVal)
-{
-    return std::make_pair(key, uVal);
-}
 
 enum jtokentype {
     JTOK_ERR        = -1,

--- a/src/univalue/lib/univalue.cpp
+++ b/src/univalue/lib/univalue.cpp
@@ -10,8 +10,6 @@
 
 #include "univalue.h"
 
-using namespace std;
-
 const UniValue NullUniValue;
 
 void UniValue::clear()
@@ -37,15 +35,15 @@ bool UniValue::setBool(bool val_)
     return true;
 }
 
-static bool validNumStr(const string& s)
+static bool validNumStr(const std::string& s)
 {
-    string tokenVal;
+    std::string tokenVal;
     unsigned int consumed;
     enum jtokentype tt = getJsonToken(tokenVal, consumed, s.data(), s.data() + s.size());
     return (tt == JTOK_NUMBER);
 }
 
-bool UniValue::setNumStr(const string& val_)
+bool UniValue::setNumStr(const std::string& val_)
 {
     if (!validNumStr(val_))
         return false;
@@ -58,7 +56,7 @@ bool UniValue::setNumStr(const string& val_)
 
 bool UniValue::setInt(uint64_t val_)
 {
-    ostringstream oss;
+    std::ostringstream oss;
 
     oss << val_;
 
@@ -67,7 +65,7 @@ bool UniValue::setInt(uint64_t val_)
 
 bool UniValue::setInt(int64_t val_)
 {
-    ostringstream oss;
+    std::ostringstream oss;
 
     oss << val_;
 
@@ -76,7 +74,7 @@ bool UniValue::setInt(int64_t val_)
 
 bool UniValue::setFloat(double val_)
 {
-    ostringstream oss;
+    std::ostringstream oss;
 
     oss << std::setprecision(16) << val_;
 
@@ -85,7 +83,7 @@ bool UniValue::setFloat(double val_)
     return ret;
 }
 
-bool UniValue::setStr(const string& val_)
+bool UniValue::setStr(const std::string& val_)
 {
     clear();
     typ = VSTR;

--- a/src/univalue/lib/univalue_read.cpp
+++ b/src/univalue/lib/univalue_read.cpp
@@ -8,8 +8,6 @@
 #include "univalue.h"
 #include "univalue_utffilter.h"
 
-using namespace std;
-
 static bool json_isdigit(int ch)
 {
     return ((ch >= '0') && (ch <= '9'));
@@ -42,7 +40,7 @@ static const char *hatoui(const char *first, const char *last,
     return first;
 }
 
-enum jtokentype getJsonToken(string& tokenVal, unsigned int& consumed,
+enum jtokentype getJsonToken(std::string& tokenVal, unsigned int& consumed,
                             const char *raw, const char *end)
 {
     tokenVal.clear();
@@ -114,7 +112,7 @@ enum jtokentype getJsonToken(string& tokenVal, unsigned int& consumed,
     case '8':
     case '9': {
         // part 1: int
-        string numStr;
+        std::string numStr;
 
         const char *first = raw;
 
@@ -174,7 +172,7 @@ enum jtokentype getJsonToken(string& tokenVal, unsigned int& consumed,
     case '"': {
         raw++;                                // skip "
 
-        string valStr;
+        std::string valStr;
         JSONUTF8StringFilter writer(valStr);
 
         while (true) {
@@ -255,9 +253,9 @@ bool UniValue::read(const char *raw, size_t size)
     clear();
 
     uint32_t expectMask = 0;
-    vector<UniValue*> stack;
+    std::vector<UniValue*> stack;
 
-    string tokenVal;
+    std::string tokenVal;
     unsigned int consumed;
     enum jtokentype tok = JTOK_NONE;
     enum jtokentype last_tok = JTOK_NONE;

--- a/src/univalue/lib/univalue_write.cpp
+++ b/src/univalue/lib/univalue_write.cpp
@@ -8,11 +8,9 @@
 #include "univalue.h"
 #include "univalue_escapes.h"
 
-using namespace std;
-
-static string json_escape(const string& inS)
+static std::string json_escape(const std::string& inS)
 {
-    string outS;
+    std::string outS;
     outS.reserve(inS.size() * 2);
 
     for (unsigned int i = 0; i < inS.size(); i++) {
@@ -28,10 +26,10 @@ static string json_escape(const string& inS)
     return outS;
 }
 
-string UniValue::write(unsigned int prettyIndent,
-                       unsigned int indentLevel) const
+std::string UniValue::write(unsigned int prettyIndent,
+                            unsigned int indentLevel) const
 {
-    string s;
+    std::string s;
     s.reserve(1024);
 
     unsigned int modIndent = indentLevel;
@@ -62,12 +60,12 @@ string UniValue::write(unsigned int prettyIndent,
     return s;
 }
 
-static void indentStr(unsigned int prettyIndent, unsigned int indentLevel, string& s)
+static void indentStr(unsigned int prettyIndent, unsigned int indentLevel, std::string& s)
 {
     s.append(prettyIndent * indentLevel, ' ');
 }
 
-void UniValue::writeArray(unsigned int prettyIndent, unsigned int indentLevel, string& s) const
+void UniValue::writeArray(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const
 {
     s += "[";
     if (prettyIndent)
@@ -89,7 +87,7 @@ void UniValue::writeArray(unsigned int prettyIndent, unsigned int indentLevel, s
     s += "]";
 }
 
-void UniValue::writeObject(unsigned int prettyIndent, unsigned int indentLevel, string& s) const
+void UniValue::writeObject(unsigned int prettyIndent, unsigned int indentLevel, std::string& s) const
 {
     s += "{";
     if (prettyIndent)

--- a/src/univalue/test/object.cpp
+++ b/src/univalue/test/object.cpp
@@ -261,6 +261,12 @@ BOOST_AUTO_TEST_CASE(univalue_object)
     strKey = "temperature";
     BOOST_CHECK(obj.pushKV(strKey, (double) 90.012));
 
+    strKey = "moon";
+    BOOST_CHECK(obj.pushKV(strKey, true));
+
+    strKey = "spoon";
+    BOOST_CHECK(obj.pushKV(strKey, false));
+
     UniValue obj2(UniValue::VOBJ);
     BOOST_CHECK(obj2.pushKV("cat1", 9000));
     BOOST_CHECK(obj2.pushKV("cat2", 12345));
@@ -268,7 +274,7 @@ BOOST_AUTO_TEST_CASE(univalue_object)
     BOOST_CHECK(obj.pushKVs(obj2));
 
     BOOST_CHECK_EQUAL(obj.empty(), false);
-    BOOST_CHECK_EQUAL(obj.size(), 9);
+    BOOST_CHECK_EQUAL(obj.size(), 11);
 
     BOOST_CHECK_EQUAL(obj["age"].getValStr(), "100");
     BOOST_CHECK_EQUAL(obj["first"].getValStr(), "John");
@@ -277,6 +283,8 @@ BOOST_AUTO_TEST_CASE(univalue_object)
     BOOST_CHECK_EQUAL(obj["time"].getValStr(), "3600");
     BOOST_CHECK_EQUAL(obj["calories"].getValStr(), "12");
     BOOST_CHECK_EQUAL(obj["temperature"].getValStr(), "90.012");
+    BOOST_CHECK_EQUAL(obj["moon"].getValStr(), "1");
+    BOOST_CHECK_EQUAL(obj["spoon"].getValStr(), "");
     BOOST_CHECK_EQUAL(obj["cat1"].getValStr(), "9000");
     BOOST_CHECK_EQUAL(obj["cat2"].getValStr(), "12345");
 
@@ -289,6 +297,8 @@ BOOST_AUTO_TEST_CASE(univalue_object)
     BOOST_CHECK(obj.exists("time"));
     BOOST_CHECK(obj.exists("calories"));
     BOOST_CHECK(obj.exists("temperature"));
+    BOOST_CHECK(obj.exists("moon"));
+    BOOST_CHECK(obj.exists("spoon"));
     BOOST_CHECK(obj.exists("cat1"));
     BOOST_CHECK(obj.exists("cat2"));
 
@@ -302,6 +312,8 @@ BOOST_AUTO_TEST_CASE(univalue_object)
     objTypes["time"] = UniValue::VNUM;
     objTypes["calories"] = UniValue::VNUM;
     objTypes["temperature"] = UniValue::VNUM;
+    objTypes["moon"] = UniValue::VBOOL;
+    objTypes["spoon"] = UniValue::VBOOL;
     objTypes["cat1"] = UniValue::VNUM;
     objTypes["cat2"] = UniValue::VNUM;
     BOOST_CHECK(obj.checkObject(objTypes));

--- a/src/univalue/test/unitester.cpp
+++ b/src/univalue/test/unitester.cpp
@@ -17,8 +17,7 @@
 #define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
 #endif
 
-using namespace std;
-string srcdir(JSON_TEST_SRC);
+std::string srcdir(JSON_TEST_SRC);
 static bool test_failed = false;
 
 #define d_assert(expr) { if (!(expr)) { test_failed = true; fprintf(stderr, "%s failed\n", filename.c_str()); } }
@@ -30,9 +29,9 @@ static std::string rtrim(std::string s)
     return s;
 }
 
-static void runtest(string filename, const string& jdata)
+static void runtest(std::string filename, const std::string& jdata)
 {
-        string prefix = filename.substr(0, 4);
+        std::string prefix = filename.substr(0, 4);
 
         bool wantPass = (prefix == "pass") || (prefix == "roun");
         bool wantFail = (prefix == "fail");
@@ -56,19 +55,19 @@ static void runtest(string filename, const string& jdata)
 
 static void runtest_file(const char *filename_)
 {
-        string basename(filename_);
-        string filename = srcdir + "/" + basename;
+        std::string basename(filename_);
+        std::string filename = srcdir + "/" + basename;
         FILE *f = fopen(filename.c_str(), "r");
         assert(f != NULL);
 
-        string jdata;
+        std::string jdata;
 
         char buf[4096];
         while (!feof(f)) {
                 int bread = fread(buf, 1, sizeof(buf), f);
                 assert(!ferror(f));
 
-                string s(buf, bread);
+                std::string s(buf, bread);
                 jdata += s;
         }
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1067,8 +1067,8 @@ UniValue getexcessiveblock(const UniValue &params, bool fHelp)
                             HelpExampleCli("getexcessiveblock", "") + HelpExampleRpc("getexcessiveblock", ""));
 
     UniValue ret(UniValue::VOBJ);
-    ret.push_back(Pair("excessiveBlockSize", (uint64_t)excessiveBlockSize));
-    ret.push_back(Pair("excessiveAcceptDepth", (uint64_t)excessiveAcceptDepth));
+    ret.pushKV("excessiveBlockSize", (uint64_t)excessiveBlockSize);
+    ret.pushKV("excessiveAcceptDepth", (uint64_t)excessiveAcceptDepth);
     return ret;
 }
 
@@ -1269,14 +1269,14 @@ UniValue gettrafficshaping(const UniValue &params, bool fHelp)
     sendShaper.get(&max, &avg);
     if (avg != std::numeric_limits<long long>::max() || max != std::numeric_limits<long long>::max())
     {
-        ret.push_back(Pair("sendBurst", max / 1024));
-        ret.push_back(Pair("sendAve", avg / 1024));
+        ret.pushKV("sendBurst", max / 1024);
+        ret.pushKV("sendAve", avg / 1024);
     }
     receiveShaper.get(&max, &avg);
     if (avg != std::numeric_limits<long long>::max() || max != std::numeric_limits<long long>::max())
     {
-        ret.push_back(Pair("recvBurst", max / 1024));
-        ret.push_back(Pair("recvAve", avg / 1024));
+        ret.pushKV("recvBurst", max / 1024);
+        ret.pushKV("recvAve", avg / 1024);
     }
     return ret;
 }
@@ -1639,11 +1639,11 @@ UniValue getstat(const UniValue &params, bool fHelp)
         UniValue ustat(UniValue::VOBJ);
         if (seriesStr == "now")
         {
-            ustat.push_back(Pair("now", base->GetNow()));
+            ustat.pushKV("now", base->GetNow());
         }
         else if (seriesStr == "total")
         {
-            ustat.push_back(Pair("total", base->GetTotal()));
+            ustat.pushKV("total", base->GetTotal());
         }
         else
         {
@@ -1656,14 +1656,14 @@ UniValue getstat(const UniValue &params, bool fHelp)
                 UniValue metaData(UniValue::VARR);
                 metaData.push_back("Series:" + seriesStr);
                 metaData.push_back("SampleSize:" + boost::lexical_cast<std::string>(count));
-                ustat.push_back(Pair(metaStr, metaData));
-                ustat.push_back(Pair(seriesStr, series[0]));
-                ustat.push_back(Pair("timestamp", series[1]));
+                ustat.pushKV(metaStr, metaData);
+                ustat.pushKV(seriesStr, series[0]);
+                ustat.pushKV("timestamp", series[1]);
             }
             else
             {
                 series = base->GetSeries(seriesStr, count);
-                ustat.push_back(Pair(seriesStr, series));
+                ustat.pushKV(seriesStr, series);
             }
         }
 
@@ -1813,18 +1813,18 @@ static UniValue MkMiningCandidateJson(CMiningCandidate &candid)
     // Save candidate so can be looked up:
     id++;
     AddMiningCandidate(candid, id);
-    ret.push_back(Pair("id", id));
+    ret.pushKV("id", id);
 
-    ret.push_back(Pair("prevhash", block.hashPrevBlock.GetHex()));
+    ret.pushKV("prevhash", block.hashPrevBlock.GetHex());
 
     {
         const CTransaction *tran = block.vtx[0].get();
-        ret.push_back(Pair("coinbase", EncodeHexTx(*tran)));
+        ret.pushKV("coinbase", EncodeHexTx(*tran));
     }
 
-    ret.push_back(Pair("version", block.nVersion));
-    ret.push_back(Pair("nBits", strprintf("%08x", block.nBits)));
-    ret.push_back(Pair("time", block.GetBlockTime()));
+    ret.pushKV("version", block.nVersion);
+    ret.pushKV("nBits", strprintf("%08x", block.nBits));
+    ret.pushKV("time", block.GetBlockTime());
 
     // merkleProof:
     {
@@ -1834,7 +1834,7 @@ static UniValue MkMiningCandidateJson(CMiningCandidate &candid)
         {
             merkleProof.push_back(i.GetHex());
         }
-        ret.push_back(Pair("merkleProof", merkleProof));
+        ret.pushKV("merkleProof", merkleProof);
 
         // merklePath parameter:
         // If the coinbase is ever allowed to be anywhere in the hash tree via a hard fork, we will need to communicate
@@ -1844,7 +1844,7 @@ static UniValue MkMiningCandidateJson(CMiningCandidate &candid)
         // Hash256(concatentate(running hash, next hash in proof)), if the bit is 1, the proof calculates
         // Hash256(concatentate(next hash in proof, running hash))
 
-        // ret.push_back(Pair("merklePath", 0));
+        // ret.pushKV("merklePath", 0);
     }
 
     return ret;
@@ -2176,9 +2176,9 @@ extern std::queue<CTxInputData> txInQ;
 extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
 {
     UniValue ret(UniValue::VOBJ);
-    ret.push_back(Pair("time", GetTime()));
-    ret.push_back(Pair("requester.mapTxnInfo", (uint64_t)requester.mapTxnInfo.size()));
-    ret.push_back(Pair("requester.mapBlkInfo", (uint64_t)requester.mapBlkInfo.size()));
+    ret.pushKV("time", GetTime());
+    ret.pushKV("requester.mapTxnInfo", (uint64_t)requester.mapTxnInfo.size());
+    ret.pushKV("requester.mapBlkInfo", (uint64_t)requester.mapBlkInfo.size());
     unsigned long int max = 0;
     unsigned long int size = 0;
     for (CRequestManager::OdMap::iterator i = requester.mapTxnInfo.begin(); i != requester.mapTxnInfo.end(); i++)
@@ -2188,8 +2188,8 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
         if (max < temp)
             max = temp;
     }
-    ret.push_back(Pair("requester.mapTxnInfo.maxobj", max));
-    ret.push_back(Pair("requester.mapTxnInfo.totobj", size));
+    ret.pushKV("requester.mapTxnInfo.maxobj", max);
+    ret.pushKV("requester.mapTxnInfo.totobj", size);
 
     max = 0;
     size = 0;
@@ -2200,45 +2200,45 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
         if (max < temp)
             max = temp;
     }
-    ret.push_back(Pair("requester.mapBlkInfo.maxobj", max));
-    ret.push_back(Pair("requester.mapBlkInfo.totobj", size));
+    ret.pushKV("requester.mapBlkInfo.maxobj", max);
+    ret.pushKV("requester.mapBlkInfo.totobj", size);
 
-    ret.push_back(Pair("mapBlockIndex", (int64_t)mapBlockIndex.size()));
+    ret.pushKV("mapBlockIndex", (int64_t)mapBlockIndex.size());
     // CChain
     {
         LOCK(cs_xval);
-        ret.push_back(Pair("setPreVerifiedTxHash", (int64_t)setPreVerifiedTxHash.size()));
-        ret.push_back(Pair("setUnVerifiedOrphanTxHash", (int64_t)setUnVerifiedOrphanTxHash.size()));
+        ret.pushKV("setPreVerifiedTxHash", (int64_t)setPreVerifiedTxHash.size());
+        ret.pushKV("setUnVerifiedOrphanTxHash", (int64_t)setUnVerifiedOrphanTxHash.size());
     }
-    ret.push_back(Pair("mapLocalHost", (int64_t)mapLocalHost.size()));
-    ret.push_back(Pair("CDoSManager::vWhitelistedRange", (int64_t)dosMan.vWhitelistedRange.size()));
-    ret.push_back(Pair("mapInboundConnectionTracker", (int64_t)mapInboundConnectionTracker.size()));
-    ret.push_back(Pair("vUseDNSSeeds", (int64_t)vUseDNSSeeds.size()));
-    ret.push_back(Pair("vAddedNodes", (int64_t)vAddedNodes.size()));
-    ret.push_back(Pair("setservAddNodeAddresses", (int64_t)setservAddNodeAddresses.size()));
-    ret.push_back(Pair("statistics", (int64_t)statistics.size()));
-    ret.push_back(Pair("tweaks", (int64_t)tweaks.size()));
-    ret.push_back(Pair("mapRelay", (int64_t)mapRelay.size()));
-    ret.push_back(Pair("vRelayExpiration", (int64_t)vRelayExpiration.size()));
-    ret.push_back(Pair("vNodes", (int64_t)vNodes.size()));
-    ret.push_back(Pair("vNodesDisconnected", (int64_t)vNodesDisconnected.size()));
+    ret.pushKV("mapLocalHost", (int64_t)mapLocalHost.size());
+    ret.pushKV("CDoSManager::vWhitelistedRange", (int64_t)dosMan.vWhitelistedRange.size());
+    ret.pushKV("mapInboundConnectionTracker", (int64_t)mapInboundConnectionTracker.size());
+    ret.pushKV("vUseDNSSeeds", (int64_t)vUseDNSSeeds.size());
+    ret.pushKV("vAddedNodes", (int64_t)vAddedNodes.size());
+    ret.pushKV("setservAddNodeAddresses", (int64_t)setservAddNodeAddresses.size());
+    ret.pushKV("statistics", (int64_t)statistics.size());
+    ret.pushKV("tweaks", (int64_t)tweaks.size());
+    ret.pushKV("mapRelay", (int64_t)mapRelay.size());
+    ret.pushKV("vRelayExpiration", (int64_t)vRelayExpiration.size());
+    ret.pushKV("vNodes", (int64_t)vNodes.size());
+    ret.pushKV("vNodesDisconnected", (int64_t)vNodesDisconnected.size());
     // CAddrMan
-    ret.push_back(Pair("mapOrphanTransactions", (int64_t)orphanpool.mapOrphanTransactions.size()));
-    ret.push_back(Pair("mapOrphanTransactionsByPrev", (int64_t)orphanpool.mapOrphanTransactionsByPrev.size()));
+    ret.pushKV("mapOrphanTransactions", (int64_t)orphanpool.mapOrphanTransactions.size());
+    ret.pushKV("mapOrphanTransactionsByPrev", (int64_t)orphanpool.mapOrphanTransactionsByPrev.size());
 
     uint32_t nExpeditedBlocks, nExpeditedTxs, nExpeditedUpstream;
     connmgr->ExpeditedNodeCounts(nExpeditedBlocks, nExpeditedTxs, nExpeditedUpstream);
-    ret.push_back(Pair("xpeditedBlk", (uint64_t)nExpeditedBlocks));
-    ret.push_back(Pair("xpeditedBlkUp", (uint64_t)nExpeditedUpstream));
-    ret.push_back(Pair("xpeditedTxn", (uint64_t)nExpeditedTxs));
+    ret.pushKV("xpeditedBlk", (uint64_t)nExpeditedBlocks);
+    ret.pushKV("xpeditedBlkUp", (uint64_t)nExpeditedUpstream);
+    ret.pushKV("xpeditedTxn", (uint64_t)nExpeditedTxs);
 
     if (txCommitQ)
-        ret.push_back(Pair("txCommitQ", (uint64_t)txCommitQ->size()));
-    ret.push_back(Pair("txInQ", (uint64_t)txInQ.size()));
-    ret.push_back(Pair("txDeferQ", (uint64_t)txDeferQ.size()));
+        ret.pushKV("txCommitQ", (uint64_t)txCommitQ->size());
+    ret.pushKV("txInQ", (uint64_t)txInQ.size());
+    ret.pushKV("txDeferQ", (uint64_t)txDeferQ.size());
 
 #ifdef DEBUG_LOCKORDER
-    ret.push_back(Pair("lockorders", (uint64_t)lockorders.size()));
+    ret.pushKV("lockorders", (uint64_t)lockorders.size());
 #endif
 
     LOCK(cs_vNodes);
@@ -2253,9 +2253,9 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
         UniValue node(UniValue::VOBJ);
         disconnected += (inode.fDisconnect) ? 1 : 0;
 
-        node.push_back(Pair("vSendMsg", (int64_t)inode.vSendMsg.size()));
-        node.push_back(Pair("vRecvGetData", (int64_t)inode.vRecvGetData.size()));
-        node.push_back(Pair("vRecvMsg", (int64_t)inode.vRecvMsg.size()));
+        node.pushKV("vSendMsg", (int64_t)inode.vSendMsg.size());
+        node.pushKV("vRecvGetData", (int64_t)inode.vRecvGetData.size());
+        node.pushKV("vRecvMsg", (int64_t)inode.vRecvMsg.size());
         {
             LOCK(inode.cs_filter);
             if (inode.pfilter)
@@ -2265,22 +2265,22 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
             }
             if (inode.pThinBlockFilter)
             {
-                node.push_back(Pair("pThinBlockFilter",
+                node.pushKV("pThinBlockFilter",
                     (int64_t)::GetSerializeSize(*inode.pThinBlockFilter, SER_NETWORK, PROTOCOL_VERSION)));
             }
         }
-        node.push_back(Pair("thinblock.vtx", (int64_t)inode.thinBlock.vtx.size()));
+        node.pushKV("thinblock.vtx", (int64_t)inode.thinBlock.vtx.size());
         uint64_t thinBlockSize = ::GetSerializeSize(inode.thinBlock, SER_NETWORK, PROTOCOL_VERSION);
         totalThinBlockSize += thinBlockSize;
-        node.push_back(Pair("thinblock.size", thinBlockSize));
-        node.push_back(Pair("thinBlockHashes", (int64_t)inode.thinBlockHashes.size()));
-        node.push_back(Pair("xThinBlockHashes", (int64_t)inode.xThinBlockHashes.size()));
-        node.push_back(Pair("vAddrToSend", (int64_t)inode.vAddrToSend.size()));
-        node.push_back(Pair("vInventoryToSend", (int64_t)inode.vInventoryToSend.size()));
-        ret.push_back(Pair(inode.addrName, node));
+        node.pushKV("thinblock.size", thinBlockSize);
+        node.pushKV("thinBlockHashes", (int64_t)inode.thinBlockHashes.size());
+        node.pushKV("xThinBlockHashes", (int64_t)inode.xThinBlockHashes.size());
+        node.pushKV("vAddrToSend", (int64_t)inode.vAddrToSend.size());
+        node.pushKV("vInventoryToSend", (int64_t)inode.vInventoryToSend.size());
+        ret.pushKV(inode.addrName, node);
     }
-    ret.push_back(Pair("totalThinBlockSize", totalThinBlockSize));
-    ret.push_back(Pair("disconnectedNodes", disconnected));
+    ret.pushKV("totalThinBlockSize", totalThinBlockSize);
+    ret.pushKV("disconnectedNodes", disconnected);
 
     return ret;
 }
@@ -2387,9 +2387,9 @@ UniValue getaddressforms(const UniValue &params, bool fHelp)
     std::string bitpayAddr = EncodeBitpayAddr(dest);
 
     UniValue node(UniValue::VOBJ);
-    node.push_back(Pair("legacy", legacyAddr));
-    node.push_back(Pair("bitcoincash", cashAddr));
-    node.push_back(Pair("bitpay", bitpayAddr));
+    node.pushKV("legacy", legacyAddr);
+    node.pushKV("bitcoincash", cashAddr);
+    node.pushKV("bitpay", bitpayAddr);
     return node;
 }
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -61,35 +61,35 @@ void EnsureWalletIsUnlocked()
 void WalletTxToJSON(const CWalletTx &wtx, UniValue &entry)
 {
     int confirms = wtx.GetDepthInMainChain();
-    entry.push_back(Pair("confirmations", confirms));
+    entry.pushKV("confirmations", confirms);
     if (wtx.IsCoinBase())
-        entry.push_back(Pair("generated", true));
+        entry.pushKV("generated", true);
     if (confirms > 0)
     {
-        entry.push_back(Pair("blockhash", wtx.hashBlock.GetHex()));
-        entry.push_back(Pair("blockindex", wtx.nIndex));
+        entry.pushKV("blockhash", wtx.hashBlock.GetHex());
+        entry.pushKV("blockindex", wtx.nIndex);
         auto *tmp = LookupBlockIndex(wtx.hashBlock);
         if (tmp)
-            entry.push_back(Pair("blocktime", tmp->GetBlockTime()));
+            entry.pushKV("blocktime", tmp->GetBlockTime());
     }
     else
     {
-        entry.push_back(Pair("trusted", wtx.IsTrusted()));
+        entry.pushKV("trusted", wtx.IsTrusted());
     }
     uint256 hash = wtx.GetHash();
-    entry.push_back(Pair("txid", hash.GetHex()));
+    entry.pushKV("txid", hash.GetHex());
     UniValue conflicts(UniValue::VARR);
     for (const uint256 &conflict : wtx.GetConflicts())
     {
         conflicts.push_back(conflict.GetHex());
     }
-    entry.push_back(Pair("walletconflicts", conflicts));
-    entry.push_back(Pair("time", wtx.GetTxTime()));
-    entry.push_back(Pair("timereceived", (int64_t)wtx.nTimeReceived));
+    entry.pushKV("walletconflicts", conflicts);
+    entry.pushKV("time", wtx.GetTxTime());
+    entry.pushKV("timereceived", (int64_t)wtx.nTimeReceived);
 
     for (const PAIRTYPE(string, string) & item : wtx.mapValue)
     {
-        entry.push_back(Pair(item.first, item.second));
+        entry.pushKV(item.first, item.second);
     }
 }
 
@@ -654,11 +654,11 @@ UniValue signdata(const UniValue &params, bool fHelp)
     if (verbose)
     {
         UniValue ret(UniValue::VOBJ);
-        ret.push_back(Pair("msghash", hash.ToString()));
-        ret.push_back(Pair("signature", GetHex(sig.data(), sig.size())));
-        ret.push_back(Pair("pubkeyhash", keyID->GetHex()));
+        ret.pushKV("msghash", hash.ToString());
+        ret.pushKV("signature", GetHex(sig.data(), sig.size()));
+        ret.pushKV("pubkeyhash", keyID->GetHex());
         CPubKey pub = key.GetPubKey();
-        ret.push_back(Pair("pubkey", GetHex(pub.begin(), pub.size())));
+        ret.pushKV("pubkey", GetHex(pub.begin(), pub.size()));
         return ret;
     }
     return UniValue(GetHex(sig.data(), sig.size()));
@@ -1354,16 +1354,16 @@ UniValue ListReceived(const UniValue &params, bool fByAccounts)
             UniValue obj(UniValue::VOBJ);
             if (fIsWatchonly)
             {
-                obj.push_back(Pair("involvesWatchonly", true));
+                obj.pushKV("involvesWatchonly", true);
             }
-            obj.push_back(Pair("address", EncodeDestination(dest)));
-            obj.push_back(Pair("account", strAccount));
-            obj.push_back(Pair("satoshi", UniValue(nAmount)));
-            obj.push_back(Pair("amount", ValueFromAmount(nAmount)));
-            obj.push_back(Pair("confirmations", (nConf == std::numeric_limits<int>::max() ? 0 : nConf)));
+            obj.pushKV("address", EncodeDestination(dest));
+            obj.pushKV("account", strAccount);
+            obj.pushKV("satoshi", UniValue(nAmount));
+            obj.pushKV("amount", ValueFromAmount(nAmount));
+            obj.pushKV("confirmations", (nConf == std::numeric_limits<int>::max() ? 0 : nConf));
             if (!fByAccounts)
             {
-                obj.push_back(Pair("label", strAccount));
+                obj.pushKV("label", strAccount);
             }
             UniValue transactions(UniValue::VARR);
             if (it != mapTally.end())
@@ -1373,7 +1373,7 @@ UniValue ListReceived(const UniValue &params, bool fByAccounts)
                     transactions.push_back(item3.GetHex());
                 }
             }
-            obj.push_back(Pair("txids", transactions));
+            obj.pushKV("txids", transactions);
             ret.push_back(obj);
         }
     }
@@ -1386,11 +1386,11 @@ UniValue ListReceived(const UniValue &params, bool fByAccounts)
             int nConf = (*it).second.nConf;
             UniValue obj(UniValue::VOBJ);
             if ((*it).second.fIsWatchonly)
-                obj.push_back(Pair("involvesWatchonly", true));
-            obj.push_back(Pair("account", (*it).first));
-            obj.push_back(Pair("satoshi", UniValue(nAmount)));
-            obj.push_back(Pair("amount", ValueFromAmount(nAmount)));
-            obj.push_back(Pair("confirmations", (nConf == std::numeric_limits<int>::max() ? 0 : nConf)));
+                obj.pushKV("involvesWatchonly", true);
+            obj.pushKV("account", (*it).first);
+            obj.pushKV("satoshi", UniValue(nAmount));
+            obj.pushKV("amount", ValueFromAmount(nAmount));
+            obj.pushKV("confirmations", (nConf == std::numeric_limits<int>::max() ? 0 : nConf));
             ret.push_back(obj);
         }
     }
@@ -1486,7 +1486,7 @@ static void MaybePushAddress(UniValue &entry, const CTxDestination &dest)
 {
     if (IsValidDestination(dest))
     {
-        entry.push_back(Pair("address", EncodeDestination(dest)));
+        entry.pushKV("address", EncodeDestination(dest));
     }
 }
 
@@ -1514,19 +1514,19 @@ void ListTransactions(const CWalletTx &wtx,
         {
             UniValue entry(UniValue::VOBJ);
             if (involvesWatchonly || (::IsMine(*pwalletMain, s.destination, chainActive.Tip()) & ISMINE_WATCH_ONLY))
-                entry.push_back(Pair("involvesWatchonly", true));
-            entry.push_back(Pair("account", strSentAccount));
+                entry.pushKV("involvesWatchonly", true);
+            entry.pushKV("account", strSentAccount);
             MaybePushAddress(entry, s.destination);
-            entry.push_back(Pair("category", "send"));
-            entry.push_back(Pair("satoshi", UniValue(-s.amount)));
-            entry.push_back(Pair("amount", ValueFromAmount(-s.amount)));
+            entry.pushKV("category", "send");
+            entry.pushKV("satoshi", UniValue(-s.amount));
+            entry.pushKV("amount", ValueFromAmount(-s.amount));
             if (pwalletMain->mapAddressBook.count(s.destination))
-                entry.push_back(Pair("label", pwalletMain->mapAddressBook[s.destination].name));
-            entry.push_back(Pair("vout", s.vout));
-            entry.push_back(Pair("fee", ValueFromAmount(-nFee)));
+                entry.pushKV("label", pwalletMain->mapAddressBook[s.destination].name);
+            entry.pushKV("vout", s.vout);
+            entry.pushKV("fee", ValueFromAmount(-nFee));
             if (fLong)
                 WalletTxToJSON(wtx, entry);
-            entry.push_back(Pair("abandoned", wtx.isAbandoned()));
+            entry.pushKV("abandoned", wtx.isAbandoned());
             ret.push_back(entry);
         }
     }
@@ -1543,27 +1543,27 @@ void ListTransactions(const CWalletTx &wtx,
             {
                 UniValue entry(UniValue::VOBJ);
                 if (involvesWatchonly || (::IsMine(*pwalletMain, r.destination, chainActive.Tip()) & ISMINE_WATCH_ONLY))
-                    entry.push_back(Pair("involvesWatchonly", true));
-                entry.push_back(Pair("account", account));
+                    entry.pushKV("involvesWatchonly", true);
+                entry.pushKV("account", account);
                 MaybePushAddress(entry, r.destination);
                 if (wtx.IsCoinBase())
                 {
                     if (wtx.GetDepthInMainChain() < 1)
-                        entry.push_back(Pair("category", "orphan"));
+                        entry.pushKV("category", "orphan");
                     else if (wtx.GetBlocksToMaturity() > 0)
-                        entry.push_back(Pair("category", "immature"));
+                        entry.pushKV("category", "immature");
                     else
-                        entry.push_back(Pair("category", "generate"));
+                        entry.pushKV("category", "generate");
                 }
                 else
                 {
-                    entry.push_back(Pair("category", "receive"));
+                    entry.pushKV("category", "receive");
                 }
-                entry.push_back(Pair("satoshi", UniValue(r.amount)));
-                entry.push_back(Pair("amount", ValueFromAmount(r.amount)));
+                entry.pushKV("satoshi", UniValue(r.amount));
+                entry.pushKV("amount", ValueFromAmount(r.amount));
                 if (pwalletMain->mapAddressBook.count(r.destination))
-                    entry.push_back(Pair("label", account));
-                entry.push_back(Pair("vout", r.vout));
+                    entry.pushKV("label", account);
+                entry.pushKV("vout", r.vout);
                 if (fLong)
                     WalletTxToJSON(wtx, entry);
                 ret.push_back(entry);
@@ -1579,13 +1579,13 @@ void AcentryToJSON(const CAccountingEntry &acentry, const string &strAccount, Un
     if (fAllAccounts || acentry.strAccount == strAccount)
     {
         UniValue entry(UniValue::VOBJ);
-        entry.push_back(Pair("account", acentry.strAccount));
-        entry.push_back(Pair("category", "move"));
-        entry.push_back(Pair("time", acentry.nTime));
-        entry.push_back(Pair("satoshi", UniValue(acentry.nCreditDebit)));
-        entry.push_back(Pair("amount", ValueFromAmount(acentry.nCreditDebit)));
-        entry.push_back(Pair("otheraccount", acentry.strOtherAccount));
-        entry.push_back(Pair("comment", acentry.strComment));
+        entry.pushKV("account", acentry.strAccount);
+        entry.pushKV("category", "move");
+        entry.pushKV("time", acentry.nTime);
+        entry.pushKV("satoshi", UniValue(acentry.nCreditDebit));
+        entry.pushKV("amount", ValueFromAmount(acentry.nCreditDebit));
+        entry.pushKV("otheraccount", acentry.strOtherAccount);
+        entry.pushKV("comment", acentry.strComment);
         ret.push_back(entry);
     }
 }
@@ -1944,7 +1944,7 @@ UniValue listaccounts(const UniValue &params, bool fHelp)
     UniValue ret(UniValue::VOBJ);
     for (const PAIRTYPE(string, CAmount) & accountBalance : mapAccountBalances)
     {
-        ret.push_back(Pair(accountBalance.first, ValueFromAmount(accountBalance.second)));
+        ret.pushKV(accountBalance.first, ValueFromAmount(accountBalance.second));
     }
     return ret;
 }
@@ -2049,8 +2049,8 @@ UniValue listsinceblock(const UniValue &params, bool fHelp)
     uint256 lastblock = pblockLast ? pblockLast->GetBlockHash() : uint256();
 
     UniValue ret(UniValue::VOBJ);
-    ret.push_back(Pair("transactions", transactions));
-    ret.push_back(Pair("lastblock", lastblock.GetHex()));
+    ret.pushKV("transactions", transactions);
+    ret.pushKV("lastblock", lastblock.GetHex());
 
     return ret;
 }
@@ -2127,19 +2127,19 @@ UniValue gettransaction(const UniValue &params, bool fHelp)
     CAmount nNet = nCredit - nDebit;
     CAmount nFee = (wtx.IsFromMe(filter) ? wtx.GetValueOut() - nDebit : 0);
 
-    entry.push_back(Pair("satoshi", UniValue(nNet - nFee)));
-    entry.push_back(Pair("amount", ValueFromAmount(nNet - nFee)));
+    entry.pushKV("satoshi", UniValue(nNet - nFee));
+    entry.pushKV("amount", ValueFromAmount(nNet - nFee));
     if (wtx.IsFromMe(filter))
-        entry.push_back(Pair("fee", ValueFromAmount(nFee)));
+        entry.pushKV("fee", ValueFromAmount(nFee));
 
     WalletTxToJSON(wtx, entry);
 
     UniValue details(UniValue::VARR);
     ListTransactions(wtx, "*", 0, false, details, filter);
-    entry.push_back(Pair("details", details));
+    entry.pushKV("details", details);
 
     string strHex = EncodeHexTx(static_cast<CTransaction>(wtx));
-    entry.push_back(Pair("hex", strHex));
+    entry.pushKV("hex", strHex);
 
     return entry;
 }
@@ -2576,8 +2576,8 @@ UniValue listlockunspent(const UniValue &params, bool fHelp)
     {
         UniValue o(UniValue::VOBJ);
 
-        o.push_back(Pair("txid", outpt.hash.GetHex()));
-        o.push_back(Pair("vout", (int)outpt.n));
+        o.pushKV("txid", outpt.hash.GetHex());
+        o.pushKV("vout", (int)outpt.n);
         ret.push_back(o);
     }
 
@@ -2644,19 +2644,19 @@ UniValue getwalletinfo(const UniValue &params, bool fHelp)
     LOCK2(cs_main, pwalletMain->cs_wallet);
 
     UniValue obj(UniValue::VOBJ);
-    obj.push_back(Pair("walletversion", pwalletMain->GetVersion()));
-    obj.push_back(Pair("balance", ValueFromAmount(pwalletMain->GetBalance())));
-    obj.push_back(Pair("unconfirmed_balance", ValueFromAmount(pwalletMain->GetUnconfirmedBalance())));
-    obj.push_back(Pair("immature_balance", ValueFromAmount(pwalletMain->GetImmatureBalance())));
-    obj.push_back(Pair("txcount", (int)pwalletMain->mapWallet.size()));
-    obj.push_back(Pair("keypoololdest", pwalletMain->GetOldestKeyPoolTime()));
-    obj.push_back(Pair("keypoolsize", (int)pwalletMain->GetKeyPoolSize()));
+    obj.pushKV("walletversion", pwalletMain->GetVersion());
+    obj.pushKV("balance", ValueFromAmount(pwalletMain->GetBalance()));
+    obj.pushKV("unconfirmed_balance", ValueFromAmount(pwalletMain->GetUnconfirmedBalance()));
+    obj.pushKV("immature_balance", ValueFromAmount(pwalletMain->GetImmatureBalance()));
+    obj.pushKV("txcount", (int)pwalletMain->mapWallet.size());
+    obj.pushKV("keypoololdest", pwalletMain->GetOldestKeyPoolTime());
+    obj.pushKV("keypoolsize", (int)pwalletMain->GetKeyPoolSize());
     if (pwalletMain->IsCrypted())
-        obj.push_back(Pair("unlocked_until", nWalletUnlockTime));
-    obj.push_back(Pair("paytxfee", ValueFromAmount(payTxFee.GetFeePerK())));
+        obj.pushKV("unlocked_until", nWalletUnlockTime);
+    obj.pushKV("paytxfee", ValueFromAmount(payTxFee.GetFeePerK()));
     CKeyID masterKeyID = pwalletMain->GetHDChain().masterKeyID;
     if (!masterKeyID.IsNull())
-        obj.push_back(Pair("hdmasterkeyid", masterKeyID.GetHex()));
+        obj.pushKV("hdmasterkeyid", masterKeyID.GetHex());
     return obj;
 }
 
@@ -2779,16 +2779,16 @@ UniValue listunspent(const UniValue &params, bool fHelp)
         CAmount nValue = out.tx->vout[out.i].nValue;
         const CScript &pk = out.tx->vout[out.i].scriptPubKey;
         UniValue entry(UniValue::VOBJ);
-        entry.push_back(Pair("txid", out.tx->GetHash().GetHex()));
-        entry.push_back(Pair("vout", out.i));
+        entry.pushKV("txid", out.tx->GetHash().GetHex());
+        entry.pushKV("vout", out.i);
         CTxDestination address;
         if (ExtractDestination(out.tx->vout[out.i].scriptPubKey, address))
         {
-            entry.push_back(Pair("address", EncodeDestination(address)));
+            entry.pushKV("address", EncodeDestination(address));
             if (pwalletMain->mapAddressBook.count(address))
-                entry.push_back(Pair("account", pwalletMain->mapAddressBook[address].name));
+                entry.pushKV("account", pwalletMain->mapAddressBook[address].name);
         }
-        entry.push_back(Pair("scriptPubKey", HexStr(pk.begin(), pk.end())));
+        entry.pushKV("scriptPubKey", HexStr(pk.begin(), pk.end()));
         if (pk.IsPayToScriptHash())
         {
             CTxDestination address2;
@@ -2797,13 +2797,13 @@ UniValue listunspent(const UniValue &params, bool fHelp)
                 const CScriptID &hash = boost::get<CScriptID>(address2);
                 CScript redeemScript;
                 if (pwalletMain->GetCScript(hash, redeemScript))
-                    entry.push_back(Pair("redeemScript", HexStr(redeemScript.begin(), redeemScript.end())));
+                    entry.pushKV("redeemScript", HexStr(redeemScript.begin(), redeemScript.end()));
             }
         }
-        entry.push_back(Pair("satoshi", UniValue(nValue)));
-        entry.push_back(Pair("amount", ValueFromAmount(nValue)));
-        entry.push_back(Pair("confirmations", out.nDepth));
-        entry.push_back(Pair("spendable", out.fSpendable));
+        entry.pushKV("satoshi", UniValue(nValue));
+        entry.pushKV("amount", ValueFromAmount(nValue));
+        entry.pushKV("confirmations", out.nDepth);
+        entry.pushKV("spendable", out.fSpendable);
         results.push_back(entry);
     }
 
@@ -2867,9 +2867,9 @@ UniValue fundrawtransaction(const UniValue &params, bool fHelp)
         throw JSONRPCError(RPC_INTERNAL_ERROR, strFailReason);
 
     UniValue result(UniValue::VOBJ);
-    result.push_back(Pair("hex", EncodeHexTx(tx)));
-    result.push_back(Pair("changepos", nChangePos));
-    result.push_back(Pair("fee", ValueFromAmount(nFee)));
+    result.pushKV("hex", EncodeHexTx(tx));
+    result.pushKV("changepos", nChangePos);
+    result.pushKV("fee", ValueFromAmount(nFee));
 
     return result;
 }


### PR DESCRIPTION
This is basically a scripted diff:

```sh
$> grep -Fr "push_back(Pair" src/ | awk -F ':' '{print $1}' | sort | uniq | xargs -I {} sed --in-place -e 's/push_back(Pair/pushKV/' {}
$> grep -IFr pushKV src/ | awk -F ':' '{print $1}' | sort | uniq | xargs -I {} sed --in-place -e '/pushKV/s/))/)/' {}
```

This include also a port of  bitcoin/bitcoin#14164 which removes the deprecated std::pair wrappers from univalue.