### PR TITLE
Add syncronisation point to wallet.py when doing maintenance tests

### DIFF
--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -446,9 +446,7 @@ class WalletTest (BitcoinTestFramework):
             wait_bitcoinds()
             self.node_args = [['-usehd=0', m], ['-usehd=0', m], ['-usehd=0', m]]
             self.nodes = start_nodes(3, self.options.tmpdir, self.node_args)
-            while m == '-reindex' and [block_count] * 3 != [self.nodes[i].getblockcount() for i in range(3)]:
-                # reindex will leave rpc warm up "early"; Wait for it to finish
-                time.sleep(0.1)
+            waitFor(60, lambda : [block_count] * 3 == [self.nodes[i].getblockcount() for i in range(3)])
             assert_equal(balance_nodes, [self.nodes[i].getbalance() for i in range(3)])
 
         # Exercise listsinceblock with the last two blocks


### PR DESCRIPTION
With all our multi-threading we need to make sure the blockchain is
fully restarted during all maintenance tests , not just -reindex, and
before we do an testing for asserts.