### PR TITLE
Remove check for CSV transactions in accepttomemorypool

### DIFF
--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -635,15 +635,6 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
     const uint32_t featureFlags = cds_flag | schnorrflag | segwit_flag | svflag;
     const uint32_t flags = STANDARD_SCRIPT_VERIFY_FLAGS | featureFlags;
 
-    // Don't relay version 2 transactions until CSV is active, and we can be
-    // sure that such transactions will be mined (unless we're on
-    // -testnet/-regtest).
-    if (fRequireStandard && tx->nVersion >= 2 &&
-        VersionBitsTipState(chainparams.GetConsensus(), Consensus::DEPLOYMENT_CSV) != THRESHOLD_ACTIVE)
-    {
-        return state.DoS(0, false, REJECT_NONSTANDARD, "premature-version2-tx");
-    }
-
     // Only accept nLockTime-using transactions that can be mined in the next
     // block; we don't want our mempool filled up with transactions that can't
     // be mined yet.


### PR DESCRIPTION
CSV is always active now for new transactions.