### PR TITLE
Do not DbgAssert on regtest when checking peers connected

### DIFF
--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -41,9 +41,21 @@ void ThinTypeRelay::RemovePeers(CNode *pfrom)
         if (pfrom->fSupportsCompactBlocks)
             nCompactBlockPeers--;
 
-        DbgAssert(nThinBlockPeers >= 0, nThinBlockPeers = 0);
-        DbgAssert(nGraphenePeers >= 0, nGraphenePeers = 0);
-        DbgAssert(nCompactBlockPeers >= 0, nCompactBlockPeers = 0);
+        if (nThinBlockPeers < 0)
+        {
+            nThinBlockPeers = 0;
+            LOG(THIN | GRAPHENE | CMPCT, "WARNING: nThinBlockPeers was less than zero");
+        }
+        if (nGraphenePeers < 0)
+        {
+            nGraphenePeers = 0;
+            LOG(THIN | GRAPHENE | CMPCT, "WARNING: nGraphenePeers was less than zero");
+        }
+        if (nCompactBlockPeers < 0)
+        {
+            nCompactBlockPeers = 0;
+            LOG(THIN | GRAPHENE | CMPCT, "WARNING: nCompactBlockPeers was less than zero");
+        }
     }
 }
 


### PR DESCRIPTION
Using DbgAsserts() causes us headaches with our unit tests because
of the need then to properly track all peer types connected. This
is not easy to apply globally in the unit tests because of the way
the counting is intitiated by making a proper connection with an
exchange of the VERSION message. Futhermore, it's not really necessary
to have the DbgAsserts() anymore since we now have a good python test
which ensures this functionality is working.

Rather we can log a message if logging is turned on for thintype blocks
which gives us a warning in the log file if these counts ever go negative.