### PR TITLE
 [util] throw proper exception in IsStringTrue

### DIFF
--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -415,7 +415,8 @@ BOOST_AUTO_TEST_CASE(rpc_help)
     BOOST_CHECK(s.substr(p + 1).find("== Mining ==") == string::npos);
 }
 
-BOOST_AUTO_TEST_CASE(rpc_setlog) {
+BOOST_AUTO_TEST_CASE(rpc_setlog)
+{
     CallRPC("log all on");
     BOOST_CHECK_EQUAL(ALL, Logging::categoriesEnabled);
     CallRPC("log all off");

--- a/src/test/rpc_tests.cpp
+++ b/src/test/rpc_tests.cpp
@@ -414,4 +414,22 @@ BOOST_AUTO_TEST_CASE(rpc_help)
     BOOST_CHECK(p != string::npos);
     BOOST_CHECK(s.substr(p + 1).find("== Mining ==") == string::npos);
 }
+
+BOOST_AUTO_TEST_CASE(rpc_setlog) {
+    CallRPC("log all on");
+    BOOST_CHECK_EQUAL(ALL, Logging::categoriesEnabled);
+    CallRPC("log all off");
+    BOOST_CHECK_EQUAL(NONE, Logging::categoriesEnabled);
+    CallRPC("log tor");
+    BOOST_CHECK_EQUAL(NONE, Logging::categoriesEnabled);
+    CallRPC("log tor on");
+    BOOST_CHECK_EQUAL(TOR, Logging::categoriesEnabled);
+    CallRPC("log tor off");
+    BOOST_CHECK_EQUAL(NONE, Logging::categoriesEnabled);
+    BOOST_CHECK_THROW(CallRPC("log tor bad-arg"), std::invalid_argument);
+    BOOST_CHECK_EQUAL(NONE, Logging::categoriesEnabled);
+    BOOST_CHECK_THROW(CallRPC("log badcategory on"), std::invalid_argument);
+    BOOST_CHECK_EQUAL(NONE, Logging::categoriesEnabled);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -732,7 +732,8 @@ BOOST_AUTO_TEST_CASE(util_Logging)
     }
 }
 
-BOOST_AUTO_TEST_CASE(isstringtrue) {
+BOOST_AUTO_TEST_CASE(isstringtrue)
+{
     BOOST_CHECK(IsStringTrue("true"));
     BOOST_CHECK(IsStringTrue("enable"));
     BOOST_CHECK(IsStringTrue("1"));

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -767,16 +767,19 @@ BOOST_AUTO_TEST_CASE(util_Logging)
         LOG(THIN, "wrong order args %s %d\n", 3, "hello");
         LOG(THIN, "null arg %s\n", NULL);
         LOG(THIN, "test no CR");
-        BOOST_CHECK(IsStringTrue("true"));
-        BOOST_CHECK(IsStringTrue("enable"));
-        BOOST_CHECK(IsStringTrue("1"));
-        BOOST_CHECK(IsStringTrue("on"));
-        BOOST_CHECK(!IsStringTrue("false"));
-        BOOST_CHECK(!IsStringTrue("disable"));
-        BOOST_CHECK(!IsStringTrue("0"));
-        BOOST_CHECK(!IsStringTrue("off"));
-        BOOST_CHECK(IsStringTrueBadArgTest("bad"));
     }
+}
+
+BOOST_AUTO_TEST_CASE(isstringtrue) {
+    BOOST_CHECK(IsStringTrue("true"));
+    BOOST_CHECK(IsStringTrue("enable"));
+    BOOST_CHECK(IsStringTrue("1"));
+    BOOST_CHECK(IsStringTrue("on"));
+    BOOST_CHECK(!IsStringTrue("false"));
+    BOOST_CHECK(!IsStringTrue("disable"));
+    BOOST_CHECK(!IsStringTrue("0"));
+    BOOST_CHECK(!IsStringTrue("off"));
+    BOOST_CHECK_THROW(IsStringTrue("bad"), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(util_wildmatch)

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -706,37 +706,6 @@ BOOST_AUTO_TEST_CASE(test_ConvertBits)
         {0x00, 0x04, 0x11, 0x14, 0x0a, 0x19, 0x1c, 0x09, 0x15, 0x0f, 0x06, 0x1e, 0x1e});
 }
 
