### PR TITLE
Reset default -g -O2 flags when enable debug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -242,6 +242,12 @@ AX_CHECK_COMPILE_FLAG([-Werror],[CXXFLAG_WERROR="-Werror"],[CXXFLAG_WERROR=""])
 
 if test "x$enable_debug" = xyes; then
     CPPFLAGS="$CPPFLAGS -DDEBUG -DDEBUG_LOCKORDER"
+
+    # Clear default -g -O2 flags
+    if test "x$CXXFLAGS_overridden" = xno; then
+        CXXFLAGS=""
+    fi
+
     if test "x$GCC" = xyes; then
         CFLAGS="$CFLAGS -g3 -O0"
     fi


### PR DESCRIPTION
9882d1f0 Reset default -g -O2 flags when enable debug (Chun Kuan Lee)

Pull request description:

  The default CXXFLAGS is -g -O2, this should not appear when enable debug.
  fixes #13432

Tree-SHA512: 79447f3e1fab9e6cd12f5ca49b3d42187e856e0c159ed01140ea93d6ef1fbb1af3d65b338308566330491052c0177d12abe26796513502ddde31692665a0dbb4

This is a port of core PR #13445

To test the patch run ./autogen.sh && ./configure --enable-debug then check that CXXFLAGS starts with "-g3 -O0" and does not contain "-O2`

That will make you so that we not going to have variable values optimized in gdb back trace.