### PR TITLE
Introduce high / low version preferences for Graphene

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -238,6 +238,7 @@ testScripts = [ RpcTest(t) for t in [
     'compactblocks_1',
     'compactblocks_2',
     'graphene_optimized',
+    'graphene_versions',
     'thinblocks',
     Disabled('checkdatasig_activation', "CDSV has been already succesfully activated, keep test around as a template for other OP activation"),
     'xversion',

--- a/qa/rpc-tests/graphene_versions.py
+++ b/qa/rpc-tests/graphene_versions.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+from grapheneblocks import GrapheneBlockTest
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+
+class GrapheneOptimizedTest(GrapheneBlockTest):
+   
+    def __init__(self, vL1, vH1, vL2, vH2, test_assertion):
+        self.vL1 = vL1
+        self.vH1 = vH1
+        self.vL2 = vL2
+        self.vH2 = vH2
+
+        super(GrapheneOptimizedTest, self).__init__(test_assertion)
+
+    def setup_network(self, split=False):
+        type1_opts = [
+            "-rpcservertimeout=0",
+            "-debug=graphene",
+            "-use-grapheneblocks=1",
+            "-use-thinblocks=0",
+            "-use-compactblocks=0",
+            "-net.grapheneMinVersionSupported=" + self.vL1,
+            "-net.grapheneMaxVersionSupported=" + self.vH1,
+            "-net.grapheneFastFilterCompatibility=0",
+            "-excessiveblocksize=6000000",
+            "-blockprioritysize=6000000",
+            "-blockmaxsize=6000000"]
+
+        type2_opts = [
+            "-rpcservertimeout=0",
+            "-debug=graphene",
+            "-use-grapheneblocks=1",
+            "-use-thinblocks=0",
+            "-use-compactblocks=0",
+            "-net.grapheneMinVersionSupported=" + self.vL2,
+            "-net.grapheneMaxVersionSupported=" + self.vH2,
+            "-net.grapheneFastFilterCompatibility=0",
+            "-excessiveblocksize=6000000",
+            "-blockprioritysize=6000000",
+            "-blockmaxsize=6000000"]
+
+        self.nodes = [
+            start_node(0, self.options.tmpdir, type1_opts),
+            start_node(1, self.options.tmpdir, type2_opts),
+            start_node(2, self.options.tmpdir, type1_opts)
+        ]
+
+        interconnect_nodes(self.nodes)
+        self.is_network_split = False
+        self.sync_all()
+
+
+if __name__ == '__main__':
+    GrapheneOptimizedTest('1', '3', '3', '4', 'success').main()
+    GrapheneOptimizedTest('0', '4', '1', '3', 'success').main()
+    GrapheneOptimizedTest('1', '2', '3', '4', 'failure').main()

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -29,6 +29,7 @@ enum FastFilterSupport
 };
 
 const uint8_t GRAPHENE_FAST_FILTER_SUPPORT = EITHER;
+const uint64_t GRAPHENE_MIN_VERSION_SUPPORTED = 0;
 const uint64_t GRAPHENE_MAX_VERSION_SUPPORTED = 4;
 const unsigned char MIN_MEMPOOL_INFO_BYTES = 8;
 const uint8_t SHORTTXIDS_LENGTH = 8;
@@ -357,5 +358,6 @@ uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &t
 // This method decides on the value of computeOptimized depending on what modes are supported
 // by both the sender and receiver
 bool NegotiateFastFilterSupport(CNode *pfrom);
+uint64_t NegotiateGrapheneVersion(CNode *pfrom);
 
 #endif // BITCOIN_GRAPHENE_H

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -358,6 +358,24 @@ CTweak<unsigned int> blockDownloadWindow("net.blockDownloadWindow",
     "How far ahead of our current height do we fetch? 0 means use algorithm.",
     0);
 
+/** This setting specifies the minimum supported Graphene version (inclusive).
+ *  The actual version used will be negotiated between sender and receiver.
+ */
+std::string grMinVerStr =
+    "Minimum Graphene version supported (default: " + std::to_string(GRAPHENE_MIN_VERSION_SUPPORTED) + ")";
+CTweak<uint64_t> grapheneMinVersionSupported("net.grapheneMinVersionSupported",
+    grMinVerStr,
+    GRAPHENE_MIN_VERSION_SUPPORTED);
+
+/** This setting specifies the maximum supported Graphene version (inclusive).
+ *  The actual version used will be negotiated between sender and receiver.
+ */
+std::string grMaxVerStr =
+    "Maximum Graphene version supported (default: " + std::to_string(GRAPHENE_MAX_VERSION_SUPPORTED) + ")";
+CTweak<uint64_t> grapheneMaxVersionSupported("net.grapheneMaxVersionSupported",
+    grMaxVerStr,
+    GRAPHENE_MAX_VERSION_SUPPORTED);
+
 /** This setting dictates the peer's Bloom filter compatibility when sending and
  * receiving Graphene blocks. In this implementation, either regular or fast Bloom
  * filters are supported. However, other (or future) implementations may elect to

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -31,6 +31,8 @@ extern std::atomic<int> nPreferredDownload;
 extern int nSyncStarted;
 extern std::map<uint256, std::pair<CBlockHeader, int64_t> > mapUnConnectedHeaders;
 extern CTweak<unsigned int> maxBlocksInTransitPerPeer;
+extern CTweak<uint64_t> grapheneMinVersionSupported;
+extern CTweak<uint64_t> grapheneMaxVersionSupported;
 extern CTweak<uint64_t> grapheneFastFilterCompatibility;
 
 // Requires cs_main
@@ -416,11 +418,11 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
     bool grapheneVersionCompatible = true;
     try
     {
+        NegotiateGrapheneVersion(pfrom);
         NegotiateFastFilterSupport(pfrom);
     }
     catch (const std::runtime_error &e)
     {
-        LOG(GRAPHENE, "Incompatible Graphene versions, graphene blocks will not be sent");
         grapheneVersionCompatible = false;
     }
 
@@ -565,7 +567,8 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         CXVersionMessage xver;
         xver.set_u64c(XVer::BU_LISTEN_PORT, GetListenPort());
         xver.set_u64c(XVer::BU_MSG_IGNORE_CHECKSUM, 1); // we will ignore 0 value msg checksums
-        xver.set_u64c(XVer::BU_GRAPHENE_VERSION_SUPPORTED, GRAPHENE_MAX_VERSION_SUPPORTED);
+        xver.set_u64c(XVer::BU_GRAPHENE_MAX_VERSION_SUPPORTED, grapheneMaxVersionSupported.Value());
+        xver.set_u64c(XVer::BU_GRAPHENE_MIN_VERSION_SUPPORTED, grapheneMinVersionSupported.Value());
         xver.set_u64c(XVer::BU_GRAPHENE_FAST_FILTER_PREF, grapheneFastFilterCompatibility.Value());
         xver.set_u64c(XVer::BU_XTHIN_VERSION, 2); // xthin version
         pfrom->PushMessage(NetMsgType::XVERSION, xver);

--- a/src/xversionkeys.dat
+++ b/src/xversionkeys.dat
@@ -20,7 +20,7 @@
 
 # this is the listening
 KEY i BU_LISTEN_PORT                            0x0002                   0x0000         u64c
-KEY i BU_GRAPHENE_VERSION_SUPPORTED             0x0002                   0x0001         u64c
+KEY i BU_GRAPHENE_MAX_VERSION_SUPPORTED         0x0002                   0x0001         u64c
 
 # BU_MSG_CHECKSUM: if 0, use the standard checksum.  If 1, you may send this client messages with the checksum field==0 and the checksum won't be checked (TCP has a checksum)
 KEY i BU_MSG_IGNORE_CHECKSUM                    0x0002                   0x0002         u64c
@@ -30,6 +30,8 @@ KEY i BU_XTHIN_VERSION                          0x0002                   0x0003 
 
 # Graphene Fast Filter Preference
 KEY i BU_GRAPHENE_FAST_FILTER_PREF              0x0002                   0x0004         u64c
+# Graphene high / low (inclusive) version numbers
+KEY i BU_GRAPHENE_MIN_VERSION_SUPPORTED         0x0002                   0x0005         u64c
 
 # KEY i ABC_...                                0x0000                   ...
 # KEY i XT_DOUBLESPEND_FORWARDING_SCHEME       0x0003                   ...            vector


### PR DESCRIPTION
Currently, it is only possible for a peer to communicate the maximum graphene version that it supports, and this preference cannot be changed at runtime. This PR introduces separate maximum and minimum graphene version preferences, which can each be set via a CTweak command line flag. The actual Graphene version used is the maximum version among intersecting supported versions of both sender and receiver.