### PR TITLE
Seed IBLT hash functions

### DIFF
--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -44,10 +44,14 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
 
     version = _version;
     if (version >= 2)
-    {
         FillShortTxIDSelector();
+
+    if (version < 2)
+        grapheneSetVersion = 0;
+    if (version == 2)
         grapheneSetVersion = 1;
-    }
+    else if (version >= 3)
+        grapheneSetVersion = 2;
 
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -49,10 +49,6 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
         grapheneSetVersion = 1;
     }
 
-    useSipHash = _useSipHash;
-    if (useSipHash)
-        FillShortTxIDSelector();
-
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)
     {
@@ -1351,8 +1347,6 @@ bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom)
 
 void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CMemPoolInfo &mempoolinfo)
 {
-    pfrom->useSipHash = pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED) >= 2;
-
     if (inv.type == MSG_GRAPHENEBLOCK)
     {
         try

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1347,8 +1347,6 @@ bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom)
 
 void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CMemPoolInfo &mempoolinfo)
 {
-    pfrom->useSipHash = pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED) >= 2;
-
     if (inv.type == MSG_GRAPHENEBLOCK)
     {
         try

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -49,7 +49,9 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
         grapheneSetVersion = 1;
     }
 
-    FillShortTxIDSelector();
+    useSipHash = _useSipHash;
+    if (useSipHash)
+        FillShortTxIDSelector();
 
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)
@@ -1349,6 +1351,8 @@ bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom)
 
 void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CMemPoolInfo &mempoolinfo)
 {
+    pfrom->useSipHash = pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED) >= 2;
+
     if (inv.type == MSG_GRAPHENEBLOCK)
     {
         try

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -49,7 +49,9 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
         grapheneSetVersion = 1;
     }
 
-    FillShortTxIDSelector();
+    useSipHash = _useSipHash;
+    if (useSipHash)
+        FillShortTxIDSelector();
 
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)
@@ -1349,6 +1351,8 @@ bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom)
 
 void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CMemPoolInfo &mempoolinfo)
 {
+    pfrom->useSipHash = pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED) >= 2;
+
     if (inv.type == MSG_GRAPHENEBLOCK)
     {
         try
@@ -1521,8 +1525,10 @@ uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &t
 }
 
 // Generate cheap hash from seeds using SipHash
-uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256& txhash) {
-    //return txhash.GetCheapHash();
+uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256& txhash, bool useSipHash) {
+    if (!useSipHash)
+        return txhash.GetCheapHash();
+
     static_assert(SHORTTXIDS_LENGTH == 8, "shorttxids calculation assumes 8-byte shorttxids");
     return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffffL;
 }

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1525,7 +1525,8 @@ uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &t
 }
 
 // Generate cheap hash from seeds using SipHash
-uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256& txhash, bool useSipHash) {
+uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &txhash, bool useSipHash)
+{
     if (!useSipHash)
         return txhash.GetCheapHash();
 

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -49,13 +49,6 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
         grapheneSetVersion = 1;
     }
 
-    version = _version;
-    if (version >= 2)
-    {
-        FillShortTxIDSelector();
-        grapheneSetVersion = 1;
-    }
-
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)
     {

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -67,10 +67,10 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
 
     if (enableCanonicalTxOrder.Value())
         pGrapheneSet = new CGrapheneSet(nReceiverMemPoolTx, nSenderMempoolPlusBlock, blockHashes, shorttxidk0,
-            shorttxidk1, grapheneSetVersion, false);
+            shorttxidk1, grapheneSetVersion, (uint32_t)nonce, false);
     else
         pGrapheneSet = new CGrapheneSet(nReceiverMemPoolTx, nSenderMempoolPlusBlock, blockHashes, shorttxidk0,
-            shorttxidk1, grapheneSetVersion, true);
+            shorttxidk1, grapheneSetVersion, (uint32_t)nonce, true);
 }
 
 CGrapheneBlock::~CGrapheneBlock()
