### PR TITLE
[qa] Support setup_clean_chain, extra_args and num_nodes

### DIFF
--- a/qa/rpc-tests/bip135basic.py
+++ b/qa/rpc-tests/bip135basic.py
@@ -26,7 +26,7 @@ class BIP135VoteTest(BitcoinTestFramework):
 
     def __init__(self):
         super().__init__()
-        self.setup_clean_chain = True
+        self.setup_clean_chain = False
         self.num_nodes = 1
         self.defined_forks = ["bip135test%d" % i for i in range(0, 8)]
 

--- a/qa/rpc-tests/maxblocksinflight.py
+++ b/qa/rpc-tests/maxblocksinflight.py
@@ -77,19 +77,16 @@ class TestManager(NodeConnCB):
 
 
 class MaxBlocksInFlightTest(BitcoinTestFramework):
+
+    def __init__(self):
+        self.num_nodes = 1
+        self.extra_args = [["-whitelist=127.0.0.1", "-debug=net"]]
+        self.setup_clean_chain = True
+
     def add_options(self, parser):
         parser.add_option("--testbinary", dest="testbinary",
                           default=os.getenv("BITCOIND", "bitcoind"),
                           help="Binary to test max block requests behavior")
-
-    def setup_chain(self):
-        print("Initializing test directory "+self.options.tmpdir)
-        initialize_chain_clean(self.options.tmpdir, 1)
-
-    def setup_network(self):
-        self.nodes = start_nodes(1, self.options.tmpdir,
-                                 extra_args=[['-debug', '-whitelist=127.0.0.1']],
-                                 binary=[self.options.testbinary])
 
     def run_test(self):
         test = TestManager()

--- a/qa/rpc-tests/mining_ctor.py
+++ b/qa/rpc-tests/mining_ctor.py
@@ -20,7 +20,7 @@ class CTORMiningTest(BitcoinTestFramework):
     def __init__(self):
         super().__init__()
         self.num_nodes = 2
-        self.setup_clean_chain = True
+        self.setup_clean_chain = False
         self.mocktime = int(time.time()) - 600 * 100
 
     def setup_network(self):

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -22,6 +22,7 @@ from sys import argv
 
 from .util import (
     initialize_chain,
+    initialize_chain_clean,
     assert_equal,
     start_nodes,
     connect_nodes_bi,
@@ -43,6 +44,9 @@ from .authproxy import JSONRPCException
 class BitcoinTestFramework(object):
     drop_to_pdb = os.getenv("DROP_TO_PDB", "")
     bins = None
+    setup_clean_chain = False
+    num_nodes = 4
+    extra_args = None
     # These may be over-ridden by subclasses:
     def run_test(self):
         for node in self.nodes:
@@ -64,13 +68,22 @@ class BitcoinTestFramework(object):
         before starting the node.
         """
         logging.info("Initializing test directory %s Bitcoin conf: %s walletfiles: %s" % (self.options.tmpdir, str(bitcoinConfDict), wallets))
-        initialize_chain(self.options.tmpdir,bitcoinConfDict, wallets, self.bins)
+        if self.setup_clean_chain:
+            initialize_chain_clean(self.options.tmpdir, self.num_nodes, bitcoinConfDict, wallets)
+        else:
+            initialize_chain(self.options.tmpdir,bitcoinConfDict, wallets, self.bins)
 
     def setup_nodes(self):
-        return start_nodes(4, self.options.tmpdir)
+        return start_nodes(self.num_nodes, self.options.tmpdir, extra_args = self.extra_args)
 
     def setup_network(self, split = False):
         self.nodes = self.setup_nodes()
+
+        if self.num_nodes == 1:
+            return
+
+        if self.num_nodes != 4:
+            raise Exception("Default setup_network for %d nodes NYI" % self.num_nodes)
 
         # Connect the nodes as a "chain".  This allows us
         # to split the network between nodes 1 and 2 to get


### PR DESCRIPTION
Currently these are hardcoded in BitcoinTestFramework, even though some
tests expect them not to be. Some tests are re-implementing setup_chain
and setup_network as a workaround.