### PR TITLE
Assert proper object type for univalue push_back and pushKV when debug enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1102,6 +1102,9 @@ unset PKG_CONFIG_LIBDIR
 PKG_CONFIG_LIBDIR="$PKGCONFIG_LIBDIR_TEMP"
 
 ac_configure_args="${ac_configure_args} --disable-shared --with-pic --with-bignum=no --enable-module-recovery --disable-jni"
+if test "x$enable_debug" = xyes; then
+    ac_configure_args="${ac_configure_args} --enable-debug"
+fi
 AC_CONFIG_SUBDIRS([src/secp256k1 src/univalue])
 
 AC_OUTPUT

--- a/src/univalue/configure.ac
+++ b/src/univalue/configure.ac
@@ -2,7 +2,7 @@ m4_define([libunivalue_major_version], [1])
 m4_define([libunivalue_minor_version], [1])
 m4_define([libunivalue_micro_version], [3])
 m4_define([libunivalue_interface_age], [3])
-# If you need a modifier for the version number. 
+# If you need a modifier for the version number.
 # Normally empty, but can be used to make "fixup" releases.
 m4_define([libunivalue_extraversion], [])
 
@@ -45,6 +45,17 @@ AC_SUBST(LIBUNIVALUE_AGE)
 LT_INIT
 LT_LANG([C++])
 
+# Enable debug
+AC_ARG_ENABLE([debug],
+    [AS_HELP_STRING([--enable-debug],
+                    [use debug compiler flags and macros (default is no)])],
+    [enable_debug=$enableval],
+    [enable_debug=no])
+
+if test "x$enable_debug" = xyes; then
+    CPPFLAGS="$CPPFLAGS -DDEBUG"
+fi
+
 case $host in
   *mingw*)
     LIBTOOL_APP_LDFLAGS="$LIBTOOL_APP_LDFLAGS -all-static"
@@ -66,4 +77,3 @@ AC_CONFIG_FILES([
 AC_SUBST(LIBTOOL_APP_LDFLAGS)
 AC_SUBST(BUILD_EXEEXT)
 AC_OUTPUT
-

--- a/src/univalue/lib/univalue.cpp
+++ b/src/univalue/lib/univalue.cpp
@@ -107,16 +107,28 @@ bool UniValue::setObject()
 
 bool UniValue::push_back(const UniValue& val_)
 {
+#ifdef DEBUG
     assert(typ == VARR);
-
+#else
+    if (typ != VARR)
+    {
+        return false;
+    }
+#endif
     values.push_back(val_);
     return true;
 }
 
 bool UniValue::push_backV(const std::vector<UniValue>& vec)
 {
+#ifdef DEBUG
     assert(typ == VARR);
-
+#else
+    if (typ != VARR)
+    {
+        return false;
+    }
+#endif
     values.insert(values.end(), vec.begin(), vec.end());
 
     return true;
@@ -130,8 +142,14 @@ void UniValue::__pushKV(const std::string& key, const UniValue& val_)
 
 bool UniValue::pushKV(const std::string& key, const UniValue& val_)
 {
+#ifdef DEBUG
     assert(typ == VOBJ);
-
+#else
+    if (typ != VOBJ)
+    {
+        return false;
+    }
+#endif
     size_t idx;
     if (findKey(key, idx))
         values[idx] = val_;
@@ -142,8 +160,14 @@ bool UniValue::pushKV(const std::string& key, const UniValue& val_)
 
 bool UniValue::pushKVs(const UniValue& obj)
 {
+#ifdef DEBUG
     assert(typ == VOBJ && obj.typ == VOBJ);
-
+#else
+    if (typ != VOBJ || obj.typ != VOBJ)
+    {
+        return false;
+    }
+#endif
     for (size_t i = 0; i < obj.keys.size(); i++)
         __pushKV(obj.keys[i], obj.values.at(i));
 

--- a/src/univalue/lib/univalue.cpp
+++ b/src/univalue/lib/univalue.cpp
@@ -107,8 +107,7 @@ bool UniValue::setObject()
 
 bool UniValue::push_back(const UniValue& val_)
 {
-    if (typ != VARR)
-        return false;
+    assert(typ == VARR);
 
     values.push_back(val_);
     return true;
@@ -116,8 +115,7 @@ bool UniValue::push_back(const UniValue& val_)
 
 bool UniValue::push_backV(const std::vector<UniValue>& vec)
 {
-    if (typ != VARR)
-        return false;
+    assert(typ == VARR);
 
     values.insert(values.end(), vec.begin(), vec.end());
 
@@ -132,8 +130,7 @@ void UniValue::__pushKV(const std::string& key, const UniValue& val_)
 
 bool UniValue::pushKV(const std::string& key, const UniValue& val_)
 {
-    if (typ != VOBJ)
-        return false;
+    assert(typ == VOBJ);
 
     size_t idx;
     if (findKey(key, idx))
@@ -145,8 +142,7 @@ bool UniValue::pushKV(const std::string& key, const UniValue& val_)
 
 bool UniValue::pushKVs(const UniValue& obj)
 {
-    if (typ != VOBJ || obj.typ != VOBJ)
-        return false;
+    assert(typ == VOBJ && obj.typ == VOBJ);
 
     for (size_t i = 0; i < obj.keys.size(); i++)
         __pushKV(obj.keys[i], obj.values.at(i));
@@ -239,4 +235,3 @@ const UniValue& find_value(const UniValue& obj, const std::string& name)
 
     return NullUniValue;
 }
-


### PR DESCRIPTION
We never wrap our push_back or pushKV functions in if statements to check if we are accidentally calling them on the wrong type. If we do call them on the wrong type the rpc call wont fail it will instead return partial or no data. Asserting here is simpler than going back through the rpc code and adding checks on everything. 