### PR TITLE
Remove find() by tx hash method from CBlockHeader

### DIFF
--- a/src/primitives/block.h
+++ b/src/primitives/block.h
@@ -9,7 +9,6 @@
 
 #include "primitives/transaction.h"
 #include "serialize.h"
-#include "sync.h"
 #include "uint256.h"
 
 const uint32_t BIP_009_MASK = 0x20000000;
@@ -100,34 +99,6 @@ public:
     {
         SetNull();
         *((CBlockHeader *)this) = header;
-    }
-
-    // return the index of the transaction in this block.  Return -1 if tx is not in this block
-    int find(uint256 hash) const
-    {
-        int nIndex;
-        for (nIndex = 0; nIndex < (int)vtx.size(); nIndex++)
-            if (vtx[nIndex] == *(CTransactionRef *)this)
-                break;
-        if (nIndex == (int)vtx.size())
-        {
-            nIndex = -1;
-        }
-        return nIndex;
-
-#if 0 // efficient but unnecessary
-        LOCK(csBlockHashToIdx);
-        // If the hash to idx map is empty, then fill it up
-        if (hashToIdx.empty()&& (!vtx.empty()))
-        {
-            for (int nIndex = 0; nIndex < (int)vtx.size(); nIndex++)
-                hashToIdx[vtx[nIndex].GetHash()] = nIndex;
-        }
-        // find the hash and return the idx
-        auto pos = hashToIdx.find(hash);
-        if (pos == hashToIdx.end()) return -1;
-        return pos->second;
-#endif
     }
 
     static bool VersionKnown(int32_t nVersion, int32_t voteBits)

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3582,27 +3582,14 @@ CWalletKey::CWalletKey(int64_t nExpires)
 int CMerkleTx::SetMerkleBranch(const CBlock &block, int txIdx)
 {
     AssertLockHeld(cs_main); // for chainActive
-    // if a bad txIdx is passed, then in release builds set the tx index to "I don't know". In debug builds assert.
-    DbgAssert(txIdx >= -1, txIdx = -1);
+    // txIdx never == -1 since the caller already know txIdx
+    assert(txIdx >= 0);
     CBlock blockTmp;
 
     // Update the tx's hashBlock
     hashBlock = block.GetHash();
-
-    if (txIdx != -1)
-    {
-        nIndex = txIdx;
-    }
-    else
-    {
-        // Locate the transaction
-        nIndex = block.find(((CTransactionRef) this)->GetHash());
-        if (nIndex == -1)
-        {
-            LOGA("ERROR: SetMerkleBranch(): couldn't find tx in block\n");
-            return 0;
-        }
-    }
+    // Set the position of the transaction in the block
+    nIndex = txIdx;
 
     // Is the tx in a block that's in the main chain
     const CBlockIndex *pindex = LookupBlockIndex(hashBlock);


### PR DESCRIPTION
The code was actually never used. The was nly one caller of the methif
but method invocation was in a never-to-be-reached if/else branch