### PR TITLE
restrict multiple public labels 

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -110,7 +110,7 @@ bool IsStandardTx(const CTransactionRef &tx, std::string &reason)
             return false;
         }
 
-        if (whichType == TX_NULL_DATA)
+        if ((whichType == TX_NULL_DATA) || (whichType == TX_LABELPUBLIC))
             nDataOut++;
         else if ((whichType == TX_MULTISIG) && (!fIsBareMultisigStd))
         {

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -374,6 +374,33 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     BOOST_CHECK_EQUAL(MAX_OP_RETURN_RELAY, t.vout[0].scriptPubKey.size());
     BOOST_CHECK(IsStandardTx(MakeTransactionRef(CTransaction(t)), reason));
 
+    // Check that 2 public labels are not allowed
+    t.vout.resize(2);
+    t.vout[1].scriptPubKey = CScript() << OP_RETURN << CScriptNum(someNumber)
+                                       << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                   "e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a671"
+                                                   "e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a671"
+                                                   "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                   "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38ce"
+                                                   "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                   "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38ce"
+                                                   "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef7105"
+                                                   "2312");
+    BOOST_CHECK(!IsStandardTx(MakeTransactionRef(CTransaction(t)), reason));
+
+    // Check that 1 pub label and 1 normal data is not allowed
+    t.vout[1].scriptPubKey = CScript() << OP_RETURN << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                                "e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a671"
+                                                                "e0ea1f61deb649f6bc3f4cef3804678afdb0fe5548271967f1a671"
+                                                                "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                                "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38ce"
+                                                                "04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962"
+                                                                "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38ce"
+                                                                "30b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef7105"
+                                                                "2312");
+    BOOST_CHECK(!IsStandardTx(MakeTransactionRef(CTransaction(t)), reason));
+    t.vout.resize(1);
+
 
     // Check max LabelPublic: MAX_OP_RETURN_RELAY-byte TX_NULL_DATA
     // MAX_OP_RETURN_RELAY+1-2 -byte TX_NULL_DATA (non-standard)


### PR DESCRIPTION
So we are aligned with the rest of the network's tx forwarding policy