@@ -1520,16 +1520,6 @@ uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &t
     // that the values have not been properly instantiated using FillShortTxIDSelector,
     // but are instead unchanged from the default initialization value.
     DbgAssert(!(shorttxidk0 == 0 && shorttxidk1 == 0), );
-
-    static_assert(SHORTTXIDS_LENGTH == 8, "shorttxids calculation assumes 8-byte shorttxids");
-    return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffffL;
-}
-
-// Generate cheap hash from seeds using SipHash
-uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &txhash, uint64_t grapheneVersion)
-{
-    if (grapheneVersion < 2)
-        return txhash.GetCheapHash();
 
     static_assert(SHORTTXIDS_LENGTH == 8, "shorttxids calculation assumes 8-byte shorttxids");
     return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffffL;

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1347,6 +1347,8 @@ bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom)
 
 void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CMemPoolInfo &mempoolinfo)
 {
+    pfrom->useSipHash = pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED) >= 2;
+
     if (inv.type == MSG_GRAPHENEBLOCK)
     {
         try

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -49,6 +49,8 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
         grapheneSetVersion = 1;
     }
 
+    FillShortTxIDSelector();
+
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)
     {
@@ -1514,6 +1516,13 @@ uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &t
     // but are instead unchanged from the default initialization value.
     DbgAssert(!(shorttxidk0 == 0 && shorttxidk1 == 0), );
 
+    static_assert(SHORTTXIDS_LENGTH == 8, "shorttxids calculation assumes 8-byte shorttxids");
+    return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffffL;
+}
+
+// Generate cheap hash from seeds using SipHash
+uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256& txhash) {
+    //return txhash.GetCheapHash();
     static_assert(SHORTTXIDS_LENGTH == 8, "shorttxids calculation assumes 8-byte shorttxids");
     return SipHashUint256(shorttxidk0, shorttxidk1, txhash) & 0xffffffffffffffL;
 }

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -49,6 +49,8 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
         grapheneSetVersion = 1;
     }
 
+    FillShortTxIDSelector();
+
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)
     {

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -64,10 +64,10 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
 
     if (enableCanonicalTxOrder.Value())
         pGrapheneSet = new CGrapheneSet(nReceiverMemPoolTx, nSenderMempoolPlusBlock, blockHashes, shorttxidk0,
-            shorttxidk1, grapheneSetVersion, (uint32_t)nonce, false);
+            shorttxidk1, grapheneSetVersion, (uint32_t)sipHashNonce, false);
     else
         pGrapheneSet = new CGrapheneSet(nReceiverMemPoolTx, nSenderMempoolPlusBlock, blockHashes, shorttxidk0,
-            shorttxidk1, grapheneSetVersion, (uint32_t)nonce, true);
+            shorttxidk1, grapheneSetVersion, (uint32_t)sipHashNonce, true);
 }
 
 CGrapheneBlock::~CGrapheneBlock()

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -49,9 +49,12 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
         grapheneSetVersion = 1;
     }
 
-    useSipHash = _useSipHash;
-    if (useSipHash)
+    version = _version;
+    if (version >= 2)
+    {
         FillShortTxIDSelector();
+        grapheneSetVersion = 1;
+    }
 
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)
@@ -1351,8 +1354,6 @@ bool ClearLargestGrapheneBlockAndDisconnect(CNode *pfrom)
 
 void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CMemPoolInfo &mempoolinfo)
 {
-    pfrom->useSipHash = pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED) >= 2;
-
     if (inv.type == MSG_GRAPHENEBLOCK)
     {
         try
@@ -1525,9 +1526,9 @@ uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &t
 }
 
 // Generate cheap hash from seeds using SipHash
-uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &txhash, bool useSipHash)
+uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &txhash, uint64_t grapheneVersion)
 {
-    if (!useSipHash)
+    if (grapheneVersion < 2)
         return txhash.GetCheapHash();
 
     static_assert(SHORTTXIDS_LENGTH == 8, "shorttxids calculation assumes 8-byte shorttxids");

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -102,7 +102,14 @@ public:
         if (nBlockTxs > (excessiveBlockSize * maxMessageSizeMultiplier / 100))
             throw std::runtime_error("nBlockTxs exceeds threshold for excessive block txs");
         if (!pGrapheneSet)
-            pGrapheneSet = new CGrapheneSet(version >= 2);
+        {
+            if (version > 2)
+                pGrapheneSet = new CGrapheneSet(2);
+            else if (version == 2)
+                pGrapheneSet = new CGrapheneSet(1);
+            else
+                pGrapheneSet = new CGrapheneSet(0);
+        }
         READWRITE(*pGrapheneSet);
     }
     uint64_t GetAdditionalTxSerializationSize()

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -20,6 +20,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
     uint64_t _shorttxidk0,
     uint64_t _shorttxidk1,
     uint64_t _version,
+    uint32_t ibltEntropy,
     bool _ordered,
     bool fDeterministic)
 {
@@ -30,6 +31,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
 
     shorttxidk0 = _shorttxidk0;
     shorttxidk1 = _shorttxidk1;
+    ibltSalt = ibltEntropy % CIblt::MaxNHash();
     version = _version;
 
     // Below is the parameter "n" from the graphene paper
@@ -79,7 +81,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
 
     // Construct IBLT
     uint64_t nIbltCells = std::max((int)IBLT_CELL_MINIMUM, (int)ceil(optSymDiff));
-    pSetIblt = new CIblt(nIbltCells);
+    pSetIblt = new CIblt(nIbltCells, ibltSalt, version >= 2);
     std::map<uint64_t, uint256> mapCheapHashes;
 
     LOG(GRAPHENE, "constructed IBLT with %d cells\n", nIbltCells);

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -31,7 +31,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
 
     shorttxidk0 = _shorttxidk0;
     shorttxidk1 = _shorttxidk1;
-    ibltSalt = ibltEntropy % CIblt::MaxNHash();
+    ibltSalt = ibltEntropy % (uint8_t)std::max(1, (int)CIblt::MaxNHash());
     version = _version;
 
     // Below is the parameter "n" from the graphene paper

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -31,7 +31,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
 
     shorttxidk0 = _shorttxidk0;
     shorttxidk1 = _shorttxidk1;
-    ibltSalt = ibltEntropy % (uint8_t)std::max(1, (int)CIblt::MaxNHash());
+    ibltSalt = ibltEntropy;
     version = _version;
 
     // Below is the parameter "n" from the graphene paper

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -33,7 +33,6 @@ const float IBLT_DEFAULT_OVERHEAD = 1.5;
 class CGrapheneSet
 {
 private:
-    mutable uint64_t shorttxidk0, shorttxidk1;
     bool ordered;
     uint64_t nReceiverUniverseItems;
     mutable uint64_t shorttxidk0, shorttxidk1;
@@ -159,8 +158,6 @@ public:
         }
         if (nReceiverUniverseItems > LARGE_MEM_POOL_SIZE)
             throw std::runtime_error("nReceiverUniverseItems exceeds threshold for excessive mempool size");
-        READWRITE(shorttxidk0);
-        READWRITE(shorttxidk1);
         READWRITE(encodedRank);
         if (!pSetFilter)
             pSetFilter = new CBloomFilter();

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -37,6 +37,7 @@ private:
     uint64_t nReceiverUniverseItems;
     mutable uint64_t shorttxidk0, shorttxidk1;
     uint64_t version;
+    uint32_t ibltSalt;
     std::vector<unsigned char> encodedRank;
     CBloomFilter *pSetFilter;
     CIblt *pSetIblt;
@@ -56,12 +57,12 @@ private:
 public:
     // The default constructor is for 2-phase construction via deserialization
     CGrapheneSet()
-        : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), version(1), pSetFilter(nullptr),
-          pSetIblt(nullptr)
+        : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), version(1), ibltSalt(0),
+          pSetFilter(nullptr), pSetIblt(nullptr)
     {
     }
     CGrapheneSet(uint64_t _version)
