### PR TITLE
Change May 2019 activation code to work by block height

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -134,8 +134,8 @@ public:
         consensus.may2018Height = 530359;
         // Nov, 15 2018 hard fork
         consensus.nov2018Height = 556766;
-        // Wed, 15 May 2019 12:00:00 UTC hard fork activation time
-        consensus.may2019ActivationTime = 1557921600;
+        // May, 15 2019 hard fork
+        consensus.may2019Height = 582679;
 
         /**
          * The message start string is designed to be unlikely to occur in normal data.
@@ -275,8 +275,8 @@ public:
         consensus.may2018Height = 0;
         // Nov, 15 2018 hard fork
         consensus.nov2018Height = 0;
-        // Wed, 15 May 2019 12:00:00 UTC hard fork activation time
-        consensus.may2019ActivationTime = 1557921600;
+        // May, 15 2019 hard fork
+        consensus.may2019Height = 0;
 
         vFixedSeeds.clear();
         vSeeds.clear();
@@ -342,8 +342,8 @@ public:
         consensus.may2018Height = 1233070;
         // Nov 15, 2018 hard fork
         consensus.nov2018Height = 1267996;
-        // Wed, 15 May 2019 12:00:00 UTC hard fork activation time
-        consensus.may2019ActivationTime = 1557921600;
+        // May, 15 2019 hard fork
+        consensus.may2019Height = 1303884;
 
 
         pchMessageStart[0] = 0x0b;
@@ -459,8 +459,8 @@ public:
         consensus.may2018Height = 0;
         // Nov, 15 2018 hard fork is always active on regtest
         consensus.nov2018Height = 0;
-        // Wed, 15 May 2019 12:00:00 UTC hard fork activation time
-        consensus.may2019ActivationTime = 1557921600;
+        // May, 15 2019 hard fork
+        consensus.may2019Height = 0;
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -210,13 +210,15 @@ public:
         checkpoints[530359] = uint256S("0x0000000000000000011ada8bd08f46074f44a8f155396f43e38acf9501c49103");
         // Nov 15th 2018 activate LTOR, DSV op_code
         checkpoints[556767] = uint256S("0x0000000000000000004626ff6e3b936941d341c5932ece4357eeccac44e6d56c");
+        // May 15th 2019 activate Schnorr, segwit recovery
+        checkpoints[582680] = uint256S("0x000000000000000001b4b8e36aec7d4f9671a47872cb9a74dc16ca398c7dcc18");
 
 
         // clang-format on
         // * UNIX timestamp of last checkpoint block
-        checkpointData.nTimeLastCheckpoint = 1542304936;
+        checkpointData.nTimeLastCheckpoint = 1557922919;
         // * total number of transactions between genesis and last checkpoint
-        checkpointData.nTransactionsLastCheckpoint = 265567564;
+        checkpointData.nTransactionsLastCheckpoint = 271769178;
         // * estimated number of transactions per day after checkpoint (~3.5 TPS)
         checkpointData.fTransactionsPerDay = 280000.0;
     }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -397,11 +397,28 @@ public:
         fMineBlocksOnDemand = false;
         fTestnetToBeDeprecatedFieldRPC = true;
 
-        checkpointData =
-            (CCheckpointData){boost::assign::map_list_of(546,
-                                  uint256S("000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70"))(1155876,
-                                  uint256S("00000000000e38fef93ed9582a7df43815d5c2ba9fd37ef70c9a0ea4a285b8f5")),
-                1501616524, 1488, 300};
+        // clang-format off
+        checkpointData = CCheckpointData();
+        MapCheckpoints &checkpoints = checkpointData.mapCheckpoints;
+        checkpoints[546]     = uint256S("0x000000002a936ca763904c3c35fce2f3556c559c0214345d31b1bcebf76acb70");
+        // August 1st 2017 CASH fork (UAHF) activation block
+        checkpoints[1155876] = uint256S("0x00000000000e38fef93ed9582a7df43815d5c2ba9fd37ef70c9a0ea4a285b8f5");
+        // Nov, 13th 2017. DAA activation block.
+        checkpoints[1188697] = uint256S("0x0000000000170ed0918077bde7b4d36cc4c91be69fa09211f748240dabe047fb");
+        // May 15th 2018, re-enabling opcodes, max block size 32MB
+        checkpoints[1233070] = uint256S("0x0000000000000253c6201a2076663cfe4722e4c75f537552cc4ce989d15f7cd5");
+        // Nov 15th 2018, CHECKDATASIG, ctor
+        checkpoints[1267996] = uint256S("0x00000000000001fae0095cd4bea16f1ce8ab63f3f660a03c6d8171485f484b24");
+        // May 15th 2019, Schnorr + segwit recovery activation block
+        checkpoints[1303885] = uint256S("0x00000000000000479138892ef0e4fa478ccc938fb94df862ef5bde7e8dee23d3");
+
+        // clang-format on
+        // Data as of block
+        checkpointData.nTimeLastCheckpoint = 1557923294;
+        // * total number of transactions between genesis and last checkpoint
+        checkpointData.nTransactionsLastCheckpoint = 23468264;
+        // * estimated number of transactions per day after checkpoint (~1.6 TPS)
+        checkpointData.fTransactionsPerDay = 140000;
     }
 };
 static CTestNetParams testNetParams;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -152,7 +152,10 @@ struct Params
     /** Nov 15, 2018 activation height */
     int nov2018Height;
     /** May 15, 2019 actication time will be 12:00:00 UTC */
