### PR TITLE
Avoid clearing thintype block data in parallel.cpp

### DIFF
--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -78,7 +78,8 @@ bool CGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
 
     // Message consistency checking
     CInv inv(MSG_GRAPHENEBLOCK, grapheneBlockTx.blockhash);
-    if (grapheneBlockTx.vMissingTx.empty() || grapheneBlockTx.blockhash.IsNull())
+    if (grapheneBlockTx.vMissingTx.empty() || grapheneBlockTx.blockhash.IsNull() ||
+        pfrom->grapheneBlockHashes.size() < grapheneBlockTx.vMissingTx.size())
     {
         graphenedata.ClearGrapheneBlockData(pfrom, inv.hash);
 

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -639,9 +639,9 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, CBlockRef p
     // either of the former.  Therefore we have to remove the thin or graphene block in flight if it
     // exists and we also need to check that the block didn't arrive from some other peer.
     {
-        // Clear thinblock data and thinblock in flight
-        thindata.ClearThinBlockData(pfrom, inv.hash);
-        graphenedata.ClearGrapheneBlockData(pfrom, inv.hash);
+        // Remove thinblock data and thinblock in flight
+        thinrelay.ClearThinTypeBlockInFlight(pfrom, inv.hash);
+        thinrelay.ClearThinTypeBlockInFlight(pfrom, inv.hash);
 
         pfrom->firstBlock += 1;
     }

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -641,7 +641,6 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, CBlockRef p
     {
         // Remove thinblock data and thinblock in flight
         thinrelay.ClearThinTypeBlockInFlight(pfrom, inv.hash);
-        thinrelay.ClearThinTypeBlockInFlight(pfrom, inv.hash);
 
         pfrom->firstBlock += 1;
     }


### PR DESCRIPTION
Currently, parallel.py suffers from an intermittent failure due to a segfault in `CGrapheneBlockTx::HandleMessage`. The problem is that the size of `grapheneBlockHashes` is expected to always be at least as large as the size of `grapheneBlockTx.vMissingTx`, but this is not the case when Graphene block data is cleared while a Graphene block is in-flight. 

The fix presented here is to first eliminate the statements in parallel.cpp that clear Graphene and XThin block data, and instead clear their in-flight status in thinrelay. Additionally, this commit adds a sanity check `CGrapheneBlockTx::HandleMessage` to abort a Graphene download if ever `grapheneBlockHashes.size() < grapheneBlockTx.vMissingTx.size()`.