### PR TITLE
Set default minlimitertxfee to 1 Sat per byte.

### DIFF
--- a/src/main.h
+++ b/src/main.h
@@ -162,7 +162,7 @@ static const bool DEFAULT_PRINTTOCONSOLE = false;
 
 // BU - Xtreme Thinblocks Auto Mempool Limiter - begin section
 /** The default value for -minrelaytxfee in sat/byte */
-static const double DEFAULT_MINLIMITERTXFEE = 0.0;
+static const double DEFAULT_MINLIMITERTXFEE = (double)DEFAULT_MIN_RELAY_TX_FEE / 1000;
 /** The default value for -maxrelaytxfee in sat/byte */
 static const double DEFAULT_MAXLIMITERTXFEE = (double)DEFAULT_MIN_RELAY_TX_FEE / 1000;
 /** The number of block heights to gradually choke spam transactions over */


### PR DESCRIPTION
That way `minlimitertxfee` and `maxlimitertxfee` will be equal, hence the default fee rate will remain constant at 1 sat/byte.

This will aligned BU with the relay policies of the rest of the BCH network.

BU fee rate is design to respond to mempool dynamics, the emptier the mempool the lower the fee. The variation is determined by the 2 params aforementioned. Setting them to the same value implies to have a constant fee rate.