### PR TITLE
[PORT] [wallet] Close DB on error

### DIFF
--- a/src/wallet/db.cpp
+++ b/src/wallet/db.cpp
@@ -102,7 +102,10 @@ bool CDBEnv::Open(const fs::path &pathIn)
         DB_CREATE | DB_INIT_LOCK | DB_INIT_LOG | DB_INIT_MPOOL | DB_INIT_TXN | DB_THREAD | DB_RECOVER | nEnvFlags,
         S_IRUSR | S_IWUSR);
     if (ret != 0)
+    {
+        dbenv->close(0);
         return error("CDBEnv::Open: Error %d opening database environment: %s\n", ret, DbEnv::strerror(ret));
+    }
 
     fDbEnvInit = true;
     fMockDb = false;
@@ -365,6 +368,7 @@ bool CDB::Rewrite(const string &strFile, const char *pszSkip)
                     if (ret > 0)
                     {
                         LOGA("CDB::Rewrite: Can't create database file %s\n", strFileRes);
+                        pdbCopy->close(0);
                         fSuccess = false;
                     }
 
@@ -405,7 +409,13 @@ bool CDB::Rewrite(const string &strFile, const char *pszSkip)
                         db.Close();
                         bitdb.CloseDb(strFile);
                         if (pdbCopy->close(0))
+                        {
                             fSuccess = false;
+                        }
+                        else
+                        {
+                            pdbCopy->close(0);
+                        }
                         delete pdbCopy;
                     }
                 }


### PR DESCRIPTION
This is a port of bitcoin/bitcoin/pull/11017

Original PR description: 

This PR intends to plug some leaks. It specifically implements adherence to the requirement in BDB to close a handle which failed to open (docs.oracle.com/cd/E17276_01/html/api_reference/C/dbopen.html)