### PR TITLE
Check nVersion before sending out sendcmpct p2p message: fixes #1701

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -376,7 +376,7 @@ static void enableSendHeaders(CNode *pfrom)
 static void enableCompactBlocks(CNode *pfrom)
 {
     // Tell our peer that we support compact blocks
-    if (IsCompactBlocksEnabled())
+    if (IsCompactBlocksEnabled() && (pfrom->nVersion >= COMPACTBLOCKS_VERSION))
     {
         bool fHighBandwidth = false;
         uint64_t nVersion = 1;


### PR DESCRIPTION
Make sure the peer is above or equal to the COMPACTBLOCKS_VERSION before
sending a sendcmpct message.