### PR TITLE
Reduce the scope of write lock on cs_mapBlockIndex in AcceptBlock

### DIFF
--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -1660,9 +1660,11 @@ bool AcceptBlock(const CBlock &block,
     {
         if (state.IsInvalid() && !state.CorruptionPossible())
         {
-            WRITELOCK(cs_mapBlockIndex);
-            pindex->nStatus |= BLOCK_FAILED_VALID;
-            setDirtyBlockIndex.insert(pindex);
+            {
+                WRITELOCK(cs_mapBlockIndex);
+                pindex->nStatus |= BLOCK_FAILED_VALID;
+                setDirtyBlockIndex.insert(pindex);
+            }
             // Now mark every block index on every chain that contains pindex as child of invalid
             MarkAllContainingChainsInvalid(pindex);
         }


### PR DESCRIPTION
Write lock on cs_mapBlockIndex need to be taken just to mark current
block as invalid w/o waiting for MarkAllContainingChainsInvalid() to
return.

Previous to this change we could end up in a deadlock due to the
fact we end up tacking locks in this order:

WRITELOCK(cs_mapBlockIndex);
LOCK(cs_main)
READLOCK(cs_mapBlockIndex);

this could potentially lead to the same thread taking a write and read
lock at the same time. Orther than that cs_main must be taken before
cs_mapBlockIndex to avoid deadlocks among different threads.