### PR TITLE
Fix a comparison warning in interpreter.cpp

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -496,7 +496,7 @@ static bool CheckSignatureEncodingSigHashChoice(const vector<unsigned char> &vch
 
     if (flags & SCRIPT_ENABLE_SCHNORR)
     {
-        if (vchSig.size() == 64 + (check_sighash == true) ? 1 : 0) // 64 sig length plus 1 sighashtype
+        if (vchSig.size() == 64 + ((check_sighash == true) ? 1 : 0)) // 64 sig length plus 1 sighashtype
         {
             // In a generic-signature context, 64-byte signatures are interpreted
             // as Schnorr signatures (always correctly encoded) when flag set.


### PR DESCRIPTION
```
script/interpreter.cpp: In function ‘bool CheckSignatureEncodingSigHashChoice(const std::vector<unsigned char>&, unsigned int, ScriptError*, bool)’:
script/interpreter.cpp:499:27: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         if (vchSig.size() == 64 + (check_sighash == true) ? 1 : 0) // 64 sig length plus 1 sighashtype
```