### PR TITLE
[Builds on 1611]  Refactor compact blocks out of CNode

### DIFF
--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -305,7 +305,7 @@ bool ThinTypeRelay::ClearLargestBlockAndDisconnect(CNode *pfrom)
 
     if (pLargestNode != nullptr)
     {
-        thindata.ClearThinBlockData(pLargestNode, pLargestBlock);
+        thinrelay.ClearAllBlockData(pLargestNode, pLargestBlock);
         pLargestNode->fDisconnect = true;
 
         // If the our node is currently using up the most thinblock bytes then return true so that we
@@ -316,3 +316,47 @@ bool ThinTypeRelay::ClearLargestBlockAndDisconnect(CNode *pfrom)
 
     return false;
 }
+
+uint64_t ThinTypeRelay::AddTotalBlockBytes(uint64_t bytes, std::shared_ptr<CBlockThinRelay> &pblock)
+{
+    pblock->nCurrentBlockSize += bytes;
+    uint64_t ret = nTotalBlockBytes.fetch_add(bytes) + bytes;
+
+    return ret;
+}
+
+void ThinTypeRelay::DeleteTotalBlockBytes(uint64_t bytes)
+{
+    if (bytes <= nTotalBlockBytes)
+    {
+        nTotalBlockBytes.fetch_sub(bytes);
+    }
+}
+
+// After a thintype block is finished processing or if for some reason we have to pre-empt the rebuilding
+// of a thintype block then we clear out the thinblock bytes from the total.
+void ThinTypeRelay::ClearBlockBytes(std::shared_ptr<CBlockThinRelay> &pblock)
+{
+    // Remove bytes from counter
+    if (pblock != nullptr)
+        DeleteTotalBlockBytes(pblock->nCurrentBlockSize);
+
+    LOG(THIN | CMPCT | GRAPHENE, "Total in memory blockbytes after clearing a thintype block is %ld bytes\n",
+        GetTotalBlockBytes());
+}
+
+void ThinTypeRelay::ClearAllBlockData(CNode *pnode, std::shared_ptr<CBlockThinRelay> &pblock)
+{
+    // We must make sure to clear the block data first before clearing the thinblock in flight.
+    uint256 hash = pblock->GetBlockHeader().GetHash();
+    ClearBlockBytes(pblock);
+    ClearBlockToReconstruct(pnode);
+    if (pblock != nullptr)
+        pblock->SetNull();
+
+    // Now clear the block in flight.
+    ClearBlockInFlight(pnode, hash);
+}
+
+void ThinTypeRelay::ResetTotalBlockBytes() { nTotalBlockBytes.store(0); }
+uint64_t ThinTypeRelay::GetTotalBlockBytes() { return nTotalBlockBytes.load(); }

