### PR TITLE
Fix spurious failures in mempool_packages.py

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -268,7 +268,7 @@ testScriptsExt = [ RpcTest(t) for t in [
     'invalidateblock',
     Disabled('rpcbind_test', "temporary, bug in libevent, see #6655"),
     'smartfees',
-    'maxblocksinflight',
+    Disabled('maxblocksinflight', "needs a rewrite and is already somewhat tested in sendheaders.py"),
     'p2p-acceptblock',
     'mempool_packages',
     'maxuploadtarget'

--- a/qa/rpc-tests/bipdersig.py
+++ b/qa/rpc-tests/bipdersig.py
@@ -15,9 +15,9 @@ class BIP66Test(BitcoinTestFramework):
 
     def setup_network(self):
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, []))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockversion=2"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockversion=3"]))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-net.msgHandlerThreads=1", "-net.txAdmissionThreads=1"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-net.msgHandlerThreads=1", "-net.txAdmissionThreads=1", "-blockversion=2"]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-net.msgHandlerThreads=1", "-net.txAdmissionThreads=1", "-blockversion=3"]))
         connect_nodes(self.nodes[1], 0)
         connect_nodes(self.nodes[2], 0)
         self.is_network_split = False

--- a/qa/rpc-tests/mempool_packages.py
+++ b/qa/rpc-tests/mempool_packages.py
@@ -161,6 +161,8 @@ class MempoolPackagesTest(BitcoinTestFramework):
         self.nodes[1].invalidateblock(self.nodes[1].getbestblockhash())
 
         # Now check that the transaction is in the mempool, with the right modified fee
+        waitFor(30, lambda: self.nodes[1].getmempoolinfo()['size'] == 5)
+        waitFor(30, lambda: self.nodes[0].getmempoolinfo()['size'] == 25)
         mempool = self.nodes[0].getrawmempool(True)
 
         descendant_fees = 0


### PR DESCRIPTION
Add a syncronization point to wait for the transactions to be
resurrencted in the mempool before proceeding.