### PR TITLE
Rename USE_CLANG to NODEPENDS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,6 +125,7 @@ matrix:
         - PACKAGES="libtool libevent-devel autoconf automake openssl-devel boost-devel python36u libdb4-devel libdb4-cxx-devel devtoolset-6-gcc* miniupnpc-devel zeromq-devel"
         - RUN_TESTS=false GOAL="install"
         - BITCOIN_CONFIG="--enable-zmq --with-gui=no --disable-bench"
+        - NODEPENDS=true
 
 before_install:
     - set -o errexit; source .travis/before_install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ matrix:
         - PACKAGES="python3-zmq libzmq3-dev qttools5-dev-tools qttools5-dev clang-5.0 libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-program-options-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev"
         - GOAL="install"
         - BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 CC=clang-5.0 --with-incompatible-bdb CXX=clang++-5.0 CPPFLAGS=-DDEBUG_LOCKORDER CXXFLAGS=\"-std=c++14\""
+        - NODEPENDS=true
     #bitcoind
     - compiler: gcc
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ env:
     - CCACHE_COMPRESS=1
     - CCACHE_DIR=$HOME/.ccache
     - BASE_OUTDIR=$TRAVIS_BUILD_DIR/out
-    - USE_CLANG=false
     - SDK_URL=https://www.bitcoinunlimited.info/sdks
     - LINTER_DEB_URL=https://www.bitcoinunlimited.info/depends-sources/
     - PYTHON_DEBUG=1
@@ -35,7 +34,6 @@ matrix:
     #bitcoind clang (no depend, only system lib installed via apt)
     - compiler: clang
       env:
-        - USE_CLANG=true
         - CXX=clang++-5.0 CC=clang-5.0
         - CXXFLAGS="-std=c++14"
         - HOST=x86_64-unknown-linux-gnu

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -13,8 +13,7 @@ if [ "$CHECK_DOC" = 1 ]; then DOCKER_EXEC contrib/devtools/check-doc.py; fi
 mkdir -p depends/SDKs depends/sdk-sources
 if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then curl --location --fail $SDK_URL/MacOSX${OSX_SDK}.sdk.tar.gz -o depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
 if [ -n "$OSX_SDK" -a -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
-echo "USE_CLANG=$USE_CLANG"
 if [[ $HOST = *-mingw32 ]]; then DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\); fi
 if [ -z "$NODEPENDS" ]; then
-  if [ "$USE_CLANG" = "false" ]; then DOCKER_EXEC CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS; fi #use sys libraries for clang
+  DOCKER_EXEC CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS;
 fi

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -15,4 +15,6 @@ if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; th
 if [ -n "$OSX_SDK" -a -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
 echo "USE_CLANG=$USE_CLANG"
 if [[ $HOST = *-mingw32 ]]; then DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\); fi
-if [ "$USE_CLANG" = "false" ]; then DOCKER_EXEC CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS; fi #use sys libraries for clang
+if [ -z "$NODEPENDS" ]; then
+  if [ "$USE_CLANG" = "false" ]; then DOCKER_EXEC CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS; fi #use sys libraries for clang
+fi