--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -256,6 +256,12 @@ std::shared_ptr<CBlockThinRelay> ThinTypeRelay::SetBlockToReconstruct(CNode *pfr
     // Store and empty block which can be used later
     std::shared_ptr<CBlockThinRelay> pblock;
     pblock = std::make_shared<CBlockThinRelay>(CBlockThinRelay());
+
+    // Initialize the thintype pointers
+    pblock->thinblock = std::make_shared<CThinBlock>(CThinBlock());
+    pblock->xthinblock = std::make_shared<CXThinBlock>(CXThinBlock());
+    pblock->cmpctblock = std::make_shared<CompactBlock>(CompactBlock());
+
     mapBlocksReconstruct.insert(
         std::make_pair(pfrom->GetId(), std::make_pair(pblock->GetBlockHeader().GetHash(), pblock)));
     return pblock;

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -25,10 +25,14 @@ struct CThinTypeBlockInFlight
 class ThinTypeRelay
 {
 public:
+    /* The sum total of all bytes for thintype blocks currently in process of being reconstructed */
+    std::atomic<uint64_t> nTotalBlockBytes{0};
+
     CCriticalSection cs_inflight;
     CCriticalSection cs_reconstruct;
 
 private:
+
     // block relay timer
     CCriticalSection cs_blockrelaytimer;
     std::map<uint256, std::pair<uint64_t, bool> > mapBlockRelayTimer GUARDED_BY(cs_blockrelaytimer);

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -25,13 +25,12 @@ struct CThinTypeBlockInFlight
 class ThinTypeRelay
 {
 public:
-    /* The sum total of all bytes for thintype blocks currently in process of being reconstructed */
-    std::atomic<uint64_t> nTotalBlockBytes{0};
-
     CCriticalSection cs_inflight;
     CCriticalSection cs_reconstruct;
 
 private:
+    /* The sum total of all bytes for thintype blocks currently in process of being reconstructed */
+    std::atomic<uint64_t> nTotalBlockBytes{0};
 
     // block relay timer
     CCriticalSection cs_blockrelaytimer;
@@ -76,6 +75,15 @@ public:
     std::shared_ptr<CBlockThinRelay> SetBlockToReconstruct(CNode *pfrom, const uint256 &hash);
     std::shared_ptr<CBlockThinRelay> GetBlockToReconstruct(CNode *pfrom);
     void ClearBlockToReconstruct(CNode *pfrom);
+
+    // Accessor methods for tracking total block bytes for all blocks currently in the process
+    // of being reconstructed.
+    uint64_t AddTotalBlockBytes(uint64_t, std::shared_ptr<CBlockThinRelay> &pblock);
+    void DeleteTotalBlockBytes(uint64_t bytes);
+    void ClearBlockBytes(std::shared_ptr<CBlockThinRelay> &pblock);
+    void ClearAllBlockData(CNode *pnode, std::shared_ptr<CBlockThinRelay> &pblock);
+    void ResetTotalBlockBytes();
+    uint64_t GetTotalBlockBytes();
 };
 extern ThinTypeRelay thinrelay;
 

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -64,6 +64,9 @@ public:
     void CheckForDownloadTimeout(CNode *pfrom);
     void RequestBlock(CNode *pfrom, const uint256 &hash);
 
+    // Find the largest block being reconstructed and disconnect it.
+    bool ClearLargestBlockAndDisconnect(CNode *pfrom);
+
     // Accessor methods to the blocks that we're reconstructing from thintype blocks such as
     // xthins or graphene.
     std::shared_ptr<CBlockThinRelay> SetBlockToReconstruct(CNode *pfrom, const uint256 &hash);

--- a/src/blockrelay/compactblock.cpp
+++ b/src/blockrelay/compactblock.cpp
@@ -123,8 +123,13 @@ void validateCompactBlock(const CompactBlock &cmpctblock)
  */
 bool CompactBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
 {
-    CompactBlock compactBlock;
-    vRecv >> compactBlock;
+    // Deserialize xthinblock and store a block to reconstruct
+    CompactBlock tmp;
+    vRecv >> tmp;
+    auto pblock = thinrelay.SetBlockToReconstruct(pfrom, tmp.header.GetHash());
+    pblock->cmpctblock = std::make_shared<CompactBlock>(std::forward<CompactBlock>(tmp));
+
+    CompactBlock &compactBlock = *pblock->cmpctblock;
 
     // Message consistency checking
     IsCompactBlockValid(pfrom, compactBlock);

--- a/src/blockrelay/compactblock.cpp
+++ b/src/blockrelay/compactblock.cpp
@@ -50,7 +50,7 @@ uint64_t GetShortID(const uint64_t &shorttxidk0, const uint64_t &shorttxidk1, co
 #define MIN_TRANSACTION_SIZE (::GetSerializeSize(CTransaction(), SER_NETWORK, PROTOCOL_VERSION))
 
 CompactBlock::CompactBlock(const CBlock &block, const CRollingFastFilter<4 * 1024 * 1024> *inventoryKnown)
-    : nonce(GetRand(std::numeric_limits<uint64_t>::max())), header(block)
+    : nonce(GetRand(std::numeric_limits<uint64_t>::max())), nWaitingFor(0), header(block)
 {
     FillShortTxIDSelector();
 
@@ -118,11 +118,9 @@ void validateCompactBlock(const CompactBlock &cmpctblock)
 }
 
 /**
- * Handle an incoming compactblock.  The block is fully validated, and if any transactions are missing, we fall
- * back to requesting a full block.
+ * Handle an incoming compactblock.  The block is fully validated, and if any
+ * transactions are missing we re-request them.
  */
-
-
 bool CompactBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
 {
     CompactBlock compactBlock;

--- a/src/blockrelay/compactblock.cpp
+++ b/src/blockrelay/compactblock.cpp
@@ -1086,21 +1086,21 @@ void CCompactBlockData::ClearCompactBlockStats()
 uint64_t CCompactBlockData::AddCompactBlockBytes(uint64_t bytes, std::shared_ptr<CBlockThinRelay> &pblock)
 {
     pblock->nCurrentBlockSize += bytes;
-    uint64_t ret = nCompactBlockBytes.fetch_add(bytes) + bytes;
+    uint64_t ret = thinrelay.nTotalBlockBytes.fetch_add(bytes) + bytes;
 
     return ret;
 }
 
 void CCompactBlockData::DeleteCompactBlockBytes(uint64_t bytes)
 {
-    if (bytes <= nCompactBlockBytes)
+    if (bytes <= thinrelay.nTotalBlockBytes)
     {
-        nCompactBlockBytes.fetch_sub(bytes);
+        thinrelay.nTotalBlockBytes.fetch_sub(bytes);
     }
 }
 
-void CCompactBlockData::ResetCompactBlockBytes() { nCompactBlockBytes.store(0); }
-uint64_t CCompactBlockData::GetCompactBlockBytes() { return nCompactBlockBytes.load(); }
+void CCompactBlockData::ResetCompactBlockBytes() { thinrelay.nTotalBlockBytes.store(0); }
+uint64_t CCompactBlockData::GetCompactBlockBytes() { return thinrelay.nTotalBlockBytes.load(); }
 void CCompactBlockData::FillCompactBlockQuickStats(CompactBlockQuickStats &stats)
 {
     if (!IsCompactBlocksEnabled())

--- a/src/blockrelay/compactblock.h
+++ b/src/blockrelay/compactblock.h
@@ -191,6 +191,14 @@ private:
     void FillShortTxIDSelector() const;
 
 public:
+    // memory only
+    mutable unsigned int nWaitingFor; // Number of txns we are still needing to recontruct the block
+
+    // memory only
+    std::vector<uint256> vTxHashes256; // List of all 256 bit transaction hashes in the block
+    std::map<uint64_t, CTransactionRef> mapMissingTx; // Map of transactions that were re-requested
+
+public:
     static const int SHORTTXIDS_LENGTH = 6;
 
     std::vector<uint64_t> shorttxids;
@@ -203,8 +211,8 @@ public:
     CompactBlock(const CBlock &block, const CRollingFastFilter<4 * 1024 * 1024> *inventoryKnown = nullptr);
 
     /**
-     * Handle an incoming thin block.  The block is fully validated, and if any transactions are missing, we fall
-     * back to requesting a full block.
+     * Handle an incoming compactblock.  The block is fully validated, and if any
+     * transactions are missing we re-request them.
      * @param[in] vRecv        The raw binary message
      * @param[in] pFrom        The node the message was from
      * @return True if handling succeeded

--- a/src/blockrelay/compactblock.h
+++ b/src/blockrelay/compactblock.h
@@ -186,6 +186,9 @@ public:
     mutable uint64_t shorttxidk0, shorttxidk1;
 
 private:
+    // memory only
+    mutable uint64_t nSize; // Serialized thinblock size in bytes
+
     uint64_t nonce;
 
     void FillShortTxIDSelector() const;
@@ -218,12 +221,19 @@ public:
      * @return True if handling succeeded
      */
     static bool HandleMessage(CDataStream &vRecv, CNode *pfrom);
-    bool process(CNode *pfrom, uint64_t nSizeCompactBlock);
+    bool process(CNode *pfrom);
     CInv GetInv() { return CInv(MSG_BLOCK, header.GetHash()); }
     uint64_t GetShortID(const uint256 &txhash) const;
 
     size_t BlockTxCount() const { return shorttxids.size() + prefilledtxn.size(); }
     ADD_SERIALIZE_METHODS;
+
+    uint64_t GetSize() const
+    {
+        if (nSize == 0)
+            nSize = ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
+        return nSize;
+    }
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream &s, Operation ser_action)

--- a/src/blockrelay/compactblock.h
+++ b/src/blockrelay/compactblock.h
@@ -304,8 +304,6 @@ struct CompactBlockQuickStats
 class CCompactBlockData
 {
 private:
-    /* The sum total of all bytes for compactblocks currently in process of being reconstructed */
-    std::atomic<uint64_t> nCompactBlockBytes{0};
 
     CCriticalSection cs_compactblockstats; // locks everything below this point
 

--- a/src/blockrelay/compactblock.h
+++ b/src/blockrelay/compactblock.h
@@ -390,14 +390,7 @@ public:
     std::string CompactBlockToString();
     std::string FullTxToString();
 
-    void ClearCompactBlockBytes(std::shared_ptr<CBlockThinRelay> &pblock);
-    void ClearCompactBlockData(CNode *pfrom, std::shared_ptr<CBlockThinRelay> &pblock);
     void ClearCompactBlockStats();
-
-    uint64_t AddCompactBlockBytes(uint64_t, std::shared_ptr<CBlockThinRelay> &pblock);
-    void DeleteCompactBlockBytes(uint64_t bytes);
-    void ResetCompactBlockBytes();
-    uint64_t GetCompactBlockBytes();
 
     void FillCompactBlockQuickStats(CompactBlockQuickStats &stats);
 };

--- a/src/blockrelay/compactblock.h
+++ b/src/blockrelay/compactblock.h
@@ -407,7 +407,6 @@ extern CCompactBlockData compactdata; // Singleton class
 
 
 bool IsCompactBlocksEnabled();
-bool ClearLargestCompactBlockAndDisconnect(CNode *pfrom);
 void SendCompactBlock(ConstCBlockRef pblock, CNode *pfrom, const CInv &inv);
 bool IsCompactBlockValid(CNode *pfrom, const CompactBlock &cmpctblock);
 

--- a/src/blockrelay/compactblock.h
+++ b/src/blockrelay/compactblock.h
@@ -199,6 +199,7 @@ public:
 
     // memory only
     std::vector<uint256> vTxHashes256; // List of all 256 bit transaction hashes in the block
+    std::vector<uint64_t> vTxHashes; // List of all 64 bit transaction hashes in the block
     std::map<uint64_t, CTransactionRef> mapMissingTx; // Map of transactions that were re-requested
 
 public:

--- a/src/blockrelay/compactblock.h
+++ b/src/blockrelay/compactblock.h
@@ -221,7 +221,7 @@ public:
      * @return True if handling succeeded
      */
     static bool HandleMessage(CDataStream &vRecv, CNode *pfrom);
-    bool process(CNode *pfrom);
+    bool process(CNode *pfrom, std::shared_ptr<CBlockThinRelay> &pblock);
     CInv GetInv() { return CInv(MSG_BLOCK, header.GetHash()); }
     uint64_t GetShortID(const uint256 &txhash) const;
 

--- a/src/blockrelay/compactblock.h
+++ b/src/blockrelay/compactblock.h
@@ -392,12 +392,12 @@ public:
     std::string CompactBlockToString();
     std::string FullTxToString();
 
-    void ClearCompactBlockData(CNode *pfrom);
-    void ClearCompactBlockData(CNode *pfrom, const uint256 &hash);
+    void ClearCompactBlockBytes(std::shared_ptr<CBlockThinRelay> &pblock);
+    void ClearCompactBlockData(CNode *pfrom, std::shared_ptr<CBlockThinRelay> &pblock);
     void ClearCompactBlockStats();
 
-    uint64_t AddCompactBlockBytes(uint64_t, CNode *pfrom);
-    void DeleteCompactBlockBytes(uint64_t, CNode *pfrom);
+    uint64_t AddCompactBlockBytes(uint64_t, std::shared_ptr<CBlockThinRelay> &pblock);
+    void DeleteCompactBlockBytes(uint64_t bytes);
     void ResetCompactBlockBytes();
     uint64_t GetCompactBlockBytes();
 

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -510,7 +510,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
         CBlockIndex *pIndex = nullptr;
         if (!AcceptBlockHeader(thinBlock.header, state, Params(), &pIndex))
         {
-            thindata.ClearThinBlockData(pfrom, pblock);
+            thinrelay.ClearAllBlockData(pfrom, pblock);
             LOGA("Received an invalid %s header from peer %s\n", strCommand, pfrom->GetLogName());
             return false;
         }

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -1290,20 +1290,20 @@ void CThinBlockData::ClearThinBlockStats()
 uint64_t CThinBlockData::AddThinBlockBytes(uint64_t bytes, std::shared_ptr<CBlockThinRelay> &pblock)
 {
     pblock->nCurrentBlockSize += bytes;
-    uint64_t ret = nThinBlockBytes.fetch_add(bytes) + bytes;
+    uint64_t ret = thinrelay.nTotalBlockBytes.fetch_add(bytes) + bytes;
     return ret;
 }
 
 void CThinBlockData::DeleteThinBlockBytes(uint64_t bytes)
 {
-    if (bytes <= nThinBlockBytes)
+    if (bytes <= thinrelay.nTotalBlockBytes)
     {
-        nThinBlockBytes.fetch_sub(bytes);
+        thinrelay.nTotalBlockBytes.fetch_sub(bytes);
     }
 }
 
-void CThinBlockData::ResetThinBlockBytes() { nThinBlockBytes.store(0); }
-uint64_t CThinBlockData::GetThinBlockBytes() { return nThinBlockBytes.load(); }
+void CThinBlockData::ResetThinBlockBytes() { thinrelay.nTotalBlockBytes.store(0); }
+uint64_t CThinBlockData::GetThinBlockBytes() { return thinrelay.nTotalBlockBytes.load(); }
 void CThinBlockData::FillThinBlockQuickStats(ThinBlockQuickStats &stats)
 {
     if (!IsThinBlocksEnabled())

--- a/src/blockrelay/thinblock.h
+++ b/src/blockrelay/thinblock.h
@@ -325,7 +325,6 @@ extern CThinBlockData thindata; // Singleton class
 
 
 bool IsThinBlocksEnabled();
-bool ClearLargestThinBlockAndDisconnect(CNode *pfrom);
 void SendXThinBlock(ConstCBlockRef pblock, CNode *pfrom, const CInv &inv);
 void RequestThinBlock(CNode *pfrom, const uint256 &hash);
 bool IsThinBlockValid(CNode *pfrom, const std::vector<CTransaction> &vMissingTx, const CBlockHeader &header);

--- a/src/blockrelay/thinblock.h
+++ b/src/blockrelay/thinblock.h
@@ -214,7 +214,6 @@ struct ThinBlockQuickStats
 class CThinBlockData
 {
 private:
-
     CCriticalSection cs_thinblockstats; // locks everything below this point
 
     CStatHistory<uint64_t> nOriginalSize;
@@ -308,14 +307,7 @@ public:
     std::string ThinBlockToString();
     std::string FullTxToString();
 
-    void ClearThinBlockBytes(std::shared_ptr<CBlockThinRelay> &pblock);
-    void ClearThinBlockData(CNode *pnode, std::shared_ptr<CBlockThinRelay> &pblock);
     void ClearThinBlockStats();
-
-    uint64_t AddThinBlockBytes(uint64_t bytes, std::shared_ptr<CBlockThinRelay> &pblock);
-    void DeleteThinBlockBytes(uint64_t bytes);
-    void ResetThinBlockBytes();
-    uint64_t GetThinBlockBytes();
 
     void FillThinBlockQuickStats(ThinBlockQuickStats &stats);
 };

--- a/src/blockrelay/thinblock.h
+++ b/src/blockrelay/thinblock.h
@@ -214,8 +214,6 @@ struct ThinBlockQuickStats
 class CThinBlockData
 {
 private:
-    /* The sum total of all bytes for thinblocks currently in process of being reconstructed */
-    std::atomic<uint64_t> nThinBlockBytes{0};
 
     CCriticalSection cs_thinblockstats; // locks everything below this point
 

--- a/src/blockrelay/thinblock.h
+++ b/src/blockrelay/thinblock.h
@@ -33,7 +33,6 @@ private:
 public:
     // memory only
     mutable unsigned int nWaitingFor; // number of txns we are still needing to recontruct the block
-
     std::map<uint64_t, CTransactionRef> mapMissingTx;
 
 public:
@@ -83,7 +82,6 @@ private:
 public:
     // memory only
     mutable unsigned int nWaitingFor; // number of txns we are still needing to recontruct the block
-    uint64_t nBlockBytes; // the bytes used in re-assembling the block, updated dynamically
     bool collision;
 
     // memory only

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2950,7 +2950,6 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
     grapheneBlockWaitingForTxns = -1;
 
     // compact blocks
-    nLocalCompactBlockBytes = 0;
     shorttxidk0 = 0;
     shorttxidk1 = 0;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2951,7 +2951,6 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
 
     // compact blocks
     nLocalCompactBlockBytes = 0;
-    compactBlockWaitingForTxns = -1;
     shorttxidk0 = 0;
     shorttxidk1 = 0;
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2951,7 +2951,6 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
 
     // compact blocks
     nLocalCompactBlockBytes = 0;
-    nSizeCompactBlock = 0;
     compactBlockWaitingForTxns = -1;
     shorttxidk0 = 0;
     shorttxidk1 = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -492,10 +492,9 @@ public:
 
     // Compact Blocks : begin
     CCriticalSection cs_compactblock;
-    CBlock compactBlock;
+    CBlockThinRelay compactBlock;
     std::map<uint64_t, CTransactionRef> mapMissingCompactBlockTx;
     uint64_t nLocalCompactBlockBytes; // the bytes used in creating this cmpctblock, updated dynamically
-    int compactBlockWaitingForTxns; // if -1 then not currently waiting
 
     std::vector<uint64_t> vShortCompactBlockHashes;
     std::vector<uint256> vCompactBlockHashes;

--- a/src/net.h
+++ b/src/net.h
@@ -493,8 +493,6 @@ public:
     // Compact Blocks : begin
     CCriticalSection cs_compactblock;
     CBlockThinRelay compactBlock;
-    std::map<uint64_t, CTransactionRef> mapMissingCompactBlockTx;
-    uint64_t nLocalCompactBlockBytes; // the bytes used in creating this cmpctblock, updated dynamically
 
     std::vector<uint64_t> vShortCompactBlockHashes;
     std::vector<uint256> vCompactBlockHashes;

--- a/src/net.h
+++ b/src/net.h
@@ -495,7 +495,6 @@ public:
     CBlock compactBlock;
     std::map<uint64_t, CTransactionRef> mapMissingCompactBlockTx;
     uint64_t nLocalCompactBlockBytes; // the bytes used in creating this cmpctblock, updated dynamically
-    uint64_t nSizeCompactBlock; // Original on-wire size of the block. Just used for reporting
     int compactBlockWaitingForTxns; // if -1 then not currently waiting
 
     std::vector<uint64_t> vShortCompactBlockHashes;

--- a/src/net.h
+++ b/src/net.h
@@ -495,7 +495,6 @@ public:
     CBlockThinRelay compactBlock;
 
     std::vector<uint64_t> vShortCompactBlockHashes;
-    std::vector<uint256> vCompactBlockHashes;
 
     uint64_t shorttxidk0;
     uint64_t shorttxidk1;

--- a/src/net.h
+++ b/src/net.h
@@ -492,8 +492,8 @@ public:
 
     // Compact Blocks : begin
     CCriticalSection cs_compactblock;
-    CBlockThinRelay compactBlock;
 
+    // Store the compactblock salt to be used for this peer
     uint64_t shorttxidk0;
     uint64_t shorttxidk1;
 

--- a/src/net.h
+++ b/src/net.h
@@ -494,8 +494,6 @@ public:
     CCriticalSection cs_compactblock;
     CBlockThinRelay compactBlock;
 
-    std::vector<uint64_t> vShortCompactBlockHashes;
-
     uint64_t shorttxidk0;
     uint64_t shorttxidk1;
 

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -660,9 +660,8 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, CBlockRef p
         // just to make sure we don't somehow get growth over time.
         if (thinrelay.TotalBlocksInFlight() == 0)
         {
-            thindata.ResetThinBlockBytes();
+            thinrelay.ResetTotalBlockBytes();
             graphenedata.ResetGrapheneBlockBytes();
-            compactdata.ResetCompactBlockBytes();
         }
 
         // Erase any txns from the orphan cache that are no longer needed

--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -19,6 +19,7 @@ const bool DEFAULT_2MB_VOTE = false;
 
 class CXThinBlock;
 class CThinBlock;
+class CompactBlock;
 
 /** Nodes collect new transactions into a block, hash them into a hash tree,
  * and scan through nonce values to make the block's hash satisfy proof-of-work
@@ -207,6 +208,7 @@ public:
     //! thinrelay block types: (memory only)
     std::shared_ptr<CThinBlock> thinblock;
     std::shared_ptr<CXThinBlock> xthinblock;
+    std::shared_ptr<CompactBlock> cmpctblock;
 
     //! Track the current block size during reconstruction: (memory only)
     uint64_t nCurrentBlockSize;
@@ -218,6 +220,7 @@ public:
         nCurrentBlockSize = 0;
         thinblock = nullptr;
         xthinblock = nullptr;
+        cmpctblock = nullptr;
     }
 };
 

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -498,651 +498,649 @@ BOOST_AUTO_TEST_CASE(block_tests)
 
 BOOST_AUTO_TEST_CASE(thinblock_tests)
 {
+    fImporting = false;
+    fReindex = false;
+    bool fInit = false;
+    IsInitialBlockDownloadInit(&fInit);
+
+    CBloomFilter filter;
+    std::vector<uint256> vOrphanHashes;
+    // Create 10 random hashes to seed the orphanhash vector.  This way we will create a bloom filter
+    // with a size of 10 elements.
+    std::string hash = "3fba505b48865fccda4e248cecc39d5dfbc6b8ef7b4adc9cd27242c1193c714";
+    for (int i = 0; i < 10; i++)
     {
-        fImporting = false;
-        fReindex = false;
-        bool fInit = false;
-        IsInitialBlockDownloadInit(&fInit);
-
-        CBloomFilter filter;
-        std::vector<uint256> vOrphanHashes;
-        // Create 10 random hashes to seed the orphanhash vector.  This way we will create a bloom filter
-        // with a size of 10 elements.
-        std::string hash = "3fba505b48865fccda4e248cecc39d5dfbc6b8ef7b4adc9cd27242c1193c714";
-        for (int i = 0; i < 10; i++)
-        {
-            std::stringstream ss;
-            ss << i;
-            hash.append(ss.str());
-            uint256 random_hash = uint256S(hash);
-            vOrphanHashes.push_back(random_hash);
-        }
-        std::unique_ptr<CNode> dummyNodeMem(new CNode(INVALID_SOCKET, addr1, "", true));
-        CNode &dummyNode = *dummyNodeMem;
-        BuildSeededBloomFilter(filter, vOrphanHashes, TestBlock1().GetHash(), &dummyNode, true);
-
-        block = TestBlock1();
-        CThinBlock thinblock(block, filter);
-        CXThinBlock xthinblock(block, &filter);
-
-        /** FILTERSIZEXTHIN tests */
-
-        CDataStream ssSend(SER_NETWORK, INIT_PROTO_VERSION);
-        ssSend << (uint32_t)36000;
-
-        dosMan.ClearBanned();
-        vRecv1.clear();
-        vRecv1 << ssSend;
-        {
-            std::unique_ptr<CNode> dummyNodeAMem(new CNode(INVALID_SOCKET, addr1, "", true));
-            CNode &dummyNodeA = *dummyNodeMem;
-            dummyNodeA.nServices |= NODE_XTHIN;
-            dummyNodeA.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNodeA.state_incoming = ConnectionStateIncoming::READY;
-            dummyNodeA.state_outgoing = ConnectionStateOutgoing::READY;
-            ProcessMessage(&dummyNodeA, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetTime());
-            BOOST_CHECK(!dummyNodeA.fDisconnect); // node should not be disconnected
-        }
-
-        dosMan.ClearBanned();
-        vRecv1.clear();
-        vRecv1 << ssSend;
-
-        {
-            std::unique_ptr<CNode> dummyNodeBMem(new CNode(INVALID_SOCKET, addr1, "", true));
-            CNode &dummyNodeB = *dummyNodeBMem;
-            dummyNodeB.nServices |= NODE_BLOOM;
-            dummyNodeB.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNodeB.state_incoming = ConnectionStateIncoming::READY;
-            dummyNodeB.state_outgoing = ConnectionStateOutgoing::READY;
-            ProcessMessage(&dummyNodeB, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetTime());
-            BOOST_CHECK(dummyNodeB.fDisconnect); // node should be disconnected
-        }
-
-        dosMan.ClearBanned();
-        vRecv1.clear();
-        vRecv1 << ssSend;
-
-        {
-            std::unique_ptr<CNode> dummyNodeCMem(new CNode(INVALID_SOCKET, addr1, "", true));
-            CNode &dummyNodeC = *dummyNodeCMem;
-            dummyNodeC.nServices |= NODE_XTHIN;
-            dummyNodeC.nServices |= NODE_BLOOM;
-            dummyNodeC.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNodeC.state_incoming = ConnectionStateIncoming::READY;
-            dummyNodeC.state_outgoing = ConnectionStateOutgoing::READY;
-            ProcessMessage(&dummyNodeC, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetTime());
-            BOOST_CHECK(!dummyNodeC.fDisconnect); // node should not be disconnected
-        }
-
-        // Send a filter message indicating a size that is less than the default 36000.
-        // This should get a disconnect.
-        CDataStream ssSend2(SER_NETWORK, INIT_PROTO_VERSION);
-        ssSend2 << (uint32_t)35999;
-
-        dosMan.ClearBanned();
-        vRecv1.clear();
-        vRecv1 << ssSend2;
-
-        {
-            std::unique_ptr<CNode> dummyNodeDMem(new CNode(INVALID_SOCKET, addr1, "", true));
-            CNode &dummyNodeD = *dummyNodeDMem;
-            dummyNodeD.nServices |= NODE_XTHIN;
-            dummyNodeD.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNodeD.state_incoming = ConnectionStateIncoming::READY;
-            dummyNodeD.state_outgoing = ConnectionStateOutgoing::READY;
-            ProcessMessage(&dummyNodeD, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetTime());
-            BOOST_CHECK(dummyNodeD.fDisconnect); // node should be disconnected
-        }
-
-        /** XTHINBLOCK message consistency checks */
-
-        // testing empty missingtx vector
-        dosMan.ClearBanned();
-        CXThinBlock xthin = xthinblock;
-        xthin.vMissingTx.clear(); // empty the missingtx vector. This should cause an error.
-        vRecv1.clear();
-        vRecv1 << xthin;
-
-        {
-            CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
-            dummyNode1.nServices |= NODE_XTHIN;
-            dummyNode1.nServices |= NODE_BLOOM;
-            dummyNode1.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNode1.state_incoming = ConnectionStateIncoming::READY;
-            dummyNode1.state_outgoing = ConnectionStateOutgoing::READY;
-            ProcessMessage(&dummyNode1, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
-            SendMessages(&dummyNode1);
-            BOOST_CHECK(xthin.vMissingTx.size() == 0);
-            BOOST_CHECK(dosMan.IsBanned(addr1));
-        }
-
-        // test invalid or missing coinbase
-        dosMan.ClearBanned();
-        vRecv1.clear();
-        xthin = xthinblock;
-        xthin.vMissingTx[0] = xthin.vMissingTx[1]; // delete the coinbase. This should cause an error.
-        vRecv1 << xthin;
-
-        {
-            CNode dummyNode1a(INVALID_SOCKET, addr1, "", true);
-            dummyNode1a.nServices |= NODE_XTHIN;
-            dummyNode1a.nServices |= NODE_BLOOM;
-            dummyNode1a.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNode1a.state_incoming = ConnectionStateIncoming::READY;
-            dummyNode1a.state_outgoing = ConnectionStateOutgoing::READY;
-            ProcessMessage(&dummyNode1a, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
-            SendMessages(&dummyNode1a);
-            BOOST_CHECK(!xthin.vMissingTx[0].IsCoinBase());
-            BOOST_CHECK(dosMan.IsBanned(addr1));
-        }
-
-        // test invalid block header
-        dosMan.ClearBanned();
-        vRecv1.clear();
-        xthin = xthinblock;
-        xthin.header.nBits = 1; // create invalid block header
-        vRecv1 << xthin;
-
-        CValidationState state;
-
-        {
-            CNode dummyNode1b(INVALID_SOCKET, addr1, "", true);
-            dummyNode1b.nServices |= NODE_XTHIN;
-            dummyNode1b.nServices |= NODE_BLOOM;
-            dummyNode1b.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNode1b.state_incoming = ConnectionStateIncoming::READY;
-            dummyNode1b.state_outgoing = ConnectionStateOutgoing::READY;
-            ProcessMessage(&dummyNode1b, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
-            SendMessages(&dummyNode1b);
-            BOOST_CHECK(!CheckBlockHeader(xthin.header, state, true));
-            BOOST_CHECK(dosMan.IsBanned(addr1));
-        }
-        /** THINBLOCK message consistency  checks */
-
-        // test empty missingtx vector
-        dosMan.ClearBanned();
-        CThinBlock thin = thinblock;
-        thin.vMissingTx.clear(); // empty the missingtx vector. This should cause an error.
-        vRecv2 << thin;
-
-        {
-            CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
-            dummyNode2.nServices |= NODE_XTHIN;
-            dummyNode2.nServices |= NODE_BLOOM;
-            dummyNode2.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNode2.state_incoming = ConnectionStateIncoming::READY;
-            dummyNode2.state_outgoing = ConnectionStateOutgoing::READY;
-            ProcessMessage(&dummyNode2, NetMsgType::THINBLOCK, vRecv2, GetTime());
-            SendMessages(&dummyNode2);
-            BOOST_CHECK(thin.vMissingTx.size() == 0);
-            BOOST_CHECK(dosMan.IsBanned(addr2));
-        }
-
-        // test invalid or missing coinbase
-        dosMan.ClearBanned();
-        vRecv2.clear();
-        thin = thinblock;
-        thin.vMissingTx[0] = thin.vMissingTx[1]; // delete the coinbase. This should cause an error.
-        vRecv2 << thin;
-
-        {
-            CNode dummyNode2a(INVALID_SOCKET, addr2, "", true);
-            dummyNode2a.nServices |= NODE_XTHIN;
-            dummyNode2a.nServices |= NODE_BLOOM;
-            dummyNode2a.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNode2a.state_incoming = ConnectionStateIncoming::READY;
-            dummyNode2a.state_outgoing = ConnectionStateOutgoing::READY;
-            ProcessMessage(&dummyNode2a, NetMsgType::THINBLOCK, vRecv2, GetTime());
-            SendMessages(&dummyNode2a);
-            BOOST_CHECK(!thin.vMissingTx[0].IsCoinBase());
-            BOOST_CHECK(dosMan.IsBanned(addr2));
-        }
-
-        // create invalid block header
-        dosMan.ClearBanned();
-        vRecv2.clear();
-        thin = thinblock;
-        thin.header.nBits = 1;
-        vRecv2 << thin;
-
-        {
-            CNode dummyNode2b(INVALID_SOCKET, addr2, "", true);
-            dummyNode2b.nServices |= NODE_XTHIN;
-            dummyNode2b.nServices |= NODE_BLOOM;
-            dummyNode2b.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNode2b.state_incoming = ConnectionStateIncoming::READY;
-            dummyNode2b.state_outgoing = ConnectionStateOutgoing::READY;
-            ProcessMessage(&dummyNode2b, NetMsgType::THINBLOCK, vRecv2, GetTime());
-            SendMessages(&dummyNode2b);
-            BOOST_CHECK(!CheckBlockHeader(thin.header, state, true));
-            BOOST_CHECK(dosMan.IsBanned(addr2));
-        }
-
-
-        /** XBLOCKTX message consistency checks */
-
-        // test null hash
-        CBlock block3 = TestBlock1();
-
-        dosMan.ClearBanned();
-        nullhash.SetNull();
-        std::vector<CTransaction> vtx;
-        for (auto &tx : block3.vtx)
-            vtx.push_back(*tx);
-
-        CXThinBlockTx xblocktx(nullhash, vtx);
-        vRecv3 << xblocktx;
-
-        {
-            CNode dummyNode3(INVALID_SOCKET, addr3, "", true);
-            dummyNode3.nServices |= NODE_XTHIN;
-            dummyNode3.nServices |= NODE_BLOOM;
-            dummyNode3.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNode3.state_incoming = ConnectionStateIncoming::READY;
-            dummyNode3.state_outgoing = ConnectionStateOutgoing::READY;
-            auto pblock = thinrelay.SetBlockToReconstruct(&dummyNode3, nullhash);
-            ProcessMessage(&dummyNode3, NetMsgType::XBLOCKTX, vRecv3, GetTime());
-            SendMessages(&dummyNode3);
-            BOOST_CHECK(nullhash.IsNull());
-            BOOST_CHECK(dosMan.IsBanned(addr3));
-        }
-
-        // no block to reconstruct available
-        {
-            CNode dummyNode3(INVALID_SOCKET, addr3, "", true);
-            std::shared_ptr<CBlockThinRelay> pblock = thinrelay.GetBlockToReconstruct(&dummyNode3);
-            BOOST_CHECK(pblock == nullptr);
-        }
-
-        // test no txns in xblocktx
-        dosMan.ClearBanned();
-        vRecv3.clear();
-        std::vector<CTransaction> vTxEmpty;
-        CXThinBlockTx xblocktx2(block3.GetHash(), vTxEmpty);
-        vRecv3 << xblocktx2;
-
-        {
-            CNode dummyNode3a(INVALID_SOCKET, addr3, "", true);
-            dummyNode3a.nServices |= NODE_XTHIN;
-            dummyNode3a.nServices |= NODE_BLOOM;
-            dummyNode3a.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNode3a.state_incoming = ConnectionStateIncoming::READY;
-            dummyNode3a.state_outgoing = ConnectionStateOutgoing::READY;
-            auto pblock = thinrelay.SetBlockToReconstruct(&dummyNode3a, block3.GetHash());
-            ProcessMessage(&dummyNode3a, NetMsgType::XBLOCKTX, vRecv3, GetTime());
-            SendMessages(&dummyNode3a);
-            BOOST_CHECK(vTxEmpty.size() == 0);
-            BOOST_CHECK(dosMan.IsBanned(addr3));
-        }
-
-        /** GET_XBLOCKTX message consistency checks */
-
-        // test null hash
-        dosMan.ClearBanned();
-        nullhash.SetNull();
-        std::set<uint64_t> setHashesToRequest;
-        setHashesToRequest.insert(1); // add a hash so that we are not empty
-        CXRequestThinBlockTx get_xblocktx(nullhash, setHashesToRequest);
-        vRecv4 << get_xblocktx;
-
-        {
-            CNode dummyNode4(INVALID_SOCKET, addr4, "", true);
-            dummyNode4.nServices |= NODE_XTHIN;
-            dummyNode4.nServices |= NODE_BLOOM;
-            dummyNode4.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNode4.state_incoming = ConnectionStateIncoming::READY;
-            dummyNode4.state_outgoing = ConnectionStateOutgoing::READY;
-            ProcessMessage(&dummyNode4, NetMsgType::GET_XBLOCKTX, vRecv4, GetTime());
-            SendMessages(&dummyNode4);
-            BOOST_CHECK(nullhash.IsNull());
-            BOOST_CHECK(dosMan.IsBanned(addr4));
-        }
-
-        // test empty setHashesToRequest
-        dosMan.ClearBanned();
-        vRecv4.clear();
-        setHashesToRequest.clear(); // clear the set
-        CXRequestThinBlockTx get_xblocktx2(block3.GetHash(), setHashesToRequest);
-        vRecv4 << get_xblocktx2;
-
-        {
-            std::unique_ptr<CNode> dummyNode4aMem(new CNode(INVALID_SOCKET, addr4, "", true));
-            CNode &dummyNode4a = *dummyNode4aMem;
-            dummyNode4a.nServices |= NODE_XTHIN;
-            dummyNode4a.nServices |= NODE_BLOOM;
-            dummyNode4a.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNode4a.state_incoming = ConnectionStateIncoming::READY;
-            dummyNode4a.state_outgoing = ConnectionStateOutgoing::READY;
-            ProcessMessage(&dummyNode4a, NetMsgType::GET_XBLOCKTX, vRecv4, GetTime());
-            SendMessages(&dummyNode4a);
-            BOOST_CHECK(setHashesToRequest.empty());
-            BOOST_CHECK(dosMan.IsBanned(addr4));
-
-
-            /** GET_XTHIN message consistency checks */
-
-            // test get_xthin with null hash
-            dosMan.ClearBanned();
-            nullhash.SetNull();
-            CInv inv(MSG_XTHINBLOCK, nullhash);
-            CBloomFilter filterMemPool;
-            BuildSeededBloomFilter(filterMemPool, vOrphanHashes, inv.hash, &dummyNode4a, true);
-            vRecv5 << inv;
-            vRecv5 << filterMemPool;
-
-            std::unique_ptr<CNode> dummyNode5Mem(new CNode(INVALID_SOCKET, addr5, "", true));
-            CNode &dummyNode5 = *dummyNode5Mem;
-            dummyNode5.nServices |= NODE_XTHIN;
-            dummyNode5.nServices |= NODE_BLOOM;
-            dummyNode5.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNode5.state_incoming = ConnectionStateIncoming::READY;
-            dummyNode5.state_outgoing = ConnectionStateOutgoing::READY;
-            ProcessMessage(&dummyNode5, NetMsgType::GET_XTHIN, vRecv5, GetTime());
-            SendMessages(&dummyNode5);
-            BOOST_CHECK(nullhash.IsNull());
-            BOOST_CHECK(dosMan.IsBanned(addr5));
-
-            // test get_xthin with invalid message type
-            dosMan.ClearBanned();
-            vRecv5.clear();
-            CInv inv2(15, block3.GetHash()); // invalid type
-            CBloomFilter filterMemPool2;
-            BuildSeededBloomFilter(filterMemPool2, vOrphanHashes, inv2.hash, &dummyNode5, true);
-            vRecv5 << inv2;
-            vRecv5 << filterMemPool2;
-
-            std::unique_ptr<CNode> dummyNode5aMem(new CNode(INVALID_SOCKET, addr5, "", true));
-            CNode &dummyNode5a = *dummyNode5aMem;
-            dummyNode5a.nServices |= NODE_XTHIN;
-            dummyNode5a.nServices |= NODE_BLOOM;
-            dummyNode5a.nVersion = MIN_PEER_PROTO_VERSION;
-            dummyNode5a.state_incoming = ConnectionStateIncoming::READY;
-            dummyNode5a.state_outgoing = ConnectionStateOutgoing::READY;
-            ProcessMessage(&dummyNode5a, NetMsgType::GET_XTHIN, vRecv5, GetTime());
-            SendMessages(&dummyNode5a);
-            BOOST_CHECK(inv2.type != MSG_THINBLOCK && inv2.type != MSG_XTHINBLOCK);
-            BOOST_CHECK(dosMan.IsBanned(addr5));
-        }
-
-
-        /* Thinblock memory exhaustion attack 1 */
-
-        uint32_t old_excessiveBlockSize = excessiveBlockSize;
-
-        // Shared pointers can be different sizes on different sysstems so get size of a shared pointer
-        // and size of the block that we'll need for later comparisons.
-        CTransactionRef pdummytx = nullptr;
-        uint32_t nSharedTxSize = sizeof(pdummytx);
-        uint32_t nSizeTxInBlock = 9 * nSharedTxSize; // there are 9 txn's in this block.
-
-        // Get size of xthin and thinblock to be used later
-        CXThinBlock xthinsize = xthinblock;
-        vRecv1.clear();
-        vRecv1 << xthinsize;
-        vRecv1.clear();
-        CThinBlock thinsize = thinblock;
-        vRecv1 << thinsize;
-        vRecv1.clear();
-
-        // test a single valid thinblock reconstruction that goes over the limit.
-        // result: the peer should have it data cleared and node should be disconnected.
-        CNode dummyNode6(INVALID_SOCKET, addr1, "", true);
-        {
-            dosMan.ClearBanned();
-            CXThinBlock xthin2 = xthinblock;
-            CXThinBlock xthin2a = xthinblock;
-            CThinBlock thin2 = thinblock;
-
-            // The number of tx bytes in this block is 3784 bytes however now that we use shared pointers for blocks
-            // we use a different calculation for max block size possible.  In order for the node to be disconnected
-            // we have to make the maxAllowedSize be less sizeof(shared_ptr) * maxMessageSizeMultiplier *
-            // excessiveBlockSize / 158.
-            // From the above the maxAllowedSize must be less than 16 * 9 (or 216) in order to trigger the oversized
-            // block and disconnect. And therefore the excessiveBlockSize must be = (144 * 158) / (16 * 16) = 88.87,
-            // or 88 to trigger a disconnection.
-            excessiveBlockSize = (nSizeTxInBlock * 158) / (nSharedTxSize * 16); // 88
-
-            // Add the node to vNodes and also we need a thinblockinflight entry
-            thinrelay.AddBlockInFlight(&dummyNode6, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
-            vNodes.push_back(&dummyNode6);
-
-            // Process an xthinblock which causes a disconnect
-            dummyNode6.fDisconnect = false;
-            pblock6->SetNull();
-            pblock6 = thinrelay.SetBlockToReconstruct(&dummyNode6, xthin2.header.GetHash());
-            pblock6->xthinblock = std::make_shared<CXThinBlock>(xthin2);
-            xthin2.process(&dummyNode6, NetMsgType::XTHINBLOCK, pblock6);
-            BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
-            BOOST_CHECK(pblock6->IsNull());
-
-            // clean up vNodes, mapthinblocksinflight and thinblock data
-            vNodes.pop_back();
-            thinrelay.ClearAllBlockData(&dummyNode6, pblock6);
-
-            // Add the node to vNodes and also we need a thinblockinflight entry
-            thinrelay.AddBlockInFlight(&dummyNode6, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
-            vNodes.push_back(&dummyNode6);
-
-            // Process a regular thinblock
-            dummyNode6.fDisconnect = false;
-            pblock6 = thinrelay.SetBlockToReconstruct(&dummyNode6, xthin2.header.GetHash());
-            pblock6->thinblock = std::make_shared<CThinBlock>(thin2);
-            thin2.process(&dummyNode6, pblock6);
-            BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
-            BOOST_CHECK(pblock6->IsNull());
-
-            // clean up vNodes, mapthinblocksinflight and thinblock data
-            vNodes.pop_back();
-            thinrelay.ClearAllBlockData(&dummyNode6, pblock6);
-
-            // TODO: it would be great to have a test with an excessiveBlockSize of one byte larger
-            //       so we can prove that a disconnect wouldn't happen for the edge case however
-            //       that causes us to sent a messae back out through an invalid socket which then
-            //       results in a crash.  It took a great deal of debugging to find this out so hence
-            //       the comment here to help someone avoid any pitalls, for any future efforts.
-        }
-
-
-        /* Thinblock memory exhaustion attack 2 */
-
-        // test correct disconnection of a multiple valid thinblock reconstruction that goes over the limit.
-        // result: the peer with largest thinblock set of data should have it data cleared
-        //         and node should be disconnected.
-        CNode dummyNode7(INVALID_SOCKET, addr2, "", true);
-        CNode dummyNode8(INVALID_SOCKET, addr3, "", true);
-        CNode dummyNode9(INVALID_SOCKET, addr4, "", true);
-
-        // The excessive block size is used as the limit for the maximum sum of bytes for
-        // all currently processing thinblocks.
-        {
-            dosMan.ClearBanned();
-            CXThinBlock xthin3 = xthinblock;
-
-            excessiveBlockSize = 100;
-            uint32_t nMaxBlockSizeAllowed = nSharedTxSize * excessiveBlockSize * 16 / 158;
-
-            // Add the node to vNodes and also we need a thinblockinflight entry
-            {
-                vNodes.push_back(&dummyNode6);
-                thinrelay.AddBlockInFlight(&dummyNode7, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
-                vNodes.push_back(&dummyNode7);
-                thinrelay.AddBlockInFlight(&dummyNode8, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
-                vNodes.push_back(&dummyNode8);
-                thinrelay.AddBlockInFlight(&dummyNode9, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
-                vNodes.push_back(&dummyNode9);
-            }
-
-            // manually set the nCurrentBlockBytes to be lower than the actual bytes of the thinblock that we will
-            // use to test the over limit condition. Also set the global bytes to be the sum of all current nodes.
-            thinrelay.ResetTotalBlockBytes();
-            pblock6->SetNull();
-            pblock7->SetNull();
-            pblock8->SetNull();
-            pblock9->SetNull();
-            uint32_t nBytes1 = 2;
-            uint32_t nBytes2 = 8;
-            thinrelay.AddTotalBlockBytes(nBytes1, pblock7);
-            thinrelay.AddTotalBlockBytes(nBytes2, pblock8);
-
-            uint32_t nBytes3 = nMaxBlockSizeAllowed - nBytes1 - nBytes2 - (nSharedTxSize * 9) + 1;
-            thinrelay.AddTotalBlockBytes(nBytes3, pblock9);
-
-            // Process an xthinblock which will be the largest over limit and will be the one that gets disconnected.
-            dummyNode6.fDisconnect = false;
-            pblock6 = thinrelay.SetBlockToReconstruct(&dummyNode6, xthin3.header.GetHash());
-            pblock6->xthinblock = std::make_shared<CXThinBlock>(xthin3);
-            xthin3.process(&dummyNode6, NetMsgType::XTHINBLOCK, pblock6);
-            BOOST_CHECK(!dummyNode7.fDisconnect); // node should *not* be disconnected
-            BOOST_CHECK_EQUAL(nBytes1, pblock7->nCurrentBlockSize);
-            BOOST_CHECK(!dummyNode8.fDisconnect); // node should *not* be disconnected
-            BOOST_CHECK_EQUAL(nBytes2, pblock8->nCurrentBlockSize);
-            BOOST_CHECK(!dummyNode9.fDisconnect); // node should *not* be disconnected
-            BOOST_CHECK_EQUAL(nBytes3, pblock9->nCurrentBlockSize);
-
-            BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
-            BOOST_CHECK(pblock6->IsNull());
-
-            // clean up vNodes, mapthinblocksinflight and thinblock data
-            vNodes.pop_back();
-            thinrelay.ClearAllBlockData(&dummyNode6, pblock6);
-            vNodes.pop_back();
-            thinrelay.ClearAllBlockData(&dummyNode7, pblock7);
-            vNodes.pop_back();
-            thinrelay.ClearAllBlockData(&dummyNode8, pblock8);
-            vNodes.pop_back();
-            thinrelay.ClearAllBlockData(&dummyNode9, pblock9);
-        }
-
-        /* Thinblock memory exhaustion attack 3 */
-
-        // test correct disconnection of a multiple valid thinblock reconstruction that goes over the limit.
-        // However here, the last thinblock although causing the limit to be exceeded is not the largest.
-        // result: the peer with largest thinblock set of data should have it data cleared
-        //         and node should be disconnected.
-        {
-            dosMan.ClearBanned();
-            CXThinBlock xthin4 = xthinblock;
-
-            // This time we don't want the xthinblock to cause an overlimit but have some other node disconnected.
-            excessiveBlockSize = 120;
-            uint32_t nMaxBlockSizeAllowed = nSharedTxSize * excessiveBlockSize * 16 / 158;
-
-            // Add the node to vNodes and also we need a thinblockinflight entry
-            {
-                thinrelay.AddBlockInFlight(&dummyNode6, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
-                vNodes.push_back(&dummyNode6);
-                thinrelay.AddBlockInFlight(&dummyNode7, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
-                vNodes.push_back(&dummyNode7);
-                thinrelay.AddBlockInFlight(&dummyNode8, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
-                vNodes.push_back(&dummyNode8);
-                thinrelay.AddBlockInFlight(&dummyNode9, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
-                vNodes.push_back(&dummyNode9);
-            }
-
-            // manually set two of the nCurrentBlockBytes to be higher than the actual bytes of the thinblock that we
-            // will use to test the over limit condition. Also set the global bytes to be the sum of all current nodes.
-            thinrelay.ResetTotalBlockBytes();
-            pblock7 = thinrelay.SetBlockToReconstruct(&dummyNode7, xthin4.header.GetHash());
-            pblock8 = thinrelay.SetBlockToReconstruct(&dummyNode8, xthin4.header.GetHash());
-            pblock9 = thinrelay.SetBlockToReconstruct(&dummyNode9, xthin4.header.GetHash());
-            // use thinblock for dummynode7 instead of xthin. The disconnect should be able to handle
-            // either type.
-            thinrelay.AddTotalBlockBytes(3000, pblock7);
-            uint32_t nBytes1 = 3;
-            uint32_t nBytes2 = nMaxBlockSizeAllowed - nBytes1 - (nSharedTxSize * 9) + 1;
-            thinrelay.AddTotalBlockBytes(nBytes1, pblock8);
-            thinrelay.AddTotalBlockBytes(nBytes2, pblock9);
-
-            // Process an xthinblock which will also be the over limit and will cause the largest block to disconnect
-            // which in this case is dummyNode7. As it continues to process it (dummyNode6) will also go over the limit
-            // and cause itself to be disconnected.
-            dummyNode6.fDisconnect = false;
-            dummyNode7.fDisconnect = false;
-            pblock6 = thinrelay.SetBlockToReconstruct(&dummyNode6, xthin4.header.GetHash());
-            pblock6->xthinblock = std::make_shared<CXThinBlock>(xthin4);
-            xthin4.process(&dummyNode6, NetMsgType::XTHINBLOCK, pblock6);
-            BOOST_CHECK(!dummyNode8.fDisconnect); // node should *not* be disconnected
-            BOOST_CHECK_EQUAL(nBytes1, pblock8->nCurrentBlockSize);
-            BOOST_CHECK(!dummyNode9.fDisconnect); // node should *not* be disconnected
-            BOOST_CHECK_EQUAL(nBytes2, pblock9->nCurrentBlockSize);
-
-            BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
-            BOOST_CHECK(pblock6->IsNull());
-
-            BOOST_CHECK(dummyNode7.fDisconnect); // node should be disconnected
-            BOOST_CHECK(pblock7->IsNull());
-
-            // clean up vNodes, mapthinblocksinflight and thinblock data
-            vNodes.pop_back();
-            thinrelay.ClearAllBlockData(&dummyNode6, pblock6);
-            vNodes.pop_back();
-            thinrelay.ClearAllBlockData(&dummyNode7, pblock7);
-            vNodes.pop_back();
-            thinrelay.ClearAllBlockData(&dummyNode8, pblock8);
-            vNodes.pop_back();
-            thinrelay.ClearAllBlockData(&dummyNode9, pblock9);
-        }
-
-        /*
-         * Test the disconnection of a peers with thinblocks in flight that has gone over the timeout limit
-         */
-        {
-            int64_t nStartTime = GetTime();
-            uint256 hash1 = uint256S("3fba505b48865fccda4e248cecc39d5dfbc6b8ef7b4adc9cd27242c1193c7141");
-            uint256 hash2 = uint256S("3fba505b48865fccda4e248cecc39d5dfbc6b8ef7b4adc9cd27242c1193c7142");
-
-            CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
-            dummyNode1.fDisconnect = false;
-            dummyNode1.state_incoming = ConnectionStateIncoming::READY;
-            dummyNode1.state_outgoing = ConnectionStateOutgoing::READY;
-
-            CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
-            dummyNode2.fDisconnect = false;
-            dummyNode2.state_incoming = ConnectionStateIncoming::READY;
-            dummyNode2.state_outgoing = ConnectionStateOutgoing::READY;
-
-            SetMockTime(nStartTime);
-            thinrelay.AddBlockInFlight(&dummyNode1, hash1, NetMsgType::XTHINBLOCK);
-            SetMockTime(nStartTime + 1);
-            thinrelay.AddBlockInFlight(&dummyNode1, hash2, NetMsgType::XTHINBLOCK);
-            SetMockTime(nStartTime + 1);
-            thinrelay.AddBlockInFlight(&dummyNode2, hash1, NetMsgType::XTHINBLOCK);
-
-            // Move clock forward to the boundary of the timeout interval
-            // No nodes should be disconnected.
-            SetMockTime(nStartTime + (6 * blkReqRetryInterval / 1000000));
-            SendMessages(&dummyNode1);
-            SendMessages(&dummyNode2);
-            BOOST_CHECK(!dummyNode1.fDisconnect);
-            BOOST_CHECK(!dummyNode2.fDisconnect);
-
-
-            // Move clock forward to 1 second past the boundary of the timeout interval
-            // DummyNode1 should be disconnected
-            // DummyNode2 should still be connected because it was added one second later.
-            SetMockTime(nStartTime + (6 * blkReqRetryInterval / 1000000) + 1);
-            SendMessages(&dummyNode1);
-            SendMessages(&dummyNode2);
-            BOOST_CHECK(dummyNode1.fDisconnect);
-            BOOST_CHECK(!dummyNode2.fDisconnect);
-
-            // Move clock forward to 1 second past the boundary of the timeout interval
-            // DummyNode2 should now be disconnected
-            SetMockTime(nStartTime + (6 * blkReqRetryInterval / 1000000) + 2);
-            SendMessages(&dummyNode2);
-            BOOST_CHECK(dummyNode2.fDisconnect);
-        }
-
-        excessiveBlockSize = old_excessiveBlockSize; // reset
-
-        // cleanup received queues
-        vRecv1.clear();
-        vRecv2.clear();
-        vRecv3.clear();
-        vRecv4.clear();
-        vRecv5.clear();
+        std::stringstream ss;
+        ss << i;
+        hash.append(ss.str());
+        uint256 random_hash = uint256S(hash);
+        vOrphanHashes.push_back(random_hash);
     }
+    std::unique_ptr<CNode> dummyNodeMem(new CNode(INVALID_SOCKET, addr1, "", true));
+    CNode &dummyNode = *dummyNodeMem;
+    BuildSeededBloomFilter(filter, vOrphanHashes, TestBlock1().GetHash(), &dummyNode, true);
+
+    block = TestBlock1();
+    CThinBlock thinblock(block, filter);
+    CXThinBlock xthinblock(block, &filter);
+
+    /** FILTERSIZEXTHIN tests */
+
+    CDataStream ssSend(SER_NETWORK, INIT_PROTO_VERSION);
+    ssSend << (uint32_t)36000;
+
+    dosMan.ClearBanned();
+    vRecv1.clear();
+    vRecv1 << ssSend;
+    {
+        std::unique_ptr<CNode> dummyNodeAMem(new CNode(INVALID_SOCKET, addr1, "", true));
+        CNode &dummyNodeA = *dummyNodeMem;
+        dummyNodeA.nServices |= NODE_XTHIN;
+        dummyNodeA.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNodeA.state_incoming = ConnectionStateIncoming::READY;
+        dummyNodeA.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNodeA, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetTime());
+        BOOST_CHECK(!dummyNodeA.fDisconnect); // node should not be disconnected
+    }
+
+    dosMan.ClearBanned();
+    vRecv1.clear();
+    vRecv1 << ssSend;
+
+    {
+        std::unique_ptr<CNode> dummyNodeBMem(new CNode(INVALID_SOCKET, addr1, "", true));
+        CNode &dummyNodeB = *dummyNodeBMem;
+        dummyNodeB.nServices |= NODE_BLOOM;
+        dummyNodeB.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNodeB.state_incoming = ConnectionStateIncoming::READY;
+        dummyNodeB.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNodeB, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetTime());
+        BOOST_CHECK(dummyNodeB.fDisconnect); // node should be disconnected
+    }
+
+    dosMan.ClearBanned();
+    vRecv1.clear();
+    vRecv1 << ssSend;
+
+    {
+        std::unique_ptr<CNode> dummyNodeCMem(new CNode(INVALID_SOCKET, addr1, "", true));
+        CNode &dummyNodeC = *dummyNodeCMem;
+        dummyNodeC.nServices |= NODE_XTHIN;
+        dummyNodeC.nServices |= NODE_BLOOM;
+        dummyNodeC.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNodeC.state_incoming = ConnectionStateIncoming::READY;
+        dummyNodeC.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNodeC, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetTime());
+        BOOST_CHECK(!dummyNodeC.fDisconnect); // node should not be disconnected
+    }
+
+    // Send a filter message indicating a size that is less than the default 36000.
+    // This should get a disconnect.
+    CDataStream ssSend2(SER_NETWORK, INIT_PROTO_VERSION);
+    ssSend2 << (uint32_t)35999;
+
+    dosMan.ClearBanned();
+    vRecv1.clear();
+    vRecv1 << ssSend2;
+
+    {
+        std::unique_ptr<CNode> dummyNodeDMem(new CNode(INVALID_SOCKET, addr1, "", true));
+        CNode &dummyNodeD = *dummyNodeDMem;
+        dummyNodeD.nServices |= NODE_XTHIN;
+        dummyNodeD.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNodeD.state_incoming = ConnectionStateIncoming::READY;
+        dummyNodeD.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNodeD, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetTime());
+        BOOST_CHECK(dummyNodeD.fDisconnect); // node should be disconnected
+    }
+
+    /** XTHINBLOCK message consistency checks */
+
+    // testing empty missingtx vector
+    dosMan.ClearBanned();
+    CXThinBlock xthin = xthinblock;
+    xthin.vMissingTx.clear(); // empty the missingtx vector. This should cause an error.
+    vRecv1.clear();
+    vRecv1 << xthin;
+
+    {
+        CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
+        dummyNode1.nServices |= NODE_XTHIN;
+        dummyNode1.nServices |= NODE_BLOOM;
+        dummyNode1.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode1.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode1.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNode1, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
+        SendMessages(&dummyNode1);
+        BOOST_CHECK(xthin.vMissingTx.size() == 0);
+        BOOST_CHECK(dosMan.IsBanned(addr1));
+    }
+
+    // test invalid or missing coinbase
+    dosMan.ClearBanned();
+    vRecv1.clear();
+    xthin = xthinblock;
+    xthin.vMissingTx[0] = xthin.vMissingTx[1]; // delete the coinbase. This should cause an error.
+    vRecv1 << xthin;
+
+    {
+        CNode dummyNode1a(INVALID_SOCKET, addr1, "", true);
+        dummyNode1a.nServices |= NODE_XTHIN;
+        dummyNode1a.nServices |= NODE_BLOOM;
+        dummyNode1a.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode1a.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode1a.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNode1a, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
+        SendMessages(&dummyNode1a);
+        BOOST_CHECK(!xthin.vMissingTx[0].IsCoinBase());
+        BOOST_CHECK(dosMan.IsBanned(addr1));
+    }
+
+    // test invalid block header
+    dosMan.ClearBanned();
+    vRecv1.clear();
+    xthin = xthinblock;
+    xthin.header.nBits = 1; // create invalid block header
+    vRecv1 << xthin;
+
+    CValidationState state;
+
+    {
+        CNode dummyNode1b(INVALID_SOCKET, addr1, "", true);
+        dummyNode1b.nServices |= NODE_XTHIN;
+        dummyNode1b.nServices |= NODE_BLOOM;
+        dummyNode1b.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode1b.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode1b.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNode1b, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
+        SendMessages(&dummyNode1b);
+        BOOST_CHECK(!CheckBlockHeader(xthin.header, state, true));
+        BOOST_CHECK(dosMan.IsBanned(addr1));
+    }
+    /** THINBLOCK message consistency  checks */
+
+    // test empty missingtx vector
+    dosMan.ClearBanned();
+    CThinBlock thin = thinblock;
+    thin.vMissingTx.clear(); // empty the missingtx vector. This should cause an error.
+    vRecv2 << thin;
+
+    {
+        CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
+        dummyNode2.nServices |= NODE_XTHIN;
+        dummyNode2.nServices |= NODE_BLOOM;
+        dummyNode2.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode2.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode2.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNode2, NetMsgType::THINBLOCK, vRecv2, GetTime());
+        SendMessages(&dummyNode2);
+        BOOST_CHECK(thin.vMissingTx.size() == 0);
+        BOOST_CHECK(dosMan.IsBanned(addr2));
+    }
+
+    // test invalid or missing coinbase
+    dosMan.ClearBanned();
+    vRecv2.clear();
+    thin = thinblock;
+    thin.vMissingTx[0] = thin.vMissingTx[1]; // delete the coinbase. This should cause an error.
+    vRecv2 << thin;
+
+    {
+        CNode dummyNode2a(INVALID_SOCKET, addr2, "", true);
+        dummyNode2a.nServices |= NODE_XTHIN;
+        dummyNode2a.nServices |= NODE_BLOOM;
+        dummyNode2a.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode2a.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode2a.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNode2a, NetMsgType::THINBLOCK, vRecv2, GetTime());
+        SendMessages(&dummyNode2a);
+        BOOST_CHECK(!thin.vMissingTx[0].IsCoinBase());
+        BOOST_CHECK(dosMan.IsBanned(addr2));
+    }
+
+    // create invalid block header
+    dosMan.ClearBanned();
+    vRecv2.clear();
+    thin = thinblock;
+    thin.header.nBits = 1;
+    vRecv2 << thin;
+
+    {
+        CNode dummyNode2b(INVALID_SOCKET, addr2, "", true);
+        dummyNode2b.nServices |= NODE_XTHIN;
+        dummyNode2b.nServices |= NODE_BLOOM;
+        dummyNode2b.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode2b.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode2b.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNode2b, NetMsgType::THINBLOCK, vRecv2, GetTime());
+        SendMessages(&dummyNode2b);
+        BOOST_CHECK(!CheckBlockHeader(thin.header, state, true));
+        BOOST_CHECK(dosMan.IsBanned(addr2));
+    }
+
+
+    /** XBLOCKTX message consistency checks */
+
+    // test null hash
+    CBlock block3 = TestBlock1();
+
+    dosMan.ClearBanned();
+    nullhash.SetNull();
+    std::vector<CTransaction> vtx;
+    for (auto &tx : block3.vtx)
+        vtx.push_back(*tx);
+
+    CXThinBlockTx xblocktx(nullhash, vtx);
+    vRecv3 << xblocktx;
+
+    {
+        CNode dummyNode3(INVALID_SOCKET, addr3, "", true);
+        dummyNode3.nServices |= NODE_XTHIN;
+        dummyNode3.nServices |= NODE_BLOOM;
+        dummyNode3.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode3.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode3.state_outgoing = ConnectionStateOutgoing::READY;
+        auto pblock = thinrelay.SetBlockToReconstruct(&dummyNode3, nullhash);
+        ProcessMessage(&dummyNode3, NetMsgType::XBLOCKTX, vRecv3, GetTime());
+        SendMessages(&dummyNode3);
+        BOOST_CHECK(nullhash.IsNull());
+        BOOST_CHECK(dosMan.IsBanned(addr3));
+    }
+
+    // no block to reconstruct available
+    {
+        CNode dummyNode3(INVALID_SOCKET, addr3, "", true);
+        std::shared_ptr<CBlockThinRelay> pblock = thinrelay.GetBlockToReconstruct(&dummyNode3);
+        BOOST_CHECK(pblock == nullptr);
+    }
+
+    // test no txns in xblocktx
+    dosMan.ClearBanned();
+    vRecv3.clear();
+    std::vector<CTransaction> vTxEmpty;
+    CXThinBlockTx xblocktx2(block3.GetHash(), vTxEmpty);
+    vRecv3 << xblocktx2;
+
+    {
+        CNode dummyNode3a(INVALID_SOCKET, addr3, "", true);
+        dummyNode3a.nServices |= NODE_XTHIN;
+        dummyNode3a.nServices |= NODE_BLOOM;
+        dummyNode3a.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode3a.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode3a.state_outgoing = ConnectionStateOutgoing::READY;
+        auto pblock = thinrelay.SetBlockToReconstruct(&dummyNode3a, block3.GetHash());
+        ProcessMessage(&dummyNode3a, NetMsgType::XBLOCKTX, vRecv3, GetTime());
+        SendMessages(&dummyNode3a);
+        BOOST_CHECK(vTxEmpty.size() == 0);
+        BOOST_CHECK(dosMan.IsBanned(addr3));
+    }
+
+    /** GET_XBLOCKTX message consistency checks */
+
+    // test null hash
+    dosMan.ClearBanned();
+    nullhash.SetNull();
+    std::set<uint64_t> setHashesToRequest;
+    setHashesToRequest.insert(1); // add a hash so that we are not empty
+    CXRequestThinBlockTx get_xblocktx(nullhash, setHashesToRequest);
+    vRecv4 << get_xblocktx;
+
+    {
+        CNode dummyNode4(INVALID_SOCKET, addr4, "", true);
+        dummyNode4.nServices |= NODE_XTHIN;
+        dummyNode4.nServices |= NODE_BLOOM;
+        dummyNode4.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode4.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode4.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNode4, NetMsgType::GET_XBLOCKTX, vRecv4, GetTime());
+        SendMessages(&dummyNode4);
+        BOOST_CHECK(nullhash.IsNull());
+        BOOST_CHECK(dosMan.IsBanned(addr4));
+    }
+
+    // test empty setHashesToRequest
+    dosMan.ClearBanned();
+    vRecv4.clear();
+    setHashesToRequest.clear(); // clear the set
+    CXRequestThinBlockTx get_xblocktx2(block3.GetHash(), setHashesToRequest);
+    vRecv4 << get_xblocktx2;
+
+    {
+        std::unique_ptr<CNode> dummyNode4aMem(new CNode(INVALID_SOCKET, addr4, "", true));
+        CNode &dummyNode4a = *dummyNode4aMem;
+        dummyNode4a.nServices |= NODE_XTHIN;
+        dummyNode4a.nServices |= NODE_BLOOM;
+        dummyNode4a.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode4a.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode4a.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNode4a, NetMsgType::GET_XBLOCKTX, vRecv4, GetTime());
+        SendMessages(&dummyNode4a);
+        BOOST_CHECK(setHashesToRequest.empty());
+        BOOST_CHECK(dosMan.IsBanned(addr4));
+
+
+        /** GET_XTHIN message consistency checks */
+
+        // test get_xthin with null hash
+        dosMan.ClearBanned();
+        nullhash.SetNull();
+        CInv inv(MSG_XTHINBLOCK, nullhash);
+        CBloomFilter filterMemPool;
+        BuildSeededBloomFilter(filterMemPool, vOrphanHashes, inv.hash, &dummyNode4a, true);
+        vRecv5 << inv;
+        vRecv5 << filterMemPool;
+
+        std::unique_ptr<CNode> dummyNode5Mem(new CNode(INVALID_SOCKET, addr5, "", true));
+        CNode &dummyNode5 = *dummyNode5Mem;
+        dummyNode5.nServices |= NODE_XTHIN;
+        dummyNode5.nServices |= NODE_BLOOM;
+        dummyNode5.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode5.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode5.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNode5, NetMsgType::GET_XTHIN, vRecv5, GetTime());
+        SendMessages(&dummyNode5);
+        BOOST_CHECK(nullhash.IsNull());
+        BOOST_CHECK(dosMan.IsBanned(addr5));
+
+        // test get_xthin with invalid message type
+        dosMan.ClearBanned();
+        vRecv5.clear();
+        CInv inv2(15, block3.GetHash()); // invalid type
+        CBloomFilter filterMemPool2;
+        BuildSeededBloomFilter(filterMemPool2, vOrphanHashes, inv2.hash, &dummyNode5, true);
+        vRecv5 << inv2;
+        vRecv5 << filterMemPool2;
+
+        std::unique_ptr<CNode> dummyNode5aMem(new CNode(INVALID_SOCKET, addr5, "", true));
+        CNode &dummyNode5a = *dummyNode5aMem;
+        dummyNode5a.nServices |= NODE_XTHIN;
+        dummyNode5a.nServices |= NODE_BLOOM;
+        dummyNode5a.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode5a.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode5a.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNode5a, NetMsgType::GET_XTHIN, vRecv5, GetTime());
+        SendMessages(&dummyNode5a);
+        BOOST_CHECK(inv2.type != MSG_THINBLOCK && inv2.type != MSG_XTHINBLOCK);
+        BOOST_CHECK(dosMan.IsBanned(addr5));
+    }
+
+
+    /* Thinblock memory exhaustion attack 1 */
+
+    uint32_t old_excessiveBlockSize = excessiveBlockSize;
+
+    // Shared pointers can be different sizes on different sysstems so get size of a shared pointer
+    // and size of the block that we'll need for later comparisons.
+    CTransactionRef pdummytx = nullptr;
+    uint32_t nSharedTxSize = sizeof(pdummytx);
+    uint32_t nSizeTxInBlock = 9 * nSharedTxSize; // there are 9 txn's in this block.
+
+    // Get size of xthin and thinblock to be used later
+    CXThinBlock xthinsize = xthinblock;
+    vRecv1.clear();
+    vRecv1 << xthinsize;
+    vRecv1.clear();
+    CThinBlock thinsize = thinblock;
+    vRecv1 << thinsize;
+    vRecv1.clear();
+
+    // test a single valid thinblock reconstruction that goes over the limit.
+    // result: the peer should have it data cleared and node should be disconnected.
+    CNode dummyNode6(INVALID_SOCKET, addr1, "", true);
+    {
+        dosMan.ClearBanned();
+        CXThinBlock xthin2 = xthinblock;
+        CXThinBlock xthin2a = xthinblock;
+        CThinBlock thin2 = thinblock;
+
+        // The number of tx bytes in this block is 3784 bytes however now that we use shared pointers for blocks
+        // we use a different calculation for max block size possible.  In order for the node to be disconnected
+        // we have to make the maxAllowedSize be less sizeof(shared_ptr) * maxMessageSizeMultiplier *
+        // excessiveBlockSize / 158.
+        // From the above the maxAllowedSize must be less than 16 * 9 (or 216) in order to trigger the oversized
+        // block and disconnect. And therefore the excessiveBlockSize must be = (144 * 158) / (16 * 16) = 88.87,
+        // or 88 to trigger a disconnection.
+        excessiveBlockSize = (nSizeTxInBlock * 158) / (nSharedTxSize * 16); // 88
+
+        // Add the node to vNodes and also we need a thinblockinflight entry
+        thinrelay.AddBlockInFlight(&dummyNode6, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
+        vNodes.push_back(&dummyNode6);
+
+        // Process an xthinblock which causes a disconnect
+        dummyNode6.fDisconnect = false;
+        pblock6->SetNull();
+        pblock6 = thinrelay.SetBlockToReconstruct(&dummyNode6, xthin2.header.GetHash());
+        pblock6->xthinblock = std::make_shared<CXThinBlock>(xthin2);
+        xthin2.process(&dummyNode6, NetMsgType::XTHINBLOCK, pblock6);
+        BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
+        BOOST_CHECK(pblock6->IsNull());
+
+        // clean up vNodes, mapthinblocksinflight and thinblock data
+        vNodes.pop_back();
+        thinrelay.ClearAllBlockData(&dummyNode6, pblock6);
+
+        // Add the node to vNodes and also we need a thinblockinflight entry
+        thinrelay.AddBlockInFlight(&dummyNode6, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
+        vNodes.push_back(&dummyNode6);
+
+        // Process a regular thinblock
+        dummyNode6.fDisconnect = false;
+        pblock6 = thinrelay.SetBlockToReconstruct(&dummyNode6, xthin2.header.GetHash());
+        pblock6->thinblock = std::make_shared<CThinBlock>(thin2);
+        thin2.process(&dummyNode6, pblock6);
+        BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
+        BOOST_CHECK(pblock6->IsNull());
+
+        // clean up vNodes, mapthinblocksinflight and thinblock data
+        vNodes.pop_back();
+        thinrelay.ClearAllBlockData(&dummyNode6, pblock6);
+
+        // TODO: it would be great to have a test with an excessiveBlockSize of one byte larger
+        //       so we can prove that a disconnect wouldn't happen for the edge case however
+        //       that causes us to sent a messae back out through an invalid socket which then
+        //       results in a crash.  It took a great deal of debugging to find this out so hence
+        //       the comment here to help someone avoid any pitalls, for any future efforts.
+    }
+
+
+    /* Thinblock memory exhaustion attack 2 */
+
+    // test correct disconnection of a multiple valid thinblock reconstruction that goes over the limit.
+    // result: the peer with largest thinblock set of data should have it data cleared
+    //         and node should be disconnected.
+    CNode dummyNode7(INVALID_SOCKET, addr2, "", true);
+    CNode dummyNode8(INVALID_SOCKET, addr3, "", true);
+    CNode dummyNode9(INVALID_SOCKET, addr4, "", true);
+
+    // The excessive block size is used as the limit for the maximum sum of bytes for
+    // all currently processing thinblocks.
+    {
+        dosMan.ClearBanned();
+        CXThinBlock xthin3 = xthinblock;
+
+        excessiveBlockSize = 100;
+        uint32_t nMaxBlockSizeAllowed = nSharedTxSize * excessiveBlockSize * 16 / 158;
+
+        // Add the node to vNodes and also we need a thinblockinflight entry
+        {
+            vNodes.push_back(&dummyNode6);
+            thinrelay.AddBlockInFlight(&dummyNode7, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
+            vNodes.push_back(&dummyNode7);
+            thinrelay.AddBlockInFlight(&dummyNode8, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
+            vNodes.push_back(&dummyNode8);
+            thinrelay.AddBlockInFlight(&dummyNode9, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
+            vNodes.push_back(&dummyNode9);
+        }
+
+        // manually set the nCurrentBlockBytes to be lower than the actual bytes of the thinblock that we will
+        // use to test the over limit condition. Also set the global bytes to be the sum of all current nodes.
+        thinrelay.ResetTotalBlockBytes();
+        pblock6->SetNull();
+        pblock7->SetNull();
+        pblock8->SetNull();
+        pblock9->SetNull();
+        uint32_t nBytes1 = 2;
+        uint32_t nBytes2 = 8;
+        thinrelay.AddTotalBlockBytes(nBytes1, pblock7);
+        thinrelay.AddTotalBlockBytes(nBytes2, pblock8);
+
+        uint32_t nBytes3 = nMaxBlockSizeAllowed - nBytes1 - nBytes2 - (nSharedTxSize * 9) + 1;
+        thinrelay.AddTotalBlockBytes(nBytes3, pblock9);
+
+        // Process an xthinblock which will be the largest over limit and will be the one that gets disconnected.
+        dummyNode6.fDisconnect = false;
+        pblock6 = thinrelay.SetBlockToReconstruct(&dummyNode6, xthin3.header.GetHash());
+        pblock6->xthinblock = std::make_shared<CXThinBlock>(xthin3);
+        xthin3.process(&dummyNode6, NetMsgType::XTHINBLOCK, pblock6);
+        BOOST_CHECK(!dummyNode7.fDisconnect); // node should *not* be disconnected
+        BOOST_CHECK_EQUAL(nBytes1, pblock7->nCurrentBlockSize);
+        BOOST_CHECK(!dummyNode8.fDisconnect); // node should *not* be disconnected
+        BOOST_CHECK_EQUAL(nBytes2, pblock8->nCurrentBlockSize);
+        BOOST_CHECK(!dummyNode9.fDisconnect); // node should *not* be disconnected
+        BOOST_CHECK_EQUAL(nBytes3, pblock9->nCurrentBlockSize);
+
+        BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
+        BOOST_CHECK(pblock6->IsNull());
+
+        // clean up vNodes, mapthinblocksinflight and thinblock data
+        vNodes.pop_back();
+        thinrelay.ClearAllBlockData(&dummyNode6, pblock6);
+        vNodes.pop_back();
+        thinrelay.ClearAllBlockData(&dummyNode7, pblock7);
+        vNodes.pop_back();
+        thinrelay.ClearAllBlockData(&dummyNode8, pblock8);
+        vNodes.pop_back();
+        thinrelay.ClearAllBlockData(&dummyNode9, pblock9);
+    }
+
+    /* Thinblock memory exhaustion attack 3 */
+
+    // test correct disconnection of a multiple valid thinblock reconstruction that goes over the limit.
+    // However here, the last thinblock although causing the limit to be exceeded is not the largest.
+    // result: the peer with largest thinblock set of data should have it data cleared
+    //         and node should be disconnected.
+    {
+        dosMan.ClearBanned();
+        CXThinBlock xthin4 = xthinblock;
+
+        // This time we don't want the xthinblock to cause an overlimit but have some other node disconnected.
+        excessiveBlockSize = 120;
+        uint32_t nMaxBlockSizeAllowed = nSharedTxSize * excessiveBlockSize * 16 / 158;
+
+        // Add the node to vNodes and also we need a thinblockinflight entry
+        {
+            thinrelay.AddBlockInFlight(&dummyNode6, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
+            vNodes.push_back(&dummyNode6);
+            thinrelay.AddBlockInFlight(&dummyNode7, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
+            vNodes.push_back(&dummyNode7);
+            thinrelay.AddBlockInFlight(&dummyNode8, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
+            vNodes.push_back(&dummyNode8);
+            thinrelay.AddBlockInFlight(&dummyNode9, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
+            vNodes.push_back(&dummyNode9);
+        }
+
+        // manually set two of the nCurrentBlockBytes to be higher than the actual bytes of the thinblock that we
+        // will use to test the over limit condition. Also set the global bytes to be the sum of all current nodes.
+        thinrelay.ResetTotalBlockBytes();
+        pblock7 = thinrelay.SetBlockToReconstruct(&dummyNode7, xthin4.header.GetHash());
+        pblock8 = thinrelay.SetBlockToReconstruct(&dummyNode8, xthin4.header.GetHash());
+        pblock9 = thinrelay.SetBlockToReconstruct(&dummyNode9, xthin4.header.GetHash());
+        // use thinblock for dummynode7 instead of xthin. The disconnect should be able to handle
+        // either type.
+        thinrelay.AddTotalBlockBytes(3000, pblock7);
+        uint32_t nBytes1 = 3;
+        uint32_t nBytes2 = nMaxBlockSizeAllowed - nBytes1 - (nSharedTxSize * 9) + 1;
+        thinrelay.AddTotalBlockBytes(nBytes1, pblock8);
+        thinrelay.AddTotalBlockBytes(nBytes2, pblock9);
+
+        // Process an xthinblock which will also be the over limit and will cause the largest block to disconnect
+        // which in this case is dummyNode7. As it continues to process it (dummyNode6) will also go over the limit
+        // and cause itself to be disconnected.
+        dummyNode6.fDisconnect = false;
+        dummyNode7.fDisconnect = false;
+        pblock6 = thinrelay.SetBlockToReconstruct(&dummyNode6, xthin4.header.GetHash());
+        pblock6->xthinblock = std::make_shared<CXThinBlock>(xthin4);
+        xthin4.process(&dummyNode6, NetMsgType::XTHINBLOCK, pblock6);
+        BOOST_CHECK(!dummyNode8.fDisconnect); // node should *not* be disconnected
+        BOOST_CHECK_EQUAL(nBytes1, pblock8->nCurrentBlockSize);
+        BOOST_CHECK(!dummyNode9.fDisconnect); // node should *not* be disconnected
+        BOOST_CHECK_EQUAL(nBytes2, pblock9->nCurrentBlockSize);
+
+        BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
+        BOOST_CHECK(pblock6->IsNull());
+
+        BOOST_CHECK(dummyNode7.fDisconnect); // node should be disconnected
+        BOOST_CHECK(pblock7->IsNull());
+
+        // clean up vNodes, mapthinblocksinflight and thinblock data
+        vNodes.pop_back();
+        thinrelay.ClearAllBlockData(&dummyNode6, pblock6);
+        vNodes.pop_back();
+        thinrelay.ClearAllBlockData(&dummyNode7, pblock7);
+        vNodes.pop_back();
+        thinrelay.ClearAllBlockData(&dummyNode8, pblock8);
+        vNodes.pop_back();
+        thinrelay.ClearAllBlockData(&dummyNode9, pblock9);
+    }
+
+    /*
+     * Test the disconnection of a peers with thinblocks in flight that has gone over the timeout limit
+     */
+    {
+        int64_t nStartTime = GetTime();
+        uint256 hash1 = uint256S("3fba505b48865fccda4e248cecc39d5dfbc6b8ef7b4adc9cd27242c1193c7141");
+        uint256 hash2 = uint256S("3fba505b48865fccda4e248cecc39d5dfbc6b8ef7b4adc9cd27242c1193c7142");
+
+        CNode dummyNode1(INVALID_SOCKET, addr1, "", true);
+        dummyNode1.fDisconnect = false;
+        dummyNode1.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode1.state_outgoing = ConnectionStateOutgoing::READY;
+
+        CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
+        dummyNode2.fDisconnect = false;
+        dummyNode2.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode2.state_outgoing = ConnectionStateOutgoing::READY;
+
+        SetMockTime(nStartTime);
+        thinrelay.AddBlockInFlight(&dummyNode1, hash1, NetMsgType::XTHINBLOCK);
+        SetMockTime(nStartTime + 1);
+        thinrelay.AddBlockInFlight(&dummyNode1, hash2, NetMsgType::XTHINBLOCK);
+        SetMockTime(nStartTime + 1);
+        thinrelay.AddBlockInFlight(&dummyNode2, hash1, NetMsgType::XTHINBLOCK);
+
+        // Move clock forward to the boundary of the timeout interval
+        // No nodes should be disconnected.
+        SetMockTime(nStartTime + (6 * blkReqRetryInterval / 1000000));
+        SendMessages(&dummyNode1);
+        SendMessages(&dummyNode2);
+        BOOST_CHECK(!dummyNode1.fDisconnect);
+        BOOST_CHECK(!dummyNode2.fDisconnect);
+
+
+        // Move clock forward to 1 second past the boundary of the timeout interval
+        // DummyNode1 should be disconnected
+        // DummyNode2 should still be connected because it was added one second later.
+        SetMockTime(nStartTime + (6 * blkReqRetryInterval / 1000000) + 1);
+        SendMessages(&dummyNode1);
+        SendMessages(&dummyNode2);
+        BOOST_CHECK(dummyNode1.fDisconnect);
+        BOOST_CHECK(!dummyNode2.fDisconnect);
+
+        // Move clock forward to 1 second past the boundary of the timeout interval
+        // DummyNode2 should now be disconnected
+        SetMockTime(nStartTime + (6 * blkReqRetryInterval / 1000000) + 2);
+        SendMessages(&dummyNode2);
+        BOOST_CHECK(dummyNode2.fDisconnect);
+    }
+
+    excessiveBlockSize = old_excessiveBlockSize; // reset
+
+    // cleanup received queues
+    vRecv1.clear();
+    vRecv2.clear();
+    vRecv3.clear();
+    vRecv4.clear();
+    vRecv5.clear();
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -918,7 +918,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode6, pblock6);
+            thinrelay.ClearAllBlockData(&dummyNode6, pblock6);
 
             // Add the node to vNodes and also we need a thinblockinflight entry
             thinrelay.AddBlockInFlight(&dummyNode6, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
@@ -934,7 +934,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode6, pblock6);
+            thinrelay.ClearAllBlockData(&dummyNode6, pblock6);
 
             // TODO: it would be great to have a test with an excessiveBlockSize of one byte larger
             //       so we can prove that a disconnect wouldn't happen for the edge case however
@@ -975,18 +975,18 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // manually set the nCurrentBlockBytes to be lower than the actual bytes of the thinblock that we will
             // use to test the over limit condition. Also set the global bytes to be the sum of all current nodes.
-            thindata.ResetThinBlockBytes();
+            thinrelay.ResetTotalBlockBytes();
             pblock6->SetNull();
             pblock7->SetNull();
             pblock8->SetNull();
             pblock9->SetNull();
             uint32_t nBytes1 = 2;
             uint32_t nBytes2 = 8;
-            thindata.AddThinBlockBytes(nBytes1, pblock7);
-            thindata.AddThinBlockBytes(nBytes2, pblock8);
+            thinrelay.AddTotalBlockBytes(nBytes1, pblock7);
+            thinrelay.AddTotalBlockBytes(nBytes2, pblock8);
 
             uint32_t nBytes3 = nMaxBlockSizeAllowed - nBytes1 - nBytes2 - (nSharedTxSize * 9) + 1;
-            thindata.AddThinBlockBytes(nBytes3, pblock9);
+            thinrelay.AddTotalBlockBytes(nBytes3, pblock9);
 
             // Process an xthinblock which will be the largest over limit and will be the one that gets disconnected.
             dummyNode6.fDisconnect = false;
@@ -1005,13 +1005,13 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode6, pblock6);
+            thinrelay.ClearAllBlockData(&dummyNode6, pblock6);
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode7, pblock7);
+            thinrelay.ClearAllBlockData(&dummyNode7, pblock7);
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode8, pblock8);
+            thinrelay.ClearAllBlockData(&dummyNode8, pblock8);
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode9, pblock9);
+            thinrelay.ClearAllBlockData(&dummyNode9, pblock9);
         }
 
         /* Thinblock memory exhaustion attack 3 */
@@ -1042,17 +1042,17 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // manually set two of the nCurrentBlockBytes to be higher than the actual bytes of the thinblock that we
             // will use to test the over limit condition. Also set the global bytes to be the sum of all current nodes.
-            thindata.ResetThinBlockBytes();
+            thinrelay.ResetTotalBlockBytes();
             pblock7 = thinrelay.SetBlockToReconstruct(&dummyNode7, xthin4.header.GetHash());
             pblock8 = thinrelay.SetBlockToReconstruct(&dummyNode8, xthin4.header.GetHash());
             pblock9 = thinrelay.SetBlockToReconstruct(&dummyNode9, xthin4.header.GetHash());
             // use thinblock for dummynode7 instead of xthin. The disconnect should be able to handle
             // either type.
-            thindata.AddThinBlockBytes(3000, pblock7);
+            thinrelay.AddTotalBlockBytes(3000, pblock7);
             uint32_t nBytes1 = 3;
             uint32_t nBytes2 = nMaxBlockSizeAllowed - nBytes1 - (nSharedTxSize * 9) + 1;
-            thindata.AddThinBlockBytes(nBytes1, pblock8);
-            thindata.AddThinBlockBytes(nBytes2, pblock9);
+            thinrelay.AddTotalBlockBytes(nBytes1, pblock8);
+            thinrelay.AddTotalBlockBytes(nBytes2, pblock9);
 
             // Process an xthinblock which will also be the over limit and will cause the largest block to disconnect
             // which in this case is dummyNode7. As it continues to process it (dummyNode6) will also go over the limit
@@ -1075,13 +1075,13 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
 
             // clean up vNodes, mapthinblocksinflight and thinblock data
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode6, pblock6);
+            thinrelay.ClearAllBlockData(&dummyNode6, pblock6);
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode7, pblock7);
+            thinrelay.ClearAllBlockData(&dummyNode7, pblock7);
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode8, pblock8);
+            thinrelay.ClearAllBlockData(&dummyNode8, pblock8);
             vNodes.pop_back();
-            thindata.ClearThinBlockData(&dummyNode9, pblock9);
+            thinrelay.ClearAllBlockData(&dummyNode9, pblock9);
         }
 
         /*

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -495,6 +495,113 @@ BOOST_AUTO_TEST_CASE(block_tests)
     // Block tests are handled in checkblock_tests.cpp and fully covered there.
 }
 
+BOOST_AUTO_TEST_CASE(compactblock_tests)
+{
+    fImporting = false;
+    fReindex = false;
+    bool fInit = false;
+    IsInitialBlockDownloadInit(&fInit);
+    dosMan.ClearBanned();
+
+    /** CompactBlock message consistency checks */
+    // Those tests are found in compactblock_tests.cpp
+
+    /** CompactReReq consistency checks */
+
+    // test empty indexes
+    {
+        CompactReRequest req1;
+        req1.blockhash = GetRandHash();
+        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+        stream << req1;
+        vRecv1.clear();
+        vRecv1 << stream;
+        std::unique_ptr<CNode> dummyNodeCompact(new CNode(INVALID_SOCKET, addr1, "", true));
+        CNode &dummyNode = *dummyNodeCompact;
+        dummyNode.fSupportsCompactBlocks = true;
+        dummyNode.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNode, NetMsgType::GETBLOCKTXN, vRecv1, GetTime());
+        SendMessages(&dummyNode);
+        BOOST_CHECK(dosMan.IsBanned(addr1));
+        dosMan.ClearBanned();
+    }
+
+    // test null hash
+    {
+        CompactReRequest req1;
+        req1.blockhash.SetNull();
+        req1.indexes.resize(4);
+        req1.indexes[0] = 0;
+        req1.indexes[1] = 1;
+        req1.indexes[2] = 3;
+        req1.indexes[3] = 4;
+
+        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+        stream << req1;
+        vRecv1.clear();
+        vRecv1 << stream;
+        std::unique_ptr<CNode> dummyNodeCompact(new CNode(INVALID_SOCKET, addr1, "", true));
+        CNode &dummyNode = *dummyNodeCompact;
+        dummyNode.fSupportsCompactBlocks = true;
+        dummyNode.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode.state_outgoing = ConnectionStateOutgoing::READY;
+        ProcessMessage(&dummyNode, NetMsgType::GETBLOCKTXN, vRecv1, GetTime());
+        SendMessages(&dummyNode);
+        BOOST_CHECK(dosMan.IsBanned(addr1));
+        dosMan.ClearBanned();
+    }
+
+    /** CompactReReqResponse consistency checks */
+
+    // test null hash
+    {
+        CompactReReqResponse response1;
+        response1.blockhash.SetNull();
+        response1.txn.resize(1);
+        response1.txn[0] = *TestBlock1().vtx[1];
+
+        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+        stream << response1;
+        vRecv1.clear();
+        vRecv1 << stream;
+        std::unique_ptr<CNode> dummyNodeCompact(new CNode(INVALID_SOCKET, addr1, "", true));
+        CNode &dummyNode = *dummyNodeCompact;
+        dummyNode.fSupportsCompactBlocks = true;
+        dummyNode.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode.state_outgoing = ConnectionStateOutgoing::READY;
+        auto pblock = thinrelay.SetBlockToReconstruct(&dummyNode, TestBlock1().GetHash());
+        ProcessMessage(&dummyNode, NetMsgType::BLOCKTXN, vRecv1, GetTime());
+        SendMessages(&dummyNode);
+        BOOST_CHECK(dosMan.IsBanned(addr1));
+        dosMan.ClearBanned();
+    }
+
+    // txn empty
+    {
+        CompactReReqResponse response2;
+        response2.blockhash = TestBlock1().GetHash();
+
+        CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+        stream << response2;
+        vRecv1.clear();
+        vRecv1 << stream;
+        std::unique_ptr<CNode> dummyNodeCompact(new CNode(INVALID_SOCKET, addr1, "", true));
+        CNode &dummyNode = *dummyNodeCompact;
+        dummyNode.fSupportsCompactBlocks = true;
+        dummyNode.nVersion = MIN_PEER_PROTO_VERSION;
+        dummyNode.state_incoming = ConnectionStateIncoming::READY;
+        dummyNode.state_outgoing = ConnectionStateOutgoing::READY;
+        auto pblock = thinrelay.SetBlockToReconstruct(&dummyNode, TestBlock1().GetHash());
+        ProcessMessage(&dummyNode, NetMsgType::BLOCKTXN, vRecv1, GetTime());
+        SendMessages(&dummyNode);
+        BOOST_CHECK(dosMan.IsBanned(addr1));
+        dosMan.ClearBanned();
+    }
+}
 
 BOOST_AUTO_TEST_CASE(thinblock_tests)
 {
@@ -502,6 +609,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     fReindex = false;
     bool fInit = false;
     IsInitialBlockDownloadInit(&fInit);
+    dosMan.ClearBanned();
 
     CBloomFilter filter;
     std::vector<uint256> vOrphanHashes;

--- a/src/test/thinblock_data_tests.cpp
+++ b/src/test/thinblock_data_tests.cpp
@@ -4,6 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "blockrelay/thinblock.h"
+#include "blockrelay/blockrelay_common.h"
 #include "net.h"
 #include "test/test_bitcoin.h"
 #include <assert.h>
@@ -50,38 +51,39 @@ BOOST_AUTO_TEST_CASE(test_thinblock_byte_tracking)
     std::shared_ptr<CBlockThinRelay> pblock = std::make_shared<CBlockThinRelay>(CBlockThinRelay());
     pblock->xthinblock = std::make_shared<CXThinBlock>(xthin);
 
-    thindata.ResetThinBlockBytes();
-    BOOST_CHECK(0 == thindata.GetThinBlockBytes());
+    thinrelay.ResetTotalBlockBytes();
+    BOOST_CHECK(0 == thinrelay.GetTotalBlockBytes());
     BOOST_CHECK(0 == pblock->nCurrentBlockSize);
 
-    thindata.AddThinBlockBytes(0, pblock);
-    BOOST_CHECK(0 == thindata.GetThinBlockBytes());
+    thinrelay.AddTotalBlockBytes(0, pblock);
+    BOOST_CHECK(0 == thinrelay.GetTotalBlockBytes());
     BOOST_CHECK(0 == pblock->nCurrentBlockSize);
 
-    thindata.AddThinBlockBytes(1000, pblock);
-    BOOST_CHECK(1000 == thindata.GetThinBlockBytes());
+    thinrelay.AddTotalBlockBytes(1000, pblock);
+    BOOST_CHECK(1000 == thinrelay.GetTotalBlockBytes());
     BOOST_CHECK(1000 == pblock->nCurrentBlockSize);
 
-    thindata.AddThinBlockBytes(449932, pblock);
-    BOOST_CHECK(450932 == thindata.GetThinBlockBytes());
+    thinrelay.AddTotalBlockBytes(449932, pblock);
+    BOOST_CHECK(450932 == thinrelay.GetTotalBlockBytes());
     BOOST_CHECK(450932 == pblock->nCurrentBlockSize);
 
-    thindata.DeleteThinBlockBytes(0);
-    BOOST_CHECK(450932 == thindata.GetThinBlockBytes());
+    thinrelay.DeleteTotalBlockBytes(0);
+    BOOST_CHECK(450932 == thinrelay.GetTotalBlockBytes());
     BOOST_CHECK(450932 == pblock->nCurrentBlockSize);
 
-    thindata.DeleteThinBlockBytes(1);
-    BOOST_CHECK(450931 == thindata.GetThinBlockBytes());
+    thinrelay.DeleteTotalBlockBytes(1);
+    BOOST_CHECK(450931 == thinrelay.GetTotalBlockBytes());
 
-    thindata.DeleteThinBlockBytes(13939);
-    BOOST_CHECK(436992 == thindata.GetThinBlockBytes());
+    thinrelay.DeleteTotalBlockBytes(13939);
+    BOOST_CHECK(436992 == thinrelay.GetTotalBlockBytes());
 
     // Try to delete more bytes than we already have tracked.  This should not be possible...we don't allow this
     // to happen in the event that we get an incorrect or invalid value returned for the dynamic memory usage of
     // a transaction.  This could then be used in a theoretical attack by resetting total byte usage to zero while
     // continuing to build more thinblocks.
-    thindata.DeleteThinBlockBytes(436993);
-    BOOST_CHECK_MESSAGE(436992 == thindata.GetThinBlockBytes(), "nThinBlockBytes is " << thindata.GetThinBlockBytes());
+    thinrelay.DeleteTotalBlockBytes(436993);
+    BOOST_CHECK_MESSAGE(
+        436992 == thinrelay.GetTotalBlockBytes(), "nThinBlockBytes is " << thinrelay.GetTotalBlockBytes());
 
 
     /**
@@ -92,22 +94,22 @@ BOOST_AUTO_TEST_CASE(test_thinblock_byte_tracking)
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
     pblock->SetNull();
 
-    thindata.AddThinBlockBytes(1000, pblock);
-    BOOST_CHECK(437992 == thindata.GetThinBlockBytes());
+    thinrelay.AddTotalBlockBytes(1000, pblock);
+    BOOST_CHECK(437992 == thinrelay.GetTotalBlockBytes());
     BOOST_CHECK(1000 == pblock->nCurrentBlockSize);
 
-    thindata.DeleteThinBlockBytes(0);
-    BOOST_CHECK(437992 == thindata.GetThinBlockBytes());
+    thinrelay.DeleteTotalBlockBytes(0);
+    BOOST_CHECK(437992 == thinrelay.GetTotalBlockBytes());
 
-    thindata.DeleteThinBlockBytes(1);
-    BOOST_CHECK(437991 == thindata.GetThinBlockBytes());
+    thinrelay.DeleteTotalBlockBytes(1);
+    BOOST_CHECK(437991 == thinrelay.GetTotalBlockBytes());
 
-    thindata.DeleteThinBlockBytes(999);
-    BOOST_CHECK(436992 == thindata.GetThinBlockBytes());
+    thinrelay.DeleteTotalBlockBytes(999);
+    BOOST_CHECK(436992 == thinrelay.GetTotalBlockBytes());
 
     // now finally reset everything
-    thindata.ResetThinBlockBytes();
-    BOOST_CHECK_MESSAGE(0 == thindata.GetThinBlockBytes(), "nThinBlockBytes is " << thindata.GetThinBlockBytes());
+    thinrelay.ResetTotalBlockBytes();
+    BOOST_CHECK_MESSAGE(0 == thinrelay.GetTotalBlockBytes(), "nThinBlockBytes is " << thinrelay.GetTotalBlockBytes());
 }
 
 BOOST_AUTO_TEST_CASE(test_thinblockdata_stats1)
@@ -132,7 +134,6 @@ BOOST_AUTO_TEST_CASE(test_thinblockdata_stats1)
         tbd.ValidationTimeToString();
         tbd.ReRequestedTxToString();
         tbd.MempoolLimiterBytesSavedToString();
-        tbd.GetThinBlockBytes();
     }
 
     {

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -2227,7 +2227,6 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
 
     LOCK(cs_vNodes);
     std::vector<CNode *>::iterator n;
-    uint64_t totalThinBlockSize = 0;
     int disconnected = 0; // watch # of disconnected nodes to ensure they are being cleaned up
     for (std::vector<CNode *>::iterator it = vNodes.begin(); it != vNodes.end(); ++it)
     {
@@ -2252,15 +2251,10 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
                     (int64_t)::GetSerializeSize(*inode.pThinBlockFilter, SER_NETWORK, PROTOCOL_VERSION));
             }
         }
-        node.pushKV("thinblock.vtx", (int64_t)inode.thinBlock.vtx.size());
-        uint64_t thinBlockSize = ::GetSerializeSize(inode.thinBlock, SER_NETWORK, PROTOCOL_VERSION);
-        totalThinBlockSize += thinBlockSize;
-        node.pushKV("thinblock.size", thinBlockSize);
         node.pushKV("vAddrToSend", (int64_t)inode.vAddrToSend.size());
         node.pushKV("vInventoryToSend", (int64_t)inode.vInventoryToSend.size());
         ret.pushKV(inode.addrName, node);
     }
-    ret.pushKV("totalThinBlockSize", totalThinBlockSize);
     ret.pushKV("disconnectedNodes", disconnected);
 
     return ret;


### PR DESCRIPTION
Also consolidates some additional common functions between thinblocks and compact blocks.  Will do the same when the refactor for graphene happens.

Just need to add some tests.