### PR TITLE
Improve reliablility of sendheaders.py

### DIFF
--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -286,7 +286,7 @@ class SendHeadersTest(BitcoinTestFramework):
         # Currently there are mininode syncronization issues when Parallel Validation is turned on
         # and therefore have -parallel=0 when running these tests.
         self.nodes = []
-        args = [["-debug", "-logtimemicros=1", "-parallel=0", "-use-thinblocks=0", "-use-grapheneblocks=0", "-use-compactblocks=0"]]*2
+        args = [["-debug", "-logtimemicros=1", "-parallel=0", "-use-thinblocks=0", "-use-grapheneblocks=0", "-use-compactblocks=0", "-net.msgHandlerThreads=1", "-net.txAdmissionThreads=1"]]*2
         self.nodes = start_nodes(2, self.options.tmpdir, args)
         connect_nodes(self.nodes[0], 1)
 


### PR DESCRIPTION
This script relies a great deal on sync_with_ping(), as a result we
need to make the client's single threaded in regards to net and message
processing.  Only allow 1 txAdmissionThread and 1 msgHandlerThread