### PR TITLE
Better dbcaching for giga-net 

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -591,7 +591,8 @@ void InitParameterInteraction()
     }
 
     // disable walletbroadcast and whitelistrelay in blocksonly mode
-    if (GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY))
+    fBlocksOnly = GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY);
+    if (fBlocksOnly)
     {
         if (SoftSetBoolArg("-whitelistrelay", false))
             LOGA("%s: parameter interaction: -blocksonly=1 -> setting -whitelistrelay=0\n", __func__);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -77,6 +77,7 @@
 // BU moved CConditionVariable cvBlockChange;
 bool fImporting = false;
 bool fReindex = false;
+bool fBlocksOnly = false;
 bool fTxIndex = false;
 bool fHavePruned = false;
 bool fPruneMode = false;

--- a/src/main.h
+++ b/src/main.h
@@ -186,6 +186,7 @@ extern CConditionVariable cvBlockChange;
 extern bool fImporting;
 extern bool fReindex;
 extern bool fTxIndex;
+extern bool fBlocksOnly;
 extern bool fIsBareMultisigStd;
 extern unsigned int nBytesPerSigOp;
 extern bool fCheckBlockIndex;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -911,8 +911,6 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             return error("message inv size() = %u", vInv.size());
         }
 
-        bool fBlocksOnly = GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY);
-
         // Allow whitelisted peers to send data other than blocks in blocks only mode if whitelistrelay is true
         if (pfrom->fWhitelisted && GetBoolArg("-whitelistrelay", DEFAULT_WHITELISTRELAY))
             fBlocksOnly = false;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -206,7 +206,6 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
                 // Only delete valid coins from the cache when we're nearly syncd.  During IBD, and also
                 // if BlockOnly mode is turned on, these coins will be used, whereas, once the chain is
                 // syncd we only need the coins that have come from accepting txns into the memory pool.
-                bool fBlocksOnly = GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY);
                 if (IsChainNearlySyncd() && !fImporting && !fReindex && !fBlocksOnly &&
                     (nCoinCacheMaxSize < DEFAULT_HIGH_PERF_MEM_CUTOFF))
                 {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -207,7 +207,8 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
                 // if BlockOnly mode is turned on, these coins will be used, whereas, once the chain is
                 // syncd we only need the coins that have come from accepting txns into the memory pool.
                 bool fBlocksOnly = GetBoolArg("-blocksonly", DEFAULT_BLOCKSONLY);
-                if (IsChainNearlySyncd() && !fImporting && !fReindex && !fBlocksOnly)
+                if (IsChainNearlySyncd() && !fImporting && !fReindex && !fBlocksOnly &&
+                    (nCoinCacheMaxSize < DEFAULT_HIGH_PERF_MEM_CUTOFF))
                 {
                     // Update the usage of the child cache before deleting the entry in the child cache
                     nChildCachedCoinsUsage -= nUsage;
@@ -239,8 +240,9 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
         _WriteBestBlock(hashBlock);
 
     bool ret = db.WriteBatch(batch);
-    LOG(COINDB, "Committing %u changed transactions (out of %u) to coin database with %u batch writes...\n",
+    LOG(COINDB, "Committing1 %u changed transactions (out of %u) to coin database with %u batch writes...\n",
         (unsigned int)changed, (unsigned int)count, (unsigned int)nBatchWrites);
+
     return ret;
 }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -239,7 +239,7 @@ bool CCoinsViewDB::BatchWrite(CCoinsMap &mapCoins,
         _WriteBestBlock(hashBlock);
 
     bool ret = db.WriteBatch(batch);
-    LOG(COINDB, "Committing1 %u changed transactions (out of %u) to coin database with %u batch writes...\n",
+    LOG(COINDB, "Committing %u changed transactions (out of %u) to coin database with %u batch writes...\n",
         (unsigned int)changed, (unsigned int)count, (unsigned int)nBatchWrites);
 
     return ret;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -838,7 +838,7 @@ void AdjustCoinCacheSize()
         // The amount of system memory currently available
         int64_t nMemAvailable = GetAvailableMemory();
         // The amount of memory we need to *keep* available.
-        int64_t nUnusedMem = std::max(GetTotalSystemMemory() * nDefaultPcntMemUnused / 100, nMinMemToKeepAvaialable);
+        int64_t nUnusedMem = std::max(GetTotalSystemMemory() * nDefaultPcntMemUnused / 100, nMinMemToKeepAvailable);
 
         // Make sure we leave enough room for the leveldb write cache's
         if (pcoinsdbview != nullptr && nUnusedMem < pcoinsdbview->TotalWriteBufferSize())

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -33,6 +33,12 @@ static const int64_t nMinDbCache = 4;
 static const int64_t nDefaultPcntMemUnused = 10;
 //! max increase in cache size since the last time we did a full flush
 static const uint64_t nMaxCacheIncreaseSinceLastFlush = 512 * 1000 * 1000;
+/** The cutoff dbcache size where a node becomes a high performance node and will keep all unspent coins in cache
+ *  after each block is processed. Lower performance nodes will purge these unspent coins from each block and
+ *  instead only keep coins in cache from incoming transactions that have been fully validated which gives these lower
+ *  performance and more marginal nodes, such as those run on rapberry pi's, a very small memory footprint.
+ */
+static const uint64_t DEFAULT_HIGH_PERF_MEM_CUTOFF = 2048 * 1000 * 1000;
 //! the minimum system memory we always keep free when doing automatic dbcache sizing
 static const uint64_t nMinMemToKeepAvaialable = 300 * 1000 * 1000;
 //! the max size a batch can get before a write to the utxo is made

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -38,9 +38,9 @@ static const uint64_t nMaxCacheIncreaseSinceLastFlush = 512 * 1000 * 1000;
  *  instead only keep coins in cache from incoming transactions that have been fully validated which gives these lower
  *  performance and more marginal nodes, such as those run on rapberry pi's, a very small memory footprint.
  */
-static const uint64_t DEFAULT_HIGH_PERF_MEM_CUTOFF = 2048 * 1000 * 1000;
+static const int64_t DEFAULT_HIGH_PERF_MEM_CUTOFF = 2048 * 1000 * 1000;
 //! the minimum system memory we always keep free when doing automatic dbcache sizing
-static const uint64_t nMinMemToKeepAvaialable = 300 * 1000 * 1000;
+static const uint64_t nMinMemToKeepAvailable = 300 * 1000 * 1000;
 //! the max size a batch can get before a write to the utxo is made
 static const size_t nMaxDBBatchSize = 16 << 20;
 //! Max memory allocated to block tree DB specific cache, if no -txindex (MiB)


### PR DESCRIPTION
While keeping the low memory footprint for marginal nodes on mainnet we can also do much better for high end nodes by keeping any dirty coins in memory after each block is found and data is flushed to disk. This should help to give us better transaction throughput numbers on the giga-net.