### PR TITLE
Move some params into consensus

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -32,6 +32,18 @@ static const unsigned int SMALLEST_MAX_BLOOM_FILTER_SIZE = 36000; // bytes
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 
+/** per May, 15 '18 upgrade specification the min value for min value for max accepted block size, i.e. EB, is 32 MB
+ * (github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/may-2018-hardfork.md#summary)
+ */
+static const unsigned int MIN_EXCESSIVE_BLOCK_SIZE = 32000000;
+static const unsigned int MIN_EXCESSIVE_BLOCK_SIZE_REGTEST = 1000;
+static const unsigned int SV_EXCESSIVE_BLOCK_SIZE = 128000000;
+static const unsigned int DEFAULT_EXCESSIVE_BLOCK_SIZE = MIN_EXCESSIVE_BLOCK_SIZE;
+
+/** Allowed messages lengths will be this * the excessive block size */
+static const unsigned int DEFAULT_MAX_MESSAGE_SIZE_MULTIPLIER = 2;
+
+
 /** Flags for nSequence and nLockTime locks */
 enum
 {

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -36,7 +36,7 @@ enum
     MIN_EXCESSIVE_BLOCK_SIZE_REGTEST = 1000,
     SV_EXCESSIVE_BLOCK_SIZE = 128000000,
     DEFAULT_EXCESSIVE_BLOCK_SIZE = MIN_EXCESSIVE_BLOCK_SIZE,
-    DEFAULT_MAX_MESSAGE_SIZE_MULTIPLIER = 16, // Allowed messages lengths will be this * the excessive block size
+    DEFAULT_MAX_MESSAGE_SIZE_MULTIPLIER = 2, // Allowed messages lengths will be this * the excessive block size
     DEFAULT_COINBASE_RESERVE_SIZE = 1000,
     MAX_COINBASE_SCRIPTSIG_SIZE = 100,
     EXCESSIVE_BLOCK_CHAIN_RESET = 6 * 24, // After 1 day of non-excessive blocks, reset the checker

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -30,13 +30,6 @@ enum
     // lucky, and potentially drive a block that the rest of the network sees as
     // "excessive" onto the blockchain.
 
-    // per May, 15 '18 upgrade specification the min value for min value for max accepted block size, i.e. EB, is 32 MB
-    // (github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/may-2018-hardfork.md#summary)
-    MIN_EXCESSIVE_BLOCK_SIZE = 32000000,
-    MIN_EXCESSIVE_BLOCK_SIZE_REGTEST = 1000,
-    SV_EXCESSIVE_BLOCK_SIZE = 128000000,
-    DEFAULT_EXCESSIVE_BLOCK_SIZE = MIN_EXCESSIVE_BLOCK_SIZE,
-    DEFAULT_MAX_MESSAGE_SIZE_MULTIPLIER = 2, // Allowed messages lengths will be this * the excessive block size
     DEFAULT_COINBASE_RESERVE_SIZE = 1000,
     MAX_COINBASE_SCRIPTSIG_SIZE = 100,
     EXCESSIVE_BLOCK_CHAIN_RESET = 6 * 24, // After 1 day of non-excessive blocks, reset the checker


### PR DESCRIPTION
Also modify the max message size multiplier to align with ABC nodes.  This multiplier value is really a consensus value because it affects which excessive blocks can be accepted and possibly included in the blockchain.