-// Log tests:
-bool TestSetLog(uint64_t categoriesExpected, const char *arg1, const char *arg2 = NULL)
-{
-    UniValue logargs(UniValue::VARR);
-    bool ret = false;
-    logargs.push_back(arg1);
-    if (arg2 != NULL)
-        logargs.push_back(arg2);
-
-    setlog(logargs, false); // The function to be tested
-
-    if (categoriesExpected == Logging::categoriesEnabled)
-        ret = true;
-
-    // LOGA("TestSetLog %s %s ret: %d\n", arg1, ((arg2 == NULL)?"":arg2),(int)ret);
-    return ret;
-}
-
-bool IsStringTrueBadArgTest(const char *arg1)
-{
-    try
-    {
-        IsStringTrue(arg1);
-    }
-    catch (...)
-    {
-        return true; // If bad arg return true
-    }
-    return false;
-}
-
 BOOST_AUTO_TEST_CASE(util_Logging)
 {
     {
@@ -755,13 +724,6 @@ BOOST_AUTO_TEST_CASE(util_Logging)
         LogToggleCategory(ALL, false);
         BOOST_CHECK_EQUAL(NONE, categoriesEnabled);
         BOOST_CHECK_EQUAL(LogGetLabel(ADDRMAN), "addrman");
-        BOOST_CHECK(TestSetLog(ALL, "all", "on"));
-        BOOST_CHECK(TestSetLog(NONE, "all", "off"));
-        BOOST_CHECK(TestSetLog(NONE, "tor"));
-        BOOST_CHECK(TestSetLog(TOR, "tor", "on"));
-        BOOST_CHECK(TestSetLog(NONE, "tor", "off"));
-        BOOST_CHECK(!TestSetLog(TOR, "tor", "bad-arg"));
-        BOOST_CHECK(TestSetLog(categoriesEnabled, "badcategory", "on"));
         LogToggleCategory(ALL, true);
         LOG(THIN, "missing args %s %d\n");
         LOG(THIN, "wrong order args %s %d\n", 3, "hello");

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1704,51 +1704,36 @@ UniValue setlog(const UniValue &params, bool fHelp)
             HelpExampleCli("log", "\"tor\" ") + HelpExampleCli("log", "\"ALL\" ") + HelpExampleCli("log", " "));
     }
 