--- a/.travis/before_script.sh
+++ b/.travis/before_script.sh
@@ -15,11 +15,4 @@ if [ -n "$OSX_SDK" -a ! -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; th
 if [ -n "$OSX_SDK" -a -f depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz ]; then tar -C depends/SDKs -xf depends/sdk-sources/MacOSX${OSX_SDK}.sdk.tar.gz; fi
 echo "USE_CLANG=$USE_CLANG"
 if [[ $HOST = *-mingw32 ]]; then DOCKER_EXEC update-alternatives --set $HOST-g++ \$\(which $HOST-g++-posix\); fi
-if [ $DIST = "RPM" ]; then
-  if [ "$USE_CLANG" = "false" ]; then
-    DOCKER_EXEC cd depends && CONFIG_SHELL= make $MAKEJOBS -C ../depends HOST=$HOST $DEP_OPTS && cd ../
-  fi #use sys libraries for clang
-fi
-if [ $DIST = "DEB" ]; then
-  if [ "$USE_CLANG" = "false" ]; then DOCKER_EXEC CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS; fi #use sys libraries for clang
-fi
+if [ "$USE_CLANG" = "false" ]; then DOCKER_EXEC CONFIG_SHELL= make $MAKEJOBS -C depends HOST=$HOST $DEP_OPTS; fi #use sys libraries for clang

--- a/.travis/script_a.sh
+++ b/.travis/script_a.sh
@@ -21,7 +21,7 @@ if [ -n "$USE_SHELL" ]; then export CONFIG_SHELL="$USE_SHELL"; fi
 OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
 BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib";
 if [ -z "$NODEPENDS" ]; then
-  if [ "$USE_CLANG" = "false" ]; then DOCKER_EXEC ccache --max-size=$CCACHE_SIZE; fi
+  then DOCKER_EXEC ccache --max-size=$CCACHE_SIZE;
 fi
 test -n "$USE_SHELL" && DOCKER_EXEC "$CONFIG_SHELL" -c "./autogen.sh 2>&1 > autogen.out" || ./autogen.sh 2>&1 > autogen.out || (cat autogen.out && false)
 END_FOLD

--- a/.travis/script_a.sh
+++ b/.travis/script_a.sh
@@ -21,7 +21,7 @@ if [ -n "$USE_SHELL" ]; then export CONFIG_SHELL="$USE_SHELL"; fi
 OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
 BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib";
 if [ -z "$NODEPENDS" ]; then
-  then DOCKER_EXEC ccache --max-size=$CCACHE_SIZE;
+  DOCKER_EXEC ccache --max-size=$CCACHE_SIZE;
 fi
 test -n "$USE_SHELL" && DOCKER_EXEC "$CONFIG_SHELL" -c "./autogen.sh 2>&1 > autogen.out" || ./autogen.sh 2>&1 > autogen.out || (cat autogen.out && false)
 END_FOLD

--- a/.travis/script_a.sh
+++ b/.travis/script_a.sh
@@ -20,7 +20,9 @@ export TRAVIS_COMMIT_LOG=`git log --format=fuller -1`
 if [ -n "$USE_SHELL" ]; then export CONFIG_SHELL="$USE_SHELL"; fi
 OUTDIR=$BASE_OUTDIR/$TRAVIS_PULL_REQUEST/$TRAVIS_JOB_NUMBER-$HOST
 BITCOIN_CONFIG_ALL="--disable-dependency-tracking --prefix=$TRAVIS_BUILD_DIR/depends/$HOST --bindir=$OUTDIR/bin --libdir=$OUTDIR/lib";
-if [ "$USE_CLANG" = "false" ]; then DOCKER_EXEC ccache --max-size=$CCACHE_SIZE; fi
+if [ -z "$NODEPENDS" ]; then
+  if [ "$USE_CLANG" = "false" ]; then DOCKER_EXEC ccache --max-size=$CCACHE_SIZE; fi
+fi
 test -n "$USE_SHELL" && DOCKER_EXEC "$CONFIG_SHELL" -c "./autogen.sh 2>&1 > autogen.out" || ./autogen.sh 2>&1 > autogen.out || (cat autogen.out && false)
 END_FOLD
 


### PR DESCRIPTION
Basically USE_CLANG is used to determine if travis needed to build dependencies from source. It was initially introduce to let the codebase to be built using clang, hence the name. Regardless the name is misleading so I decided to change it. `NODEPENDS` seems self explanatory. 

In the process use `[ -z ]` to check for  `NODEPENDS` existence rather than setting the var for every stanza. 

**this PR is supposed to fail on travis with centos due to #1655**

we need to figure out what to do for centos. maybe we could just build boost from source or we could boost >= 1.55 from some other source