-        : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), pSetFilter(nullptr),
+        : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), ibltSalt(0), pSetFilter(nullptr),
           pSetIblt(nullptr)
     {
         version = _version;
@@ -71,7 +72,8 @@ public:
         const std::vector<uint256> &_itemHashes,
         uint64_t _shorttxidk0,
         uint64_t _shorttxidk1,
-        uint64_t _version,
+        uint64_t _version = 1,
+        uint32_t ibltEntropy = 0,
         bool _ordered = false,
         bool fDeterministic = false);
 
@@ -156,6 +158,8 @@ public:
             READWRITE(shorttxidk0);
             READWRITE(shorttxidk1);
         }
+        if (version >= 2)
+            READWRITE(ibltSalt);
         if (nReceiverUniverseItems > LARGE_MEM_POOL_SIZE)
             throw std::runtime_error("nReceiverUniverseItems exceeds threshold for excessive mempool size");
         READWRITE(encodedRank);

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -33,6 +33,7 @@ const float IBLT_DEFAULT_OVERHEAD = 1.5;
 class CGrapheneSet
 {
 private:
+    mutable uint64_t shorttxidk0, shorttxidk1;
     bool ordered;
     uint64_t nReceiverUniverseItems;
     mutable uint64_t shorttxidk0, shorttxidk1;
@@ -158,6 +159,8 @@ public:
         }
         if (nReceiverUniverseItems > LARGE_MEM_POOL_SIZE)
             throw std::runtime_error("nReceiverUniverseItems exceeds threshold for excessive mempool size");
+        READWRITE(shorttxidk0);
+        READWRITE(shorttxidk1);
         READWRITE(encodedRank);
         if (!pSetFilter)
             pSetFilter = new CBloomFilter();

--- a/src/iblt.cpp
+++ b/src/iblt.cpp
@@ -143,8 +143,13 @@ void CIblt::resize(size_t _expectedNumEntries)
 
 uint32_t CIblt::saltedHashValue(size_t hashFuncIdx, const std::vector<uint8_t> &kvec) const
 {
-    uint32_t seed = mapHashIdxSeeds.at(hashFuncIdx);
-    return MurmurHash3(seed, kvec) & KEYCHECK_MASK;
+    if (version > 0)
+    {
+        uint32_t seed = mapHashIdxSeeds.at(hashFuncIdx);
+        return MurmurHash3(seed, kvec) & KEYCHECK_MASK;
+    }
+    else
+        return MurmurHash3(hashFuncIdx, kvec);
 }
 
 void CIblt::_insert(int plusOrMinus, uint64_t k, const std::vector<uint8_t> &v)

--- a/src/iblt.cpp
+++ b/src/iblt.cpp
@@ -91,20 +91,32 @@ CIblt::CIblt()
     version = 0;
 }
 
-CIblt::CIblt(size_t _expectedNumEntries) : version(0), n_hash(0), is_modified(false), salt(0)
+CIblt::CIblt(uint64_t _version)
 {
+    salt = 0;
+    n_hash = 1;
+    is_modified = false;
+
+    CIblt::version = _version;
+}
+
+CIblt::CIblt(size_t _expectedNumEntries, uint64_t _version) : n_hash(0), is_modified(false), salt(0)
+{
+    CIblt::version = _version;
     CIblt::resize(_expectedNumEntries);
 }
 
-CIblt::CIblt(size_t _expectedNumEntries, uint32_t _salt) : version(0), n_hash(0), is_modified(false)
+CIblt::CIblt(size_t _expectedNumEntries, uint32_t _salt, uint64_t _version) : n_hash(0), is_modified(false)
 {
+    CIblt::version = _version;
     CIblt::salt = _salt;
     CIblt::resize(_expectedNumEntries);
 }
 
