### PR TITLE
[Giga-Net:Experimental] Refactor SendRequests() to send by peer rather than in one batch

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2295,7 +2295,8 @@ void ThreadMessageHandler()
             }
             if (shutdown_threads.load() == true)
             {
-                break; // skip down to where we release the node refs
+                // release the node refs
+                break;
             }
 
             // Put transaction and block requests into the request manager
@@ -2314,14 +2315,12 @@ void ThreadMessageHandler()
             }
             if (shutdown_threads.load() == true)
             {
-                break; // skip down to where we release the node refs
+                // release the node refs
+                break;
             }
+            requester.SendRequests(pnode);
         }
 
-        // From the request manager, make requests for transactions and blocks. We do this before potentially
-        // sleeping in the step below so as to allow requests to return during the sleep time.
-        if (shutdown_threads.load() == false)
-            requester.SendRequests();
 
         // A cs_vNodes lock is not required here when releasing refs for two reasons: one, this only decrements
         // an atomic counter, and two, the counter will always be > 0 at this point, so we don't have to worry

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -736,6 +736,13 @@ void CRequestManager::SendRequests(CNode *pnode)
                         item->lastRequestTime = nPreviousRequestTime;
                     }
 
+                    // Move the item to the back of the queue
+                    if (blkPeerIter->second.size() >= 2)
+                    {
+                        blkPeerIter->second.push_back(blkPeerIter->second.front());
+                        blkPeerIter->second.pop_front();
+                    }
+
                     // Break because the queue won't be empty
                     break;
                 }

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -215,7 +215,8 @@ public:
     // Resets the last request time to zero when a node disconnects and has blocks in flight.
     void ResetLastBlockRequestTime(const uint256 &hash);
 
-    void SendRequests();
+    // Sends all message requests for a particular node
+    void SendRequests(CNode *pnode);
 
     // Check whether the limit for thintype object requests has been exceeded
     bool CheckForRequestDOS(CNode *pfrom, const CChainParams &chainparams);

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -2081,13 +2081,15 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
 {
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("time", GetTime());
+    ret.pushKV("requester.mapTxnInfo_ByPeer", (uint64_t)requester.mapTxnInfo_ByPeer.size());
+    ret.pushKV("requester.mapBlkInfo_ByPeer", (uint64_t)requester.mapBlkInfo_ByPeer.size());
     ret.pushKV("requester.mapTxnInfo", (uint64_t)requester.mapTxnInfo.size());
     ret.pushKV("requester.mapBlkInfo", (uint64_t)requester.mapBlkInfo.size());
     unsigned long int max = 0;
     unsigned long int size = 0;
     for (CRequestManager::OdMap::iterator i = requester.mapTxnInfo.begin(); i != requester.mapTxnInfo.end(); i++)
     {
-        unsigned long int temp = i->second.availableFrom.size();
+        unsigned long int temp = i->second->availableFrom.size();
         size += temp;
         if (max < temp)
             max = temp;
@@ -2099,7 +2101,7 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
     size = 0;
     for (CRequestManager::OdMap::iterator i = requester.mapBlkInfo.begin(); i != requester.mapBlkInfo.end(); i++)
     {
-        unsigned long int temp = i->second.availableFrom.size();
+        unsigned long int temp = i->second->availableFrom.size();
         size += temp;
         if (max < temp)
             max = temp;

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -2081,10 +2081,20 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
 {
     UniValue ret(UniValue::VOBJ);
     ret.pushKV("time", GetTime());
-    ret.pushKV("requester.mapTxnInfo_ByPeer", (uint64_t)requester.mapTxnInfo_ByPeer.size());
-    ret.pushKV("requester.mapBlkInfo_ByPeer", (uint64_t)requester.mapBlkInfo_ByPeer.size());
-    ret.pushKV("requester.mapTxnInfo", (uint64_t)requester.mapTxnInfo.size());
-    ret.pushKV("requester.mapBlkInfo", (uint64_t)requester.mapBlkInfo.size());
+    {
+        uint64_t nSizeTxnInfoByPeer = 0;
+        uint64_t nSizeBlkInfoByPeer = 0;
+        LOCK(requester.cs_objDownloader);
+        for (auto iter : requester.mapTxnInfo_ByPeer)
+        {
+            nSizeTxnInfoByPeer += (requester.mapTxnInfo_ByPeer.at(iter.first)).size();
+            nSizeBlkInfoByPeer += (requester.mapTxnInfo_ByPeer.at(iter.first)).size();
+        }
+        ret.pushKV("requester.mapTxnInfo_ByPeer", nSizeTxnInfoByPeer);
+        ret.pushKV("requester.mapBlkInfo_ByPeer", nSizeBlkInfoByPeer);
+        ret.pushKV("requester.mapTxnInfo", (uint64_t)requester.mapTxnInfo.size());
+        ret.pushKV("requester.mapBlkInfo", (uint64_t)requester.mapBlkInfo.size());
+    }
     unsigned long int max = 0;
     unsigned long int size = 0;
     for (CRequestManager::OdMap::iterator i = requester.mapTxnInfo.begin(); i != requester.mapTxnInfo.end(); i++)


### PR DESCRIPTION
Currently SendRequests() sends out all block/txn requests in one batch for all peers combined causing a bursty network traffic. By sending them out by peer right after we process SendMessages(pnode), we can smooth out this traffic and hopefully get a more sustained and higher throughput (hopefully much higher).  I think this bears out by casual observation during IBD but I'd like to try this out during giga-net testing to verify.  This new approach however does require more memory but I think its' well contained and again we'll need to verify the data structures don't get out of hand.  

The approach is to simulate a multi-index container using two datasets (a map and a deque) linked by shared pointers to their underlying data.  (I looked at using boost containers but found them difficult for what I was trying to do and I believe I would have ended up with much larger datasets ).   The map is the standard OdMap that we already use and is accessed by hash, whereas the deque contains shared pointers to the CUnknownObj which are also referenced in the OdMap.  We make requests by looking in the deque and delete objects when they're received in the OdMap by hash...secondarily we delete the objects from the deque in a somewhat lazy fashion when either we requested them or they were received and are processing or have been processed.

