### PR TITLE
[Version1] Fix SPV node edge case

### DIFF
--- a/src/bloom.cpp
+++ b/src/bloom.cpp
@@ -143,10 +143,13 @@ void CBloomFilter::insert(const uint256 &hash)
 
 bool CBloomFilter::contains(const vector<unsigned char> &vKey) const
 {
-    if (isFull)
-        return true;
+    // NOTE: The check for empty must come first because in the case of a filter of size(0)
+    //       the filter will be showing as both empty and full but we want to make sure we return
+    //       here and indicate that no relavant matches were found.
     if (isEmpty)
         return false;
+    if (isFull)
+        return true;
     for (unsigned int i = 0; i < nHashFuncs; i++)
     {
         unsigned int nIndex = Hash(i, vKey);
@@ -187,10 +190,15 @@ bool CBloomFilter::IsRelevantAndUpdate(const CTransactionRef &tx)
     bool fFound = false;
     // Match if the filter contains the hash of tx
     //  for finding tx when they appear in a block
-    if (isFull)
-        return true;
+    //
+    // NOTE: The check for empty must come first because in the case of a filter of size(0)
+    //       the filter will be showing as both empty and full but we want to make sure we return
+    //       here and indicate that no relavant matches were found.
     if (isEmpty)
         return false;
+    if (isFull)
+        return true;
+
     const uint256 &hash = tx->GetHash();
     if (contains(hash))
         fFound = true;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2650,7 +2650,7 @@ void RelayTransaction(const CTransactionRef &ptx, const bool fRespend)
             if (!fRespend && pnode->pfilter->IsRelevantAndUpdate(ptx))
                 pnode->PushInventory(inv);
         }
-        else
+        else if (!pnode->pfilter)
             pnode->PushInventory(inv);
     }
 }
@@ -2931,7 +2931,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
     nNextInvSend = 0;
     fRelayTxes = false;
     fSentAddr = false;
-    pfilter = new CBloomFilter();
+    pfilter = nullptr;
     pThinBlockFilter = new CBloomFilter(); // BUIP010 - Xtreme Thinblocks
     nPingNonceSent = 0;
     nPingUsecStart = 0;

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2931,7 +2931,7 @@ CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNa
     nNextInvSend = 0;
     fRelayTxes = false;
     fSentAddr = false;
-    pfilter = nullptr;
+    pfilter = nullptr; // must be nullptr for RelayTransaction() edge case
     pThinBlockFilter = new CBloomFilter(); // BUIP010 - Xtreme Thinblocks
     nPingNonceSent = 0;
     nPingUsecStart = 0;

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -175,6 +175,21 @@ BOOST_AUTO_TEST_CASE(bloom_match)
     CTransaction spendingTx;
     spendStream >> spendingTx;
 
+    // check empty filter
+    CBloomFilter emptyfilter1;
+    BOOST_CHECK_MESSAGE(!emptyfilter1.IsRelevantAndUpdate(ptx), "Simple Bloom filter was not empty");
+    BOOST_CHECK(emptyfilter1.IsEmpty());
+    CBloomFilter emptyfilter2(1024, 0.001, 0, BLOOM_UPDATE_ALL);
+    BOOST_CHECK_MESSAGE(!emptyfilter2.IsRelevantAndUpdate(ptx), "Simple Bloom filter was not empty");
+    BOOST_CHECK(emptyfilter2.IsEmpty());
+    CBloomFilter emptyfilter3(1024, 0.001, 0, BLOOM_UPDATE_NONE);
+    BOOST_CHECK_MESSAGE(!emptyfilter3.IsRelevantAndUpdate(ptx), "Simple Bloom filter was not empty");
+    BOOST_CHECK(emptyfilter3.IsEmpty());
+    CBloomFilter emptyfilter4(1024, 0.001, 0, BLOOM_UPDATE_NONE, true, 0);
+    BOOST_CHECK_MESSAGE(!emptyfilter4.IsRelevantAndUpdate(ptx), "Simple Bloom filter was not empty");
+    BOOST_CHECK(emptyfilter4.IsEmpty());
+
+    // basic check
     CBloomFilter filter(10, 0.000001, 0, BLOOM_UPDATE_ALL);
     filter.insert(uint256S("0xb4749f017444b051c44dfd2720e88f314ff94f3dd6d56d40ef65854fcd7fff6b"));
     BOOST_CHECK_MESSAGE(filter.IsRelevantAndUpdate(ptx), "Simple Bloom filter didn't match tx hash");
