### PR TITLE
A few relatively minor thinrelay changes

### DIFF
--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -24,6 +24,8 @@ blockrelay/graphene_set.h
 blockrelay/graphene_set.cpp
 blockrelay/thinblock.h
 blockrelay/thinblock.cpp
+blockrelay/compactblock.cpp
+blockrelay/compactblock.h
 blockrelay/blockrelay_common.h
 blockrelay/blockrelay_common.cpp
 blockstorage/blockleveldb.cpp

--- a/src/blockrelay/compactblock.cpp
+++ b/src/blockrelay/compactblock.cpp
@@ -545,8 +545,6 @@ bool CompactReReqResponse::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     if (pblock->hashMerkleRoot != merkleroot || mutated)
     {
         thinrelay.ClearAllBlockData(pfrom, pblock);
-
-        dosMan.Misbehaving(pfrom, 100);
         return error("Merkle root for %s does not match computed merkle root, peer=%s", inv.hash.ToString(),
             pfrom->GetLogName());
     }
@@ -615,8 +613,6 @@ static bool ReconstructBlock(CNode *pfrom,
         if (setHashes.size() != pblock->cmpctblock->vTxHashes256.size())
         {
             thinrelay.ClearAllBlockData(pfrom, pblock);
-
-            dosMan.Misbehaving(pfrom, 10);
             return error("Duplicate transaction ids, peer=%s", pfrom->GetLogName());
         }
     }

--- a/src/blockrelay/compactblock.cpp
+++ b/src/blockrelay/compactblock.cpp
@@ -136,11 +136,11 @@ bool CompactBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     std::shared_ptr<CompactBlock> compactBlock = pblock->cmpctblock;
 
     // Message consistency checking
-    if(!IsCompactBlockValid(pfrom, compactBlock))
+    if (!IsCompactBlockValid(pfrom, compactBlock))
     {
-       dosMan.Misbehaving(pfrom, 100);
-       thinrelay.ClearAllBlockData(pfrom, pblock);
-       return error("Received an invalid compactblock from peer %s\n", pfrom->GetLogName());
+        dosMan.Misbehaving(pfrom, 100);
+        thinrelay.ClearAllBlockData(pfrom, pblock);
+        return error("Received an invalid compactblock from peer %s\n", pfrom->GetLogName());
     }
 
     // Is there a previous block or header to connect with?
