### PR TITLE
[Version2] Fix SPV edge case

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1859,13 +1859,14 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             dosMan.Misbehaving(pfrom, 100);
             return false;
         }
+
+        LOCK(pfrom->cs_filter);
+        delete pfrom->pfilter;
+        pfrom->pfilter = new CBloomFilter(filter);
+        if (!pfrom->pfilter->IsEmpty())
+            pfrom->fRelayTxes = true;
         else
-        {
-            LOCK(pfrom->cs_filter);
-            delete pfrom->pfilter;
-            pfrom->pfilter = new CBloomFilter(filter);
-        }
-        pfrom->fRelayTxes = true;
+            pfrom->fRelayTxes = false;
     }
 
 


### PR DESCRIPTION
Do not relay transactions if the bloom filter is empty

When an SPV peer sends us a filterload we were automatically turning
on fRelayTxes=true however if they send us an empty filter we were
ending up sending them all INV's whereas really we should not be sending
them any.

I'll ask Joshua to test this version out...