-CIblt::CIblt(const CIblt &other) : version(0), n_hash(0), is_modified(false)
+CIblt::CIblt(const CIblt &other) : n_hash(0), is_modified(false)
 {
     salt = other.salt;
+    version = other.version;
     n_hash = other.n_hash;
     hashTable = other.hashTable;
     mapHashIdxSeeds = other.mapHashIdxSeeds;
@@ -351,3 +363,15 @@ std::string CIblt::DumpTable() const
 
 size_t CIblt::OptimalNHash(size_t expectedNumEntries) { return CIbltParams::Lookup(expectedNumEntries).numhashes; }
 float CIblt::OptimalOverhead(size_t expectedNumEntries) { return CIbltParams::Lookup(expectedNumEntries).overhead; }
+uint8_t CIblt::MaxNHash()
+{
+    uint8_t maxHashes = 4;
+
+    for (auto &pair : CIbltParams::paramMap)
+    {
+        if (pair.second.numhashes > maxHashes)
+            maxHashes = pair.second.numhashes;
+    }
+
+    return maxHashes;
+}

--- a/src/iblt.cpp
+++ b/src/iblt.cpp
@@ -138,12 +138,9 @@ void CIblt::resize(size_t _expectedNumEntries)
 
     CIblt::n_hash = OptimalNHash(_expectedNumEntries);
 
-    if (salt > VALS_32 / n_hash)
-        throw std::runtime_error("salt * n_hash must fit in uint32_t");
-
     // set hash seeds from salt
     for (size_t i = 0; i < n_hash; i++)
-        mapHashIdxSeeds[i] = salt * n_hash + i;
+        mapHashIdxSeeds[i] = salt % (0xffffffff - n_hash) + i;
 
     // reduce probability of failure by increasing by overhead factor
     size_t nEntries = (size_t)(_expectedNumEntries * OptimalOverhead(_expectedNumEntries));

--- a/src/iblt.cpp
+++ b/src/iblt.cpp
@@ -155,7 +155,7 @@ uint32_t CIblt::saltedHashValue(size_t hashFuncIdx, const std::vector<uint8_t> &
     if (version > 0)
     {
         uint32_t seed = mapHashIdxSeeds.at(hashFuncIdx);
-        return MurmurHash3(seed, kvec) & KEYCHECK_MASK;
+        return MurmurHash3(seed, kvec);
     }
     else
         return MurmurHash3(hashFuncIdx, kvec);

--- a/src/iblt.h
+++ b/src/iblt.h
@@ -152,6 +152,8 @@ public:
 protected:
     void _insert(int plusOrMinus, uint64_t k, const std::vector<uint8_t> &v);
 
+    // This salt is used to seed the IBLT hash functions. When its value (passed in via constructor)
+    // is derived from a pseudo-random value, the IBLT hash functions themselves become randomized.
     uint32_t salt;
     uint64_t version;
     uint8_t n_hash;

--- a/src/iblt.h
+++ b/src/iblt.h
@@ -122,9 +122,12 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
-        READWRITE(salt);
-        if (salt > VALS_32 / n_hash)
-            throw std::ios_base::failure("salt * n_hash must fit in uint32_t");
+        if (version > 0)
+        {
+            READWRITE(salt);
+            if (salt > VALS_32 / n_hash)
+                throw std::ios_base::failure("salt * n_hash must fit in uint32_t");
+        }
 
         READWRITE(COMPACTSIZE(version));
         if (ser_action.ForRead() && version != 0)

--- a/src/iblt.h
+++ b/src/iblt.h
@@ -29,8 +29,6 @@ SOFTWARE.
 #include <set>
 #include <vector>
 
-static const size_t VALS_32 = 4294967295;
-
 //
 // Invertible Bloom Lookup Table implementation
 // References:
@@ -77,7 +75,7 @@ public:
     // Pass the expected number of entries in the IBLT table. If the number of entries exceeds
     // the expected, then the decode failure rate will increase dramatically.
     CIblt(size_t _expectedNumEntries, uint64_t _version);
-    // IBLTs with different salts are guaranteed to use different hash functions.
+    // The salt value is used to create a distinct hash seed for each hash function.
     CIblt(size_t _expectedNumEntries, uint32_t salt, uint64_t _version);
     // Copy constructor
     CIblt(const CIblt &other);
@@ -131,8 +129,6 @@ public:
         {
             READWRITE(mapHashIdxSeeds);
             READWRITE(salt);
-            if (salt > VALS_32 / n_hash)
-                throw std::ios_base::failure("salt * n_hash must fit in uint32_t");
         }
 
         if (ser_action.ForRead() && version > 1)

--- a/src/net.h
+++ b/src/net.h
@@ -489,14 +489,6 @@ public:
     int grapheneBlockWaitingForTxns; // if -1 then not currently waiting
     CCriticalSection cs_grapheneadditionaltxs; // lock grapheneAdditionalTxs
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
-    uint64_t shorttxidk0; // Used for generating cheap hash from SipHash
-    uint64_t shorttxidk1;
-
-    std::atomic<double> nGetGrapheneBlockTxCount; // Count how many get_xblocktx requests are made
-    std::atomic<uint64_t> nGetGrapheneBlockTxLastTime; // The last time a get_xblocktx request was made
-    std::atomic<double> nGetGrapheneCount; // Count how many get_graphene requests are made
-    std::atomic<uint64_t> nGetGrapheneLastTime; // The last time a get_graphene request was made
-    uint32_t nGrapheneBloomfilterSize; // The maximum graphene bloom filter size (in bytes) that our peer will accept.
     uint64_t gr_shorttxidk0;
     uint64_t gr_shorttxidk1;
     // BUIPXXX Graphene blocks: end section

--- a/src/net.h
+++ b/src/net.h
@@ -489,6 +489,13 @@ public:
     int grapheneBlockWaitingForTxns; // if -1 then not currently waiting
     CCriticalSection cs_grapheneadditionaltxs; // lock grapheneAdditionalTxs
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
+    uint64_t shorttxidk0; // Used for generating cheap hash from SipHash
+    uint64_t shorttxidk1;
+
+    std::atomic<double> nGetGrapheneBlockTxCount; // Count how many get_xblocktx requests are made
+    std::atomic<uint64_t> nGetGrapheneBlockTxLastTime; // The last time a get_xblocktx request was made
+    std::atomic<double> nGetGrapheneCount; // Count how many get_graphene requests are made
+    std::atomic<uint64_t> nGetGrapheneLastTime; // The last time a get_graphene request was made
     uint32_t nGrapheneBloomfilterSize; // The maximum graphene bloom filter size (in bytes) that our peer will accept.
     uint64_t gr_shorttxidk0;
     uint64_t gr_shorttxidk1;

--- a/src/net.h
+++ b/src/net.h
@@ -491,7 +491,6 @@ public:
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
     uint64_t shorttxidk0; // Used for generating cheap hash from SipHash
     uint64_t shorttxidk1;
-    bool useSipHash;
 
     std::atomic<double> nGetGrapheneBlockTxCount; // Count how many get_xblocktx requests are made
     std::atomic<uint64_t> nGetGrapheneBlockTxLastTime; // The last time a get_xblocktx request was made

--- a/src/net.h
+++ b/src/net.h
@@ -491,6 +491,7 @@ public:
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
     uint64_t shorttxidk0; // Used for generating cheap hash from SipHash
     uint64_t shorttxidk1;
+    bool useSipHash;
 
     std::atomic<double> nGetGrapheneBlockTxCount; // Count how many get_xblocktx requests are made
     std::atomic<uint64_t> nGetGrapheneBlockTxLastTime; // The last time a get_xblocktx request was made

--- a/src/net.h
+++ b/src/net.h
@@ -489,13 +489,6 @@ public:
     int grapheneBlockWaitingForTxns; // if -1 then not currently waiting
     CCriticalSection cs_grapheneadditionaltxs; // lock grapheneAdditionalTxs
     std::vector<CTransactionRef> grapheneAdditionalTxs; // entire transactions included in graphene block
-    uint64_t shorttxidk0; // Used for generating cheap hash from SipHash
-    uint64_t shorttxidk1;
-
-    std::atomic<double> nGetGrapheneBlockTxCount; // Count how many get_xblocktx requests are made
-    std::atomic<uint64_t> nGetGrapheneBlockTxLastTime; // The last time a get_xblocktx request was made
-    std::atomic<double> nGetGrapheneCount; // Count how many get_graphene requests are made
-    std::atomic<uint64_t> nGetGrapheneLastTime; // The last time a get_graphene request was made
     uint32_t nGrapheneBloomfilterSize; // The maximum graphene bloom filter size (in bytes) that our peer will accept.
     uint64_t gr_shorttxidk0;
     uint64_t gr_shorttxidk1;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -532,7 +532,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         CXVersionMessage xver;
         xver.set_u64c(XVer::BU_LISTEN_PORT, GetListenPort());
         xver.set_u64c(XVer::BU_MSG_IGNORE_CHECKSUM, 1); // we will ignore 0 value msg checksums
-        xver.set_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED, 2);
+        xver.set_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED, 3);
         xver.set_u64c(XVer::BU_XTHIN_VERSION, 2); // xthin version
         pfrom->PushMessage(NetMsgType::XVERSION, xver);
 