@@ -923,6 +938,7 @@ BOOST_AUTO_TEST_CASE(bloom_full_and_size_tests)
         // a filter with good parameters should be non-full upon construction
         CBloomFilter filter(8, 0.01, 0, BLOOM_UPDATE_ALL);
         BOOST_CHECK(!filter.IsFull());
+        BOOST_CHECK(filter.IsEmpty());
     }
 
     {
@@ -930,12 +946,14 @@ BOOST_AUTO_TEST_CASE(bloom_full_and_size_tests)
         // and yield non-full filters as nElements will be set to 1
         CBloomFilter filter(0, 0.01, 0, BLOOM_UPDATE_ALL);
         BOOST_CHECK(!filter.IsFull());
+        BOOST_CHECK(filter.IsEmpty());
     }
 
     {
-        // default empty filter is full
+        // default empty filter is full and empty
         CBloomFilter filter;
         BOOST_CHECK(filter.IsFull());
+        BOOST_CHECK(filter.IsEmpty());
     }
 
     {

--- a/src/test/bloom_tests.cpp
+++ b/src/test/bloom_tests.cpp
@@ -82,6 +82,24 @@ BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize)
 
 BOOST_AUTO_TEST_CASE(bloom_create_insert_serialize_with_tweak)
 {
+    // check empty filter
+    CBloomFilter emptyfilter1;
+    BOOST_CHECK_MESSAGE(!emptyfilter1.contains(ParseHex("99108ad8ed9bb6274d3980bab5a85c048f0950c8")),
+        "Simple Bloom filter was not empty");
+    BOOST_CHECK(emptyfilter1.IsEmpty());
+    CBloomFilter emptyfilter2(1024, 0.001, 0, BLOOM_UPDATE_ALL);
+    BOOST_CHECK_MESSAGE(!emptyfilter2.contains(ParseHex("99108ad8ed9bb6274d3980bab5a85c048f0950c8")),
+        "Simple Bloom filter was not empty");
+    BOOST_CHECK(emptyfilter2.IsEmpty());
+    CBloomFilter emptyfilter3(1024, 0.001, 0, BLOOM_UPDATE_NONE);
+    BOOST_CHECK_MESSAGE(!emptyfilter3.contains(ParseHex("99108ad8ed9bb6274d3980bab5a85c048f0950c8")),
+        "Simple Bloom filter was not empty");
+    BOOST_CHECK(emptyfilter3.IsEmpty());
+    CBloomFilter emptyfilter4(1024, 0.001, 0, BLOOM_UPDATE_NONE, true, 0);
+    BOOST_CHECK_MESSAGE(!emptyfilter4.contains(ParseHex("99108ad8ed9bb6274d3980bab5a85c048f0950c8")),
+        "Simple Bloom filter was not empty");
+    BOOST_CHECK(emptyfilter4.IsEmpty());
+
     // Same test as bloom_create_insert_serialize, but we add a nTweak of 100
     CBloomFilter filter(3, 0.01, 2147483649UL, BLOOM_UPDATE_ALL);
 


### PR DESCRIPTION
This fixes a couple of things...firstly IsRelevantAndUpdate() should return false if the bloom filter is empty and full and the same time...currently it was returning true.  Second, we have to test whether pfilter is null or what will happen when and SPV peer sends us an empty filter, we will end up sending them everything.

NOTE: the only issue here is that we have to initialize pfilter to nullptr, which isn't the safest but we are already checking everywhere for whether it's null or not.