### PR TITLE
Cleanup finalize node

### DIFF
--- a/qa/rpc-tests/nodehandling.py
+++ b/qa/rpc-tests/nodehandling.py
@@ -91,21 +91,21 @@ class NodeHandlingTest (BitcoinTestFramework):
         connect_nodes(self.nodes[1], 2)
         # Each node should have two each of xthin/graph/cmpct peers connected
         for node in self.nodes:
-            waitFor(10, lambda: node.getinfo()["peers_graph"] == 2)
-            waitFor(10, lambda: node.getinfo()["peers_xthin"] == 2)
-            waitFor(10, lambda: node.getinfo()["peers_cmpct"] == 2)
+            waitFor(10, lambda: node.getinfo()["peers_graphene"] == 2)
+            waitFor(10, lambda: node.getinfo()["peers_xthinblock"] == 2)
+            waitFor(10, lambda: node.getinfo()["peers_cmpctblock"] == 2)
         
         disconnect_nodes(self.nodes[0], 1)
         # node0 and node1 should now only have 1 each of xthin/graph/cmpct peers but node2 should have 2 of each.
-        waitFor(10, lambda: self.nodes[0].getinfo()["peers_graph"] == 1)
-        waitFor(10, lambda: self.nodes[0].getinfo()["peers_xthin"] == 1)
-        waitFor(10, lambda: self.nodes[0].getinfo()["peers_cmpct"] == 1)
-        waitFor(10, lambda: self.nodes[1].getinfo()["peers_graph"] == 1)
-        waitFor(10, lambda: self.nodes[1].getinfo()["peers_xthin"] == 1)
-        waitFor(10, lambda: self.nodes[1].getinfo()["peers_cmpct"] == 1)
-        waitFor(10, lambda: self.nodes[2].getinfo()["peers_graph"] == 2)
-        waitFor(10, lambda: self.nodes[2].getinfo()["peers_xthin"] == 2)
-        waitFor(10, lambda: self.nodes[2].getinfo()["peers_cmpct"] == 2)
+        waitFor(10, lambda: self.nodes[0].getinfo()["peers_graphene"] == 1)
+        waitFor(10, lambda: self.nodes[0].getinfo()["peers_xthinblock"] == 1)
+        waitFor(10, lambda: self.nodes[0].getinfo()["peers_cmpctblock"] == 1)
+        waitFor(10, lambda: self.nodes[1].getinfo()["peers_graphene"] == 1)
+        waitFor(10, lambda: self.nodes[1].getinfo()["peers_xthinblock"] == 1)
+        waitFor(10, lambda: self.nodes[1].getinfo()["peers_cmpctblock"] == 1)
+        waitFor(10, lambda: self.nodes[2].getinfo()["peers_graphene"] == 2)
+        waitFor(10, lambda: self.nodes[2].getinfo()["peers_xthinblock"] == 2)
+        waitFor(10, lambda: self.nodes[2].getinfo()["peers_cmpctblock"] == 2)
 
 if __name__ == '__main__':
     NodeHandlingTest ().main ()

--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -210,6 +210,18 @@ void ThinTypeRelay::ClearBlockInFlight(CNode *pfrom, const uint256 &hash)
     }
 }
 
