### PR TITLE
OpenSSL 1.1 API usage updates

### DIFF
--- a/src/bitnodes.cpp
+++ b/src/bitnodes.cpp
@@ -73,8 +73,11 @@ public:
                 GENERAL_NAME *generalName = sk_GENERAL_NAME_value(altNames, i);
                 if ((generalName->type == GEN_URI) || (generalName->type == GEN_DNS))
                 {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#define ASN1_STRING_get0_data ASN1_STRING_data
+#endif
                     std::string san = std::string(
-                        reinterpret_cast<char *>(ASN1_STRING_data(generalName->d.uniformResourceIdentifier)),
+                        reinterpret_cast<const char *>(ASN1_STRING_get0_data(generalName->d.uniformResourceIdentifier)),
                         ASN1_STRING_length(generalName->d.uniformResourceIdentifier));
                     if (san.find(cert_hostname_) != std::string::npos)
                     {


### PR DESCRIPTION
_In case there's no interest in upgrading to or supporting OpenSSL 1.1 please let me know and I'll drop these efforts, I came upon this trying to build BitcoinUnlimited after a few months and having OpenSSL 1.1 in my include path from other projects I'm working on, thought we should probably move to a safer and more modern OpenSSL version._

 - Replaces ASN1_STRING_data deprecated call for ASN1_STRING_get0_data. The new function returns a const char*
 - No more need for CRYPTO_set_locking_callback
 - Initialization with OPENSSL_no_config() is no more, replaced with OPENSSL_init_crypto()
 - On CInit() destructor added a call to OPENSSL_cleanup(), I'm not 100% sure this is needed

Question: What's with "instance_of_cinit" right after "class CInit"'s definition. Seems unused by the project, some sort of C++ trick?