### PR TITLE
[port] Avoid triggering undefined behaviour in base_uint<BITS>::bits()

### DIFF
--- a/src/arith_uint256.cpp
+++ b/src/arith_uint256.cpp
@@ -187,7 +187,7 @@ unsigned int base_uint<BITS>::bits() const
         {
             for (int bits = 31; bits > 0; bits--)
             {
-                if (pn[pos] & 1 << bits)
+                if (pn[pos] & 1U << bits)
                     return 32 * pos + bits + 1;
             }
             return 32 * pos + 1;


### PR DESCRIPTION
Avoid triggering undefined behaviour in `base_uint<BITS>::bits()`.
    
`1 << 31` is undefined behaviour in C++11.
    
Given the reasonable assumption of `sizeof(int) * CHAR_BIT == 32`.

this is a port of bitcoin/bitcoin/pull/14510