### PR TITLE
Refactor Xthin data out of CNode

### DIFF
--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -247,21 +247,21 @@ void ThinTypeRelay::RequestBlock(CNode *pfrom, const uint256 &hash)
     pfrom->PushMessage(NetMsgType::GETDATA, vGetData);
 }
 
-std::shared_ptr<CBlock_ThinRelay> ThinTypeRelay::SetBlockToReconstruct(CNode *pfrom, const uint256 &hash)
+std::shared_ptr<CBlockThinRelay> ThinTypeRelay::SetBlockToReconstruct(CNode *pfrom, const uint256 &hash)
 {
     // Make sure we are starting with a fresh instance.
     LOCK(cs_reconstruct);
     ClearBlockToReconstruct(pfrom);
 
     // Store and empty block which can be used later
-    std::shared_ptr<CBlock_ThinRelay> pblock;
-    pblock = std::make_shared<CBlock_ThinRelay>(CBlock_ThinRelay());
+    std::shared_ptr<CBlockThinRelay> pblock;
+    pblock = std::make_shared<CBlockThinRelay>(CBlockThinRelay());
     mapBlocksReconstruct.insert(
         std::make_pair(pfrom->GetId(), std::make_pair(pblock->GetBlockHeader().GetHash(), pblock)));
     return pblock;
 }
 
-std::shared_ptr<CBlock_ThinRelay> ThinTypeRelay::GetBlockToReconstruct(CNode *pfrom)
+std::shared_ptr<CBlockThinRelay> ThinTypeRelay::GetBlockToReconstruct(CNode *pfrom)
 {
     // Retrieve a current instance of a block being reconstructed. This is typically used
     // when we have received the response of a re-request for more transactions.

--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -272,7 +272,7 @@ std::shared_ptr<CBlock_ThinRelay> ThinTypeRelay::GetBlockToReconstruct(CNode *pf
         return iter->second.second;
     }
     else
-        return std::shared_ptr<CBlock_ThinRelay>{};
+        return nullptr;
 }
 
 void ThinTypeRelay::ClearBlockToReconstruct(CNode *pfrom)

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -12,7 +12,7 @@
 
 class CNode;
 class uint256;