--- a/src/test/graphene_tests.cpp
+++ b/src/test/graphene_tests.cpp
@@ -183,7 +183,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_approx_opt_close_to_optimal)
     float totalBytesBrute =
         (float)ProjectedGrapheneSizeBytes(n, m - mu, grapheneSet.BruteForceSymDiff(n, m, m - mu, 0));
 
-    BOOST_CHECK_CLOSE(totalBytesApprox, totalBytesBrute, 10);
+    BOOST_CHECK_CLOSE(totalBytesApprox, totalBytesBrute, 15);
 }
 
 BOOST_AUTO_TEST_CASE(graphene_set_decodes_empty_intersection)

--- a/src/test/iblt_tests.cpp
+++ b/src/test/iblt_tests.cpp
@@ -23,10 +23,11 @@ BOOST_FIXTURE_TEST_SUITE(iblt_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(iblt_handles_small_quantities)
 {
+    uint64_t version = 0;
 	bool allPassed = true;
 	for (size_t nItems=1;nItems < 100;nItems++)
 	{
-		CIblt t(nItems);
+		CIblt t(nItems, version);
 
 		for (size_t i=0;i < nItems;i++)
 			t.insert(i, IBLT_NULL_VALUE);
@@ -41,8 +42,9 @@ BOOST_AUTO_TEST_CASE(iblt_handles_small_quantities)
 BOOST_AUTO_TEST_CASE(iblt_arbitrary_salt)
 {
     uint32_t salt = 17;
+    uint64_t version = 1;
     size_t nItems = 2;
-    CIblt t(nItems, salt);
+    CIblt t(nItems, salt, version);
 
     t.insert(0, ParseHex("00000000"));
     t.insert(1, ParseHex("00000001"));
@@ -60,9 +62,10 @@ BOOST_AUTO_TEST_CASE(iblt_salted_reset)
 {
     size_t nHash = 1;
     uint32_t salt = 17;
+    uint64_t version = 1;
     bool gotResult;
     std::vector<uint8_t> result;
-    CIblt t(nHash, salt);
+    CIblt t(nHash, salt, version);
 
     t.insert(0, ParseHex("00000000"));
     gotResult = t.get(0, result);
@@ -112,7 +115,8 @@ BOOST_AUTO_TEST_CASE(iblt_reset)
 
 BOOST_AUTO_TEST_CASE(iblt_erases_properly)
 {
-    CIblt t(20);
+    uint64_t version = 0;
+    CIblt t(20, version);
     t.insert(0, ParseHex("00000000"));
     t.insert(1, ParseHex("00000001"));
     t.insert(11, ParseHex("00000011"));
@@ -149,7 +153,8 @@ BOOST_AUTO_TEST_CASE(iblt_erases_properly)
 
 BOOST_AUTO_TEST_CASE(iblt_handles_overload)
 {
-    CIblt t(20);
+    uint64_t version = 0;
+    CIblt t(20, version);
 
     // 1,000 values in an IBLT that has room for 20,
     // all lookups should fail.
@@ -179,8 +184,9 @@ BOOST_AUTO_TEST_CASE(iblt_handles_overload)
 
 BOOST_AUTO_TEST_CASE(iblt_lists_entries_properly)
 {
+    uint64_t version = 0;
     std::set<std::pair<uint64_t, std::vector<uint8_t> > > expected;
-    CIblt t(20);
+    CIblt t(20, version);
     for (int i = 0; i < 20; i++)
     {
         t.insert(i, PseudoRandomValue(i * 2));
@@ -193,8 +199,9 @@ BOOST_AUTO_TEST_CASE(iblt_lists_entries_properly)
 
 BOOST_AUTO_TEST_CASE(iblt_performs_subtraction_properly)
 {
-    CIblt t1(11);
-    CIblt t2(11);
+    uint64_t version = 0;
+    CIblt t1(11, version);
+    CIblt t2(11, version);
 
     for (int i = 0; i < 195; i++)
     {
@@ -230,7 +237,7 @@ BOOST_AUTO_TEST_CASE(iblt_performs_subtraction_properly)
     BOOST_CHECK(negative == expectedPositive);
 
 
-    CIblt emptyIBLT(11);
+    CIblt emptyIBLT(11, version);
     std::set<std::pair<uint64_t, std::vector<uint8_t> > > emptySet;
 
     // Test edge cases for empty IBLT:

--- a/src/test/iblt_tests.cpp
+++ b/src/test/iblt_tests.cpp
@@ -38,6 +38,45 @@ BOOST_AUTO_TEST_CASE(iblt_handles_small_quantities)
 	BOOST_CHECK(allPassed);
 }
 
+BOOST_AUTO_TEST_CASE(iblt_arbitrary_salt)
+{
+    uint32_t salt = 17;
+    size_t nItems = 2;
+    CIblt t(nItems, salt);
+
+    t.insert(0, ParseHex("00000000"));
+    t.insert(1, ParseHex("00000001"));
+    bool gotResult;
+    std::vector<uint8_t> result;
+
+    gotResult = t.get(0, result);
+    BOOST_CHECK(gotResult && result == ParseHex("00000000"));
+
+    gotResult = t.get(1, result);
+    BOOST_CHECK(gotResult && result == ParseHex("00000001"));
+}
+
+BOOST_AUTO_TEST_CASE(iblt_salted_reset)
+{
+    size_t nHash = 1;
+    uint32_t salt = 17;
+    bool gotResult;
+    std::vector<uint8_t> result;
+    CIblt t(nHash, salt);
+
+    t.insert(0, ParseHex("00000000"));
+    gotResult = t.get(0, result);
+    BOOST_CHECK(gotResult && result == ParseHex("00000000"));
+
+    t.reset();
+    t.resize(20);
+    t.insert(1, ParseHex("00000001"));
+    t.insert(11, ParseHex("00000011"));
+
+    gotResult = t.get(1, result);
+    BOOST_CHECK(gotResult && result == ParseHex("00000001"));
+}
+
 BOOST_AUTO_TEST_CASE(iblt_reset)
 {
     CIblt t;


### PR DESCRIPTION
Previously, in the construction of a CGrapheneSet, the ith hash function operating on input x always evaluated to the same value across all instantiations. This is undesirable because IBLT decode failures, which are pseudo-random, have the potential to occur for multiple peers when reconciling the same block.

The present PR adds the ability to pass the CIblt object an arbitrary 32-bit salt value. This salt is used to seed the IBLT hash functions. For entropy, we use the random nonce created by the Graphene block sender when seeding the SipHash used for Graphene cheap hashes.