### PR TITLE
[WIP] [CONSENSUS] BIP101 block size scaling

### DIFF
--- a/src/serialize.h
+++ b/src/serialize.h
@@ -24,6 +24,8 @@
 
 #include "prevector.h"
 
+// BIP101 : The MAX_SIZE limit needs to be periodicaly adjusted to account for growing
+// block sizes under this bip
 static const unsigned int MAX_SIZE = 0x02000000 * 8; // BU Allow 256MB JSON encodings
 
 /**

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -985,8 +985,8 @@ const uint64_t BLOCK_SIZE_START = 32000000; // 32 MB
 const uint64_t ARBITRARY_START_HEIGHT = 10;
 // number of blocks in 2 years assuming 10 min block time; 6 x 24 x 365 x 2
 const uint64_t BLOCK_ADJUSTMENT_INTERVAL = 1050120;
-// the highest multiplier, right now it has an arbitrary value of 10
-const uint64_t MAX_INTERVAL = 10;
+// the highest multiplier, at 30 intervals the block size caps at ~ 34,359,738,368 MB or ~ 34.4 PB
+const uint64_t MAX_INTERVAL = 30;
 
 // we do not consider leap years
 void EnforceBIP101BlockSize(const int &nHeight)

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -978,6 +978,36 @@ int isChainExcessive(const CBlockIndex *blk, unsigned int goBack)
     return (recentExcessive && !oldExcessive);
 }
 
+
+// some arbitrary start height that will be determined later
+const uint64_t BLOCK_SIZE_START = 32000000; // 32 MB
+// the start height is the block we want to be the first block size double (when it goes to 64MB)
+const uint64_t ARBITRARY_START_HEIGHT = 10;
+// number of blocks in 2 years assuming 10 min block time; 6 x 24 x 365 x 2
+const uint64_t BLOCK_ADJUSTMENT_INTERVAL = 1050120;
+// the highest multiplier, right now it has an arbitrary value of 10
+const uint64_t MAX_INTERVAL = 10;
+
+// we do not consider leap years
+void EnforceBIP101BlockSize(const int &nHeight)
+{
+    if(nHeight < ARBITRARY_START_HEIGHT)
+        return;
+    uint64_t heightPastStart = nHeight - ARBITRARY_START_HEIGHT;
+    // we want to round down, using ints will drop any remainder for us
+    uint64_t interval = heightPastStart / BLOCK_ADJUSTMENT_INTERVAL;
+    // some stop internval to cap the max block size
+    if (interval > MAX_INTERVAL)
+    {
+        interval = MAX_INTERVAL;
+    }
+    uint64_t minExcessiveBlockSize = (BLOCK_SIZE_START * (2 * (interval + 1)));
+    if (excessiveBlockSize < minExcessiveBlockSize)
+    {
+        excessiveBlockSize = minExcessiveBlockSize;
+    }
+}
+
 bool CheckExcessive(const CBlock &block, uint64_t blockSize, uint64_t nSigOps, uint64_t nTx, uint64_t largestTx)
 {
     if (blockSize > excessiveBlockSize)

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -150,6 +150,9 @@ extern bool TestConservativeBlockValidity(CValidationState &state,
     bool fCheckPOW,
     bool fCheckMerkleRoot);
 
+// Check that our excessive block size is at least the network upgrade schedule
+void EnforceBIP101BlockSize(const int &nHeight);
+
 // Check whether this block is bigger in some metric than we really want to accept
 extern bool CheckExcessive(const CBlock &block, uint64_t blockSize, uint64_t nSigOps, uint64_t nTx, uint64_t largestTx);
 

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -1458,6 +1458,9 @@ bool ContextualCheckBlock(const CBlock &block,
     if (fConservative && (nSigOps > BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS))
         return state.DoS(100, error("CheckBlock(): out-of-bounds SigOpCount"), REJECT_INVALID, "bad-blk-sigops", true);
 
+    // BU: Before we check for excessive size, check our current excessive size to ensure it is at least on schedule
+    EnforceBIP101BlockSize(nHeight);
+
     // BU: Check whether this block exceeds what we want to relay.
     block.fExcessive = CheckExcessive(block, block.GetBlockSize(), nSigOps, nTx, nLargestTx);
 


### PR DESCRIPTION
BIP 101 style scaling of doubling the block size every 2 years as re-proposed by Dr. Peter Rizun. This PR is not complete. A full spec should be written either from scratch or using BIP101 as a base. 

Once more details of this proposal are specified, I will update this code and write a test to match. 

Yes the enforce function does override the users set values for EB size whenever it checks a block, this is intentional. I know it is not the "ideal" way to do it. It still needs to be determined if we are to remove EB logic and once again use a hard block size limit with this proposal. I figured removing the EB logic at this time without a full spec would be premature