### PR TITLE
Basic integration with the electrum server electrs

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -218,6 +218,10 @@ endif
 check-formatting:
 	$(MAKE) -C src $@
 
+.PHONY: electrs
+electrs:
+	$(top_srcdir)/contrib/electrs/build_electrs.py
+
 dist_noinst_SCRIPTS = autogen.sh
 
 EXTRA_DIST = $(top_srcdir)/share/genbuild.sh qa/pull-tester/rpc-tests.py qa/pull-tester/test_classes.py qa/rpc-tests $(DIST_DOCS) $(WINDOWS_PACKAGING) $(OSX_PACKAGING) $(BIN_CHECKS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,7 @@
 
 ACLOCAL_AMFLAGS = -I build-aux/m4
 SUBDIRS = src
-.PHONY: deploy FORCE
+.PHONY: deploy FORCE electrs
 
 GZIP_ENV="-9n"
 export PYTHONPATH
@@ -218,8 +218,8 @@ endif
 check-formatting:
 	$(MAKE) -C src $@
 
-electrs: ${PWD}/src/electrs
-	$(top_srcdir)/contrib/electrs/build_electrs.py --dst=${PWD}/src
+electrs:
+	$(top_srcdir)/contrib/electrs/build_electrs.py --dst=${PWD}/src --target=$(host)
 
 dist_noinst_SCRIPTS = autogen.sh
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -223,7 +223,7 @@ electrs: ${PWD}/src/electrs
 
 dist_noinst_SCRIPTS = autogen.sh
 
-EXTRA_DIST = $(top_srcdir)/share/genbuild.sh qa/pull-tester/rpc-tests.py qa/pull-tester/test_classes.py qa/rpc-tests $(DIST_DOCS) $(WINDOWS_PACKAGING) $(OSX_PACKAGING) $(BIN_CHECKS)
+EXTRA_DIST = $(top_srcdir)/share/genbuild.sh qa/pull-tester/rpc-tests.py qa/pull-tester/test_classes.py qa/rpc-tests $(DIST_DOCS) $(WINDOWS_PACKAGING) $(OSX_PACKAGING) $(BIN_CHECKS) $(top_srcdir)/contrib/electrs/build_electrs.py
 
 CLEANFILES = $(OSX_DMG) $(BITCOIN_WIN_INSTALLER)
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -79,7 +79,7 @@ $(OSX_APP)/Contents/PkgInfo:
 
 $(OSX_APP)/Contents/Resources/empty.lproj:
 	$(MKDIR_P) $(@D)
-	@touch $@ 
+	@touch $@
 
 $(OSX_APP)/Contents/Info.plist: $(OSX_PLIST)
 	$(MKDIR_P) $(@D)
@@ -218,9 +218,8 @@ endif
 check-formatting:
 	$(MAKE) -C src $@
 
-.PHONY: electrs
-electrs:
-	$(top_srcdir)/contrib/electrs/build_electrs.py
+electrs: ${PWD}/src/electrs
+	$(top_srcdir)/contrib/electrs/build_electrs.py --dst=${PWD}/src
 
 dist_noinst_SCRIPTS = autogen.sh
 

--- a/contrib/electrs/build_electrs.py
+++ b/contrib/electrs/build_electrs.py
@@ -17,6 +17,8 @@ parser.add_argument('--allow-modified', help='Allow building modified/dirty repo
         action = "store_true")
 parser.add_argument('--verbose', help='Sets log level to DEBUG',
         action = "store_true")
+parser.add_argument('--dst', help='Where to copy produced binary',
+    default=os.path.join(ROOT_DIR, "src"))
 args = parser.parse_args()
 
 level = logging.DEBUG if args.verbose else logging.INFO
@@ -46,6 +48,9 @@ def check_dependencies():
         logging.error("Cannot find 'cargo', will not be able to build electrs")
         logging.error("You need to install rust (1.28+) https://rustup.rs/")
         bail("rust not found")
+
+    if not os.path.isdir(args.dst):
+        bail("--dst provided '%s' is not a directory", args.dst)
 
 def clone_repo():
     import git
@@ -109,8 +114,7 @@ cargo_run(["build", "--release"])
 cargo_run(["test", "--release"])
 
 src = os.path.join(ELECTRS_DIR, "target", "release", "electrs")
-dst = os.path.join(ROOT_DIR, "src")
-logging.info("Copying %s to %s", src, dst)
-shutil.copy(src, dst)
+logging.info("Copying %s to %s", src, args.dst)
+shutil.copy(src, args.dst)
 
 logging.info("Done")

--- a/contrib/electrs/build_electrs.py
+++ b/contrib/electrs/build_electrs.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+import argparse
+import logging
+import os
+import sys
+import shutil
+GIT_REPO = "https://github.com/dagurval/electrs.git"
+GIT_BRANCH = "v0.5.0bu"
+EXPECT_HEAD = "84d449ed283296dfc266433a6919ffcb3ca55344"
+
+ROOT_DIR = os.path.realpath(
+        os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
+ELECTRS_DIR = os.path.join(ROOT_DIR, "electrs")
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--allow-modified', help='Allow building modified/dirty repo',
+        action = "store_true")
+parser.add_argument('--verbose', help='Sets log level to DEBUG',
+        action = "store_true")
+args = parser.parse_args()
+
+level = logging.DEBUG if args.verbose else logging.INFO
+
+logging.basicConfig(format = '%(asctime)s.%(levelname)s: %(message)s',
+        level=level,
+        stream=sys.stdout)
+
+def bail(*args):
+    logging.error(*args)
+    sys.exit(1)
+
+def check_dependencies():
+    v = sys.version_info
+    if v[0] < 3 or (v[0] == 3 and v[1] < 3):
+        bail("python >= 3.3 required");
+
+    try:
+        import git
+    except Exception as e:
+        logging.error("Failed to 'import git'")
+        logging.error("Tip: On Debian/Ubuntu you need to install python3-git")
+        bail(str(e))
+
+    import shutil
+    if shutil.which("cargo") is None:
+        logging.error("Cannot find 'cargo', will not be able to build electrs")
+        logging.error("You need to install rust (1.28+) https://rustup.rs/")
+        bail("rust not found")
+
+def clone_repo():
+    import git
+    logging.info("Cloning %s to %s", GIT_REPO, ELECTRS_DIR)
+    repo = git.Repo.clone_from(GIT_REPO, ELECTRS_DIR, branch=GIT_BRANCH)
+
+def verify_repo(allow_modified):
+    import git
+    repo = git.Repo(ELECTRS_DIR)
+    if repo.is_dirty():
+        logging.error("Validation failed - electrs has local modifications.")
+        allow_modified or bail("Bailing")
+
+    if repo.head.object.hexsha != EXPECT_HEAD:
+        # TODO: Add command line option to reset HEAD to GIT_BRANCH at EXPECT_HEAD
+        logging.error("Validation failed - electrs HEAD differs from expected (%s vs %s)",
+                repo.head.object.hexsha, EXPECT_HEAD)
+        allow_modified or bail("Bailing")
+
+def output_reader(pipe, queue):
+    try:
+        with pipe:
+            for l in iter(pipe.readline, b''):
+                queue.put(l)
+    finally:
+        queue.put(None)
+
+def cargo_run(args):
+    import subprocess
+    from threading import Thread
+    from queue import Queue
+
+    cargo = shutil.which("cargo")
+    args = [cargo] + args
+    logging.info("Running %s", args)
+    assert cargo is not None
+
+    p = subprocess.Popen(args, cwd = ELECTRS_DIR,
+        stdout = subprocess.PIPE, stderr = subprocess.PIPE)
+
+    q = Queue()
+    Thread(target = output_reader, args = [p.stdout, q]).start()
+    Thread(target = output_reader, args = [p.stderr, q]).start()
+
+    for line in iter(q.get, None):
+        logging.info(line.decode('utf-8').rstrip())
+
+    p.wait()
+    rc = p.returncode
+    assert rc is not None
+    if rc != 0:
+        bail("cargo failed with return code %s", rc)
+
+check_dependencies()
+
+if not os.path.exists(ELECTRS_DIR):
+    clone_repo()
+verify_repo(args.allow_modified)
+
+cargo_run(["build", "--release"])
+cargo_run(["test", "--release"])
+
+src = os.path.join(ELECTRS_DIR, "target", "release", "electrs")
+dst = os.path.join(ROOT_DIR, "src")
+logging.info("Copying %s to %s", src, dst)
+shutil.copy(src, dst)
+
+logging.info("Done")

--- a/contrib/gitian-descriptors/gitian-linux.yml
+++ b/contrib/gitian-descriptors/gitian-linux.yml
@@ -20,6 +20,9 @@ packages:
 - "bsdmainutils"
 - "ca-certificates"
 - "python"
+- "python3-git" # building electrs
+- "clang" # for rocksdb in electrs
+- "cmake" # for rocksdb in electrs
 reference_datetime: "2019-04-09 00:00:00"
 remotes:
 - "url": "https://github.com/BitcoinUnlimited/BitcoinUnlimited.git"
@@ -153,6 +156,11 @@ script: |
     mkdir -p ${INSTALLPATH}
     tar --strip-components=1 -xf ../$SOURCEDIST
     CONFIG_SITE=${BASEPREFIX}/${i}/share/config.site ./configure --prefix=/ --disable-ccache --disable-maintainer-mode --disable-dependency-tracking ${CONFIGFLAGS} CFLAGS="${HOST_CFLAGS}" CXXFLAGS="${HOST_CXXFLAGS}" LDFLAGS="${HOST_LDFLAGS}"
+    if [ "$i" = "x86_64-linux-gnu" ]; then
+        # Scope of electrs support is for servers running linux.
+        # We'll support x86_64 only for now.
+        make ${MAKEOPTS} electrs
+    fi
     make -j7 ${MAKEOPTS}
     make ${MAKEOPTS} -C src check-security
     make ${MAKEOPTS} -C src check-symbols

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -244,7 +244,8 @@ testScripts = [ RpcTest(t) for t in [
     'xversion',
     'sighashmatch',
     'getlogcategories',
-    'getrawtransaction'
+    'getrawtransaction',
+    Disabled('electrum_basics', "Needs to be skipped if electrs is not built")
 ] ]
 
 testScriptsExt = [ RpcTest(t) for t in [

--- a/qa/rpc-tests/electrum_basics.py
+++ b/qa/rpc-tests/electrum_basics.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2017 The Bitcoin Unlimited developers
+"""
+Tests to check if basic electrum server integration works
+"""
+import random
+from test_framework.util import waitFor, assert_equal
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.loginit import logging
+
+def compare(node, key, expected):
+    info = node.getelectruminfo()
+    logging.debug("expecting %s == %s from %s", key, expected, info)
+    if key not in info:
+        return False
+    return info[key] == expected
+
+class ElectrumBasicTests(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.electrum_port = random.randint(40000, 60000)
+        self.monitoring_port = random.randint(40000, 60000)
+
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+        self.extra_args = [["-debug=electrum", "-electrum=1", "-debug=rpc",
+            "-electrumport=" + str(self.electrum_port),
+            "-electrummonitoringport=" + str(self.monitoring_port)]]
+
+    def run_test(self):
+        n = self.nodes[0]
+
+        logging.info("Checking that blocks are indexed")
+        n.generate(200)
+
+        # waitFor throws on timeout, failing the test
+
+        waitFor(10, lambda: compare(n, "index_height", n.getblockcount()))
+        waitFor(10, lambda: compare(n, "index_txns", n.getblockcount() + 1)) # +1 is genesis tx
+        waitFor(10, lambda: compare(n, "mempool_count", 0))
+
+        logging.info("Check that mempool is communicated")
+        n.sendtoaddress(n.getnewaddress(), 1)
+        assert_equal(1, len(n.getrawmempool()))
+        waitFor(10, lambda: compare(n, "mempool_count", 1))
+
+        n.generate(1)
+        assert_equal(0, len(n.getrawmempool()))
+        waitFor(10, lambda: compare(n, "index_height", n.getblockcount()))
+        waitFor(10, lambda: compare(n, "mempool_count", 0))
+        waitFor(10, lambda: compare(n, "index_txns", n.getblockcount() + 2))
+
+
+    def setup_network(self, dummy = None):
+        self.nodes = self.setup_nodes()
+
+if __name__ == '__main__':
+    ElectrumBasicTests().main()

--- a/qa/rpc-tests/getlogcategories.py
+++ b/qa/rpc-tests/getlogcategories.py
@@ -45,10 +45,10 @@ class GetLogCategories (BitcoinTestFramework):
         self.is_network_split = False
 
     def run_test (self):
-        exp0 = "coindb tor addrman libevent http rpc partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks cmpctblock"
-        exp1 = "libevent http partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks cmpctblock"
-        exp2 = "libevent http partitioncheck bench prune reindex mempoolrej parallel rand req bloom estimatefee dbase selectcoins zmq qt ibd respend weakblocks cmpctblock"
-        exp3 = "libevent http partitioncheck bench prune reindex mempoolrej parallel req bloom estimatefee dbase selectcoins respend weakblocks cmpctblock"
+        exp0 = "coindb tor addrman libevent http rpc partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks cmpctblock electrum"
+        exp1 = "libevent http partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks cmpctblock electrum"
+        exp2 = "libevent http partitioncheck bench prune reindex mempoolrej parallel rand req bloom estimatefee dbase selectcoins zmq qt ibd respend weakblocks cmpctblock electrum"
+        exp3 = "libevent http partitioncheck bench prune reindex mempoolrej parallel req bloom estimatefee dbase selectcoins respend weakblocks cmpctblock electrum"
         exp4 = exp1
         exp5 = exp0
         exp6 = ""

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -414,6 +414,7 @@ respend/test/respendrelayer_tests.cpp
 rpc/blockchain.cpp
 rpc/client.cpp
 rpc/client.h
+rpc/electrum.cpp
 rpc/mining.cpp
 rpc/misc.cpp
 rpc/net.cpp

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -72,6 +72,10 @@ dosman.cpp
 dosman.h
 dstencode.cpp
 dstencode.h
+electrum/electrs.cpp
+electrum/electrs.cpp
+electrum/electrumserver.cpp
+electrum/electrumserver.cpp
 expedited.cpp
 expedited.h
 fastfilter.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -283,6 +283,7 @@ libbitcoin_server_a_SOURCES = \
   pow.cpp \
   rest.cpp \
   rpc/blockchain.cpp \
+  rpc/electrum.cpp \
   rpc/mining.cpp \
   rpc/misc.cpp \
   rpc/net.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -137,6 +137,8 @@ BITCOIN_CORE_H = \
   dosman.h \
   dstencode.h \
   expedited.h \
+  electrum/electrs.h \
+  electrum/electrumserver.h \
   fast-cpp-csv-parser/csv.h \
   fastfilter.h \
   forks_csv.h \
@@ -260,6 +262,8 @@ libbitcoin_server_a_SOURCES = \
   consensus/tx_verify.cpp \
   dosman.cpp \
   expedited.cpp \
+  electrum/electrs.cpp \
+  electrum/electrumserver.cpp \
   forks_csv.cpp \
   httprpc.cpp \
   httpserver.cpp \

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -712,6 +712,16 @@ static void addRpcServerOptions(AllowedArgs &allowedArgs)
         .addDebugArg("rpcconnect=<ip>", requiredStr,
             strprintf(_("Send commands to node running on <ip> (default: %s)"), DEFAULT_RPCCONNECT));
 }
+static void addElectrumOptions(AllowedArgs &allowedArgs)
+{
+    allowedArgs.addHeader(_("Electrum server options:"))
+        .addArg("electrum", optionalBool, "Enable electrum server")
+        .addArg("electrumdir", requiredStr, "Data directory for electrum database")
+        .addArg("electrumport", requiredStr,
+            "Port to listen to for electrum connections (default: mainnet 50001, testnet: 60001")
+        .addDebugArg("electrumexec", requiredStr, "Path to electrum daemon executable")
+        .addDebugArg("electrummonitoringport", requiredStr, "Port to bind minitoring service");
+}
 
 static void addUiOptions(AllowedArgs &allowedArgs)
 {
@@ -773,6 +783,7 @@ static void addAllNodeOptions(AllowedArgs &allowedArgs, HelpMessageMode mode, CT
     addNodeRelayOptions(allowedArgs);
     addBlockCreationOptions(allowedArgs);
     addRpcServerOptions(allowedArgs);
+    addElectrumOptions(allowedArgs);
     if (pTweaks)
         addTweaks(allowedArgs, pTweaks);
     if (mode == HMM_BITCOIN_QT)

--- a/src/electrum/electrs.cpp
+++ b/src/electrum/electrs.cpp
@@ -1,0 +1,120 @@
+#include "electrum/electrs.h"
+#include "util.h"
+#include "utilhttp.h"
+#include "utilprocess.h"
+
+#include <map>
+#include <regex>
+#include <sstream>
+
+#include <boost/filesystem.hpp>
+
+static std::string monitoring_port() { return GetArg("-electrummonitoringport", "4224"); }
+namespace electrum
+{
+std::string electrs_path()
+{
+    // look for electrs in same path as bitcoind
+    boost::filesystem::path bitcoind_dir(this_process_path());
+    bitcoind_dir = bitcoind_dir.remove_filename();
+
+    auto default_path = bitcoind_dir / "electrs";
+    const std::string path = GetArg("-electrumexec", default_path.string());
+
+    if (path.empty())
+    {
+        throw std::runtime_error("Path to electrum server executable not found. "
+                                 "You can specify full path with -electrumexec");
+    }
+    if (!boost::filesystem::exists(path))
+    {
+        std::stringstream ss;
+        ss << "Cannot find electrum executable at " << path;
+        throw std::runtime_error(ss.str());
+    }
+    return path;
+}
+
+//! Arguments to start electrs server with
+std::vector<std::string> electrs_args(int rpcport, const std::string &network)
+{
+    std::vector<std::string> args;
+
+    if (Logging::LogAcceptCategory(ELECTRUM))
+    {
+        // increase verboseness when electrum logging is enabled
+        args.push_back("-vvvv");
+    }
+
+    // address to bitcoind rpc interface
+    {
+        rpcport = GetArg("-rpcport", rpcport);
+        std::stringstream ss;
+        ss << "--daemon-rpc-addr=localhost:" << rpcport;
+        args.push_back(ss.str());
+    }
+
+    const std::string electrumport = GetArg("-electrumport", "DEFAULT");
+    if (electrumport != "DEFAULT")
+    {
+        args.push_back("--electrum-rpc-addr=127.0.0.1:" + electrumport);
+    }
+
+    // bitcoind data dir (for cookie file)
+    args.push_back("--daemon-dir=" + GetDataDir().string());
+
+    // Use rpc interface instead of attempting to parse *blk files
+    args.push_back("--jsonrpc-import");
+
+    // Where to store electrs database files.
+    const std::string defaultDir = (GetDataDir() / "electrs").string();
+    args.push_back("--db-dir=" + GetArg("-electrumdir", defaultDir));
+
+    // Tell electrs what network we're on
+    const std::map<std::string, std::string> netmapping = {
+        {"main", "mainnet"}, {"test", "testnet"}, {"regtest", "regtest"}};
+    if (!netmapping.count(network))
+    {
+        std::stringstream ss;
+        ss << "Electrum server does not support '" << network << "' network.";
+        throw std::invalid_argument(ss.str());
+    }
+    args.push_back("--network=" + netmapping.at(network));
+    args.push_back("--monitoring-addr=127.0.0.1:" + monitoring_port());
+
+    if (!GetArg("-rpcpassword", "").empty())
+    {
+        args.push_back("--cookie=" + GetArg("-rpcuser", "") + ":" + GetArg("-rpcpassword", ""));
+    }
+
+    // max txs to look up per address
+    args.push_back("--txid-limit=500");
+
+    return args;
+}
+
+std::map<std::string, int> fetch_electrs_info()
+{
+    if (!GetBoolArg("-electrum", false))
+    {
+        throw std::runtime_error("Electrum server is disabled");
+    }
+
+    std::stringstream infostream = http_get("127.0.0.1", std::stoi(monitoring_port()), "/");
+
+    const std::regex keyval("^([a-z_]+)\\s(\\d+)\\s*$");
+    std::map<std::string, int> info;
+    std::string line;
+    std::smatch match;
+    while (std::getline(infostream, line, '\n'))
+    {
+        if (!std::regex_match(line, match, keyval))
+        {
+            continue;
+        }
+        info[match[1].str()] = std::stoi(match[2].str());
+    }
+    return info;
+}
+
+} // ns electrum

--- a/src/electrum/electrs.h
+++ b/src/electrum/electrs.h
@@ -1,0 +1,20 @@
+#ifndef ELECTRUM_ELECTRS_H
+#define ELECTRUM_ELECTRS_H
+
+#include <string>
+#include <vector>
+#include <map>
+
+/// Electrs specific code goes in here. Separating generic electrum code allows
+/// us to support multiple, or swap electrum implementation in the future.
+
+namespace electrum {
+
+std::string electrs_path();
+std::vector<std::string> electrs_args(int rpcport, const std::string& network);
+
+std::map<std::string, int> fetch_electrs_info();
+
+} // ns electrum
+
+#endif

--- a/src/electrum/electrumserver.cpp
+++ b/src/electrum/electrumserver.cpp
@@ -1,0 +1,146 @@
+#include "electrum/electrumserver.h"
+#include "electrum/electrs.h"
+#include "util.h"
+#include "utilprocess.h"
+
+#include <chrono>
+#include <string>
+
+//! give the program a second to complain about startup issues, such as invalid
+//! parameters.
+static bool startup_check(const SubProcess &p)
+{
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(1s);
+    if (p.IsRunning())
+    {
+        // process hasn't exited, good.
+        return true;
+    }
+    LOGA("Electrum: startup check failed, server exited within 1 second");
+    return false;
+}
+
+static void log_args(const std::string &path, const std::vector<std::string> &args)
+{
+    if (!Logging::LogAcceptCategory(ELECTRUM))
+    {
+        return;
+    }
+
+    std::stringstream ss;
+    ss << path;
+    for (auto &a : args)
+    {
+        ss << " " << a;
+    }
+    LOGA("Electrum: spawning %s", ss.str());
+}
+
+namespace electrum
+{
+ElectrumServer::ElectrumServer() {}
+ElectrumServer::~ElectrumServer()
+{
+    if (started)
+        Stop();
+}
+
+//! called when electrs produces a line in stdout/stderr
+static void callb_logger(const std::string &line) { LOGA("Electrum: %s", line); }
+bool ElectrumServer::Start(int rpcport, const std::string &network)
+{
+    DbgAssert(!started, return false);
+    if (!GetBoolArg("-electrum", false))
+    {
+        LOGA("Electrum: Disabled. Not starting server.");
+        return true;
+    }
+
+    auto path = electrs_path();
+    auto args = electrs_args(rpcport, network);
+    log_args(path, args);
+    process.reset(new SubProcess(path, args, callb_logger, callb_logger));
+
+    process_thread = std::thread([this]() {
+        LOGA("Electrum: Starting server");
+        try
+        {
+            this->process->Run();
+        }
+        catch (const subprocess_error &e)
+        {
+            LOGA("Electrum: Server not running: %s, exit status %d, termination signal %d", e.what(), e.exit_status,
+                e.termination_signal);
+        }
+        catch (...)
+        {
+            LOGA("Electrum: Unknown error running server");
+        }
+    });
+    started = true;
+    return startup_check(*process);
+}
+
+static void stop_server(SubProcess &p)
+{
+    if (!p.IsRunning())
+    {
+        return;
+    }
+    LOGA("Electrum: Stopping server");
+
+    try
+    {
+        p.Interrupt();
+    }
+    catch (const subprocess_error &e)
+    {
+        LOGA("Electrum: %s", e.what());
+        p.Terminate();
+        return;
+    }
+
+    using namespace std::chrono_literals;
+    using namespace std::chrono;
+
+    auto timeout = 60s;
+    auto start = system_clock::now();
+    while (p.IsRunning())
+    {
+        if ((system_clock::now() - start) < timeout)
+        {
+            std::this_thread::sleep_for(1s);
+            continue;
+        }
+        LOGA("Electrum: Timed out waiting for clean shutdown (%s seconds)", timeout.count());
+        p.Terminate();
+        return;
+    }
+}
+
+void ElectrumServer::Stop()
+{
+    if (!started)
+    {
+        return;
+    }
+    try
+    {
+        stop_server(*process);
+    }
+    catch (const std::exception &e)
+    {
+        LOGA("Electrum: Error stopping server %s", e.what());
+    }
+    process_thread.join();
+    started = false;
+}
+
+ElectrumServer &ElectrumServer::Instance()
+{
+    static ElectrumServer instance;
+    return instance;
+}
+
+} // ns electrum

--- a/src/electrum/electrumserver.h
+++ b/src/electrum/electrumserver.h
@@ -1,0 +1,31 @@
+#ifndef ELECTRUM_ELECTRUMSERVER_H
+#define ELECTRUM_ELECTRUMSERVER_H
+
+#include <memory>
+#include <thread>
+
+class SubProcess;
+
+namespace electrum {
+
+struct Process;
+
+class ElectrumServer {
+public:
+    static ElectrumServer& Instance();
+    bool Start(int rpcport, const std::string& network);
+    void Stop();
+    ~ElectrumServer();
+
+private:
+    ElectrumServer();
+
+    std::unique_ptr<SubProcess> process;
+    std::thread process_thread;
+
+    bool started = false;
+};
+
+} // ns electrum
+
+#endif

--- a/src/rpc/electrum.cpp
+++ b/src/rpc/electrum.cpp
@@ -1,0 +1,36 @@
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "electrum/electrs.h"
+#include "rpc/server.h"
+#include <univalue.h>
+
+UniValue getelectruminfo(const UniValue &params, bool fHelp)
+{
+    if (fHelp || params.size() != 0)
+    {
+        throw std::invalid_argument("getelectruminfo\n"
+                                    "\nReturns status of the electrum server"
+                                    "\nExamples:\n" +
+                                    HelpExampleCli("getblockcount", "") + HelpExampleRpc("getblockcount", ""));
+    }
+
+    UniValue info(UniValue::VOBJ);
+    for (auto &kv : electrum::fetch_electrs_info())
+    {
+        info.pushKV(kv.first, kv.second);
+    }
+    return info;
+}
+
+static const CRPCCommand commands[] = {
+    //  category, name, function, okSafeMode
+    {"electrum", "getelectruminfo", &getelectruminfo, true},
+};
+
+void RegisterElectrumRPC(CRPCTable &table)
+{
+    for (auto cmd : commands)
+        table.appendCommand(cmd);
+}

--- a/src/rpc/register.h
+++ b/src/rpc/register.h
@@ -21,6 +21,7 @@ void RegisterMiningRPCCommands(CRPCTable &tableRPC);
 void RegisterRawTransactionRPCCommands(CRPCTable &tableRPC);
 /** Register Bitcoin Unlimited's RPC commands */
 void RegisterUnlimitedRPCCommands(CRPCTable &tableRPC);
+void RegisterElectrumRPC(CRPCTable &tableRPC);
 
 static inline void RegisterAllCoreRPCCommands(CRPCTable &tableRPC)
 {
@@ -30,6 +31,7 @@ static inline void RegisterAllCoreRPCCommands(CRPCTable &tableRPC)
     RegisterMiningRPCCommands(tableRPC);
     RegisterRawTransactionRPCCommands(tableRPC);
     RegisterUnlimitedRPCCommands(tableRPC);
+    RegisterElectrumRPC(tableRPC);
 }
 
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -172,7 +172,9 @@ enum
     GRAPHENE = 0x10000000,
     RESPEND = 0x20000000,
     WB = 0x40000000, // weak blocks
-    CMPCT = 0x80000000 // compact blocks
+    CMPCT = 0x80000000, // compact blocks
+
+    ELECTRUM = 0x100000000
 };
 
 namespace Logging
@@ -196,6 +198,7 @@ To add a new log category:
             {REQ, "req"}, {BLOOM, "bloom"}, {LCK, "lck"}, {PROXY, "proxy"}, {DBASE, "dbase"},                   \
             {SELECTCOINS, "selectcoins"}, {ESTIMATEFEE, "estimatefee"}, {QT, "qt"}, {IBD, "ibd"},               \
             {GRAPHENE, "graphene"}, {RESPEND, "respend"}, {WB, "weakblocks"}, {CMPCT, "cmpctblock"},            \
+            {ELECTRUM, "electrum"},                                                                             \
         {                                                                                                       \
             ZMQ, "zmq"                                                                                          \
         }                                                                                                       \


### PR DESCRIPTION
This is a MVP for integrating electrum server with Bitcoin Unlimited.

To enable the server, you need to run `make electrs` and add `electrum=1` to `bitcoin.conf`. Adding `debug=electrum` will enable more useful logging.
