### PR TITLE
Make sure to lock cs_mapBlockIndex when accessing nStatus or nSequenceId

### DIFF
--- a/qa/rpc-tests/keypool.py
+++ b/qa/rpc-tests/keypool.py
@@ -62,7 +62,7 @@ class KeyPoolTest(BitcoinTestFramework):
         nodes[0].walletpassphrase('test', 1)
         nodes[0].keypoolrefill(3)
         # test walletpassphrase timeout
-        time.sleep(1.1)
+        waitFor(20, lambda: nodes[0].getwalletinfo()["unlocked_until"] == 0)
         assert_equal(nodes[0].getwalletinfo()["unlocked_until"], 0)
 
         # drain them by mining

--- a/qa/rpc-tests/reindex.py
+++ b/qa/rpc-tests/reindex.py
@@ -54,12 +54,7 @@ class ReindexTest(BitcoinTestFramework):
         wait_bitcoinds()
 
         self.nodes.append(start_node(0, self.options.tmpdir, ["-debug", "-reindex", "-checkblockindex=1"]))
-        i = 0
-        while (i < 10):
-            if (self.nodes[0].getblockcount() == nBlocks):
-                break
-            i += 1
-            time.sleep(1)
+        waitFor(10, lambda: self.nodes[0].getblockcount() == nBlocks)
         assert_equal(self.nodes[0].getblockcount(), nBlocks)
 
         print("Success")

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -394,7 +394,7 @@ bool CGrapheneBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string
         requester.UpdateBlockAvailability(pfrom->GetId(), inv.hash);
 
         // Return early if we already have the block data
