### PR TITLE
add HasData() methods to CTransaction

### DIFF
--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -165,7 +165,7 @@ size_t CTransaction::GetTxSize() const
 
 bool CTransaction::HasData()
 {
-    for (auto out : vout)
+    for (auto &out : vout)
     {
         if ((out.scriptPubKey.size() >= 1) && (out.scriptPubKey[0] == OP_RETURN))
             return true;
@@ -175,7 +175,7 @@ bool CTransaction::HasData()
 
 bool CTransaction::HasData(uint32_t dataID)
 {
-    for (auto out : vout)
+    for (auto &out : vout)
     {
         if ((out.scriptPubKey.size() >= 6) && (out.scriptPubKey[0] == OP_RETURN) &&
             (out.scriptPubKey[1] == 4)) // IDs must be 4 bytes so check that the pushdata opcode is correct

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -161,3 +161,29 @@ size_t CTransaction::GetTxSize() const
         nTxSize = ::GetSerializeSize(*this, SER_NETWORK, CTransaction::CURRENT_VERSION);
     return nTxSize;
 }
+
+
+bool CTransaction::HasData()
+{
+    for (auto out : vout)
+    {
+        if ((out.scriptPubKey.size() >= 1) && (out.scriptPubKey[0] == OP_RETURN))
+            return true;
+    }
+    return false;
+}
+
+bool CTransaction::HasData(uint32_t dataID)
+{
+    for (auto out : vout)
+    {
+        if ((out.scriptPubKey.size() >= 6) && (out.scriptPubKey[0] == OP_RETURN) &&
+            (out.scriptPubKey[1] == 4)) // IDs must be 4 bytes so check that the pushdata opcode is correct
+        {
+            uint32_t thisProto = ReadLE32(&out.scriptPubKey[2]);
+            if (thisProto == dataID)
+                return true;
+        }
+    }
+    return false;
+}

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -232,6 +232,12 @@ public:
     // True if only scriptSigs are different
     bool IsEquivalentTo(const CTransaction &tx) const;
 
+    //* Return true if this transaction contains at least one OP_RETURN output.
+    bool HasData();
+    //* Return true if this transaction contains at least one OP_RETURN output, with the specified data ID
+    // the data ID is defined as a 4 byte pushdata containing a little endian 4 byte integer.
+    bool HasData(uint32_t dataID);
+
     // Return sum of txouts.
     CAmount GetValueOut() const;
     // GetValueIn() is a method on CCoinsViewCache, because


### PR DESCRIPTION
These methods return whether a transaction has OP_RETURN data fields, and whether at least one of those fields match the passed OP_RETURN protocol id following the spec defined here: https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/op_return-prefix-guideline.md