+void ThinTypeRelay::ClearAllBlocksInFlight(NodeId id)
+{
+    LOCK(cs_inflight);
+    std::pair<std::multimap<const NodeId, CThinTypeBlockInFlight>::iterator,
+        std::multimap<const NodeId, CThinTypeBlockInFlight>::iterator>
+        range = mapThinTypeBlocksInFlight.equal_range(id);
+    while (range.first != range.second)
+    {
+        range.first = mapThinTypeBlocksInFlight.erase(range.first);
+    }
+}
+
 void ThinTypeRelay::CheckForDownloadTimeout(CNode *pfrom)
 {
     LOCK(cs_inflight);
@@ -261,7 +273,7 @@ std::shared_ptr<CBlockThinRelay> ThinTypeRelay::SetBlockToReconstruct(CNode *pfr
     // Otherwise, start with a fresh instance.
     else
     {
-        ClearBlockToReconstruct(pfrom);
+        ClearBlockToReconstruct(pfrom->GetId());
 
         // Store and empty block which can be used later
         std::shared_ptr<CBlockThinRelay> pblock;
@@ -293,10 +305,10 @@ std::shared_ptr<CBlockThinRelay> ThinTypeRelay::GetBlockToReconstruct(CNode *pfr
         return nullptr;
 }
 
-void ThinTypeRelay::ClearBlockToReconstruct(CNode *pfrom)
+void ThinTypeRelay::ClearBlockToReconstruct(NodeId id)
 {
     LOCK(cs_reconstruct);
-    mapBlocksReconstruct.erase(pfrom->GetId());
+    mapBlocksReconstruct.erase(id);
 }
 
 void ThinTypeRelay::AddBlockBytes(uint64_t bytes, std::shared_ptr<CBlockThinRelay> pblock)
@@ -309,8 +321,10 @@ void ThinTypeRelay::ClearAllBlockData(CNode *pnode, std::shared_ptr<CBlockThinRe
 {
     // We must make sure to clear the block data first before clearing the thinblock in flight.
     uint256 hash = pblock->GetBlockHeader().GetHash();
-    ClearBlockToReconstruct(pnode);
-    if (pblock != nullptr)
+    ClearBlockToReconstruct(pnode->GetId());
+
+    // Clear block data
+    if (pblock)
         pblock->SetNull();
 
     // Now clear the block in flight.

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -51,6 +51,9 @@ private:
 
 public:
     void AddPeers(CNode *pfrom);
+    uint32_t GetGraphenePeers() { return nGraphenePeers.load(); }
+    uint32_t GetThinBlockPeers() { return nThinBlockPeers.load(); }
+    uint32_t GetCompactBlockPeers() { return nCompactBlockPeers.load(); }
     void AddCompactBlockPeer(CNode *pfrom);
     void RemovePeers(CNode *pfrom);
     bool HasBlockRelayTimerExpired(const uint256 &hash);
@@ -61,6 +64,7 @@ public:
     void BlockWasReceived(CNode *pfrom, const uint256 &hash);
     bool AddBlockInFlight(CNode *pfrom, const uint256 &hash, const std::string thinType);
     void ClearBlockInFlight(CNode *pfrom, const uint256 &hash);
+    void ClearAllBlocksInFlight(NodeId id);
     void CheckForDownloadTimeout(CNode *pfrom);
     void RequestBlock(CNode *pfrom, const uint256 &hash);
 
@@ -68,7 +72,7 @@ public:
     // xthins or graphene.
     std::shared_ptr<CBlockThinRelay> SetBlockToReconstruct(CNode *pfrom, const uint256 &hash);
     std::shared_ptr<CBlockThinRelay> GetBlockToReconstruct(CNode *pfrom);
-    void ClearBlockToReconstruct(CNode *pfrom);
+    void ClearBlockToReconstruct(NodeId id);
 
     // Accessor methods for tracking total block bytes for all blocks currently in the process
     // of being reconstructed.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -145,8 +145,9 @@ void InitializeNode(const CNode *pnode)
 
 void FinalizeNode(NodeId nodeid)
 {
-    // Decrement thin type peer counters
-    thinrelay.RemovePeers(connmgr->FindNodeFromId(nodeid).get());
+    // Clear thintype block data if we have any.
+    thinrelay.ClearBlockToReconstruct(nodeid);
+    thinrelay.ClearAllBlocksInFlight(nodeid);
 
     // Update block sync counters
     {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -15,6 +15,7 @@
 #include "net.h"
 
 #include "addrman.h"
+#include "blockrelay/blockrelay_common.h"
 #include "blockrelay/graphene.h"
 #include "chainparams.h"
 #include "connmgr.h"
@@ -3026,6 +3027,9 @@ CNode::~CNode()
     // Update addrman timestamp
     if (nMisbehavior == 0 && successfullyConnected())
         addrman.Connected(addr);
+
+    // Decrement thintype peer counters
+    thinrelay.RemovePeers(this);
 
     GetNodeSignals().FinalizeNode(GetId());
 }

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -649,15 +649,14 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, CBlockRef p
         }
 
         // When we request a thin type block we may get back a regular block if it is smaller than
-        // either of the former.  Therefore we have to remove the thin or graphene block in flight if it
+        // either of the former.  Therefore we have to remove the thintype block in flight if it
         // exists and we also need to check that the block didn't arrive from some other peer.
-        {
-            // Remove thinblock data and thinblock in flight
-            thinrelay.ClearBlockInFlight(pfrom, inv.hash);
-            pfrom->firstBlock += 1;
-        }
+        thinrelay.ClearBlockInFlight(pfrom, inv.hash);
 
-        // Erase any txns from the orphan cache that are no longer needed
+        // Increment block counter
+        pfrom->firstBlock += 1;
+
+        // Erase any txns from the orphan cache, which were in this block, and that are now no longer needed.
         PV->ClearOrphanCache(pblock);
 
         // If chain is nearly caught up then flush the state after a block is finished processing and the

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -4,6 +4,7 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include "blockrelay/blockrelay_common.h"
 #include "dstencode.h"
 #include "init.h"
 #include "main.h"
@@ -54,6 +55,9 @@ UniValue getinfo(const UniValue &params, bool fHelp)
             "  \"blocks\": xxxxxx,           (numeric) the current number of blocks processed in the server\n"
             "  \"timeoffset\": xxxxx,        (numeric) the time offset\n"
             "  \"connections\": xxxxx,       (numeric) the number of connections\n"
+            "  \"peers_graph\": xxxxx,       (numeric) the number of grapheneblock peers\n"
+            "  \"peers_xthin\": xxxxx,       (numeric) the number of xthinblock peers\n"
+            "  \"peers_cmpct\": xxxxx,       (numeric) the number of compactblock peers\n"
             "  \"proxy\": \"host:port\",     (string, optional) the proxy used by the server\n"
             "  \"difficulty\": xxxxxx,       (numeric) the current difficulty\n"
             "  \"testnet\": true|false,      (boolean) if the server is using testnet or not\n"
@@ -68,10 +72,10 @@ UniValue getinfo(const UniValue &params, bool fHelp)
             "  \"relayfee\": x.xxxx,         (numeric) minimum relay fee for non-free transactions in " +
             CURRENCY_UNIT +
             "/kB\n"
-            "  \"fork\": \"...\"             (string) \"Bitcoin Cash\" or \"Bitcoin\".  Will display as Bitcoin "
-            "pre-fork.\n"
             "  \"status\":\"...\"            (string) long running operations are indicated here (rescan).\n"
             "  \"errors\": \"...\"           (string) any error messages\n"
+            "  \"fork\": \"...\"             (string) \"Bitcoin Cash\" or \"Bitcoin\".  Will display as Bitcoin "
+            "pre-fork.\n"
             "}\n"
             "\nExamples:\n" +
             HelpExampleCli("getinfo", "") + HelpExampleRpc("getinfo", ""));
@@ -106,6 +110,9 @@ UniValue getinfo(const UniValue &params, bool fHelp)
     obj.pushKV("blocks", (int)chainActive.Height());
     obj.pushKV("timeoffset", GetTimeOffset());
     obj.pushKV("connections", nNodes);
+    obj.pushKV("peers_graph", (int)thinrelay.GetGraphenePeers());
+    obj.pushKV("peers_xthin", (int)thinrelay.GetThinBlockPeers());
+    obj.pushKV("peers_cmpct", (int)thinrelay.GetCompactBlockPeers());
     obj.pushKV("proxy", (proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string()));
     obj.pushKV("difficulty", (double)GetDifficulty());
     obj.pushKV("testnet", Params().TestnetToBeDeprecatedFieldRPC());

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -55,9 +55,9 @@ UniValue getinfo(const UniValue &params, bool fHelp)
             "  \"blocks\": xxxxxx,           (numeric) the current number of blocks processed in the server\n"
             "  \"timeoffset\": xxxxx,        (numeric) the time offset\n"
             "  \"connections\": xxxxx,       (numeric) the number of connections\n"
-            "  \"peers_graph\": xxxxx,       (numeric) the number of grapheneblock peers\n"
-            "  \"peers_xthin\": xxxxx,       (numeric) the number of xthinblock peers\n"
-            "  \"peers_cmpct\": xxxxx,       (numeric) the number of compactblock peers\n"
+            "  \"peers_graphene\": xxxxx     (numeric) the number of grapheneblock peers\n"
+            "  \"peers_xthinblock\": xxxxx,  (numeric) the number of xthinblock peers\n"
+            "  \"peers_cmpctblock\": xxxxx,  (numeric) the number of compactblock peers\n"
             "  \"proxy\": \"host:port\",     (string, optional) the proxy used by the server\n"
             "  \"difficulty\": xxxxxx,       (numeric) the current difficulty\n"
             "  \"testnet\": true|false,      (boolean) if the server is using testnet or not\n"
@@ -110,9 +110,9 @@ UniValue getinfo(const UniValue &params, bool fHelp)
     obj.pushKV("blocks", (int)chainActive.Height());
     obj.pushKV("timeoffset", GetTimeOffset());
     obj.pushKV("connections", nNodes);
-    obj.pushKV("peers_graph", (int)thinrelay.GetGraphenePeers());
-    obj.pushKV("peers_xthin", (int)thinrelay.GetThinBlockPeers());
-    obj.pushKV("peers_cmpct", (int)thinrelay.GetCompactBlockPeers());
+    obj.pushKV("peers_graphene", (int)thinrelay.GetGraphenePeers());
+    obj.pushKV("peers_xthinblock", (int)thinrelay.GetThinBlockPeers());
+    obj.pushKV("peers_cmpctblock", (int)thinrelay.GetCompactBlockPeers());
     obj.pushKV("proxy", (proxy.IsValid() ? proxy.proxy.ToStringIPPort() : string()));
     obj.pushKV("difficulty", (double)GetDifficulty());
     obj.pushKV("testnet", Params().TestnetToBeDeprecatedFieldRPC());


### PR DESCRIPTION
 I believe moving thinrelay.RemovePeers(pnode) to ~CNode may be the fix for the occasional crash on exit we've been having.

This PR also adds new output to getinfo() along with py tests which show us how many of each peer (cmpct, graph, xthin) are currently connected.