### PR TITLE
[UI] Save column width/sort for peers tables on debug dialog

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -907,6 +907,21 @@ void restoreWindowGeometry(const QString &strSetting, const QSize &defaultSize, 
         parent->move(posCenter);
 }
 
+void saveColumnConfiguration(const QString &strSetting, QHeaderView *header)
+{
+    QSettings settings;
+    settings.setValue(strSetting + "Columns", header->saveState());
+}
+
+bool restoreColumnConfiguration(const QString &strSetting, QHeaderView *header)
+{
+    QSettings settings;
+    if (!settings.contains(strSetting + "Columns"))
+        return false;
+
+    return header->restoreState(settings.value(strSetting + "Columns").toByteArray());
+}
+
 void setClipboard(const QString &str)
 {
     QApplication::clipboard()->setText(str, QClipboard::Clipboard);

--- a/src/qt/guiutil.h
+++ b/src/qt/guiutil.h
@@ -199,6 +199,11 @@ void saveWindowGeometry(const QString &strSetting, QWidget *parent);
 /** Restore window size and position */
 void restoreWindowGeometry(const QString &strSetting, const QSize &defaultSizeIn, QWidget *parent);
 
+/** Save table column header configuration */
+void saveColumnConfiguration(const QString &strSetting, QHeaderView *header);
+/** Restore table column header configuration */
+bool restoreColumnConfiguration(const QString &strSetting, QHeaderView *header);
+
 /* Convert QString to OS specific boost path through UTF-8 */
 fs::path qstringToBoostPath(const QString &path);
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -986,6 +986,10 @@ void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
 void RPCConsole::resizeEvent(QResizeEvent *event) { QWidget::resizeEvent(event); }
 void RPCConsole::showEvent(QShowEvent *event)
 {
+    // restore column state
+    GUIUtil::restoreColumnConfiguration("nPeersTable", ui->peerWidget->horizontalHeader());
+    GUIUtil::restoreColumnConfiguration("nBannedPeersTable", ui->banlistWidget->horizontalHeader());
+
     QWidget::showEvent(event);
 
     if (!clientModel || !clientModel->getPeerTableModel())
@@ -1004,6 +1008,10 @@ void RPCConsole::hideEvent(QHideEvent *event)
 
     // stop PeerTableModel auto refresh
     clientModel->getPeerTableModel()->stopAutoRefresh();
+
+    // save column state
+    GUIUtil::saveColumnConfiguration("nPeersTable", ui->peerWidget->horizontalHeader());
+    GUIUtil::saveColumnConfiguration("nBannedPeersTable", ui->banlistWidget->horizontalHeader());
 }
 
 void RPCConsole::showPeersTableContextMenu(const QPoint &point)


### PR DESCRIPTION
Got tired of having to resize and resort the columns for the peers table on the debug dialog every time I restarted the client, so added functionality to save/restore this information as part of the QSettings.

I placed the save in the dialog `hideEvent` and restore in the dialog `showEvent` because attempting to do the restore earlier (in the constructor or `setClientModel`) did not behave properly.  This implementation bookends the restore and save actions with the opening and closing of the dialog.