-class CBlock_ThinRelay;
+class CBlockThinRelay;
 
 struct CThinTypeBlockInFlight
 {
@@ -37,7 +37,7 @@ private:
     std::multimap<const NodeId, CThinTypeBlockInFlight> mapThinTypeBlocksInFlight GUARDED_BY(cs_inflight);
 
     // blocks that are currently being reconstructed.
-    std::map<NodeId, std::pair<uint256, std::shared_ptr<CBlock_ThinRelay> > > mapBlocksReconstruct GUARDED_BY(
+    std::map<NodeId, std::pair<uint256, std::shared_ptr<CBlockThinRelay> > > mapBlocksReconstruct GUARDED_BY(
         cs_reconstruct);
 
     // put a cap on the total number of thin type blocks we can have in flight. This lowers any possible
@@ -66,8 +66,8 @@ public:
 
     // Accessor methods to the blocks that we're reconstructing from thintype blocks such as
     // xthins or graphene.
-    std::shared_ptr<CBlock_ThinRelay> SetBlockToReconstruct(CNode *pfrom, const uint256 &hash);
-    std::shared_ptr<CBlock_ThinRelay> GetBlockToReconstruct(CNode *pfrom);
+    std::shared_ptr<CBlockThinRelay> SetBlockToReconstruct(CNode *pfrom, const uint256 &hash);
+    std::shared_ptr<CBlockThinRelay> GetBlockToReconstruct(CNode *pfrom);
     void ClearBlockToReconstruct(CNode *pfrom);
 };
 extern ThinTypeRelay thinrelay;

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -170,7 +170,7 @@ bool CGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     size_t idx = 0;
     for (const CTransaction &tx : grapheneBlockTx.vMissingTx)
     {
-        pfrom->mapMissingTx[GetShortID(pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, tx.GetHash(),
+        pfrom->mapGrapheneMissingTx[GetShortID(pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, tx.GetHash(),
             NegotiateGrapheneVersion(pfrom))] = MakeTransactionRef(tx);
 
         uint256 hash = tx.GetHash();
@@ -645,7 +645,7 @@ bool CGrapheneBlock::process(CNode *pfrom,
     pfrom->grapheneBlockWaitingForTxns = missingCount;
     LOG(GRAPHENE, "Graphene block waiting for: %d, unnecessary: %d, total txns: %d received txns: %d\n",
         pfrom->grapheneBlockWaitingForTxns, unnecessaryCount, pfrom->grapheneBlock.vtx.size(),
-        pfrom->mapMissingTx.size());
+        pfrom->mapGrapheneMissingTx.size());
 
     // If there are any missing hashes or transactions then we request them here.
     // This must be done outside of the mempool.cs lock or may deadlock.
@@ -754,8 +754,8 @@ static bool ReconstructBlock(CNode *pfrom, int &missingCount, int &unnecessaryCo
                     inMemPool = true;
             }
 
-            bool inMissingTx = pfrom->mapMissingTx.count(GetShortID(pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, hash,
-                                   NegotiateGrapheneVersion(pfrom))) > 0;
+            bool inMissingTx = pfrom->mapGrapheneMissingTx.count(GetShortID(pfrom->gr_shorttxidk0,
+                                   pfrom->gr_shorttxidk1, hash, NegotiateGrapheneVersion(pfrom))) > 0;
             bool inAdditionalTxs = mapAdditionalTxs.count(hash) > 0;
             bool inOrphanCache = orphanpool.mapOrphanTransactions.count(hash) > 0;
 
@@ -774,7 +774,7 @@ static bool ReconstructBlock(CNode *pfrom, int &missingCount, int &unnecessaryCo
             }
             else if (inMissingTx)
             {
-                ptx = pfrom->mapMissingTx[GetShortID(
+                ptx = pfrom->mapGrapheneMissingTx[GetShortID(
                     pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, hash, NegotiateGrapheneVersion(pfrom))];
                 pfrom->grapheneBlock.setUnVerifiedTxns.insert(hash);
             }

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -35,7 +35,7 @@ static bool ReconstructBlock(CNode *pfrom,
     int &missingCount,
     int &unnecessaryCount,
     const std::vector<uint256> &vHashes,
-    std::shared_ptr<CBlock_ThinRelay> &pblock);
+    std::shared_ptr<CBlockThinRelay> &pblock);
 
 CThinBlock::CThinBlock(const CBlock &block, const CBloomFilter &filter) : nSize(0), nWaitingFor(0)
 {
@@ -120,7 +120,7 @@ bool CThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     return thinBlock.process(pfrom, pblock);
 }
 
-bool CThinBlock::process(CNode *pfrom, std::shared_ptr<CBlock_ThinRelay> &pblock)
+bool CThinBlock::process(CNode *pfrom, std::shared_ptr<CBlockThinRelay> &pblock)
 {
     pblock->nVersion = header.nVersion;
     pblock->nBits = header.nBits;
@@ -274,7 +274,7 @@ bool CXThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
 
     // Get already partially reconstructed block from memory. This block was created when the xthinblock
     // was first received.
-    std::shared_ptr<CBlock_ThinRelay> pblock = thinrelay.GetBlockToReconstruct(pfrom);
+    std::shared_ptr<CBlockThinRelay> pblock = thinrelay.GetBlockToReconstruct(pfrom);
     if (pblock == nullptr)
         return error("No block available to reconstruct for xblocktx");
 
@@ -580,7 +580,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
     return thinBlock.process(pfrom, strCommand, pblock);
 }
 
-bool CXThinBlock::process(CNode *pfrom, std::string strCommand, std::shared_ptr<CBlock_ThinRelay> &pblock)
+bool CXThinBlock::process(CNode *pfrom, std::string strCommand, std::shared_ptr<CBlockThinRelay> &pblock)
 // TODO: request from the "best" txn source not necessarily from the block source
 {
     // In PV we must prevent two thinblocks from simulaneously processing from that were recieved from the
@@ -757,7 +757,7 @@ static bool ReconstructBlock(CNode *pfrom,
     int &missingCount,
     int &unnecessaryCount,
     const std::vector<uint256> &vHashes,
-    std::shared_ptr<CBlock_ThinRelay> &pblock)
+    std::shared_ptr<CBlockThinRelay> &pblock)
 {
     AssertLockHeld(orphanpool.cs);
 
@@ -1243,7 +1243,7 @@ std::string CThinBlockData::FullTxToString()
 
 // After a thinblock is finished processing or if for some reason we have to pre-empt the rebuilding
 // of a thinblock then we clear out the thinblock bytes from the total.
-void CThinBlockData::ClearThinBlockBytes(std::shared_ptr<CBlock_ThinRelay> &pblock)
+void CThinBlockData::ClearThinBlockBytes(std::shared_ptr<CBlockThinRelay> &pblock)
 {
     // Remove bytes from counter
     if (pblock != nullptr)
@@ -1253,7 +1253,7 @@ void CThinBlockData::ClearThinBlockBytes(std::shared_ptr<CBlock_ThinRelay> &pblo
         thindata.GetThinBlockBytes());
 }
 
-void CThinBlockData::ClearThinBlockData(CNode *pnode, std::shared_ptr<CBlock_ThinRelay> &pblock)
+void CThinBlockData::ClearThinBlockData(CNode *pnode, std::shared_ptr<CBlockThinRelay> &pblock)
 {
     // We must make sure to clear the thinblock data first before clearing the thinblock in flight.
     ClearThinBlockBytes(pblock);
@@ -1287,7 +1287,7 @@ void CThinBlockData::ClearThinBlockStats()
     mapFullTx.clear();
 }
 
-uint64_t CThinBlockData::AddThinBlockBytes(uint64_t bytes, std::shared_ptr<CBlock_ThinRelay> &pblock)
+uint64_t CThinBlockData::AddThinBlockBytes(uint64_t bytes, std::shared_ptr<CBlockThinRelay> &pblock)
 {
     pblock->nCurrentBlockSize += bytes;
     uint64_t ret = nThinBlockBytes.fetch_add(bytes) + bytes;
@@ -1333,12 +1333,12 @@ bool ClearLargestThinBlockAndDisconnect(CNode *pfrom)
 {
     CNode *pLargestNode = nullptr;
     uint64_t nLargestBytes = 0;
-    std::shared_ptr<CBlock_ThinRelay> pLargestBlock = nullptr;
+    std::shared_ptr<CBlockThinRelay> pLargestBlock = nullptr;
 
     LOCK(cs_vNodes);
     for (CNode *pnode : vNodes)
     {
-        std::shared_ptr<CBlock_ThinRelay> pblock = thinrelay.GetBlockToReconstruct(pnode);
+        std::shared_ptr<CBlockThinRelay> pblock = thinrelay.GetBlockToReconstruct(pnode);
         if (pblock == nullptr)
             continue;
 

--- a/src/blockrelay/thinblock.h
+++ b/src/blockrelay/thinblock.h
@@ -64,7 +64,7 @@ public:
     }
 
     CInv GetInv() { return CInv(MSG_BLOCK, header.GetHash()); }
-    bool process(CNode *pfrom);
+    bool process(CNode *pfrom, std::shared_ptr<CBlock_ThinRelay> &pblock);
 
     uint64_t GetSize() const
     {
@@ -123,7 +123,7 @@ public:
         READWRITE(vMissingTx);
     }
     CInv GetInv() { return CInv(MSG_BLOCK, header.GetHash()); }
-    bool process(CNode *pfrom, std::string strCommand);
+    bool process(CNode *pfrom, std::string strCommand, std::shared_ptr<CBlock_ThinRelay> &pblock);
     bool CheckBlockHeader(const CBlockHeader &block, CValidationState &state);
 
     uint64_t GetSize() const
@@ -312,11 +312,11 @@ public:
     std::string ThinBlockToString();
     std::string FullTxToString();
 
-    void ClearThinBlockData(CNode *pfrom);
-    void ClearThinBlockData(CNode *pfrom, const uint256 &hash);
+    void ClearThinBlockBytes(std::shared_ptr<CBlock_ThinRelay> &pblock);
+    void ClearThinBlockData(CNode *pnode, std::shared_ptr<CBlock_ThinRelay> &pblock);
     void ClearThinBlockStats();
 
-    uint64_t AddThinBlockBytes(uint64_t bytes, CNode *pfrom);
+    uint64_t AddThinBlockBytes(uint64_t bytes, std::shared_ptr<CBlock_ThinRelay> &pblock);
     void DeleteThinBlockBytes(uint64_t bytes);
     void ResetThinBlockBytes();
     uint64_t GetThinBlockBytes();

--- a/src/blockrelay/thinblock.h
+++ b/src/blockrelay/thinblock.h
@@ -31,13 +31,17 @@ private:
     mutable uint64_t nSize; // Serialized thinblock size in bytes
 
 public:
+    // memory only
+    mutable unsigned int nWaitingFor;
+
+public:
     CBlockHeader header;
     std::vector<uint256> vTxHashes; // List of all transaction ids in the block
     std::vector<CTransaction> vMissingTx; // vector of transactions that did not match the bloom filter
 
 public:
     CThinBlock(const CBlock &block, const CBloomFilter &filter);
-    CThinBlock() : nSize(0) {}
+    CThinBlock() : nSize(0), nWaitingFor(0) {}
     /**
      * Handle an incoming thin block.  The block is fully validated, and if any transactions are missing, we fall
      * back to requesting a full block.
@@ -75,16 +79,20 @@ private:
     mutable uint64_t nSize; // Serialized thinblock size in bytes
 
 public:
+    // memory only
+    mutable unsigned int nWaitingFor;
+    bool collision;
+
+public:
     CBlockHeader header;
     std::vector<uint64_t> vTxHashes; // List of all transaction ids in the block
     std::vector<CTransaction> vMissingTx; // vector of transactions that did not match the bloom filter
-    bool collision;
 
 public:
     // Use the filter to determine which txns the client has
     CXThinBlock(const CBlock &block, const CBloomFilter *filter);
     CXThinBlock(const CBlock &block); // Assume client has all of the transactions (except coinbase)
-    CXThinBlock() : nSize(0), collision(false){}
+    CXThinBlock() : nSize(0), nWaitingFor(0), collision(false) {}
     /**
      * Handle an incoming Xthin or Xpedited block
      * Once the block is validated apart from the Merkle root, forward the Xpedited block with a hop count of nHops.

--- a/src/blockrelay/thinblock.h
+++ b/src/blockrelay/thinblock.h
@@ -64,7 +64,7 @@ public:
     }
 
     CInv GetInv() { return CInv(MSG_BLOCK, header.GetHash()); }
-    bool process(CNode *pfrom, std::shared_ptr<CBlock_ThinRelay> &pblock);
+    bool process(CNode *pfrom, std::shared_ptr<CBlockThinRelay> &pblock);
 
     uint64_t GetSize() const
     {
@@ -123,7 +123,7 @@ public:
         READWRITE(vMissingTx);
     }
     CInv GetInv() { return CInv(MSG_BLOCK, header.GetHash()); }
-    bool process(CNode *pfrom, std::string strCommand, std::shared_ptr<CBlock_ThinRelay> &pblock);
+    bool process(CNode *pfrom, std::string strCommand, std::shared_ptr<CBlockThinRelay> &pblock);
     bool CheckBlockHeader(const CBlockHeader &block, CValidationState &state);
 
     uint64_t GetSize() const
@@ -312,11 +312,11 @@ public:
     std::string ThinBlockToString();
     std::string FullTxToString();
 
-    void ClearThinBlockBytes(std::shared_ptr<CBlock_ThinRelay> &pblock);
-    void ClearThinBlockData(CNode *pnode, std::shared_ptr<CBlock_ThinRelay> &pblock);
+    void ClearThinBlockBytes(std::shared_ptr<CBlockThinRelay> &pblock);
+    void ClearThinBlockData(CNode *pnode, std::shared_ptr<CBlockThinRelay> &pblock);
     void ClearThinBlockStats();
 
-    uint64_t AddThinBlockBytes(uint64_t bytes, std::shared_ptr<CBlock_ThinRelay> &pblock);
+    uint64_t AddThinBlockBytes(uint64_t bytes, std::shared_ptr<CBlockThinRelay> &pblock);
     void DeleteThinBlockBytes(uint64_t bytes);
     void ResetThinBlockBytes();
     uint64_t GetThinBlockBytes();

--- a/src/blockrelay/thinblock.h
+++ b/src/blockrelay/thinblock.h
@@ -32,16 +32,17 @@ private:
 
 public:
     // memory only
-    mutable unsigned int nWaitingFor;
+    mutable unsigned int nWaitingFor; // number of txns we are still needing to recontruct the block
+    mutable uint64_t nCurrentBlockSize; // In memory block size calculated during reconstruction
 
 public:
     CBlockHeader header;
-    std::vector<uint256> vTxHashes; // List of all transaction ids in the block
+    std::vector<uint256> vTxHashes; // List of all 256 bit transaction ids in the block
     std::vector<CTransaction> vMissingTx; // vector of transactions that did not match the bloom filter
 
 public:
     CThinBlock(const CBlock &block, const CBloomFilter &filter);
-    CThinBlock() : nSize(0), nWaitingFor(0) {}
+    CThinBlock() : nSize(0), nWaitingFor(0), nCurrentBlockSize(0) {}
     /**
      * Handle an incoming thin block.  The block is fully validated, and if any transactions are missing, we fall
      * back to requesting a full block.
@@ -80,8 +81,12 @@ private:
 
 public:
     // memory only
-    mutable unsigned int nWaitingFor;
+    mutable unsigned int nWaitingFor; // number of txns we are still needing to recontruct the block
+    mutable uint64_t nCurrentBlockSize; // In memory block size calculated during reconstruction
     bool collision;
+
+    // memory only
+    std::vector<uint256> vTxHashes256; // List of all 256 bit transaction hashes in the block
 
 public:
     CBlockHeader header;
@@ -92,7 +97,7 @@ public:
     // Use the filter to determine which txns the client has
     CXThinBlock(const CBlock &block, const CBloomFilter *filter);
     CXThinBlock(const CBlock &block); // Assume client has all of the transactions (except coinbase)
-    CXThinBlock() : nSize(0), nWaitingFor(0), collision(false) {}
+    CXThinBlock() : nSize(0), nWaitingFor(0), nCurrentBlockSize(0), collision(false) {}
     /**
      * Handle an incoming Xthin or Xpedited block
      * Once the block is validated apart from the Merkle root, forward the Xpedited block with a hop count of nHops.

--- a/src/blockrelay/thinblock.h
+++ b/src/blockrelay/thinblock.h
@@ -35,6 +35,8 @@ public:
     mutable unsigned int nWaitingFor; // number of txns we are still needing to recontruct the block
     mutable uint64_t nCurrentBlockSize; // In memory block size calculated during reconstruction
 
+    std::map<uint64_t, CTransactionRef> mapMissingTx;
+
 public:
     CBlockHeader header;
     std::vector<uint256> vTxHashes; // List of all 256 bit transaction ids in the block
@@ -87,6 +89,7 @@ public:
 
     // memory only
     std::vector<uint256> vTxHashes256; // List of all 256 bit transaction hashes in the block
+    std::map<uint64_t, CTransactionRef> mapMissingTx;
 
 public:
     CBlockHeader header;

--- a/src/blockrelay/thinblock.h
+++ b/src/blockrelay/thinblock.h
@@ -33,7 +33,6 @@ private:
 public:
     // memory only
     mutable unsigned int nWaitingFor; // number of txns we are still needing to recontruct the block
-    mutable uint64_t nCurrentBlockSize; // In memory block size calculated during reconstruction
 
     std::map<uint64_t, CTransactionRef> mapMissingTx;
 
@@ -44,7 +43,7 @@ public:
 
 public:
     CThinBlock(const CBlock &block, const CBloomFilter &filter);
-    CThinBlock() : nSize(0), nWaitingFor(0), nCurrentBlockSize(0) {}
+    CThinBlock() : nSize(0), nWaitingFor(0) {}
     /**
      * Handle an incoming thin block.  The block is fully validated, and if any transactions are missing, we fall
      * back to requesting a full block.
@@ -84,7 +83,7 @@ private:
 public:
     // memory only
     mutable unsigned int nWaitingFor; // number of txns we are still needing to recontruct the block
-    mutable uint64_t nCurrentBlockSize; // In memory block size calculated during reconstruction
+    uint64_t nBlockBytes; // the bytes used in re-assembling the block, updated dynamically
     bool collision;
 
     // memory only
@@ -100,7 +99,7 @@ public:
     // Use the filter to determine which txns the client has
     CXThinBlock(const CBlock &block, const CBloomFilter *filter);
     CXThinBlock(const CBlock &block); // Assume client has all of the transactions (except coinbase)
-    CXThinBlock() : nSize(0), nWaitingFor(0), nCurrentBlockSize(0), collision(false) {}
+    CXThinBlock() : nSize(0), nWaitingFor(0), collision(false) {}
     /**
      * Handle an incoming Xthin or Xpedited block
      * Once the block is validated apart from the Merkle root, forward the Xpedited block with a hop count of nHops.
@@ -317,8 +316,8 @@ public:
     void ClearThinBlockData(CNode *pfrom, const uint256 &hash);
     void ClearThinBlockStats();
 
-    uint64_t AddThinBlockBytes(uint64_t, CNode *pfrom);
-    void DeleteThinBlockBytes(uint64_t, CNode *pfrom);
+    uint64_t AddThinBlockBytes(uint64_t bytes, CNode *pfrom);
+    void DeleteThinBlockBytes(uint64_t bytes);
     void ResetThinBlockBytes();
     uint64_t GetThinBlockBytes();
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2942,7 +2942,6 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
 
     // xthinblocks
     nLocalThinBlockBytes = 0;
-    thinBlockWaitingForTxns = -1;
     nXthinBloomfilterSize = 0;
     addrFromPort = 0;
 
@@ -3024,7 +3023,6 @@ CNode::~CNode()
         }
     }
 
-    thinBlockWaitingForTxns = -1;
     thinBlock.SetNull();
     grapheneBlockWaitingForTxns = -1;
     grapheneBlock.SetNull();

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2942,7 +2942,6 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
 
     // xthinblocks
     nLocalThinBlockBytes = 0;
-    nSizeThinBlock = 0;
     thinBlockWaitingForTxns = -1;
     nXthinBloomfilterSize = 0;
     addrFromPort = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2941,9 +2941,15 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
     nMinPingUsecTime = std::numeric_limits<int64_t>::max();
 
     // xthinblocks
-    nLocalThinBlockBytes = 0;
     nXthinBloomfilterSize = 0;
     addrFromPort = 0;
+
+    // Initialize the pointers held in CBlock. We have to do this here rather than in the CBlock
+    // constructor.
+    CXThinBlock xthin;
+    CThinBlock thin;
+    thinBlock.xthinblock = std::make_shared<CXThinBlock>(std::forward<CXThinBlock>(xthin));
+    thinBlock.thinblock = std::make_shared<CThinBlock>(std::forward<CThinBlock>(thin));
 
     // graphene
     nLocalGrapheneBlockBytes = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1798,8 +1798,8 @@ void ThreadOpenConnections()
         }
     }
 
-    // NOTE: If we are in the block above, then no seeding should occur as "-connect" and "-connect-thinblock"
-    // are intended as "only make outbound connections to the configured nodes".
+    // NOTE: If we are in the block above, then no seeding should occur as "-connect""
+    // is intended as "only make outbound connections to the configured nodes".
 
     // Initiate network connections
     int64_t nStart = GetTime();
@@ -2944,13 +2944,6 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
     nXthinBloomfilterSize = 0;
     addrFromPort = 0;
 
-    // Initialize the pointers held in CBlock. We have to do this here rather than in the CBlock
-    // constructor.
-    CXThinBlock xthin;
-    CThinBlock thin;
-    thinBlock.xthinblock = std::make_shared<CXThinBlock>(std::forward<CXThinBlock>(xthin));
-    thinBlock.thinblock = std::make_shared<CThinBlock>(std::forward<CThinBlock>(thin));
-
     // graphene
     nLocalGrapheneBlockBytes = 0;
     nSizeGrapheneBlock = 0;
@@ -3029,7 +3022,6 @@ CNode::~CNode()
         }
     }
 
-    thinBlock.SetNull();
     grapheneBlockWaitingForTxns = -1;
     grapheneBlock.SetNull();
 

--- a/src/net.h
+++ b/src/net.h
@@ -470,12 +470,10 @@ public:
     bool fShouldBan;
 
     // BUIP010 Xtreme Thinblocks: begin section
-    uint32_t nXthinBloomfilterSize; // The maximum xthin bloom filter size (in bytes) that our peer will accept.
+    std::atomic<uint32_t> nXthinBloomfilterSize; // Max xthin bloom filter size (in bytes) that our peer will accept.
 
     CCriticalSection cs_xthinblock;
     CBlock thinBlock;
-    std::vector<uint256> thinBlockHashes;
-    std::vector<uint64_t> xThinBlockHashes;
     std::map<uint64_t, CTransactionRef> mapMissingTx;
     uint64_t nLocalThinBlockBytes; // the bytes used in creating this thinblock, updated dynamically
     // BUIP010 Xtreme Thinblocks: end section

--- a/src/net.h
+++ b/src/net.h
@@ -474,7 +474,6 @@ public:
 
     CCriticalSection cs_xthinblock;
     CBlock thinBlock;
-    std::map<uint64_t, CTransactionRef> mapMissingTx;
     uint64_t nLocalThinBlockBytes; // the bytes used in creating this thinblock, updated dynamically
     // BUIP010 Xtreme Thinblocks: end section
 

--- a/src/net.h
+++ b/src/net.h
@@ -473,7 +473,6 @@ public:
     std::atomic<uint32_t> nXthinBloomfilterSize; // Max xthin bloom filter size (in bytes) that our peer will accept.
 
     CCriticalSection cs_xthinblock;
-    CBlock thinBlock;
     // BUIP010 Xtreme Thinblocks: end section
 
     // BUIPXXX Graphene blocks: begin section

--- a/src/net.h
+++ b/src/net.h
@@ -476,7 +476,6 @@ public:
     std::vector<uint64_t> xThinBlockHashes;
     std::map<uint64_t, CTransactionRef> mapMissingTx;
     uint64_t nLocalThinBlockBytes; // the bytes used in creating this thinblock, updated dynamically
-    int nSizeThinBlock; // Original on-wire size of the block. Just used for reporting
     int thinBlockWaitingForTxns; // if -1 then not currently waiting
     uint32_t nXthinBloomfilterSize; // The maximum xthin bloom filter size (in bytes) that our peer will accept.
     // BUIP010 Xtreme Thinblocks: end section

--- a/src/net.h
+++ b/src/net.h
@@ -483,7 +483,7 @@ public:
     CBlock grapheneBlock;
     std::vector<uint256> grapheneBlockHashes;
     std::map<uint64_t, uint32_t> grapheneMapHashOrderIndex;
-    std::map<uint64_t, CTransaction> mapGrapheneMissingTx;
+    std::map<uint64_t, CTransactionRef> mapGrapheneMissingTx;
     uint64_t nLocalGrapheneBlockBytes; // the bytes used in creating this graphene block, updated dynamically
     int nSizeGrapheneBlock; // Original on-wire size of the block. Just used for reporting
     int grapheneBlockWaitingForTxns; // if -1 then not currently waiting

--- a/src/net.h
+++ b/src/net.h
@@ -474,7 +474,6 @@ public:
 
     CCriticalSection cs_xthinblock;
     CBlock thinBlock;
-    uint64_t nLocalThinBlockBytes; // the bytes used in creating this thinblock, updated dynamically
     // BUIP010 Xtreme Thinblocks: end section
 
     // BUIPXXX Graphene blocks: begin section

--- a/src/net.h
+++ b/src/net.h
@@ -470,14 +470,14 @@ public:
     bool fShouldBan;
 
     // BUIP010 Xtreme Thinblocks: begin section
+    uint32_t nXthinBloomfilterSize; // The maximum xthin bloom filter size (in bytes) that our peer will accept.
+
     CCriticalSection cs_xthinblock;
     CBlock thinBlock;
     std::vector<uint256> thinBlockHashes;
     std::vector<uint64_t> xThinBlockHashes;
     std::map<uint64_t, CTransactionRef> mapMissingTx;
     uint64_t nLocalThinBlockBytes; // the bytes used in creating this thinblock, updated dynamically
-    int thinBlockWaitingForTxns; // if -1 then not currently waiting
-    uint32_t nXthinBloomfilterSize; // The maximum xthin bloom filter size (in bytes) that our peer will accept.
     // BUIP010 Xtreme Thinblocks: end section
 
     // BUIPXXX Graphene blocks: begin section

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -713,7 +713,9 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
     {
         if (pfrom->ThinBlockCapable())
         {
-            vRecv >> pfrom->nXthinBloomfilterSize;
+            uint32_t nSize = 0;
+            vRecv >> nSize;
+            pfrom->nXthinBloomfilterSize.store(nSize);
 
             // As a safeguard don't allow a smaller max bloom filter size than the default max size.
             if (!pfrom->nXthinBloomfilterSize || (pfrom->nXthinBloomfilterSize < SMALLEST_MAX_BLOOM_FILTER_SIZE))

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -85,9 +85,12 @@ public:
     bool fXVal;
 
 public:
-    // thinrelay block types
+    // thinrelay block types: (memory only)
     std::shared_ptr<CThinBlock> thinblock;
     std::shared_ptr<CXThinBlock> xthinblock;
+
+    // Track the current block size during reconstruction: (memory only)
+    uint64_t nCurrentBlockSize;
 
 public:
     // network and disk
@@ -179,6 +182,7 @@ public:
         fExcessive = false;
         fXVal = false;
         nBlockSize = 0;
+        nCurrentBlockSize = 0;
     }
 
     CBlockHeader GetBlockHeader() const

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -85,14 +85,6 @@ public:
     bool fXVal;
 
 public:
-    // thinrelay block types: (memory only)
-    std::shared_ptr<CThinBlock> thinblock;
-    std::shared_ptr<CXThinBlock> xthinblock;
-
-    // Track the current block size during reconstruction: (memory only)
-    uint64_t nCurrentBlockSize;
-
-public:
     // network and disk
     std::vector<CTransactionRef> vtx;
 
@@ -182,7 +174,6 @@ public:
         fExcessive = false;
         fXVal = false;
         nBlockSize = 0;
-        nCurrentBlockSize = 0;
     }
 
     CBlockHeader GetBlockHeader() const
@@ -204,6 +195,26 @@ public:
     uint64_t GetBlockSize() const;
 };
 
+// Used for thin type blocks that we want to reconstruct
+class CBlock_ThinRelay : public CBlock
+{
+public:
+    // thinrelay block types: (memory only)
+    std::shared_ptr<CThinBlock> thinblock;
+    std::shared_ptr<CXThinBlock> xthinblock;
+
+    // Track the current block size during reconstruction: (memory only)
+    uint64_t nCurrentBlockSize;
+
+    CBlock_ThinRelay() { SetNull(); }
+    void SetNull()
+    {
+        CBlock::SetNull();
+        nCurrentBlockSize = 0;
+        thinblock = nullptr;
+        xthinblock = nullptr;
+    }
+};
 
 /** Describes a place in the block chain to another node such that if the
  * other node doesn't have the same branch, it can find a recent common trunk.

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -78,10 +78,11 @@ private:
 
 public:
     // Xpress Validation: (memory only)
-    // Orphans, or Missing transactions that have been re-requested, are stored here.
+    //! Orphans, or Missing transactions that have been re-requested, are stored here.
     std::set<uint256> setUnVerifiedTxns;
 
     // Xpress Validation: (memory only)
+    //! A flag which when true indicates that Xpress validation is enabled for this block.
     bool fXVal;
 
 public:
@@ -195,15 +196,19 @@ public:
     uint64_t GetBlockSize() const;
 };
 
-// Used for thin type blocks that we want to reconstruct
+/**
+ * Used for thin type blocks that we want to reconstruct into a full block. All the data
+ * necessary to recreate the block are held within the thinrelay objects which are subsequently
+ * stored within this class as smart pointers.
+ */
 class CBlockThinRelay : public CBlock
 {
 public:
-    // thinrelay block types: (memory only)
+    //! thinrelay block types: (memory only)
     std::shared_ptr<CThinBlock> thinblock;
     std::shared_ptr<CXThinBlock> xthinblock;
 
-    // Track the current block size during reconstruction: (memory only)
+    //! Track the current block size during reconstruction: (memory only)
     uint64_t nCurrentBlockSize;
 
     CBlockThinRelay() { SetNull(); }

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -17,6 +17,9 @@ const uint32_t BASE_VERSION = 0x20000000;
 const uint32_t FORK_BIT_2MB = 0x10000000; // Vote for 2MB fork
 const bool DEFAULT_2MB_VOTE = false;
 
+class CXThinBlock;
+class CThinBlock;
+
 /** Nodes collect new transactions into a block, hash them into a hash tree,
  * and scan through nonce values to make the block's hash satisfy proof-of-work
  * requirements.  When they solve the proof-of-work, they broadcast the block
@@ -75,12 +78,16 @@ private:
 
 public:
     // Xpress Validation: (memory only)
-    // However Orphans or Missing transactions that have been re-requested must be verifed
-    // because their inputs have never been checked.
+    // Orphans, or Missing transactions that have been re-requested, are stored here.
     std::set<uint256> setUnVerifiedTxns;
 
     // Xpress Validation: (memory only)
     bool fXVal;
+
+public:
+    // thinrelay block types
+    std::shared_ptr<CThinBlock> thinblock;
+    std::shared_ptr<CXThinBlock> xthinblock;
 
 public:
     // network and disk

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -196,7 +196,7 @@ public:
 };
 
 // Used for thin type blocks that we want to reconstruct
-class CBlock_ThinRelay : public CBlock
+class CBlockThinRelay : public CBlock
 {
 public:
     // thinrelay block types: (memory only)
@@ -206,7 +206,7 @@ public:
     // Track the current block size during reconstruction: (memory only)
     uint64_t nCurrentBlockSize;
 
-    CBlock_ThinRelay() { SetNull(); }
+    CBlockThinRelay() { SetNull(); }
     void SetNull()
     {
         CBlock::SetNull();

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -866,11 +866,9 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         CXThinBlock xthinsize = xthinblock;
         vRecv1.clear();
         vRecv1 << xthinsize;
-        uint32_t nSizeXthin = vRecv1.size();
         vRecv1.clear();
         CThinBlock thinsize = thinblock;
         vRecv1 << thinsize;
-        uint32_t nSizeThinblock = vRecv1.size();
         vRecv1.clear();
 
 
@@ -898,7 +896,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // Process an xthinblock which causes a disconnect
             dummyNode6.fDisconnect = false;
-            xthin2.process(&dummyNode6, nSizeXthin, NetMsgType::XTHINBLOCK);
+            xthin2.process(&dummyNode6, NetMsgType::XTHINBLOCK);
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
             BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
             BOOST_CHECK_EQUAL(-1, dummyNode6.thinBlockWaitingForTxns);
@@ -916,7 +914,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // Process a regular thinblock
             dummyNode6.fDisconnect = false;
-            thin2.process(&dummyNode6, nSizeThinblock);
+            thin2.process(&dummyNode6);
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
             BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
             BOOST_CHECK_EQUAL(-1, dummyNode6.thinBlockWaitingForTxns);
@@ -982,7 +980,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // Process an xthinblock which will be the largest over limit and will be the one that gets disconnected.
             dummyNode6.fDisconnect = false;
-            xthin3.process(&dummyNode6, nSizeXthin, NetMsgType::XTHINBLOCK);
+            xthin3.process(&dummyNode6, NetMsgType::XTHINBLOCK);
             BOOST_CHECK(!dummyNode7.fDisconnect); // node should *not* be disconnected
             BOOST_CHECK_EQUAL(nBytes1, dummyNode7.nLocalThinBlockBytes);
             BOOST_CHECK(!dummyNode8.fDisconnect); // node should *not* be disconnected
@@ -1053,7 +1051,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             // and cause itself to be disconnected.
             dummyNode6.fDisconnect = false;
             dummyNode7.fDisconnect = false;
-            xthin4.process(&dummyNode6, nSizeXthin, NetMsgType::XTHINBLOCK);
+            xthin4.process(&dummyNode6, NetMsgType::XTHINBLOCK);
             BOOST_CHECK(!dummyNode8.fDisconnect); // node should *not* be disconnected
             BOOST_CHECK_EQUAL(nBytes1, dummyNode8.nLocalThinBlockBytes);
             BOOST_CHECK(!dummyNode9.fDisconnect); // node should *not* be disconnected

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -896,12 +896,11 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // Process an xthinblock which causes a disconnect
             dummyNode6.fDisconnect = false;
+            dummyNode6.thinBlock.xthinblock = std::make_shared<CXThinBlock>(xthin2);
             xthin2.process(&dummyNode6, NetMsgType::XTHINBLOCK);
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
             BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
             BOOST_CHECK(dummyNode6.thinBlock.IsNull());
-            BOOST_CHECK(dummyNode6.xThinBlockHashes.empty());
-            BOOST_CHECK(dummyNode6.thinBlockHashes.empty());
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
             vNodes.pop_back();
@@ -913,12 +912,11 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // Process a regular thinblock
             dummyNode6.fDisconnect = false;
+            dummyNode6.thinBlock.thinblock = std::make_shared<CThinBlock>(thin2);
             thin2.process(&dummyNode6);
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
             BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
             BOOST_CHECK(dummyNode6.thinBlock.IsNull());
-            BOOST_CHECK(dummyNode6.xThinBlockHashes.empty());
-            BOOST_CHECK(dummyNode6.thinBlockHashes.empty());
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
             vNodes.pop_back();
@@ -978,6 +976,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // Process an xthinblock which will be the largest over limit and will be the one that gets disconnected.
             dummyNode6.fDisconnect = false;
+            dummyNode6.thinBlock.xthinblock = std::make_shared<CXThinBlock>(xthin3);
             xthin3.process(&dummyNode6, NetMsgType::XTHINBLOCK);
             BOOST_CHECK(!dummyNode7.fDisconnect); // node should *not* be disconnected
             BOOST_CHECK_EQUAL(nBytes1, dummyNode7.nLocalThinBlockBytes);
@@ -989,8 +988,6 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
             BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
             BOOST_CHECK(dummyNode6.thinBlock.IsNull());
-            BOOST_CHECK(dummyNode6.xThinBlockHashes.empty());
-            BOOST_CHECK(dummyNode6.thinBlockHashes.empty());
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
             vNodes.pop_back();
@@ -1048,6 +1045,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             // and cause itself to be disconnected.
             dummyNode6.fDisconnect = false;
             dummyNode7.fDisconnect = false;
+            dummyNode6.thinBlock.xthinblock = std::make_shared<CXThinBlock>(xthin4);
             xthin4.process(&dummyNode6, NetMsgType::XTHINBLOCK);
             BOOST_CHECK(!dummyNode8.fDisconnect); // node should *not* be disconnected
             BOOST_CHECK_EQUAL(nBytes1, dummyNode8.nLocalThinBlockBytes);
@@ -1057,14 +1055,10 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
             BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
             BOOST_CHECK(dummyNode6.thinBlock.IsNull());
-            BOOST_CHECK(dummyNode6.xThinBlockHashes.empty());
-            BOOST_CHECK(dummyNode6.thinBlockHashes.empty());
 
             BOOST_CHECK(dummyNode7.fDisconnect); // node should be disconnected
             BOOST_CHECK_EQUAL(0, dummyNode7.nLocalThinBlockBytes);
             BOOST_CHECK(dummyNode7.thinBlock.IsNull());
-            BOOST_CHECK(dummyNode7.xThinBlockHashes.empty());
-            BOOST_CHECK(dummyNode7.thinBlockHashes.empty());
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
             vNodes.pop_back();

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -137,10 +137,10 @@ CDataStream vRecv5(SER_NETWORK, PROTOCOL_VERSION);
 uint256 nullhash;
 
 // create a general shared pointers for a thintype block
-std::shared_ptr<CBlock_ThinRelay> pblock6 = std::make_shared<CBlock_ThinRelay>(CBlock_ThinRelay());
-std::shared_ptr<CBlock_ThinRelay> pblock7 = std::make_shared<CBlock_ThinRelay>(CBlock_ThinRelay());
-std::shared_ptr<CBlock_ThinRelay> pblock8 = std::make_shared<CBlock_ThinRelay>(CBlock_ThinRelay());
-std::shared_ptr<CBlock_ThinRelay> pblock9 = std::make_shared<CBlock_ThinRelay>(CBlock_ThinRelay());
+std::shared_ptr<CBlockThinRelay> pblock6 = std::make_shared<CBlockThinRelay>(CBlockThinRelay());
+std::shared_ptr<CBlockThinRelay> pblock7 = std::make_shared<CBlockThinRelay>(CBlockThinRelay());
+std::shared_ptr<CBlockThinRelay> pblock8 = std::make_shared<CBlockThinRelay>(CBlockThinRelay());
+std::shared_ptr<CBlockThinRelay> pblock9 = std::make_shared<CBlockThinRelay>(CBlockThinRelay());
 
 BOOST_FIXTURE_TEST_SUITE(exploit_tests, TestingSetup)
 
@@ -751,7 +751,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         // no block to reconstruct available
         {
             CNode dummyNode3(INVALID_SOCKET, addr3, "", true);
-            std::shared_ptr<CBlock_ThinRelay> pblock = thinrelay.GetBlockToReconstruct(&dummyNode3);
+            std::shared_ptr<CBlockThinRelay> pblock = thinrelay.GetBlockToReconstruct(&dummyNode3);
             BOOST_CHECK(pblock == nullptr);
         }
 

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -899,7 +899,6 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             xthin2.process(&dummyNode6, NetMsgType::XTHINBLOCK);
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
             BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
-            BOOST_CHECK_EQUAL(-1, dummyNode6.thinBlockWaitingForTxns);
             BOOST_CHECK(dummyNode6.thinBlock.IsNull());
             BOOST_CHECK(dummyNode6.xThinBlockHashes.empty());
             BOOST_CHECK(dummyNode6.thinBlockHashes.empty());
@@ -917,7 +916,6 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             thin2.process(&dummyNode6);
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
             BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
-            BOOST_CHECK_EQUAL(-1, dummyNode6.thinBlockWaitingForTxns);
             BOOST_CHECK(dummyNode6.thinBlock.IsNull());
             BOOST_CHECK(dummyNode6.xThinBlockHashes.empty());
             BOOST_CHECK(dummyNode6.thinBlockHashes.empty());
@@ -990,7 +988,6 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
             BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
-            BOOST_CHECK_EQUAL(-1, dummyNode6.thinBlockWaitingForTxns);
             BOOST_CHECK(dummyNode6.thinBlock.IsNull());
             BOOST_CHECK(dummyNode6.xThinBlockHashes.empty());
             BOOST_CHECK(dummyNode6.thinBlockHashes.empty());
@@ -1059,14 +1056,12 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
             BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
-            BOOST_CHECK_EQUAL(-1, dummyNode6.thinBlockWaitingForTxns);
             BOOST_CHECK(dummyNode6.thinBlock.IsNull());
             BOOST_CHECK(dummyNode6.xThinBlockHashes.empty());
             BOOST_CHECK(dummyNode6.thinBlockHashes.empty());
 
             BOOST_CHECK(dummyNode7.fDisconnect); // node should be disconnected
             BOOST_CHECK_EQUAL(0, dummyNode7.nLocalThinBlockBytes);
-            BOOST_CHECK_EQUAL(-1, dummyNode7.thinBlockWaitingForTxns);
             BOOST_CHECK(dummyNode7.thinBlock.IsNull());
             BOOST_CHECK(dummyNode7.xThinBlockHashes.empty());
             BOOST_CHECK(dummyNode7.thinBlockHashes.empty());

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -136,6 +136,11 @@ CDataStream vRecv5(SER_NETWORK, PROTOCOL_VERSION);
 // create a basic nullhash
 uint256 nullhash;
 
+// create a general shared pointers for a thintype block
+std::shared_ptr<CBlock_ThinRelay> pblock6 = std::make_shared<CBlock_ThinRelay>(CBlock_ThinRelay());
+std::shared_ptr<CBlock_ThinRelay> pblock7 = std::make_shared<CBlock_ThinRelay>(CBlock_ThinRelay());
+std::shared_ptr<CBlock_ThinRelay> pblock8 = std::make_shared<CBlock_ThinRelay>(CBlock_ThinRelay());
+std::shared_ptr<CBlock_ThinRelay> pblock9 = std::make_shared<CBlock_ThinRelay>(CBlock_ThinRelay());
 
 BOOST_FIXTURE_TEST_SUITE(exploit_tests, TestingSetup)
 
@@ -736,6 +741,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             dummyNode3.nVersion = MIN_PEER_PROTO_VERSION;
             dummyNode3.state_incoming = ConnectionStateIncoming::READY;
             dummyNode3.state_outgoing = ConnectionStateOutgoing::READY;
+            auto pblock = thinrelay.SetBlockToReconstruct(&dummyNode3, nullhash);
             ProcessMessage(&dummyNode3, NetMsgType::XBLOCKTX, vRecv3, GetTime());
             SendMessages(&dummyNode3);
             BOOST_CHECK(nullhash.IsNull());
@@ -756,6 +762,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             dummyNode3a.nVersion = MIN_PEER_PROTO_VERSION;
             dummyNode3a.state_incoming = ConnectionStateIncoming::READY;
             dummyNode3a.state_outgoing = ConnectionStateOutgoing::READY;
+            auto pblock = thinrelay.SetBlockToReconstruct(&dummyNode3a, block3.GetHash());
             ProcessMessage(&dummyNode3a, NetMsgType::XBLOCKTX, vRecv3, GetTime());
             SendMessages(&dummyNode3a);
             BOOST_CHECK(vTxEmpty.size() == 0);
@@ -871,7 +878,6 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         vRecv1 << thinsize;
         vRecv1.clear();
 
-
         // test a single valid thinblock reconstruction that goes over the limit.
         // result: the peer should have it data cleared and node should be disconnected.
         CNode dummyNode6(INVALID_SOCKET, addr1, "", true);
@@ -896,14 +902,16 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // Process an xthinblock which causes a disconnect
             dummyNode6.fDisconnect = false;
-            dummyNode6.thinBlock.xthinblock = std::make_shared<CXThinBlock>(xthin2);
-            xthin2.process(&dummyNode6, NetMsgType::XTHINBLOCK);
+            pblock6->SetNull();
+            pblock6 = thinrelay.SetBlockToReconstruct(&dummyNode6, xthin2.header.GetHash());
+            pblock6->xthinblock = std::make_shared<CXThinBlock>(xthin2);
+            xthin2.process(&dummyNode6, NetMsgType::XTHINBLOCK, pblock6);
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
-            BOOST_CHECK(dummyNode6.thinBlock.IsNull());
+            BOOST_CHECK(pblock6->IsNull());
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode6, TestBlock1().GetHash());
+            thindata.ClearThinBlockData(&dummyNode6, pblock6);
 
             // Add the node to vNodes and also we need a thinblockinflight entry
             thinrelay.AddBlockInFlight(&dummyNode6, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
@@ -911,14 +919,15 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // Process a regular thinblock
             dummyNode6.fDisconnect = false;
-            dummyNode6.thinBlock.thinblock = std::make_shared<CThinBlock>(thin2);
-            thin2.process(&dummyNode6);
+            pblock6 = thinrelay.SetBlockToReconstruct(&dummyNode6, xthin2.header.GetHash());
+            pblock6->thinblock = std::make_shared<CThinBlock>(thin2);
+            thin2.process(&dummyNode6, pblock6);
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
-            BOOST_CHECK(dummyNode6.thinBlock.IsNull());
+            BOOST_CHECK(pblock6->IsNull());
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode6, TestBlock1().GetHash());
+            thindata.ClearThinBlockData(&dummyNode6, pblock6);
 
             // TODO: it would be great to have a test with an excessiveBlockSize of one byte larger
             //       so we can prove that a disconnect wouldn't happen for the edge case however
@@ -960,39 +969,43 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             // manually set the nCurrentBlockBytes to be lower than the actual bytes of the thinblock that we will
             // use to test the over limit condition. Also set the global bytes to be the sum of all current nodes.
             thindata.ResetThinBlockBytes();
+            pblock6->SetNull();
+            pblock7->SetNull();
+            pblock8->SetNull();
+            pblock9->SetNull();
             uint32_t nBytes1 = 2;
             uint32_t nBytes2 = 8;
-            thindata.AddThinBlockBytes(nBytes1, &dummyNode7);
-            thindata.AddThinBlockBytes(nBytes2, &dummyNode8);
+            thindata.AddThinBlockBytes(nBytes1, pblock7);
+            thindata.AddThinBlockBytes(nBytes2, pblock8);
 
             uint32_t nBytes3 = nMaxBlockSizeAllowed - nBytes1 - nBytes2 - (nSharedTxSize * 9) + 1;
-            thindata.AddThinBlockBytes(nBytes3, &dummyNode9);
+            thindata.AddThinBlockBytes(nBytes3, pblock9);
 
             // Process an xthinblock which will be the largest over limit and will be the one that gets disconnected.
             dummyNode6.fDisconnect = false;
-            dummyNode6.thinBlock.xthinblock = std::make_shared<CXThinBlock>(xthin3);
-            xthin3.process(&dummyNode6, NetMsgType::XTHINBLOCK);
+            pblock6 = thinrelay.SetBlockToReconstruct(&dummyNode6, xthin3.header.GetHash());
+            pblock6->xthinblock = std::make_shared<CXThinBlock>(xthin3);
+            xthin3.process(&dummyNode6, NetMsgType::XTHINBLOCK, pblock6);
             BOOST_CHECK(!dummyNode7.fDisconnect); // node should *not* be disconnected
-            BOOST_CHECK_EQUAL(nBytes1, dummyNode7.thinBlock.nCurrentBlockSize);
+            BOOST_CHECK_EQUAL(nBytes1, pblock7->nCurrentBlockSize);
             BOOST_CHECK(!dummyNode8.fDisconnect); // node should *not* be disconnected
-            BOOST_CHECK_EQUAL(nBytes2, dummyNode8.thinBlock.nCurrentBlockSize);
+            BOOST_CHECK_EQUAL(nBytes2, pblock8->nCurrentBlockSize);
             BOOST_CHECK(!dummyNode9.fDisconnect); // node should *not* be disconnected
-            BOOST_CHECK_EQUAL(nBytes3, dummyNode9.thinBlock.nCurrentBlockSize);
+            BOOST_CHECK_EQUAL(nBytes3, pblock9->nCurrentBlockSize);
 
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
-            BOOST_CHECK(dummyNode6.thinBlock.IsNull());
+            BOOST_CHECK(pblock6->IsNull());
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode6, TestBlock1().GetHash());
+            thindata.ClearThinBlockData(&dummyNode6, pblock6);
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode7, TestBlock1().GetHash());
+            thindata.ClearThinBlockData(&dummyNode7, pblock7);
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode8, TestBlock1().GetHash());
+            thindata.ClearThinBlockData(&dummyNode8, pblock8);
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode9, TestBlock1().GetHash());
+            thindata.ClearThinBlockData(&dummyNode9, pblock9);
         }
-
 
         /* Thinblock memory exhaustion attack 3 */
 
@@ -1023,42 +1036,45 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             // manually set two of the nCurrentBlockBytes to be higher than the actual bytes of the thinblock that we
             // will use to test the over limit condition. Also set the global bytes to be the sum of all current nodes.
             thindata.ResetThinBlockBytes();
-            dummyNode6.thinBlock.nCurrentBlockSize = 0;
+            pblock7 = thinrelay.SetBlockToReconstruct(&dummyNode7, xthin4.header.GetHash());
+            pblock8 = thinrelay.SetBlockToReconstruct(&dummyNode8, xthin4.header.GetHash());
+            pblock9 = thinrelay.SetBlockToReconstruct(&dummyNode9, xthin4.header.GetHash());
             // use thinblock for dummynode7 instead of xthin. The disconnect should be able to handle
             // either type.
-            thindata.AddThinBlockBytes(3000, &dummyNode7);
+            thindata.AddThinBlockBytes(3000, pblock7);
             uint32_t nBytes1 = 3;
             uint32_t nBytes2 = nMaxBlockSizeAllowed - nBytes1 - (nSharedTxSize * 9) + 1;
-            thindata.AddThinBlockBytes(nBytes1, &dummyNode8);
-            thindata.AddThinBlockBytes(nBytes2, &dummyNode9);
+            thindata.AddThinBlockBytes(nBytes1, pblock8);
+            thindata.AddThinBlockBytes(nBytes2, pblock9);
 
             // Process an xthinblock which will also be the over limit and will cause the largest block to disconnect
             // which in this case is dummyNode7. As it continues to process it (dummyNode6) will also go over the limit
             // and cause itself to be disconnected.
             dummyNode6.fDisconnect = false;
             dummyNode7.fDisconnect = false;
-            dummyNode6.thinBlock.xthinblock = std::make_shared<CXThinBlock>(xthin4);
-            xthin4.process(&dummyNode6, NetMsgType::XTHINBLOCK);
+            pblock6 = thinrelay.SetBlockToReconstruct(&dummyNode6, xthin4.header.GetHash());
+            pblock6->xthinblock = std::make_shared<CXThinBlock>(xthin4);
+            xthin4.process(&dummyNode6, NetMsgType::XTHINBLOCK, pblock6);
             BOOST_CHECK(!dummyNode8.fDisconnect); // node should *not* be disconnected
-            BOOST_CHECK_EQUAL(nBytes1, dummyNode8.thinBlock.nCurrentBlockSize);
+            BOOST_CHECK_EQUAL(nBytes1, pblock8->nCurrentBlockSize);
             BOOST_CHECK(!dummyNode9.fDisconnect); // node should *not* be disconnected
-            BOOST_CHECK_EQUAL(nBytes2, dummyNode9.thinBlock.nCurrentBlockSize);
+            BOOST_CHECK_EQUAL(nBytes2, pblock9->nCurrentBlockSize);
 
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
-            BOOST_CHECK(dummyNode6.thinBlock.IsNull());
+            BOOST_CHECK(pblock6->IsNull());
 
             BOOST_CHECK(dummyNode7.fDisconnect); // node should be disconnected
-            BOOST_CHECK(dummyNode7.thinBlock.IsNull());
+            BOOST_CHECK(pblock7->IsNull());
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode6, TestBlock1().GetHash());
+            thindata.ClearThinBlockData(&dummyNode6, pblock6);
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode7, TestBlock1().GetHash());
+            thindata.ClearThinBlockData(&dummyNode7, pblock7);
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode8, TestBlock1().GetHash());
+            thindata.ClearThinBlockData(&dummyNode8, pblock8);
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode9, TestBlock1().GetHash());
+            thindata.ClearThinBlockData(&dummyNode9, pblock9);
         }
 
         /*

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -899,7 +899,6 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             dummyNode6.thinBlock.xthinblock = std::make_shared<CXThinBlock>(xthin2);
             xthin2.process(&dummyNode6, NetMsgType::XTHINBLOCK);
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
-            BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
             BOOST_CHECK(dummyNode6.thinBlock.IsNull());
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
@@ -915,7 +914,6 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             dummyNode6.thinBlock.thinblock = std::make_shared<CThinBlock>(thin2);
             thin2.process(&dummyNode6);
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
-            BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
             BOOST_CHECK(dummyNode6.thinBlock.IsNull());
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
@@ -959,13 +957,9 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
                 vNodes.push_back(&dummyNode9);
             }
 
-            // manually set the nLocalThinBlockBytes to be lower than the actual bytes of the thinblock that we will
+            // manually set the nCurrentBlockBytes to be lower than the actual bytes of the thinblock that we will
             // use to test the over limit condition. Also set the global bytes to be the sum of all current nodes.
             thindata.ResetThinBlockBytes();
-            dummyNode6.nLocalThinBlockBytes = 0;
-            dummyNode7.nLocalThinBlockBytes = 0;
-            dummyNode8.nLocalThinBlockBytes = 0;
-            dummyNode9.nLocalThinBlockBytes = 0;
             uint32_t nBytes1 = 2;
             uint32_t nBytes2 = 8;
             thindata.AddThinBlockBytes(nBytes1, &dummyNode7);
@@ -979,14 +973,13 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             dummyNode6.thinBlock.xthinblock = std::make_shared<CXThinBlock>(xthin3);
             xthin3.process(&dummyNode6, NetMsgType::XTHINBLOCK);
             BOOST_CHECK(!dummyNode7.fDisconnect); // node should *not* be disconnected
-            BOOST_CHECK_EQUAL(nBytes1, dummyNode7.nLocalThinBlockBytes);
+            BOOST_CHECK_EQUAL(nBytes1, dummyNode7.thinBlock.nCurrentBlockSize);
             BOOST_CHECK(!dummyNode8.fDisconnect); // node should *not* be disconnected
-            BOOST_CHECK_EQUAL(nBytes2, dummyNode8.nLocalThinBlockBytes);
+            BOOST_CHECK_EQUAL(nBytes2, dummyNode8.thinBlock.nCurrentBlockSize);
             BOOST_CHECK(!dummyNode9.fDisconnect); // node should *not* be disconnected
-            BOOST_CHECK_EQUAL(nBytes3, dummyNode9.nLocalThinBlockBytes);
+            BOOST_CHECK_EQUAL(nBytes3, dummyNode9.thinBlock.nCurrentBlockSize);
 
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
-            BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
             BOOST_CHECK(dummyNode6.thinBlock.IsNull());
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
@@ -1027,13 +1020,12 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
                 vNodes.push_back(&dummyNode9);
             }
 
-            // manually set two of the nLocalThinBlockBytes to be higher than the actual bytes of the thinblock that we
+            // manually set two of the nCurrentBlockBytes to be higher than the actual bytes of the thinblock that we
             // will use to test the over limit condition. Also set the global bytes to be the sum of all current nodes.
             thindata.ResetThinBlockBytes();
-            dummyNode6.nLocalThinBlockBytes = 0;
-            dummyNode7.nLocalThinBlockBytes = 0;
-            dummyNode8.nLocalThinBlockBytes = 0;
-            dummyNode9.nLocalThinBlockBytes = 0;
+            dummyNode6.thinBlock.nCurrentBlockSize = 0;
+            // use thinblock for dummynode7 instead of xthin. The disconnect should be able to handle
+            // either type.
             thindata.AddThinBlockBytes(3000, &dummyNode7);
             uint32_t nBytes1 = 3;
             uint32_t nBytes2 = nMaxBlockSizeAllowed - nBytes1 - (nSharedTxSize * 9) + 1;
@@ -1048,16 +1040,14 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             dummyNode6.thinBlock.xthinblock = std::make_shared<CXThinBlock>(xthin4);
             xthin4.process(&dummyNode6, NetMsgType::XTHINBLOCK);
             BOOST_CHECK(!dummyNode8.fDisconnect); // node should *not* be disconnected
-            BOOST_CHECK_EQUAL(nBytes1, dummyNode8.nLocalThinBlockBytes);
+            BOOST_CHECK_EQUAL(nBytes1, dummyNode8.thinBlock.nCurrentBlockSize);
             BOOST_CHECK(!dummyNode9.fDisconnect); // node should *not* be disconnected
-            BOOST_CHECK_EQUAL(nBytes2, dummyNode9.nLocalThinBlockBytes);
+            BOOST_CHECK_EQUAL(nBytes2, dummyNode9.thinBlock.nCurrentBlockSize);
 
             BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
-            BOOST_CHECK_EQUAL(0, dummyNode6.nLocalThinBlockBytes);
             BOOST_CHECK(dummyNode6.thinBlock.IsNull());
 
             BOOST_CHECK(dummyNode7.fDisconnect); // node should be disconnected
-            BOOST_CHECK_EQUAL(0, dummyNode7.nLocalThinBlockBytes);
             BOOST_CHECK(dummyNode7.thinBlock.IsNull());
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
@@ -1070,7 +1060,6 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             vNodes.pop_back();
             thindata.ClearThinBlockData(&dummyNode9, TestBlock1().GetHash());
         }
-
 
         /*
          * Test the disconnection of a peers with thinblocks in flight that has gone over the timeout limit

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -748,6 +748,13 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
             BOOST_CHECK(dosMan.IsBanned(addr3));
         }
 
+        // no block to reconstruct available
+        {
+            CNode dummyNode3(INVALID_SOCKET, addr3, "", true);
+            std::shared_ptr<CBlock_ThinRelay> pblock = thinrelay.GetBlockToReconstruct(&dummyNode3);
+            BOOST_CHECK(pblock == nullptr);
+        }
+
         // test no txns in xblocktx
         dosMan.ClearBanned();
         vRecv3.clear();

--- a/src/test/thinblock_data_tests.cpp
+++ b/src/test/thinblock_data_tests.cpp
@@ -45,29 +45,30 @@ BOOST_AUTO_TEST_CASE(test_thinblock_byte_tracking)
 
     CAddress addr1(ipaddress(0xa0b0c001, 10000));
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
- 
+
     CXThinBlock xthin;
-    dummyNode1.thinBlock.xthinblock = std::make_shared<CXThinBlock>(xthin);
+    std::shared_ptr<CBlock_ThinRelay> pblock = std::make_shared<CBlock_ThinRelay>(CBlock_ThinRelay());
+    pblock->xthinblock = std::make_shared<CXThinBlock>(xthin);
 
     thindata.ResetThinBlockBytes();
     BOOST_CHECK(0 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(0 == dummyNode1.thinBlock.nCurrentBlockSize);
+    BOOST_CHECK(0 == pblock->nCurrentBlockSize);
 
-    thindata.AddThinBlockBytes(0, &dummyNode1);
+    thindata.AddThinBlockBytes(0, pblock);
     BOOST_CHECK(0 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(0 == dummyNode1.thinBlock.nCurrentBlockSize);
+    BOOST_CHECK(0 == pblock->nCurrentBlockSize);
 
-    thindata.AddThinBlockBytes(1000, &dummyNode1);
+    thindata.AddThinBlockBytes(1000, pblock);
     BOOST_CHECK(1000 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(1000 == dummyNode1.thinBlock.nCurrentBlockSize);
+    BOOST_CHECK(1000 == pblock->nCurrentBlockSize);
 
-    thindata.AddThinBlockBytes(449932, &dummyNode1);
+    thindata.AddThinBlockBytes(449932, pblock);
     BOOST_CHECK(450932 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(450932 == dummyNode1.thinBlock.nCurrentBlockSize);
+    BOOST_CHECK(450932 == pblock->nCurrentBlockSize);
 
     thindata.DeleteThinBlockBytes(0);
     BOOST_CHECK(450932 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(450932 == dummyNode1.thinBlock.nCurrentBlockSize);
+    BOOST_CHECK(450932 == pblock->nCurrentBlockSize);
 
     thindata.DeleteThinBlockBytes(1);
     BOOST_CHECK(450931 == thindata.GetThinBlockBytes());
@@ -89,10 +90,11 @@ BOOST_AUTO_TEST_CASE(test_thinblock_byte_tracking)
 
     CAddress addr2(ipaddress(0xa0b0c002, 10000));
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
+    pblock->SetNull();
 
-    thindata.AddThinBlockBytes(1000, &dummyNode2);
+    thindata.AddThinBlockBytes(1000, pblock);
     BOOST_CHECK(437992 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(1000 == dummyNode2.thinBlock.nCurrentBlockSize);
+    BOOST_CHECK(1000 == pblock->nCurrentBlockSize);
 
     thindata.DeleteThinBlockBytes(0);
     BOOST_CHECK(437992 == thindata.GetThinBlockBytes());

--- a/src/test/thinblock_data_tests.cpp
+++ b/src/test/thinblock_data_tests.cpp
@@ -45,43 +45,42 @@ BOOST_AUTO_TEST_CASE(test_thinblock_byte_tracking)
 
     CAddress addr1(ipaddress(0xa0b0c001, 10000));
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
+ 
+    CXThinBlock xthin;
+    dummyNode1.thinBlock.xthinblock = std::make_shared<CXThinBlock>(xthin);
 
     thindata.ResetThinBlockBytes();
     BOOST_CHECK(0 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(0 == dummyNode1.nLocalThinBlockBytes);
+    BOOST_CHECK(0 == dummyNode1.thinBlock.nCurrentBlockSize);
 
     thindata.AddThinBlockBytes(0, &dummyNode1);
     BOOST_CHECK(0 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(0 == dummyNode1.nLocalThinBlockBytes);
+    BOOST_CHECK(0 == dummyNode1.thinBlock.nCurrentBlockSize);
 
     thindata.AddThinBlockBytes(1000, &dummyNode1);
     BOOST_CHECK(1000 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(1000 == dummyNode1.nLocalThinBlockBytes);
+    BOOST_CHECK(1000 == dummyNode1.thinBlock.nCurrentBlockSize);
 
     thindata.AddThinBlockBytes(449932, &dummyNode1);
     BOOST_CHECK(450932 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(450932 == dummyNode1.nLocalThinBlockBytes);
+    BOOST_CHECK(450932 == dummyNode1.thinBlock.nCurrentBlockSize);
 
-    thindata.DeleteThinBlockBytes(0, &dummyNode1);
+    thindata.DeleteThinBlockBytes(0);
     BOOST_CHECK(450932 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(450932 == dummyNode1.nLocalThinBlockBytes);
+    BOOST_CHECK(450932 == dummyNode1.thinBlock.nCurrentBlockSize);
 
-    thindata.DeleteThinBlockBytes(1, &dummyNode1);
+    thindata.DeleteThinBlockBytes(1);
     BOOST_CHECK(450931 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(450931 == dummyNode1.nLocalThinBlockBytes);
 
-    thindata.DeleteThinBlockBytes(13939, &dummyNode1);
+    thindata.DeleteThinBlockBytes(13939);
     BOOST_CHECK(436992 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(436992 == dummyNode1.nLocalThinBlockBytes);
 
     // Try to delete more bytes than we already have tracked.  This should not be possible...we don't allow this
     // to happen in the event that we get an incorrect or invalid value returned for the dynamic memory usage of
     // a transaction.  This could then be used in a theoretical attack by resetting total byte usage to zero while
     // continuing to build more thinblocks.
-    thindata.DeleteThinBlockBytes(436993, &dummyNode1);
+    thindata.DeleteThinBlockBytes(436993);
     BOOST_CHECK_MESSAGE(436992 == thindata.GetThinBlockBytes(), "nThinBlockBytes is " << thindata.GetThinBlockBytes());
-    BOOST_CHECK_MESSAGE(
-        436992 == dummyNode1.nLocalThinBlockBytes, "nLocalThinBlockBytes is " << dummyNode1.nLocalThinBlockBytes);
 
 
     /**
@@ -93,22 +92,16 @@ BOOST_AUTO_TEST_CASE(test_thinblock_byte_tracking)
 
     thindata.AddThinBlockBytes(1000, &dummyNode2);
     BOOST_CHECK(437992 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(436992 == dummyNode1.nLocalThinBlockBytes);
-    BOOST_CHECK(1000 == dummyNode2.nLocalThinBlockBytes);
+    BOOST_CHECK(1000 == dummyNode2.thinBlock.nCurrentBlockSize);
 
-    thindata.DeleteThinBlockBytes(0, &dummyNode2);
+    thindata.DeleteThinBlockBytes(0);
     BOOST_CHECK(437992 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(1000 == dummyNode2.nLocalThinBlockBytes);
 
-    thindata.DeleteThinBlockBytes(1, &dummyNode2);
+    thindata.DeleteThinBlockBytes(1);
     BOOST_CHECK(437991 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(436992 == dummyNode1.nLocalThinBlockBytes);
-    BOOST_CHECK(999 == dummyNode2.nLocalThinBlockBytes);
 
-    thindata.DeleteThinBlockBytes(999, &dummyNode2);
+    thindata.DeleteThinBlockBytes(999);
     BOOST_CHECK(436992 == thindata.GetThinBlockBytes());
-    BOOST_CHECK(436992 == dummyNode1.nLocalThinBlockBytes);
-    BOOST_CHECK(0 == dummyNode2.nLocalThinBlockBytes);
 
     // now finally reset everything
     thindata.ResetThinBlockBytes();

--- a/src/test/thinblock_data_tests.cpp
+++ b/src/test/thinblock_data_tests.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE(test_thinblock_byte_tracking)
     CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
 
     CXThinBlock xthin;
-    std::shared_ptr<CBlock_ThinRelay> pblock = std::make_shared<CBlock_ThinRelay>(CBlock_ThinRelay());
+    std::shared_ptr<CBlockThinRelay> pblock = std::make_shared<CBlockThinRelay>(CBlockThinRelay());
     pblock->xthinblock = std::make_shared<CXThinBlock>(xthin);
 
     thindata.ResetThinBlockBytes();

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -2256,8 +2256,6 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
         uint64_t thinBlockSize = ::GetSerializeSize(inode.thinBlock, SER_NETWORK, PROTOCOL_VERSION);
         totalThinBlockSize += thinBlockSize;
         node.pushKV("thinblock.size", thinBlockSize);
-        node.pushKV("thinBlockHashes", (int64_t)inode.thinBlockHashes.size());
-        node.pushKV("xThinBlockHashes", (int64_t)inode.xThinBlockHashes.size());
         node.pushKV("vAddrToSend", (int64_t)inode.vAddrToSend.size());
         node.pushKV("vInventoryToSend", (int64_t)inode.vInventoryToSend.size());
         ret.pushKV(inode.addrName, node);


### PR DESCRIPTION
Take any xthin related data out of CNode.  Carry the xthin data, in memory, directly in the thinblock or xthinblock.  Furthermore store the xthinblock/thinblock's as smart pointers within a class CBlock_ThinRelay which itself is derived from CBlock().  This way way just can pass around a shared pointer to the CBlock_ThinRelay() which contains all the data  to reconstruct the block as well as the block itself.

Also store the block pointers in a new map so we can access them, in the cases where we need to re-request transactions and then finally reconstruct the block.

Once this PR gets approved I'll pull in the Graphene and Compact Block data as well but I don't want to take the time to do that until this PR is finalized.