-        if (pIndex->nStatus & BLOCK_HAVE_DATA)
+        if (AlreadyHaveBlock(inv))
         {
             // Tell the Request Manager we received this block
             requester.AlreadyReceived(pfrom, inv);

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -527,7 +527,7 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
         requester.UpdateBlockAvailability(pfrom->GetId(), inv.hash);
 
         // Return early if we already have the block data
-        if (pIndex->nStatus & BLOCK_HAVE_DATA)
+        if (AlreadyHaveBlock(inv))
         {
             // Tell the Request Manager we received this block
             requester.AlreadyReceived(pfrom, inv);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -94,150 +94,156 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
             if (inv.type == MSG_BLOCK || inv.type == MSG_FILTERED_BLOCK || inv.type == MSG_THINBLOCK ||
                 inv.type == MSG_CMPCT_BLOCK)
             {
-                bool fSend = false;
                 auto *mi = LookupBlockIndex(inv.hash);
                 if (mi)
                 {
-                    LOCK(cs_main);
-                    if (chainActive.Contains(mi))
+                    bool fSend = false;
                     {
-                        fSend = true;
-                    }
-                    else
-                    {
-                        READLOCK(cs_mapBlockIndex);
-                        static const int nOneMonth = 30 * 24 * 60 * 60;
-                        // To prevent fingerprinting attacks, only send blocks outside of the active
-                        // chain if they are valid, and no more than a month older (both in time, and in
-                        // best equivalent proof of work) than the best header chain we know about.
-                        fSend = mi->IsValid(BLOCK_VALID_SCRIPTS) && (pindexBestHeader != NULL) &&
-                                (pindexBestHeader.load()->GetBlockTime() - mi->GetBlockTime() < nOneMonth) &&
-                                (GetBlockProofEquivalentTime(
-                                     *pindexBestHeader, *mi, *pindexBestHeader, consensusParams) < nOneMonth);
-                        if (!fSend)
+                        LOCK(cs_main);
+                        if (chainActive.Contains(mi))
                         {
-                            LOG(NET, "%s: ignoring request from peer=%s for old block that isn't in the main chain\n",
-                                __func__, pfrom->GetLogName());
+                            fSend = true;
                         }
                         else
                         {
-                            // BU: don't relay excessive blocks that are not on the active chain
-                            if (mi->nStatus & BLOCK_EXCESSIVE)
-                                fSend = false;
+                            READLOCK(cs_mapBlockIndex);
+                            static const int nOneMonth = 30 * 24 * 60 * 60;
+                            // To prevent fingerprinting attacks, only send blocks outside of the active
+                            // chain if they are valid, and no more than a month older (both in time, and in
+                            // best equivalent proof of work) than the best header chain we know about.
+                            fSend = mi->IsValid(BLOCK_VALID_SCRIPTS) && (pindexBestHeader != NULL) &&
+                                    (pindexBestHeader.load()->GetBlockTime() - mi->GetBlockTime() < nOneMonth) &&
+                                    (GetBlockProofEquivalentTime(
+                                         *pindexBestHeader, *mi, *pindexBestHeader, consensusParams) < nOneMonth);
                             if (!fSend)
-                                LOG(NET, "%s: ignoring request from peer=%s for excessive block of height %d not on "
-                                         "the main chain\n",
-                                    __func__, pfrom->GetLogName(), mi->nHeight);
-                        }
-                        // BU: in the future we can throttle old block requests by setting send=false if we are out of
-                        // bandwidth
-                    }
-                }
-                // disconnect node in case we have reached the outbound limit for serving historical blocks
-                // never disconnect whitelisted nodes
-                static const int nOneWeek = 7 * 24 * 60 * 60; // assume > 1 week = historical
-                if (fSend && CNode::OutboundTargetReached(true) &&
-                    (((pindexBestHeader != nullptr) &&
-                         (pindexBestHeader.load()->GetBlockTime() - mi->GetBlockTime() > nOneWeek)) ||
-                        inv.type == MSG_FILTERED_BLOCK) &&
-                    !pfrom->fWhitelisted)
-                {
-                    LOG(NET, "historical block serving limit reached, disconnect peer %s\n", pfrom->GetLogName());
-
-                    // disconnect node
-                    pfrom->fDisconnect = true;
-                    fSend = false;
-                }
-                // Avoid leaking prune-height by never sending blocks below the
-                // NODE_NETWORK_LIMITED threshold.
-                // Add two blocks buffer extension for possible races
-                if (fSend && !pfrom->fWhitelisted &&
-                    ((((nLocalServices & NODE_NETWORK_LIMITED) == NODE_NETWORK_LIMITED) &&
-                        ((nLocalServices & NODE_NETWORK) != NODE_NETWORK) &&
-                        (chainActive.Tip()->nHeight - mi->nHeight > (int)NODE_NETWORK_LIMITED_MIN_BLOCKS + 2))))
-                {
-                    LOG(NET, "Ignore block request below NODE_NETWORK_LIMITED threshold from peer=%d\n",
-                        pfrom->GetId());
-                    // disconnect node and prevent it from stalling (would
-                    // otherwise wait for the missing block)
-                    pfrom->fDisconnect = true;
-                    fSend = false;
-                }
-                // Pruned nodes may have deleted the block, so check whether
-                // it's available before trying to send.
-                bool fHaveData = false;
-                {
-                    READLOCK(cs_mapBlockIndex);
-                    fHaveData = mi->nStatus & BLOCK_HAVE_DATA;
-                }
-                if (fSend && fHaveData)
-                {
-                    // Send block from disk
-                    CBlock block;
-                    if (!ReadBlockFromDisk(block, mi, consensusParams))
-                    {
-                        // its possible that I know about it but haven't stored it yet
-                        LOG(THIN, "unable to load block %s from disk\n",
-                            mi->phashBlock ? mi->phashBlock->ToString() : "");
-                        // no response
-                    }
-                    else
-                    {
-                        if (inv.type == MSG_BLOCK)
-                        {
-                            pfrom->blocksSent += 1;
-                            pfrom->PushMessage(NetMsgType::BLOCK, block);
-                        }
-                        else if (inv.type == MSG_THINBLOCK && pfrom->xVersion.as_u64c(XVer::BU_XTHIN_VERSION) < 2 &&
-                                 pfrom->ThinBlockCapable())
-                        {
-                            // TODO: This code path enables backward compatibility for older BU nodes
-                            // and can be removed in the future.
-                            LOG(THIN, "Sending thinblock via getdata message\n");
-                            SendXThinBlock(MakeBlockRef(block), pfrom, inv);
-                        }
-                        else if (inv.type == MSG_CMPCT_BLOCK)
-                        {
-                            LOG(CMPCT, "Sending compactblock via getdata message\n");
-                            SendCompactBlock(MakeBlockRef(block), pfrom, inv);
-                        }
-                        else // MSG_FILTERED_BLOCK)
-                        {
-                            LOCK(pfrom->cs_filter);
-                            if (pfrom->pfilter)
                             {
-                                CMerkleBlock merkleBlock(block, *pfrom->pfilter);
-                                pfrom->PushMessage(NetMsgType::MERKLEBLOCK, merkleBlock);
-                                pfrom->blocksSent += 1;
-                                // CMerkleBlock just contains hashes, so also push any transactions in the block the
-                                // client did not see
-                                // This avoids hurting performance by pointlessly requiring a round-trip
-                                // Note that there is currently no way for a node to request any single transactions we
-                                // didn't send here -
-                                // they must either disconnect and retry or request the full block.
-                                // Thus, the protocol spec specified allows for us to provide duplicate txn here,
-                                // however we MUST always provide at least what the remote peer needs
-                                typedef std::pair<unsigned int, uint256> PairType;
-                                for (PairType &pair : merkleBlock.vMatchedTxn)
-                                {
-                                    pfrom->txsSent += 1;
-                                    pfrom->PushMessage(NetMsgType::TX, block.vtx[pair.first]);
-                                }
+                                LOG(NET,
+                                    "%s: ignoring request from peer=%s for old block that isn't in the main chain\n",
+                                    __func__, pfrom->GetLogName());
                             }
-                            // else
+                            else
+                            {
+                                // BU: don't relay excessive blocks that are not on the active chain
+                                if (mi->nStatus & BLOCK_EXCESSIVE)
+                                    fSend = false;
+                                if (!fSend)
+                                    LOG(NET,
+                                        "%s: ignoring request from peer=%s for excessive block of height %d not on "
+                                        "the main chain\n",
+                                        __func__, pfrom->GetLogName(), mi->nHeight);
+                            }
+                            // BU: in the future we can throttle old block requests by setting send=false if we are out
+                            // of
+                            // bandwidth
+                        }
+                    }
+                    // disconnect node in case we have reached the outbound limit for serving historical blocks
+                    // never disconnect whitelisted nodes
+                    static const int nOneWeek = 7 * 24 * 60 * 60; // assume > 1 week = historical
+                    if (fSend && CNode::OutboundTargetReached(true) &&
+                        (((pindexBestHeader != nullptr) &&
+                             (pindexBestHeader.load()->GetBlockTime() - mi->GetBlockTime() > nOneWeek)) ||
+                            inv.type == MSG_FILTERED_BLOCK) &&
+                        !pfrom->fWhitelisted)
+                    {
+                        LOG(NET, "historical block serving limit reached, disconnect peer %s\n", pfrom->GetLogName());
+
+                        // disconnect node
+                        pfrom->fDisconnect = true;
+                        fSend = false;
+                    }
+                    // Avoid leaking prune-height by never sending blocks below the
+                    // NODE_NETWORK_LIMITED threshold.
+                    // Add two blocks buffer extension for possible races
+                    if (fSend && !pfrom->fWhitelisted &&
+                        ((((nLocalServices & NODE_NETWORK_LIMITED) == NODE_NETWORK_LIMITED) &&
+                            ((nLocalServices & NODE_NETWORK) != NODE_NETWORK) &&
+                            (chainActive.Tip()->nHeight - mi->nHeight > (int)NODE_NETWORK_LIMITED_MIN_BLOCKS + 2))))
+                    {
+                        LOG(NET, "Ignore block request below NODE_NETWORK_LIMITED threshold from peer=%d\n",
+                            pfrom->GetId());
+                        // disconnect node and prevent it from stalling (would
+                        // otherwise wait for the missing block)
+                        pfrom->fDisconnect = true;
+                        fSend = false;
+                    }
+                    // Pruned nodes may have deleted the block, so check whether
+                    // it's available before trying to send.
+                    bool fHaveData = false;
+                    {
+                        READLOCK(cs_mapBlockIndex);
+                        fHaveData = (mi->nStatus & BLOCK_HAVE_DATA);
+                    }
+                    if (fSend && fHaveData)
+                    {
+                        // Send block from disk
+                        CBlock block;
+                        if (!ReadBlockFromDisk(block, mi, consensusParams))
+                        {
+                            // its possible that I know about it but haven't stored it yet
+                            LOG(THIN, "unable to load block %s from disk\n",
+                                mi->phashBlock ? mi->phashBlock->ToString() : "");
                             // no response
                         }
-
-                        // Trigger the peer node to send a getblocks request for the next batch of inventory
-                        if (inv.hash == pfrom->hashContinue)
+                        else
                         {
-                            // Bypass PushInventory, this must send even if redundant,
-                            // and we want it right after the last block so they don't
-                            // wait for other stuff first.
-                            std::vector<CInv> oneInv;
-                            oneInv.push_back(CInv(MSG_BLOCK, chainActive.Tip()->GetBlockHash()));
-                            pfrom->PushMessage(NetMsgType::INV, oneInv);
-                            pfrom->hashContinue.SetNull();
+                            if (inv.type == MSG_BLOCK)
+                            {
+                                pfrom->blocksSent += 1;
+                                pfrom->PushMessage(NetMsgType::BLOCK, block);
+                            }
+                            else if (inv.type == MSG_THINBLOCK && pfrom->xVersion.as_u64c(XVer::BU_XTHIN_VERSION) < 2 &&
+                                     pfrom->ThinBlockCapable())
+                            {
+                                // TODO: This code path enables backward compatibility for older BU nodes
+                                // and can be removed in the future.
+                                LOG(THIN, "Sending thinblock via getdata message\n");
+                                SendXThinBlock(MakeBlockRef(block), pfrom, inv);
+                            }
+                            else if (inv.type == MSG_CMPCT_BLOCK)
+                            {
+                                LOG(CMPCT, "Sending compactblock via getdata message\n");
+                                SendCompactBlock(MakeBlockRef(block), pfrom, inv);
+                            }
+                            else // MSG_FILTERED_BLOCK)
+                            {
+                                LOCK(pfrom->cs_filter);
+                                if (pfrom->pfilter)
+                                {
+                                    CMerkleBlock merkleBlock(block, *pfrom->pfilter);
+                                    pfrom->PushMessage(NetMsgType::MERKLEBLOCK, merkleBlock);
+                                    pfrom->blocksSent += 1;
+                                    // CMerkleBlock just contains hashes, so also push any transactions in the block the
+                                    // client did not see
+                                    // This avoids hurting performance by pointlessly requiring a round-trip
+                                    // Note that there is currently no way for a node to request any single transactions
+                                    // we
+                                    // didn't send here -
+                                    // they must either disconnect and retry or request the full block.
+                                    // Thus, the protocol spec specified allows for us to provide duplicate txn here,
+                                    // however we MUST always provide at least what the remote peer needs
+                                    typedef std::pair<unsigned int, uint256> PairType;
+                                    for (PairType &pair : merkleBlock.vMatchedTxn)
+                                    {
+                                        pfrom->txsSent += 1;
+                                        pfrom->PushMessage(NetMsgType::TX, block.vtx[pair.first]);
+                                    }
+                                }
+                                // else
+                                // no response
+                            }
+
+                            // Trigger the peer node to send a getblocks request for the next batch of inventory
+                            if (inv.hash == pfrom->hashContinue)
+                            {
+                                // Bypass PushInventory, this must send even if redundant,
+                                // and we want it right after the last block so they don't
+                                // wait for other stuff first.
+                                std::vector<CInv> oneInv;
+                                oneInv.push_back(CInv(MSG_BLOCK, chainActive.Tip()->GetBlockHash()));
+                                pfrom->PushMessage(NetMsgType::INV, oneInv);
+                                pfrom->hashContinue.SetNull();
+                            }
                         }
                     }
                 }

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -106,15 +106,17 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                         }
                         else
                         {
-                            READLOCK(cs_mapBlockIndex);
                             static const int nOneMonth = 30 * 24 * 60 * 60;
                             // To prevent fingerprinting attacks, only send blocks outside of the active
                             // chain if they are valid, and no more than a month older (both in time, and in
                             // best equivalent proof of work) than the best header chain we know about.
-                            fSend = mi->IsValid(BLOCK_VALID_SCRIPTS) && (pindexBestHeader != NULL) &&
-                                    (pindexBestHeader.load()->GetBlockTime() - mi->GetBlockTime() < nOneMonth) &&
-                                    (GetBlockProofEquivalentTime(
-                                         *pindexBestHeader, *mi, *pindexBestHeader, consensusParams) < nOneMonth);
+                            {
+                                READLOCK(cs_mapBlockIndex);
+                                fSend = mi->IsValid(BLOCK_VALID_SCRIPTS) && (pindexBestHeader != NULL) &&
+                                        (pindexBestHeader.load()->GetBlockTime() - mi->GetBlockTime() < nOneMonth) &&
+                                        (GetBlockProofEquivalentTime(
+                                             *pindexBestHeader, *mi, *pindexBestHeader, consensusParams) < nOneMonth);
+                            }
                             if (!fSend)
                             {
                                 LOG(NET,

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -171,12 +171,7 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                     }
                     // Pruned nodes may have deleted the block, so check whether
                     // it's available before trying to send.
-                    bool fHaveData = false;
-                    {
-                        READLOCK(cs_mapBlockIndex);
-                        fHaveData = (mi->nStatus & BLOCK_HAVE_DATA);
-                    }
-                    if (fSend && fHaveData)
+                    if (fSend && mi->nStatus & BLOCK_HAVE_DATA)
                     {
                         // Send block from disk
                         CBlock block;

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -176,6 +176,7 @@ void CParallelValidation::Cleanup(const CBlock &block, CBlockIndex *pindex)
         }
         std::sort(vSequenceId.begin(), vSequenceId.end());
 
+        WRITELOCK(cs_mapBlockIndex);
         std::vector<std::pair<uint32_t, uint256> >::reverse_iterator riter = vSequenceId.rbegin();
         while (riter != vSequenceId.rend())
         {
@@ -193,7 +194,6 @@ void CParallelValidation::Cleanup(const CBlock &block, CBlockIndex *pindex)
                 pindex->nSequenceId = (*riter).first;
                 (*riter).first = nId;
 
-                WRITELOCK(cs_mapBlockIndex);
                 BlockMap::iterator it = mapBlockIndex.find((*riter).second);
                 if (it != mapBlockIndex.end())
                     it->second->nSequenceId = nId;

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -230,8 +230,11 @@ static bool rest_block(HTTPRequest *req, const std::string &strURIPart, bool sho
     if (!pblockindex)
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
 
-    if (fHavePruned && !(pblockindex->nStatus & BLOCK_HAVE_DATA) && pblockindex->nTx > 0)
-        return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not available (pruned data)");
+    {
+        READLOCK(cs_mapBlockIndex); // for nStatus
+        if (fHavePruned && !(pblockindex->nStatus & BLOCK_HAVE_DATA) && pblockindex->nTx > 0)
+            return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not available (pruned data)");
+    }
 
     if (!ReadBlockFromDisk(block, pblockindex, Params().GetConsensus()))
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1164,7 +1164,7 @@ static std::set<CBlockIndex *, CompareBlocksByHeight> GetChainTips()
     std::set<CBlockIndex *> setPrevs;
 
     AssertLockHeld(cs_main); // for chainActive
-    AssertLockHeld(cs_mapBlockIndex);
+    READLOCK(cs_mapBlockIndex);
     for (const std::pair<const uint256, CBlockIndex *> &item : mapBlockIndex)
     {
         if (!chainActive.Contains(item.second))
@@ -1219,13 +1219,13 @@ UniValue getchaintips(const UniValue &params, bool fHelp)
             HelpExampleCli("getchaintips", "") + HelpExampleRpc("getchaintips", ""));
 
     LOCK(cs_main);
-    READLOCK(cs_mapBlockIndex);
 
     // Get the set of chaintips
     std::set<CBlockIndex *, CompareBlocksByHeight> setTips;
     setTips = GetChainTips();
 
     /* Construct the output array.  */
+    WRITELOCK(cs_mapBlockIndex); // for nStatus
     UniValue res(UniValue::VARR);
     for (const CBlockIndex *block : setTips)
     {

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -577,6 +577,7 @@ UniValue mkblocktemplate(const UniValue &params, int64_t coinbaseSize, CBlock *p
             {
                 uint256 hash = block.GetHash();
                 CBlockIndex *pindex = LookupBlockIndex(hash);
+                READLOCK(cs_mapBlockIndex);
                 if (pindex)
                 {
                     if (pindex->IsValid(BLOCK_VALID_SCRIPTS))
@@ -853,6 +854,7 @@ UniValue SubmitBlock(CBlock &block)
     bool fBlockPresent = false;
     {
         CBlockIndex *pindex = LookupBlockIndex(hash);
+        READLOCK(cs_mapBlockIndex);
         if (pindex)
         {
             if (pindex->IsValid(BLOCK_VALID_SCRIPTS))

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -221,6 +221,7 @@ UniValue getrawtransaction(const UniValue &params, bool fHelp)
         uint256 blockhash = ParseHashV(params[2], "parameter 3");
         if (!blockhash.IsNull())
         {
+            READLOCK(cs_mapBlockIndex);
             BlockMap::iterator it = mapBlockIndex.find(blockhash);
             if (it == mapBlockIndex.end())
             {
@@ -238,6 +239,7 @@ UniValue getrawtransaction(const UniValue &params, bool fHelp)
         std::string errmsg;
         if (blockindex)
         {
+            READLOCK(cs_mapBlockIndex);
             if (!(blockindex->nStatus & BLOCK_HAVE_DATA))
             {
                 throw JSONRPCError(RPC_MISC_ERROR, "Block not available");

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -1556,6 +1556,7 @@ bool ReceivedBlockTransactions(const CBlock &block,
             queue.pop_front();
             pindex->nChainTx = (pindex->pprev ? pindex->pprev->nChainTx : 0) + pindex->nTx;
             {
+                WRITELOCK(cs_mapBlockIndex);
                 pindex->nSequenceId = ++nBlockSequenceId;
             }
             if (chainActive.Tip() == NULL || !setBlockIndexCandidates.value_comp()(pindex, chainActive.Tip()))
@@ -3297,6 +3298,7 @@ bool ActivateBestChain(CValidationState &returnedState,
         // nSequenceId
         if (fParallel && pblock)
         {
+            READLOCK(cs_mapBlockIndex);
             std::set<CBlockIndex *, CBlockIndexWorkComparator>::reverse_iterator it = setBlockIndexCandidates.rbegin();
             while (it != setBlockIndexCandidates.rend())
             {

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -1273,16 +1273,20 @@ bool InvalidateBlock(CValidationState &state, const Consensus::Params &consensus
 
     // Mark the block itself as invalid.
     {
-        WRITELOCK(cs_mapBlockIndex);
-        pindex->nStatus |= BLOCK_FAILED_VALID;
-
+        {
+            WRITELOCK(cs_mapBlockIndex);
+            pindex->nStatus |= BLOCK_FAILED_VALID;
+        }
         setDirtyBlockIndex.insert(pindex);
         setBlockIndexCandidates.erase(pindex);
 
         while (chainActive.Contains(pindex))
         {
             CBlockIndex *pindexWalk = chainActive.Tip();
-            pindexWalk->nStatus |= BLOCK_FAILED_CHILD;
+            {
+                WRITELOCK(cs_mapBlockIndex);
+                pindexWalk->nStatus |= BLOCK_FAILED_CHILD;
+            }
             setDirtyBlockIndex.insert(pindexWalk);
             setBlockIndexCandidates.erase(pindexWalk);
             // ActivateBestChain considers blocks already in chainActive

--- a/src/validation/verifydb.cpp
+++ b/src/validation/verifydb.cpp
@@ -43,11 +43,14 @@ bool CVerifyDB::VerifyDB(const CChainParams &chainparams, CCoinsView *coinsview,
                                            (nCheckLevel >= 4 ? 50 : 100)))));
         if (pindex->nHeight < chainActive.Height() - nCheckDepth)
             break;
-        if (fPruneMode && !(pindex->nStatus & BLOCK_HAVE_DATA))
         {
-            // If pruning, only go back as far as we have data.
-            LOGA("VerifyDB(): block verification stopping at height %d (pruning, no data)\n", pindex->nHeight);
-            break;
+            READLOCK(cs_mapBlockIndex); // for nStatus
+            if (fPruneMode && !(pindex->nStatus & BLOCK_HAVE_DATA))
+            {
+                // If pruning, only go back as far as we have data.
+                LOGA("VerifyDB(): block verification stopping at height %d (pruning, no data)\n", pindex->nHeight);
+                break;
+            }
         }
         CBlock block;
         // check level 0: read from disk


### PR DESCRIPTION
Most of the data in blockindex is immutable and doesn't need to be locked when we access it as long as we have a valid pointer. We only need to lock when we actually do a lookup to the blockindex (which we do already) but since moving to the atomic chainActive.TIp() we are at times not locking the underlying mutable data: nStatus and nSequenceId.  This PR remedies that and locks all access to these two items.