### PR TITLE
Properly initialize CVariableFastFilter members in default constructor

### DIFF
--- a/src/fastfilter.h
+++ b/src/fastfilter.h
@@ -37,8 +37,7 @@ public:
     uint32_t nFilterBytes;
     uint64_t nFilterItems;
 
-    CVariableFastFilter() : nHashFuncs(2), nFilterItems(2){};
-
+    CVariableFastFilter() : nHashFuncs(MIN_N_HASH_FUNC), nFilterBytes(1), nFilterItems(8) { vData.resize(1); }
     CVariableFastFilter(uint64_t nElements, double nFPRate)
     {
         if (nElements == 0)

--- a/src/fastfilter.h
+++ b/src/fastfilter.h
@@ -24,7 +24,7 @@ class uint256;
  * If nHashFuncs is 16 and nFilterItems is >= 64k all bits in the uint256 input data will be used to set bits in
  * the filter.
  *
- * nHashFuncs may range from 2 to 32 inclusive.
+ * nHashFuncs may range from 1 to 32 inclusive.
  */
 class CVariableFastFilter
 {

--- a/src/test/fastfilter_tests.cpp
+++ b/src/test/fastfilter_tests.cpp
@@ -54,6 +54,16 @@ void TestVariableFastFilter(CVariableFastFilter filt, int buffer, int n, double 
 
 BOOST_FIXTURE_TEST_SUITE(fastfilter_tests, BasicTestingSetup)
 
+BOOST_AUTO_TEST_CASE(variablefastfilter_dummy_constructor)
+{
+    CVariableFastFilter filt;
+
+    uint256 t = ArithToUint256(1);
+    uint256 tmp = Hash(t.begin(), t.end());
+    filt.insert(tmp);
+    BOOST_CHECK(filt.contains(tmp));
+}
+
 BOOST_AUTO_TEST_CASE(variablefastfilter_many_hash_funcs)
 {
     int n = 4 * 1024 * 1024;


### PR DESCRIPTION
Previously, `nHashFuncs` and `nFilterBytes` were initialized to 2, but they can actually be as small as 1. Also, `nFilterItems` was not initialized at all and `vData` was not properly sized. This commit addresses all these issues and adds a unit test to verify that the default constructor produces a filter that behaves as expected. 