-    try
+    if (nparm == 0)
+        ret = UniValue(Logging::LogGetAllString(true));
+
+    if (nparm > 0)
     {
-        if (nparm == 0)
-            ret = UniValue(Logging::LogGetAllString(true));
-
-        if (nparm > 0)
-        {
-            std::string category;
-            std::string data = params[0].get_str();
-            std::transform(data.begin(), data.end(), std::back_inserter(category), ::tolower);
-            catg = Logging::LogFindCategory(category);
-            if (catg == NONE)
-                return UniValue("Category not found: " + params[0].get_str()); // quit
-        }
-
-        switch (nparm)
-        {
-        case 1:
-            if (catg == ALL)
-                ret = UniValue(Logging::LogGetAllString());
-            else
-                ret = UniValue(Logging::LogAcceptCategory(catg) ? "on" : "off");
-            break;
-
-        case 2:
-            try
-            {
-                action = IsStringTrue(params[1].get_str());
-            }
-            catch (...)
-            {
-                ret = UniValue("Please pass on|off as last argument.");
-                break; // quit
-            }
-
-            Logging::LogToggleCategory(catg, action);
-
-        default:
-            break;
+        std::string category;
+        std::string data = params[0].get_str();
+        std::transform(data.begin(), data.end(), std::back_inserter(category), ::tolower);
+        catg = Logging::LogFindCategory(category);
+        if (catg == NONE) {
+            throw std::invalid_argument("Category not found: " + params[0].get_str());
         }
     }
-    catch (...)
+
+    switch (nparm)
     {
-        LOG(ALL, "LOG: Something went wrong in setlog function \n");
-        ret = UniValue("Something went wrong. That is all we know.");
+    case 1:
+        if (catg == ALL)
+            ret = UniValue(Logging::LogGetAllString());
+        else
+            ret = UniValue(Logging::LogAcceptCategory(catg) ? "on" : "off");
+        break;
+
+    case 2:
+        action = IsStringTrue(params[1].get_str());
+
+        Logging::LogToggleCategory(catg, action);
+
+    default:
+        break;
     }
 
     return ret;

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1713,7 +1713,8 @@ UniValue setlog(const UniValue &params, bool fHelp)
         std::string data = params[0].get_str();
         std::transform(data.begin(), data.end(), std::back_inserter(category), ::tolower);
         catg = Logging::LogFindCategory(category);
-        if (catg == NONE) {
+        if (catg == NONE)
+        {
             throw std::invalid_argument("Category not found: " + params[0].get_str());
         }
     }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1024,8 +1024,8 @@ std::string CopyrightHolders(const std::string &strPrefix)
 
 bool IsStringTrue(const std::string &str)
 {
-    static const std::set<std::string> strOn = {"enable", "1", "true", "on"};
-    static const std::set<std::string> strOff = {"disable", "0", "false", "off"};
+    static const std::set<std::string> strOn = {"enable", "1", "true", "True", "on"};
+    static const std::set<std::string> strOff = {"disable", "0", "false", "False", "off"};
 
     if (strOn.count(str))
         return true;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -1024,20 +1024,21 @@ std::string CopyrightHolders(const std::string &strPrefix)
 
 bool IsStringTrue(const std::string &str)
 {
-    const std::set<std::string> strOn = {"enable", "1", "true", "on"};
-    const std::set<std::string> strOff = {"disable", "0", "false", "off"};
-    const std::string lowstr = boost::algorithm::to_lower_copy(str);
+    static const std::set<std::string> strOn = {"enable", "1", "true", "on"};
+    static const std::set<std::string> strOff = {"disable", "0", "false", "off"};
 
-    if (strOn.count(lowstr))
+    if (strOn.count(str))
         return true;
 
-    if (strOff.count(lowstr))
+    if (strOff.count(str))
         return false;
 
-    // If not found:
-    throw std::string("IsStringTrue() was passed an Invalid string");
-
-    return false;
+    std::ostringstream err;
+    err << "invalid argument '" << str << "', expected any of: ";
+    std::copy(begin(strOn), end(strOn), std::ostream_iterator<std::string>(err, ", "));
+    std::copy(begin(strOff), end(strOff), std::ostream_iterator<std::string>(err, ", "));
+    // substr to chop off last ', '
+    throw std::invalid_argument(err.str().substr(0, err.str().size() - 2));
 }
 
 static const int wildmatch_max_length = 1024;

--- a/src/util.h
+++ b/src/util.h
@@ -329,11 +329,6 @@ inline void LogWrite(const std::string &str)
 // Flush log file (if you know you are about to abort)
 void LogFlush();
 
-// Log tests:
-UniValue setlog(const UniValue &params, bool fHelp);
-// END logging.
-
-
 /**
  * Translate a boolean string to a bool.
  * Throws an exception if not one of the strings.


### PR DESCRIPTION
* Throw `std::invalid_argument` instead of std::string
* Don't accept mixed case input
* Remove what looks to be workarounds for `IsStringTrue` not throwing proper exceptions.
* Move/rewrite rpc unit test from `util_tests` to `rpc_tests`.