### PR TITLE
Update rpm travis build and doc instructions to use boost 1.66.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -120,7 +120,7 @@ matrix:
         - DOCKER_NAME_TAG=centos:latest
         - DIST=RPM
         - DEP_OPTS="ALLOW_HOST_PACKAGES=1"
-        - PACKAGES="libtool libevent-devel autoconf automake openssl-devel boost-devel python36u libdb4-devel libdb4-cxx-devel devtoolset-6-gcc* miniupnpc-devel zeromq-devel"
+        - PACKAGES="libtool libevent-devel autoconf automake openssl-devel python36u libdb4-devel libdb4-cxx-devel devtoolset-6-gcc* miniupnpc-devel zeromq-devel"
         - RUN_TESTS=false GOAL="install"
         - BITCOIN_CONFIG="--enable-zmq --with-gui=no --disable-bench"
         - NODEPENDS=true

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -29,6 +29,8 @@ if [ $DIST = "RPM" ]; then
   travis_retry DOCKER_EXEC yum update -y
   travis_retry DOCKER_EXEC yum groupinstall -y development
   travis_retry DOCKER_EXEC yum install -y https://centos7.iuscommunity.org/ius-release.rpm
+  travis_retry DOCKER_EXEC yum install -y http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-1.noarch.rpm
+  travis_retry DOCKER_EXEC yum install -y boost166-devel
   # this is temporary until the default compiler on centos/rhel supports c++14
   travis_retry DOCKER_EXEC yum install -y centos-release-scl
   travis_retry DOCKER_EXEC yum install -y $PACKAGES $DOCKER_PACKAGES

--- a/doc/build-unix-rpm.md
+++ b/doc/build-unix-rpm.md
@@ -60,11 +60,14 @@ compilation will take much longer due to swap thrashing.
 
 Build requirements:
 
+## NOTE: you do not need to get boost from this source, but you do need at least boost 1.55 and CentOS7 by default has boost 1.53. This was the only place I could find a higher version of boost for CentOS7 that avoided compiling from source. If you do not trust it feel free to compile boost from source from the official boost github.
 ```bash
 sudo yum groupinstall development
 sudo yum install https://centos7.iuscommunity.org/ius-release.rpm
 sudo yum install centos-release-scl
-sudo yum install libtool libevent-devel autoconf automake openssl-devel boost-devel python36u libdb4-devel libdb4-cxx-devel
+sudo yum install http://repo.okay.com.mx/centos/7/x86_64/release/okay-release-1-1.noarch.rpm
+sudo yum install boost166-devel
+sudo yum install libtool libevent-devel autoconf automake openssl-devel python36u libdb4-devel libdb4-cxx-devel
 sudo yum install devtoolset-6-gcc*
 sudo scl enable devtoolset-6 bash
 ```


### PR DESCRIPTION
repo is from pkgs.com, it was the only one I could find