### PR TITLE
Output a message if script verification fails

### DIFF
--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -47,7 +47,10 @@ bool CScriptCheck::operator()()
     const CScript &scriptSig = ptxTo->vin[nIn].scriptSig;
     CachingTransactionSignatureChecker checker(ptxTo, nIn, amount, nFlags, cacheStore);
     if (!VerifyScript(scriptSig, scriptPubKey, nFlags, maxOps, checker, &error, &sighashType))
+    {
+        LOG(PARALLEL, "Signature verification failed: %s\n", ScriptErrorString(GetScriptError()));
         return false;
+    }
     if (resourceTracker)
         resourceTracker->Update(ptxTo->GetHash(), checker.GetNumSigops(), checker.GetBytesHashed());
     return true;


### PR DESCRIPTION
This is really helpful when/if there are signature failures in a block
and your trying to debug what the failure is about.

Only print out the message if logging for PARALLEL is turned on, in order
to limit any log spam.