### PR TITLE
[elects] Bump to version 0.6.1

### DIFF
--- a/contrib/electrs/build_electrs.py
+++ b/contrib/electrs/build_electrs.py
@@ -5,8 +5,8 @@ import os
 import sys
 import shutil
 GIT_REPO = "https://github.com/dagurval/electrs.git"
-GIT_BRANCH = "v0.5.0bu"
-EXPECT_HEAD = "84d449ed283296dfc266433a6919ffcb3ca55344"
+GIT_BRANCH = "v0.6.1bu"
+EXPECT_HEAD = "175c1d161b5d30c60a20b5b9922e65fd05e6b59c"
 
 ROOT_DIR = os.path.realpath(
         os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -245,7 +245,8 @@ testScripts = [ RpcTest(t) for t in [
     'sighashmatch',
     'getlogcategories',
     'getrawtransaction',
-    Disabled('electrum_basics', "Needs to be skipped if electrs is not built")
+    Disabled('electrum_basics', "Needs to be skipped if electrs is not built"),
+    Disabled('electrum_reorg', "Needs to be skipped if electrs is not built")
 ] ]
 
 testScriptsExt = [ RpcTest(t) for t in [

--- a/qa/rpc-tests/electrum_reorg.py
+++ b/qa/rpc-tests/electrum_reorg.py
@@ -9,8 +9,7 @@ from test_framework.test_framework import BitcoinTestFramework
 from test_framework.loginit import logging
 from test_framework.electrumutil import compare, bitcoind_electrum_args
 
-
-class ElectrumBasicTests(BitcoinTestFramework):
+class ElectrumReorgTests(BitcoinTestFramework):
 
     def __init__(self):
         super().__init__()
@@ -21,29 +20,34 @@ class ElectrumBasicTests(BitcoinTestFramework):
     def run_test(self):
         n = self.nodes[0]
 
-        logging.info("Checking that blocks are indexed")
         n.generate(200)
 
         # waitFor throws on timeout, failing the test
 
         waitFor(10, lambda: compare(n, "index_height", n.getblockcount()))
-        waitFor(10, lambda: compare(n, "index_txns", n.getblockcount() + 1, True)) # +1 is genesis tx
         waitFor(10, lambda: compare(n, "mempool_count", 0, True))
-
-        logging.info("Check that mempool is communicated")
         n.sendtoaddress(n.getnewaddress(), 1)
         assert_equal(1, len(n.getrawmempool()))
         waitFor(10, lambda: compare(n, "mempool_count", 1, True))
 
-        n.generate(1)
-        assert_equal(0, len(n.getrawmempool()))
+        blocks = n.generate(50)
         waitFor(10, lambda: compare(n, "index_height", n.getblockcount()))
         waitFor(10, lambda: compare(n, "mempool_count", 0, True))
-        waitFor(10, lambda: compare(n, "index_txns", n.getblockcount() + 2, True))
+
+        logging.info("invalidating %d blocks", len(blocks))
+        n.invalidateblock(blocks[0])
+        # electrum server should trim its chain as well and see our
+        # transaction go back into mempool
+        waitFor(10, lambda: compare(n, "index_height", n.getblockcount()))
+        waitFor(10, lambda: compare(n, "mempool_count", 1, True))
+
+        n.generate(50)
+        waitFor(10, lambda: compare(n, "index_height", n.getblockcount()))
+        waitFor(10, lambda: compare(n, "mempool_count", 0, True))
 
 
     def setup_network(self, dummy = None):
         self.nodes = self.setup_nodes()
 
 if __name__ == '__main__':
-    ElectrumBasicTests().main()
+    ElectrumReorgTests().main()

--- a/qa/rpc-tests/test_framework/electrumutil.py
+++ b/qa/rpc-tests/test_framework/electrumutil.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2019 The Bitcoin Unlimited developers
+
+from test_framework.loginit import logging
+
+def compare(node, key, expected, is_debug_data = False):
+    info = node.getelectruminfo()
+    if is_debug_data:
+        info = info['debuginfo']
+        key = "electrs_" + key
+    logging.debug("expecting %s == %s from %s", key, expected, info)
+    if key not in info:
+        return False
+    return info[key] == expected
+
+def bitcoind_electrum_args():
+    import random
+    return ["-electrum=1", "-debug=electrum", "-debug=rpc",
+            "-electrum.port=" + str(random.randint(40000, 60000)),
+            "-electrum.monitoring.port=" + str(random.randint(40000, 60000))]

--- a/src/electrum/electrumrpcinfo.cpp
+++ b/src/electrum/electrumrpcinfo.cpp
@@ -11,8 +11,6 @@
 
 namespace electrum
 {
-static constexpr const char *INDEX_HEIGHT_KEY = "index_height";
-
 static int64_t get_index_height(const std::map<std::string, int> &info)
 {
     auto height_it = info.find(INDEX_HEIGHT_KEY);

--- a/src/electrum/electrumrpcinfo.h
+++ b/src/electrum/electrumrpcinfo.h
@@ -4,12 +4,12 @@
 #ifndef BITCOIN_ELECTRUM_ELECTRUMRPCINFO_H
 #define BITCOIN_ELECTRUM_ELECTRUMRPCINFO_H
 
-#include "electrum/electrs.h"
 #include <string>
 #include <univalue.h>
 
 namespace electrum
 {
+static constexpr const char *INDEX_HEIGHT_KEY = "electrs_index_height";
 class ElectrumRPCInfo
 {
 public:

--- a/src/test/electrumrpcinfo_tests.cpp
+++ b/src/test/electrumrpcinfo_tests.cpp
@@ -9,7 +9,9 @@
 #include <map>
 #include <string>
 
-class ElectrumRPCInfoMOC : public electrum::ElectrumRPCInfo
+using namespace electrum;
+
+class ElectrumRPCInfoMOC : public ElectrumRPCInfo
 {
 public:
     bool ibd = false;
@@ -25,7 +27,7 @@ public:
 
 BOOST_FIXTURE_TEST_SUITE(electrumrpcinfo_tests, BasicTestingSetup)
 
-BOOST_AUTO_TEST_CASE(help_throws) { BOOST_CHECK_THROW(electrum::ElectrumRPCInfo::ThrowHelp(), std::invalid_argument); }
+BOOST_AUTO_TEST_CASE(help_throws) { BOOST_CHECK_THROW(ElectrumRPCInfo::ThrowHelp(), std::invalid_argument); }
 BOOST_AUTO_TEST_CASE(info_status)
 {
     ElectrumRPCInfoMOC rpc;
@@ -47,12 +49,12 @@ BOOST_AUTO_TEST_CASE(info_status)
     BOOST_CHECK_EQUAL("initializing", status["status"].get_str());
 
     rpc.height = 100;
-    rpc.info = {{"index_height", 99}};
+    rpc.info = {{INDEX_HEIGHT_KEY, 99}};
     status = rpc.GetElectrumInfo();
     BOOST_CHECK_EQUAL("indexing", status["status"].get_str());
 
     rpc.height = 100;
-    rpc.info = {{"index_height", 100}};
+    rpc.info = {{INDEX_HEIGHT_KEY, 100}};
     status = rpc.GetElectrumInfo();
     BOOST_CHECK_EQUAL("ok", status["status"].get_str());
 }
@@ -61,7 +63,7 @@ BOOST_AUTO_TEST_CASE(info_progress)
 {
     ElectrumRPCInfoMOC rpc;
     rpc.height = 100;
-    rpc.info = {{"index_height", 99}};
+    rpc.info = {{INDEX_HEIGHT_KEY, 99}};
     UniValue status = rpc.GetElectrumInfo();
     BOOST_CHECK_EQUAL(99., status["index_progress"].get_real());
 
@@ -78,7 +80,7 @@ BOOST_AUTO_TEST_CASE(info_indexheight)
     UniValue status = rpc.GetElectrumInfo();
     BOOST_CHECK_EQUAL(-1, status["index_height"].get_int());
 
-    rpc.info = {{"index_height", 100}};
+    rpc.info = {{INDEX_HEIGHT_KEY, 100}};
     status = rpc.GetElectrumInfo();
     BOOST_CHECK_EQUAL(100, status["index_height"].get_int());
 }


### PR DESCRIPTION
Bump electrs to 0.6.1

I also added a basic reorg test. This test would triggering an assert in electrs and thus fail with previous version.

[Full change log](https://github.com/romanz/electrs/blob/master/RELEASE-NOTES.md)