### PR TITLE
Check that a Public Label is within size constraints

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -52,8 +52,11 @@ bool IsStandard(const CScript &scriptPubKey, txnouttype &whichType)
     {
         return true; // CLTV Freeze are standard enable(disable)
     }
-    else if (whichType == TX_NULL_DATA && (!fAcceptDatacarrier || scriptPubKey.size() > nMaxDatacarrierBytes))
-        return false;
+    else if (whichType == TX_NULL_DATA || whichType == TX_LABELPUBLIC)
+    {
+        if (!fAcceptDatacarrier || scriptPubKey.size() > nMaxDatacarrierBytes)
+            return false;
+    }
 
     return whichType != TX_NONSTANDARD;
 }

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -578,6 +578,13 @@ void SendCoinsDialog::processSendCoinsReturn(const WalletModel::SendCoinsReturn 
         msgParams.first = tr("Payment request expired.");
         msgParams.second = CClientUIInterface::MSG_ERROR;
         break;
+    case WalletModel::LabelPublicExceedsLimits:
+        msgParams.first = tr("Public Label exeeds limit of ");
+        // append max byte size. Byte size will be 7 bytes less than max data carrier
+        // to account for the other op codes within the scriptPubKey
+        msgParams.first.append(QString::number(nMaxDatacarrierBytes - 7) + " bytes");
+        msgParams.second = CClientUIInterface::MSG_ERROR;
+        break;
     // included to prevent a compiler warning.
     case WalletModel::OK:
     default:

--- a/src/qt/walletmodel.cpp
+++ b/src/qt/walletmodel.cpp
@@ -225,6 +225,11 @@ WalletModel::SendCoinsReturn WalletModel::prepareTransaction(WalletModelTransact
                 scriptPubKey = GetScriptLabelPublic(rcp.labelPublic.toStdString());
                 // remove duplicate address as rcp.adddress was copied in SendCoinsDialog::on_sendButton_clicked()
                 --nAddresses;
+
+                // Make sure scriptPubKey is within size constraints and that we are configured
+                // to foward OP_RETURN transactions.
+                if (!fAcceptDatacarrier || scriptPubKey.size() > nMaxDatacarrierBytes)
+                    return LabelPublicExceedsLimits;
             }
 
             CRecipient recipient = {scriptPubKey, rcp.amount, rcp.fSubtractFeeFromAmount};

--- a/src/qt/walletmodel.h
+++ b/src/qt/walletmodel.h
@@ -139,7 +139,8 @@ public:
         TransactionCreationFailed, // Error returned when wallet is still locked
         TransactionCommitFailed,
         AbsurdFee,
-        PaymentRequestExpired
+        PaymentRequestExpired,
+        LabelPublicExceedsLimits
     };
 
     enum EncryptionStatus

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -44,17 +44,8 @@ std::string getLabelPublic(const CScript &scriptPubKey)
     {
         if (whichType == TX_LABELPUBLIC)
         {
-            CScriptNum labelPublic0(vSolutions[0], true, 5);
-            // vSolutions[1] small format contains data size
-            CScript labelPublic1(vSolutions[1]);
-
-            if (labelPublic0 == OP_PUSHDATA1)
-                return ""; // TODO long formats not implemented yet
-            else if (labelPublic0 == OP_PUSHDATA2)
-                return ""; // TODO long formats not implemented yet
-            else
-                // small format
-                return std::string(labelPublic1.begin() + 1, labelPublic1.end());
+            CScript labelPublic(vSolutions[1]);
+            return std::string(labelPublic.begin() + 1, labelPublic.end());
         }
     }
 

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -355,27 +355,11 @@ CScript GetScriptLabelPublic(const string &labelPublic)
     {
         scriptDataPublic = CScript();
     }
-    else if (sizeLabelPublic <= 75)
+    else
     {
         // length byte + data (https://en.bitcoin.it/wiki/Script);
         // scriptDataPublic = bytearray((sizeLabelPublic,))+ labelPublic;
         scriptDataPublic = CScript() << OP_RETURN << CScriptNum(sizeLabelPublic)
-                                     << std::vector<unsigned char>(labelPublic.begin(), labelPublic.end());
-    }
-    else if (sizeLabelPublic <= 256)
-    {
-        // OP_PUSHDATA1 format
-        // scriptDataPublic = "\x4c" + bytearray((metadata_len,)) + labelPublic;
-        scriptDataPublic = CScript() << OP_RETURN << OP_PUSHDATA1 << CScriptNum(sizeLabelPublic)
-                                     << std::vector<unsigned char>(labelPublic.begin(), labelPublic.end());
-    }
-    else
-    {
-        // OP_PUSHDATA2 format
-        // scriptDataPublic = "\x4d"+ bytearray((sizeLabelPublic%256,)) + bytearray((int(sizeLabelPublic/256),)) +
-        // labelPublic;
-        scriptDataPublic = CScript() << OP_RETURN << OP_PUSHDATA2 << CScriptNum(sizeLabelPublic % 256)
-                                     << CScriptNum(int(sizeLabelPublic / 256))
                                      << std::vector<unsigned char>(labelPublic.begin(), labelPublic.end());
     }
     return scriptDataPublic;

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -358,6 +358,39 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     BOOST_CHECK(!IsStandardTx(MakeTransactionRef(CTransaction(t)), reason));
     BOOST_CHECK(CTransaction(t).HasData() == false);
 
+    // Check max LabelPublic: MAX_OP_RETURN_RELAY-2 byte TX_NULL_DATA
+    nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
+    uint64_t someNumber = 1;
+    t.vout[0].scriptPubKey = CScript() << OP_RETURN << CScriptNum(someNumber)
+                                       << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                   "e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a671"
+                                                   "e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a671"
+                                                   "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                   "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38ce"
+                                                   "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                   "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38ce"
+                                                   "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef7105"
+                                                   "2312");
+    BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY, t.vout[0].scriptPubKey.size());
+    BOOST_CHECK(IsStandardTx(MakeTransactionRef(CTransaction(t)), reason));
+
+
+    // Check max LabelPublic: MAX_OP_RETURN_RELAY-byte TX_NULL_DATA
+    // MAX_OP_RETURN_RELAY+1-2 -byte TX_NULL_DATA (non-standard)
+    t.vout[0].scriptPubKey = CScript() << OP_RETURN << CScriptNum(someNumber)
+                                       << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                   "e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a671"
+                                                   "e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a671"
+                                                   "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                   "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38ce"
+                                                   "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                   "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38ce"
+                                                   "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef7105"
+                                                   "2312ac");
+    BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY + 1, t.vout[0].scriptPubKey.size());
+    BOOST_CHECK(!IsStandardTx(MakeTransactionRef(CTransaction(t)), reason));
+
+
     // MAX_OP_RETURN_RELAY-byte TX_NULL_DATA (standard)
     nMaxDatacarrierBytes = MAX_OP_RETURN_RELAY;
     t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"


### PR DESCRIPTION
When we check for standardness we have to also check the scriptPubKey.size()
is within constraints for a transaction using a public label.

Check that a public label is within size constraints

When creating a transaction through the QT ui, notify the user that a tx
with a public label can not be propagated if it has too large a size
before actually sending it.

Add tests