### PR TITLE
use rsm_debug_assertion in configure instead of debug_assertion in util

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -241,7 +241,7 @@ AC_LANG_PUSH([C++])
 AX_CHECK_COMPILE_FLAG([-Werror],[CXXFLAG_WERROR="-Werror"],[CXXFLAG_WERROR=""])
 
 if test "x$enable_debug" = xyes; then
-    CPPFLAGS="$CPPFLAGS -DDEBUG -DDEBUG_LOCKORDER"
+    CPPFLAGS="$CPPFLAGS -DDEBUG -DDEBUG_LOCKORDER -DRSM_DEBUG_ASSERTION"
 
     # Clear default -g -O2 flags
     if test "x$CXXFLAGS_overridden" = xno; then

--- a/src/rsm/recursive_shared_mutex.cpp
+++ b/src/rsm/recursive_shared_mutex.cpp
@@ -26,7 +26,7 @@ bool recursive_shared_mutex::check_for_write_unlock(const std::thread::id &locki
     {
         if (_shared_while_exclusive_counter == 0)
         {
-#ifdef DEBUG_ASSERTION
+#ifdef RSM_DEBUG_ASSERTION
             throw std::logic_error("can not unlock_shared more times than we locked for shared ownership while holding "
                                    "exclusive ownership");
 #else
@@ -61,7 +61,7 @@ void recursive_shared_mutex::unlock_shared_internal(const std::thread::id &locki
     auto it = _read_owner_ids.find(locking_thread_id);
     if (it == _read_owner_ids.end())
     {
-#ifdef DEBUG_ASSERTION
+#ifdef RSM_DEBUG_ASSERTION
         throw std::logic_error("can not unlock_shared more times than we locked for shared ownership");
 #else
         return;
@@ -161,7 +161,7 @@ void recursive_shared_mutex::unlock()
     // this might be redundant with the mutex being locked
     if (_write_counter == 0 || _write_owner_id != locking_thread_id)
     {
-#ifdef DEBUG_ASSERTION
+#ifdef RSM_DEBUG_ASSERTION
         throw std::logic_error("unlock(standard logic) incorrectly called on a thread with no exclusive lock");
 #else
         return;
@@ -169,7 +169,7 @@ void recursive_shared_mutex::unlock()
     }
     if (_promotion_candidate_id != NON_THREAD_ID && _write_owner_id != _promotion_candidate_id)
     {
-#ifdef DEBUG_ASSERTION
+#ifdef RSM_DEBUG_ASSERTION
         throw std::logic_error("unlock(promotion logic) incorrectly called on a thread with no exclusive lock");
 #else
         return;
@@ -180,7 +180,7 @@ void recursive_shared_mutex::unlock()
         _write_counter--;
         if (_write_counter == 0)
         {
-#ifdef DEBUG_ASSERTION
+#ifdef RSM_DEBUG_ASSERTION
             assert(_shared_while_exclusive_counter == 0);
 #endif
             if (_shared_while_exclusive_counter > 0)
@@ -208,7 +208,7 @@ void recursive_shared_mutex::unlock()
     else
     {
         _write_counter--;
-#ifdef DEBUG_ASSERTION
+#ifdef RSM_DEBUG_ASSERTION
         assert(_write_counter_reserve == 0);
 #endif
         if (end_of_exclusive_ownership())
@@ -281,7 +281,7 @@ void recursive_shared_mutex::unlock_shared()
     }
     if (_read_owner_ids.size() == 0)
     {
-#ifdef DEBUG_ASSERTION
+#ifdef RSM_DEBUG_ASSERTION
         throw std::logic_error("unlock_shared incorrectly called on a thread with no shared lock");
 #else
         return;

--- a/src/rsm/test/rsm_simple_tests.cpp
+++ b/src/rsm/test/rsm_simple_tests.cpp
@@ -24,7 +24,7 @@ BOOST_AUTO_TEST_CASE(rsm_lock_unlock)
 // try to unlock_shared an exclusive lock
 // we should error here because exclusive locks can
 // be not be unlocked by shared_ unlock method
-#ifdef DEBUG_ASSERTION
+#ifdef RSM_DEBUG_ASSERTION
     BOOST_CHECK_THROW(rsm.unlock_shared(), std::logic_error);
 #endif
 
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE(rsm_lock_unlock)
     // try to unlock exclusive lock
     BOOST_CHECK_NO_THROW(rsm.unlock());
 
-#ifdef DEBUG_ASSERTION
+#ifdef RSM_DEBUG_ASSERTION
     // try to unlock exclusive lock more times than we locked
     BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
 #endif
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(rsm_lock_shared_unlock_shared)
     // lock shared
     rsm.lock_shared();
 
-#ifdef DEBUG_ASSERTION
+#ifdef RSM_DEBUG_ASSERTION
     // try to unlock exclusive when we only have shared
     BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
 #endif
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(rsm_lock_shared_unlock_shared)
     // unlock shared
     rsm.unlock_shared();
 
-#ifdef DEBUG_ASSERTION
+#ifdef RSM_DEBUG_ASSERTION
     // we should error here because we are unlocking more times than we locked
     BOOST_CHECK_THROW(rsm.unlock_shared(), std::logic_error);
 #endif
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(rsm_try_lock)
     // try lock
     rsm.try_lock();
 
-#ifdef DEBUG_ASSERTION
+#ifdef RSM_DEBUG_ASSERTION
     // try to unlock_shared an exclusive lock
     // we should error here because exclusive locks can
     // be not be unlocked by shared_ unlock method
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(rsm_try_lock)
     // try to unlock exclusive lock
     BOOST_CHECK_NO_THROW(rsm.unlock());
 
-#ifdef DEBUG_ASSERTION
+#ifdef RSM_DEBUG_ASSERTION
     // try to unlock exclusive lock more times than we locked
     BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
 #endif
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(rsm_try_lock_shared)
     // try lock shared
     rsm.try_lock_shared();
 
-#ifdef DEBUG_ASSERTION
+#ifdef RSM_DEBUG_ASSERTION
     // unlock exclusive while we have shared lock
     BOOST_CHECK_THROW(rsm.unlock(), std::logic_error);
 #endif
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(rsm_try_lock_shared)
     // unlock shared
     BOOST_CHECK_NO_THROW(rsm.unlock_shared());
 
-#ifdef DEBUG_ASSERTION
+#ifdef RSM_DEBUG_ASSERTION
     // we should error here because we are unlocking more times than we locked
     BOOST_CHECK_THROW(rsm.unlock_shared(), std::logic_error);
 #endif


### PR DESCRIPTION
util is not included in rsm causing the test suite to expect an error 
while rsm does not have the define to throw it.