-    int may2019ActivationTime;
+    // we still need this variable until we won't add Nov 2019 activation time
+    int may2019ActivationTime = 1557921600;
+    /** May 15, 2019 actication height */
+    int may2019Height;
 };
 } // namespace Consensus
 

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -622,9 +622,9 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
     const uint32_t cds_flag =
         (IsNov2018Activated(chainparams.GetConsensus(), chainActive.Tip())) ? SCRIPT_ENABLE_CHECKDATASIG : 0;
     const uint32_t schnorrflag =
-        (IsMay2019Enabled(chainparams.GetConsensus(), chainActive.Tip())) ? SCRIPT_ENABLE_SCHNORR : 0;
+        (IsMay2019Activated(chainparams.GetConsensus(), chainActive.Tip())) ? SCRIPT_ENABLE_SCHNORR : 0;
     const uint32_t segwit_flag =
-        (IsMay2019Enabled(chainparams.GetConsensus(), chainActive.Tip()) && !fRequireStandard) ?
+        (IsMay2019Activated(chainparams.GetConsensus(), chainActive.Tip()) && !fRequireStandard) ?
             SCRIPT_ALLOW_SEGWIT_RECOVERY :
             0;
 

--- a/src/validation/forks.cpp
+++ b/src/validation/forks.cpp
@@ -96,11 +96,16 @@ bool IsNov2018Activated(const Consensus::Params &consensusparams, const CBlockIn
     return IsNov2018Activated(consensusparams, pindexTip->nHeight);
 }
 
-bool IsMay2019Enabled(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip)
+bool IsMay2019Activated(const Consensus::Params &consensusparams, const int32_t nHeight)
+{
+    return nHeight >= consensusparams.may2019Height;
+}
+
+bool IsMay2019Activated(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip)
 {
     if (pindexTip == nullptr)
     {
         return false;
     }
-    return pindexTip->IsforkActiveOnNextBlock(miningForkTime.Value());
+    return IsMay2019Activated(consensusparams, pindexTip->nHeight);
 }

--- a/src/validation/forks.cpp
+++ b/src/validation/forks.cpp
@@ -104,12 +104,3 @@ bool IsMay2019Enabled(const Consensus::Params &consensusparams, const CBlockInde
     }
     return pindexTip->IsforkActiveOnNextBlock(miningForkTime.Value());
 }
-
-bool IsMay2019Next(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip)
-{
-    if (pindexTip == nullptr)
-    {
-        return false;
-    }
-    return pindexTip->forkAtNextBlock(miningForkTime.Value());
-}

--- a/src/validation/forks.h
+++ b/src/validation/forks.h
@@ -42,9 +42,6 @@ bool IsDAAEnabled(const Consensus::Params &consensusparams, const CBlockIndex *p
 bool IsNov2018Activated(const Consensus::Params &consensusparams, const int32_t nHeight);
 bool IsNov2018Activated(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip);
 
-/** Check if the next will be the first block where the new set of rules will be enforced */
-bool IsMay2019Next(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip);
-
 /** Test if May 15th 2019 fork has actived */
 bool IsMay2019Enabled(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip);
 

--- a/src/validation/forks.h
+++ b/src/validation/forks.h
@@ -43,6 +43,7 @@ bool IsNov2018Activated(const Consensus::Params &consensusparams, const int32_t 
 bool IsNov2018Activated(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip);
 
 /** Test if May 15th 2019 fork has actived */
-bool IsMay2019Enabled(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip);
+bool IsMay2019Activated(const Consensus::Params &consensusparams, const int32_t nHeight);
+bool IsMay2019Activated(const Consensus::Params &consensusparams, const CBlockIndex *pindexTip);
 
 #endif

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -1769,7 +1769,7 @@ uint32_t GetBlockScriptFlags(const CBlockIndex *pindex, const Consensus::Params 
     // 65/64-byte Schnorr signatures in CHECKSIG and CHECKDATASIG respectively,
     // and their verify variants. We also stop accepting 65 byte signatures in
     // CHECKMULTISIG and its verify variant.
-    if (IsMay2019Enabled(consensusparams, pindex->pprev))
+    if (IsMay2019Activated(consensusparams, pindex->pprev))
     {
         flags |= SCRIPT_ALLOW_SEGWIT_RECOVERY;
         flags |= SCRIPT_ENABLE_SCHNORR;
@@ -2874,7 +2874,8 @@ bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusPa
 
     if (IsNov2018Activated(consensusParams, chainActive.Tip()))
     {
-        if (IsMay2019Enabled(consensusParams, pindexDelete) && !IsMay2019Enabled(consensusParams, pindexDelete->pprev))
+        if (IsMay2019Activated(consensusParams, pindexDelete) &&
+            !IsMay2019Activated(consensusParams, pindexDelete->pprev))
         {
             mempool.clear();
         }

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -2872,13 +2872,9 @@ bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusPa
     // If this block enabled the may152019 protocol upgrade, then we need to clear the mempool of any transaction using
     // not previously avaiable features (e.g. OP_CHECKDATASIGVERIFY).
 
-    if (IsNov2018Activated(consensusParams, chainActive.Tip()))
+    if (IsMay2019Activated(consensusParams, pindexDelete) && !IsMay2019Activated(consensusParams, pindexDelete->pprev))
     {
-        if (IsMay2019Activated(consensusParams, pindexDelete) &&
-            !IsMay2019Activated(consensusParams, pindexDelete->pprev))
-        {
-            mempool.clear();
-        }
+        mempool.clear();
     }
 
     // these bloom filters stop us from doing duplicate work on tx we already know about.


### PR DESCRIPTION
Probably won't be needed once we got #1750 in and also another future one to make Schnorr and segwit recovery flag active by default (because they were additive changes). I'm not entirely sure about the latter 2 so I put out this PR as a place holder rather than anything else.

This PR is build **on top of #1770**