### PR TITLE
Make sure to wait for all script validation threads to finish

### DIFF
--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -353,7 +353,6 @@ bool CParallelValidation::QuitReceived(const boost::thread::id this_id, const bo
 
 bool CParallelValidation::ChainWorkHasChanged(const arith_uint256 &nStartingChainWork)
 {
-    LOCK(cs_main);
     if (chainActive.Tip()->nChainWork != nStartingChainWork)
     {
         LOG(PARALLEL, "Quitting - Chain Work %s is not the same as the starting Chain Work %s\n",

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -185,6 +185,9 @@ public:
     /* Clear thread data from mapBlockValidationThreads */
     void Erase(const boost::thread::id this_id);
 
+    /* Quit a block validation thread and associated script validation threads */
+    void Quit(std::map<boost::thread::id, CHandleBlockMsgThreads>::iterator iter);
+
     /* Post the semaphore when the thread exits.  */
     void Post() { semThreadCount.post(); }
     /* Was the fQuit flag set to true which causes the PV thread to exit */

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -111,16 +111,16 @@ public:
 class CParallelValidation
 {
 private:
-    // txn hashes that are in the previous block
+    /** txn hashes that are in the previous block */
     CCriticalSection cs_previousblock;
     std::vector<uint256> vPreviousBlock;
-    // Vector of script check queues
+    /** Vector of script check queues */
     std::vector<CCheckQueue<CScriptCheck> *> vQueues;
-    // Number of threads
+    /** Number of threads */
     unsigned int nThreads;
-    // All threads currently running
+    /** All threads currently running */
     boost::thread_group threadGroup;
-    // The semaphore limits the number of parallel validation threads
+    /** The semaphore limits the number of parallel validation threads */
     CSemaphore semThreadCount;
 
     struct CHandleBlockMsgThreads
@@ -153,74 +153,75 @@ public:
 
     ~CParallelValidation();
 
-    /* Initialize mapBlockValidationThreads*/
+    /** Initialize mapBlockValidationThreads */
     void InitThread(const boost::thread::id this_id,
         const CNode *pfrom,
         CBlockRef pblock,
         const CInv &inv,
         uint64_t blockSize);
 
-    /* Initialize a PV session */
+    /** Initialize a PV session */
     bool Initialize(const boost::thread::id this_id, const CBlockIndex *pindex, const bool fParallel);
 
-    /* Cleanup PV threads after one has finished and won the validation race */
+    /** Cleanup PV threads after one has finished and won the validation race */
     void Cleanup(const CBlock &block, CBlockIndex *pindex);
 
-    /* Send quit to competing threads */
+    /** Send quit to competing threads */
     void QuitCompetingThreads(const uint256 &prevBlockHash);
 
-    /* Is this block already running a validation thread? */
+    /** Is this block already running a validation thread? */
     bool IsAlreadyValidating(const NodeId id);
 
-    /* Terminate all currently running Block Validation threads, except the passed thread */
+    /** Terminate all currently running Block Validation threads, except the passed thread */
     void StopAllValidationThreads(const boost::thread::id this_id = boost::thread::id());
-    /* Terminate all currently running Block Validation threads whose chainWork is <= the passed parameter, except the
-     * calling thread  */
+    /** Terminate all currently running Block Validation threads whose chainWork is <= the passed parameter, except the
+     * calling thread
+     */
     void StopAllValidationThreads(const uint32_t nChainWork);
     void WaitForAllValidationThreadsToStop();
 
-    /* Has parallel block validation been turned on via the config settings */
+    /** Has parallel block validation been turned on via the config settings */
     bool Enabled();
 
-    /* Clear thread data from mapBlockValidationThreads */
+    /** Clear thread data from mapBlockValidationThreads */
     void Erase(const boost::thread::id this_id);
 
-    /* Quit a block validation thread and associated script validation threads */
+    /** Quit a block validation thread and associated script validation threads */
     void Quit(std::map<boost::thread::id, CHandleBlockMsgThreads>::iterator iter);
 
-    /* Post the semaphore when the thread exits.  */
+    /** Post the semaphore when the thread exits.  */
     void Post() { semThreadCount.post(); }
-    /* Was the fQuit flag set to true which causes the PV thread to exit */
+    /** Was the fQuit flag set to true which causes the PV thread to exit */
     bool QuitReceived(const boost::thread::id this_id, const bool fParallel);
 
-    /* Used to determine if another thread has already updated the utxo and advance the chain tip */
+    /** Used to determine if another thread has already updated the utxo and advance the chain tip */
     bool ChainWorkHasChanged(const arith_uint256 &nStartingChainWork);
 
-    /* Set the correct locks and locking order before returning from a PV session */
+    /** Set the correct locks and locking order before returning from a PV session */
     void SetLocks(const bool fParallel);
 
-    /* Is there a re-org in progress */
+    /** Is there a re-org in progress */
     void IsReorgInProgress(const boost::thread::id this_id, const bool fReorg, const bool fParallel);
     bool IsReorgInProgress();
 
-    /* Update the nMostWorkOurFork when a new header arrives */
+    /** Update the nMostWorkOurFork when a new header arrives */
     void UpdateMostWorkOurFork(const CBlockHeader &header);
 
-    /* Update the nMostWorkOurFork when a new header arrives */
+    /** Update the nMostWorkOurFork when a new header arrives */
     uint32_t MaxWorkChainBeingProcessed();
 
-    /* Clear orphans from the orphan cache that are no longer needed*/
+    /** Clear orphans from the orphan cache that are no longer needed */
     void ClearOrphanCache(const CBlockRef pblock);
 
-    /* Process a block message */
+    /** Process a block message */
     void HandleBlockMessage(CNode *pfrom, const std::string &strCommand, CBlockRef pblock, const CInv &inv);
 
-    // The number of script validation threads
+    /** The number of script validation threads */
     unsigned int ThreadCount() { return nThreads; }
-    // The number of script check queues
+    /** The number of script check queues */
     unsigned int QueueCount();
 
-    // For newly mined block validation, return the first queue not in use.
+    /** For newly mined block validation, return the first queue not in use. */
     CCheckQueue<CScriptCheck> *GetScriptCheckQueue();
 };
 

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -2028,8 +2028,17 @@ bool ConnectBlockDependencyOrdering(const CBlock &block,
     // Begin Section for Boost Scope Guard
     {
         // Scope guard to make sure cs_main is set and resources released if we encounter an exception.
-        BOOST_SCOPE_EXIT(&fParallel, &control)
+        BOOST_SCOPE_EXIT(&fParallel, &control, &pScriptQueue)
         {
+            // Typically the script validations would be stopped by issuing a PV->Quit() however under
+            // certain conditions block validation may retur early from some error or if the chain tip has changed
+            // during block validation. So here we make sure to stop the script validation threads. This prevents a
+            // long to validate block from continuing to use resources when it is in fact not even a valid block.
+            //
+            // In the typcial case we will end up issuing the Quit() twice. This is fine because all were doing
+            // is setting a boolean flag.
+            pScriptQueue->Quit();
+
             // As a final check, make sure all the script validation threads have stopped. Sometimes
             // if a PV thread is terminated early or a block is found to be invalid for some reason
             // then we'll end up returning without getting to the control.Wait() at the end of this scope.
@@ -2244,8 +2253,17 @@ bool ConnectBlockCanonicalOrdering(const CBlock &block,
     // Begin Section for Boost Scope Guard
     {
         // Scope guard to make sure cs_main is set and resources released if we encounter an exception.
-        BOOST_SCOPE_EXIT(&fParallel, &control)
+        BOOST_SCOPE_EXIT(&fParallel, &control, &pScriptQueue)
         {
+            // Typically the script validations would be stopped by issuing a PV->Quit() however under
+            // certain conditions block validation may retur early from some error or if the chain tip has changed
+            // during block validation. So here we make sure to stop the script validation threads. This prevents a
+            // long to validate block from continuing to use resources when it is in fact not even a valid block.
+            //
+            // In the typcial case we will end up issuing the Quit() twice. This is fine because all were doing
+            // is setting a boolean flag.
+            pScriptQueue->Quit();
+
             // As a final check, make sure all the script validation threads have stopped. Sometimes
             // if a PV thread is terminated early or a block is found to be invalid for some reason
             // then we'll end up returning without getting to the control.Wait() at the end of this scope.

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -1965,6 +1965,33 @@ bool ConnectBlockPrevalidations(const CBlock &block,
     return true;
 }
 
+/** Ensure that the script validation threads have finished running and locks are set correctly
+ *  before exiting ConnectBlock.
+ */
+static void ConnectBlockScopeExit(bool fParallel,
+    CCheckQueueControl<CScriptCheck> &control,
+    CCheckQueue<CScriptCheck> *pScriptQueue)
+{
+    // Typically the script validations would be stopped by issuing a PV->Quit() however under
+    // certain conditions block validation may retur early from some error or if the chain tip has changed
+    // during block validation. So here we make sure to stop the script validation threads. This prevents a
+    // long to validate block from continuing to use resources when it is in fact not even a valid block.
+    //
+    // In the typcial case we will end up issuing the Quit() twice. This is fine because all were doing
+    // is setting a boolean flag.
+    pScriptQueue->Quit();
+
+    // As a final check, make sure all the script validation threads have stopped. Sometimes
+    // if a PV thread is terminated early or a block is found to be invalid for some reason
+    // then we'll end up returning without getting to the control.Wait() at the end of this scope.
+    // While in single threaded operation this is not an issue but when PV is in sue we MUST wait
+    // for all threads to terminate before continuing otherwise we can end up trying to access
+    // data which has already been destroyed in the main thread.
+    control.Wait();
+
+    // Make sure locks have set locks correctly on leaving this scope.
+    PV->SetLocks(fParallel);
+}
 
 bool ConnectBlockDependencyOrdering(const CBlock &block,
     CValidationState &state,
@@ -2030,25 +2057,7 @@ bool ConnectBlockDependencyOrdering(const CBlock &block,
         // Scope guard to make sure cs_main is set and resources released if we encounter an exception.
         BOOST_SCOPE_EXIT(&fParallel, &control, &pScriptQueue)
         {
-            // Typically the script validations would be stopped by issuing a PV->Quit() however under
-            // certain conditions block validation may retur early from some error or if the chain tip has changed
-            // during block validation. So here we make sure to stop the script validation threads. This prevents a
-            // long to validate block from continuing to use resources when it is in fact not even a valid block.
-            //
-            // In the typcial case we will end up issuing the Quit() twice. This is fine because all were doing
-            // is setting a boolean flag.
-            pScriptQueue->Quit();
-
-            // As a final check, make sure all the script validation threads have stopped. Sometimes
-            // if a PV thread is terminated early or a block is found to be invalid for some reason
-            // then we'll end up returning without getting to the control.Wait() at the end of this scope.
-            // While in single threaded operation this is not an issue but when PV is in sue we MUST wait
-            // for all threads to terminate before continuing otherwise we can end up trying to access
-            // data which has already been destroyed in the main thread.
-            control.Wait();
-
-            // Make sure locks have set locks correctly on leaving this scope.
-            PV->SetLocks(fParallel);
+            ConnectBlockScopeExit(fParallel, control, pScriptQueue);
         }
         BOOST_SCOPE_EXIT_END
 
@@ -2255,25 +2264,7 @@ bool ConnectBlockCanonicalOrdering(const CBlock &block,
         // Scope guard to make sure cs_main is set and resources released if we encounter an exception.
         BOOST_SCOPE_EXIT(&fParallel, &control, &pScriptQueue)
         {
-            // Typically the script validations would be stopped by issuing a PV->Quit() however under
-            // certain conditions block validation may retur early from some error or if the chain tip has changed
-            // during block validation. So here we make sure to stop the script validation threads. This prevents a
-            // long to validate block from continuing to use resources when it is in fact not even a valid block.
-            //
-            // In the typcial case we will end up issuing the Quit() twice. This is fine because all were doing
-            // is setting a boolean flag.
-            pScriptQueue->Quit();
-
-            // As a final check, make sure all the script validation threads have stopped. Sometimes
-            // if a PV thread is terminated early or a block is found to be invalid for some reason
-            // then we'll end up returning without getting to the control.Wait() at the end of this scope.
-            // While in single threaded operation this is not an issue but when PV is in sue we MUST wait
-            // for all threads to terminate before continuing otherwise we can end up trying to access
-            // data which has already been destroyed in the main thread.
-            control.Wait();
-
-            // Make sure locks have set locks correctly on leaving this scope.
-            PV->SetLocks(fParallel);
+            ConnectBlockScopeExit(fParallel, control, pScriptQueue);
         }
         BOOST_SCOPE_EXIT_END
 


### PR DESCRIPTION
Within the ConnectBlock() functions we can return from the validation
loop early, either because we've recieved a PV->Quit() or because
the block has been rejected for any number of reasons. This prevents
us from getting to the control.Wait() at the end of the scope. We
must make sure that the script validation threads are truly finished
before allowing the main PV block validation thread to exit, otherwise
we may end up having script validatin threads still running which
are accessing data which no longer exists because the main PV thread
has exited already.