### PR TITLE
[test only] inject fields into bitcoin.conf during qa tests

### DIFF
--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -210,6 +210,22 @@ class BitcoinTestFramework(object):
 
         check_json_precision()
 
+        # By setting the environment variable BITCOIN_CONF_OVERRIDE to "key=value,key2=value2,..." you can inject bitcoin configuration into every test
+        baseConf = os.environ.get("BITCOIN_CONF_OVERRIDE")
+        if baseConf is None:
+            baseConf= {}
+        else:
+            lines = baseConf.split(",")
+            baseConf = {}
+            for line in lines:
+                (key,val) = line.split("=")
+                baseConf[key.strip()] = val.strip()
+
+        if bitcoinConfDict is None:
+            bitcoinConfDict = {}
+
+        bitcoinConfDict.update(baseConf)
+
         success = False
         try:
             try:


### PR DESCRIPTION
add an environment variable that allows you to push configuration into every bitcoin.conf file generated by the test framework.  For example, this lets us run the qa test in a post-fork configuration by doing:

export BITCOIN_CONF_OVERRIDE="consensus.forkMay2019Time=1"
./rpc-tests