### PR TITLE
Fix a timing bug in ctor.py

### DIFF
--- a/qa/rpc-tests/ctor.py
+++ b/qa/rpc-tests/ctor.py
@@ -97,6 +97,7 @@ class MyTest (BitcoinTestFramework):
         # we need to generate another block so the CTOR chain exceeds the DTOR
         self.nodes[2].generate(1)
         sync_blocks_to(103, self.nodes[2:])
+        time.sleep(2) # wait for the rollback to begin before getbestblockhash() is called
         waitFor(10, lambda: self.nodes[0].getbestblockhash() == dtorBlock)
         ct = self.nodes[0].getchaintips()
         tip = next(x for x in ct if x["status"] == "active")


### PR DESCRIPTION
We need to wait for the rollback of the chain to begin before
any call to getbestblockhash(), otherwise we won't end up waiting
for the chain to re-connect before testing the chain height.