### PR TITLE
Do not re-request a block if it is currently being processed

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1162,7 +1162,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         vRecv >> txd.tx;
 
         // Indicate that the tx was received and is about to be processed. Setting the processing flag
-        // prevents us from re-requesting the txn during the time of procesing and before mempool acceptance.
+        // prevents us from re-requesting the txn during the time of processing and before mempool acceptance.
         requester.ProcessingTxn(txd.tx->GetHash(), pfrom);
 
         // Processing begins here where we enqueue the transaction.

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -289,30 +289,28 @@ void CRequestManager::UpdateTxnResponseTime(const CInv &obj, CNode *pfrom)
     }
 }
 
-// Indicate that we are processing this object.
-void CRequestManager::Processing(const CInv &obj, CNode *pfrom)
+void CRequestManager::ProcessingTxn(const uint256 &hash, CNode *pfrom)
 {
     LOCK(cs_objDownloader);
-    if (obj.type == MSG_TX)
-    {
-        OdMap::iterator item = mapTxnInfo.find(obj.hash);
-        if (item == mapTxnInfo.end())
-            return;
+    OdMap::iterator item = mapTxnInfo.find(hash);
+    if (item == mapTxnInfo.end())
+        return;
 
-        item->second.fProcessing = true;
-        LOG(REQ, "ReqMgr: Processing %s (received from %s).\n", item->second.obj.ToString(),
-            pfrom ? pfrom->GetLogName() : "unknown");
-    }
-    else if (obj.type == MSG_BLOCK || obj.type == MSG_CMPCT_BLOCK || obj.type == MSG_XTHINBLOCK)
-    {
-        OdMap::iterator item = mapBlkInfo.find(obj.hash);
-        if (item == mapBlkInfo.end())
-            return;
+    item->second.fProcessing = true;
+    LOG(REQ, "ReqMgr: Processing %s (received from %s).\n", item->second.obj.ToString(),
+        pfrom ? pfrom->GetLogName() : "unknown");
+}
 
-        item->second.fProcessing = true;
-        LOG(BLK, "ReqMgr: Processing %s (received from %s).\n", item->second.obj.ToString(),
-            pfrom ? pfrom->GetLogName() : "unknown");
-    }
+void CRequestManager::ProcessingBlock(const uint256 &hash, CNode *pfrom)
+{
+    LOCK(cs_objDownloader);
+    OdMap::iterator item = mapBlkInfo.find(hash);
+    if (item == mapBlkInfo.end())
+        return;
+
+    item->second.fProcessing = true;
+    LOG(BLK, "ReqMgr: Processing %s (received from %s).\n", item->second.obj.ToString(),
+        pfrom ? pfrom->GetLogName() : "unknown");
 }
 
 // Indicate that we got this object.

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -644,6 +644,11 @@ void CRequestManager::SendRequests()
         ++sendBlkIter; // move it forward up here in case we need to erase the item we are working with.
         CUnknownObj &item = itemIter->second;
 
+        // If we've already received the item and it's in processing then skip it here so we don't
+        // end up re-requesting it again.
+        if (item.fProcessing)
+            continue;
+
         // if never requested then lastRequestTime==0 so this will always be true
         if (now - item.lastRequestTime > _blkReqRetryInterval)
         {

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -187,8 +187,11 @@ public:
     // Update the response time for this transaction request
     void UpdateTxnResponseTime(const CInv &obj, CNode *pfrom);
 
-    // Indicate that we are processing this object.
-    void Processing(const CInv &obj, CNode *pfrom);
+    // Indicate that we are processing this transaction
+    void ProcessingTxn(const uint256 &hash, CNode *pfrom);
+
+    // Indicate that we are processing this block
+    void ProcessingBlock(const uint256 &hash, CNode *pfrom);
 
     // Indicate that we got this object
     void Received(const CInv &obj, CNode *pfrom);


### PR DESCRIPTION
Solves the performance issue where a large and long to validate block would end up being re-requested multiple times by the request manager.