@@ -529,8 +529,7 @@ bool CompactReReqResponse::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     {
         if (cmpctBlock->vTxHashes256[i].IsNull())
         {
-            std::map<uint64_t, CTransactionRef>::iterator val =
-                cmpctBlock->mapMissingTx.find(cmpctBlock->vTxHashes[i]);
+            std::map<uint64_t, CTransactionRef>::iterator val = cmpctBlock->mapMissingTx.find(cmpctBlock->vTxHashes[i]);
             if (val != cmpctBlock->mapMissingTx.end())
             {
                 cmpctBlock->vTxHashes256[i] = val->second->GetHash();
@@ -1111,7 +1110,7 @@ bool IsCompactBlockValid(CNode *pfrom, std::shared_ptr<CompactBlock> compactBloc
     // set of hashes
     uint64_t nTxnsInBlock = compactBlock->shorttxids.size() + compactBlock->prefilledtxn.size();
     if (nTxnsInBlock > (thinrelay.GetMaxAllowedBlockSize() / MIN_TX_SIZE))
-        return error("Number of hashes in thinblock or xthinblock would reconstruct a block the block size limit\n");
+        return error("Number of hashes in compactblock would reconstruct a block greather than the block size limit\n");
 
     // check block header
     CValidationState state;

--- a/src/blockrelay/compactblock.cpp
+++ b/src/blockrelay/compactblock.cpp
@@ -95,23 +95,23 @@ uint64_t CompactBlock::GetShortID(const uint256 &txhash) const
     return ::GetShortID(shorttxidk0, shorttxidk1, txhash);
 }
 
-void validateCompactBlock(const CompactBlock &cmpctblock)
+void validateCompactBlock(std::shared_ptr<CompactBlock> cmpctblock)
 {
-    if (cmpctblock.header.IsNull() || (cmpctblock.shorttxids.empty() && cmpctblock.prefilledtxn.empty()))
+    if (cmpctblock->header.IsNull() || (cmpctblock->shorttxids.empty() && cmpctblock->prefilledtxn.empty()))
         throw std::invalid_argument("empty data in compact block");
 
     int64_t lastprefilledindex = -1;
-    for (size_t i = 0; i < cmpctblock.prefilledtxn.size(); i++)
+    for (size_t i = 0; i < cmpctblock->prefilledtxn.size(); i++)
     {
-        if (cmpctblock.prefilledtxn[i].tx.IsNull())
+        if (cmpctblock->prefilledtxn[i].tx.IsNull())
             throw std::invalid_argument("null tx in compact block");
 
         // index is a uint32_t, so cant overflow here
-        lastprefilledindex += static_cast<uint64_t>(cmpctblock.prefilledtxn[i].index) + 1;
+        lastprefilledindex += static_cast<uint64_t>(cmpctblock->prefilledtxn[i].index) + 1;
         if (lastprefilledindex > std::numeric_limits<uint32_t>::max())
             throw std::invalid_argument("tx index overflows");
 
-        if (static_cast<uint64_t>(lastprefilledindex) > cmpctblock.shorttxids.size() + i)
+        if (static_cast<uint64_t>(lastprefilledindex) > cmpctblock->shorttxids.size() + i)
         {
             // If we are inserting a tx at an index greater than our full list of shorttxids
             // plus the number of prefilled txn we've inserted, then we have txn for which we
@@ -136,7 +136,12 @@ bool CompactBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     std::shared_ptr<CompactBlock> compactBlock = pblock->cmpctblock;
 
     // Message consistency checking
-    IsCompactBlockValid(pfrom, *compactBlock);
+    if(!IsCompactBlockValid(pfrom, compactBlock))
+    {
+       dosMan.Misbehaving(pfrom, 100);
+       thinrelay.ClearAllBlockData(pfrom, pblock);
+       return error("Received an invalid compactblock from peer %s\n", pfrom->GetLogName());
+    }
 
     // Is there a previous block or header to connect with?
     CBlockIndex *pprev = LookupBlockIndex(compactBlock->header.hashPrevBlock);
@@ -1098,21 +1103,27 @@ void SendCompactBlock(ConstCBlockRef pblock, CNode *pfrom, const CInv &inv)
     }
 }
 
-bool IsCompactBlockValid(CNode *pfrom, const CompactBlock &compactBlock)
+bool IsCompactBlockValid(CNode *pfrom, std::shared_ptr<CompactBlock> compactBlock)
 {
     validateCompactBlock(compactBlock);
 
+    // Check that we havn't exceeded the max allowable block size that would be reconstructed from this
+    // set of hashes
+    uint64_t nTxnsInBlock = compactBlock->shorttxids.size() + compactBlock->prefilledtxn.size();
+    if (nTxnsInBlock > (thinrelay.GetMaxAllowedBlockSize() / MIN_TX_SIZE))
+        return error("Number of hashes in thinblock or xthinblock would reconstruct a block the block size limit\n");
+
     // check block header
     CValidationState state;
-    if (!CheckBlockHeader(compactBlock.header, state, true))
+    if (!CheckBlockHeader(compactBlock->header, state, true))
     {
         return error("Received invalid header for compactblock %s from peer %s",
-            compactBlock.header.GetHash().ToString(), pfrom->GetLogName());
+            compactBlock->header.GetHash().ToString(), pfrom->GetLogName());
     }
     if (state.Invalid())
     {
         return error("Received invalid header for compactblock %s from peer %s",
-            compactBlock.header.GetHash().ToString(), pfrom->GetLogName());
+            compactBlock->header.GetHash().ToString(), pfrom->GetLogName());
     }
 
     return true;

--- a/src/blockrelay/compactblock.h
+++ b/src/blockrelay/compactblock.h
@@ -284,7 +284,7 @@ public:
     }
 };
 
-void validateCompactBlock(const CompactBlock &cmpctblock);
+void validateCompactBlock(std::shared_ptr<CompactBlock> cmpctblock);
 
 
 // This struct is so we can obtain a quick summar of stats for UI display purposes
@@ -404,7 +404,7 @@ extern CCompactBlockData compactdata; // Singleton class
 
 bool IsCompactBlocksEnabled();
 void SendCompactBlock(ConstCBlockRef pblock, CNode *pfrom, const CInv &inv);
-bool IsCompactBlockValid(CNode *pfrom, const CompactBlock &cmpctblock);
+bool IsCompactBlockValid(CNode *pfrom, std::shared_ptr<CompactBlock> compactBlock);
 
 // Xpress Validation: begin
 // Transactions that have already been accepted into the memory pool do not need to be

--- a/src/blockrelay/compactblock.h
+++ b/src/blockrelay/compactblock.h
@@ -309,7 +309,6 @@ struct CompactBlockQuickStats
 class CCompactBlockData
 {
 private:
-
     CCriticalSection cs_compactblockstats; // locks everything below this point
 
     CStatHistory<uint64_t> nOriginalSize;

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -3,7 +3,6 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "blockrelay/graphene.h"
-#include "blockrelay/blockrelay_common.h"
 #include "blockstorage/blockstorage.h"
 #include "chainparams.h"
 #include "connmgr.h"
@@ -353,10 +352,8 @@ bool CGrapheneBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string
     if (!IsGrapheneBlockValid(pfrom, grapheneBlock->header))
     {
         dosMan.Misbehaving(pfrom, 100);
-        LOGA("Received an invalid %s from peer %s\n", strCommand, pfrom->GetLogName());
-
         thinrelay.ClearAllBlockData(pfrom, pblock);
-        return false;
+        return error("Received an invalid %s from peer %s\n", strCommand, pfrom->GetLogName());
     }
 
     // Is there a previous block or header to connect with?
@@ -461,8 +458,6 @@ bool CGrapheneBlock::process(CNode *pfrom, std::string strCommand, std::shared_p
     pfrom->gr_shorttxidk1 = shorttxidk1;
 
     // Create a map of all 8 bytes tx hashes pointing to their full tx hash counterpart
-    // We need to check all transaction sources (orphan list, mempool, and new (incoming) transactions in this block)
-    // for a collision.
     int missingCount = 0;
     int unnecessaryCount = 0;
     bool collision = false;

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -203,7 +203,6 @@ bool CGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     if (pblock->hashMerkleRoot != merkleroot || mutated)
     {
         thinrelay.ClearAllBlockData(pfrom, pblock);
-
         return error("Merkle root for %s does not match computed merkle root, peer=%s", inv.hash.ToString(),
             pfrom->GetLogName());
     }
@@ -695,8 +694,6 @@ static bool ReconstructBlock(CNode *pfrom,
         if (setHashes.size() != grapheneBlock->vTxHashes256.size())
         {
             thinrelay.ClearAllBlockData(pfrom, pblock);
-
-            dosMan.Misbehaving(pfrom, 10);
             return error("Repeating Transaction Id sequence, peer=%s", pfrom->GetLogName());
         }
     }

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -5,6 +5,7 @@
 #ifndef BITCOIN_GRAPHENE_H
 #define BITCOIN_GRAPHENE_H
 
+#include "blockrelay/blockrelay_common.h"
 #include "blockrelay/graphene_set.h"
 #include "bloom.h"
 #include "config.h"
@@ -138,7 +139,7 @@ public:
         // This logic assumes a smallest transaction size of MIN_TX_SIZE bytes.  This is optimistic for realistic
         // transactions and the downside for pathological blocks is just that graphene won't work so we fall back
         // to xthin
-        if (nBlockTxs > (excessiveBlockSize * maxMessageSizeMultiplier / MIN_TX_SIZE))
+        if (nBlockTxs > (thinrelay.GetMaxAllowedBlockSize() / MIN_TX_SIZE))
             throw std::runtime_error("nBlockTxs exceeds threshold for excessive block txs");
         if (!pGrapheneSet)
         {

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -140,6 +140,9 @@ bool CThinBlock::process(CNode *pfrom, std::shared_ptr<CBlockThinRelay> pblock)
     {
         thinrelay.ClearAllBlockData(pfrom, pblock);
 
+        // This is the only place where we ban a peer for having the incorrect merkelroot because the
+        // hashes provided in this thinblock must be the correct ones. (In other thintype block relay there
+        // may be instances where collisions are possibly a false positive and so we don't ban in those cases.)
         dosMan.Misbehaving(pfrom, 100);
         return error("Thinblock merkle root does not match computed merkle root, peer=%s", pfrom->GetLogName());
     }
@@ -774,8 +777,6 @@ static bool ReconstructBlock(CNode *pfrom,
         if (setHashes.size() != vHashes.size())
         {
             thinrelay.ClearAllBlockData(pfrom, pblock);
-
-            dosMan.Misbehaving(pfrom, 10);
             return error("Duplicate transaction ids, peer=%s", pfrom->GetLogName());
         }
     }

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -141,7 +141,7 @@ bool CThinBlock::process(CNode *pfrom, std::shared_ptr<CBlockThinRelay> pblock)
     {
         thinrelay.ClearAllBlockData(pfrom, pblock);
 
-        // This is the only place where we ban a peer for having the incorrect merkelroot because the
+        // This is the only place where we ban a peer for having the incorrect merkleroot because the
         // hashes provided in this thinblock must be the correct ones. (In other thintype block relay there
         // may be instances where collisions are possibly a false positive and so we don't ban in those cases.)
         dosMan.Misbehaving(pfrom, 100);
@@ -1409,7 +1409,8 @@ bool IsThinBlockValid(CNode *pfrom,
     // Check that we havn't exceeded the max allowable block size that would be reconstructed from this
     // set of hashes
     if (nHashes > (thinrelay.GetMaxAllowedBlockSize() / MIN_TX_SIZE))
-        return error("Number of hashes in thinblock or xthinblock would reconstruct a block the block size limit\n");
+        return error("Number of hashes in thinblock or xthinblock would reconstruct a block greater than the block "
+                     "size limit\n");
 
     // check block header
     CValidationState state;

--- a/src/blockrelay/thinblock.h
+++ b/src/blockrelay/thinblock.h
@@ -317,7 +317,10 @@ extern CThinBlockData thindata; // Singleton class
 bool IsThinBlocksEnabled();
 void SendXThinBlock(ConstCBlockRef pblock, CNode *pfrom, const CInv &inv);
 void RequestThinBlock(CNode *pfrom, const uint256 &hash);
-bool IsThinBlockValid(CNode *pfrom, const std::vector<CTransaction> &vMissingTx, const CBlockHeader &header);
+bool IsThinBlockValid(CNode *pfrom,
+    const std::vector<CTransaction> &vMissingTx,
+    const CBlockHeader &header,
+    const uint64_t nHashes);
 void BuildSeededBloomFilter(CBloomFilter &memPoolFilter,
     std::vector<uint256> &vOrphanHashes,
     uint256 hash,


### PR DESCRIPTION
Don't ban peers for merkelblock failure when reconstructing from a thintype block. Basically making it less ban prone in the event a block fails to reconstruct properly for any reason.

In a few areas we were passing references to shared pointers (not a good practice) instead of the shared pointer. 

Added a check before block reconstruction to pre-determine based on the number of hashes we have whether the reconstructed block would go over the size limit.