### PR TITLE
Fix bug in limitfreerelay

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -22,6 +22,7 @@
 #include "tinyformat.h"
 #include "torcontrol.h"
 #include "tweak.h"
+#include "txadmission.h"
 #include "txdb.h"
 #include "util.h"
 #include "utilmoneystr.h"

--- a/src/main.h
+++ b/src/main.h
@@ -126,12 +126,6 @@ static const uint32_t UNCONNECTED_HEADERS_TIMEOUT = 120;
 /** Maximum number of INV's that can be send in one message */
 static const int MAX_INV_TO_SEND = 1000;
 
-/** The maximum number of free transactions (in KB) that can enter the mempool per minute.
- *  For a 1MB block we allow 15KB of free transactions per 1 minute.
- */
-static const uint32_t DEFAULT_LIMITFREERELAY = DEFAULT_BLOCK_MAX_SIZE * 0.000015;
-/** Subject free transactions to priority checking when entering the mempool */
-static const bool DEFAULT_RELAYPRIORITY = false;
 /** The number of MiB that we will wait for the block storage method to go over before pruning */
 static const uint64_t DEFAULT_PRUNE_INTERVAL = 100;
 
@@ -155,17 +149,6 @@ static const bool DEFAULT_PEERBLOOMFILTERS = true;
 static const bool DEFAULT_REINDEX = false;
 static const bool DEFAULT_DISCOVER = true;
 static const bool DEFAULT_PRINTTOCONSOLE = false;
-
-// BU - Xtreme Thinblocks Auto Mempool Limiter - begin section
-/** The default value for -minrelaytxfee in sat/byte */
-static const double DEFAULT_MINLIMITERTXFEE = (double)DEFAULT_MIN_RELAY_TX_FEE / 1000;
-/** The default value for -maxrelaytxfee in sat/byte */
-static const double DEFAULT_MAXLIMITERTXFEE = (double)DEFAULT_MIN_RELAY_TX_FEE / 1000;
-/** The number of block heights to gradually choke spam transactions over */
-static const unsigned int MAX_BLOCK_SIZE_MULTIPLIER = 3;
-/** The minimum value possible for -limitfreerelay when rate limiting */
-static const unsigned int DEFAULT_MIN_LIMITFREERELAY = 1;
-// BU - Xtreme Thinblocks Auto Mempool Limiter - end section
 
 struct BlockHasher
 {

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -10,7 +10,7 @@
 #include "dosman.h"
 #include "fastfilter.h"
 #include "init.h"
-#include "main.h" // for cs_main
+#include "main.h"
 #include "net.h"
 #include "parallel.h"
 #include "requestManager.h"

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -872,7 +872,8 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
             LOG(MEMPOOL, "MempoolBytes:%d  LimitFreeRelay:%.5g  nMinRelay:%.4g  FeesSatoshiPerByte:%.4g  TxBytes:%d  "
                          "TxFees:%d\n",
                 poolBytes, nFreeLimit, nMinRelay, ((double)nFees) / nSize, nSize, nFees);
-            if (fLimitFree && nFees < ::minRelayTxFee.GetFee(nSize))
+            if ((fLimitFree && nFees < ::minRelayTxFee.GetFee(nSize)) ||
+                (nLimitFreeRelay == 0 && nFees < ::minRelayTxFee.GetFee(nSize)))
             {
                 static double dFreeCount = 0;
 

--- a/src/txadmission.h
+++ b/src/txadmission.h
@@ -6,10 +6,28 @@
 #define BITCOIN_TXADMISSION_H
 
 #include "fastfilter.h"
+#include "main.h"
 #include "net.h"
 #include "threadgroup.h"
 #include "txmempool.h"
 #include <queue>
+
+/** The default value for -minrelaytxfee in sat/byte */
+static const double DEFAULT_MINLIMITERTXFEE = (double)DEFAULT_MIN_RELAY_TX_FEE / 1000;
+/** The default value for -maxrelaytxfee in sat/byte */
+static const double DEFAULT_MAXLIMITERTXFEE = (double)DEFAULT_MIN_RELAY_TX_FEE / 1000;
+/** The number of block heights to gradually choke spam transactions over */
+static const unsigned int MAX_BLOCK_SIZE_MULTIPLIER = 3;
+
+/** The maximum number of free transactions (in KB) that can enter the mempool per minute.
+ *  For a 1MB block we allow 15KB of free transactions per 1 minute.
+ */
+static const uint32_t DEFAULT_LIMITFREERELAY = DEFAULT_BLOCK_MAX_SIZE * 0.000015;
+/** The minimum value possible for -limitfreerelay when rate limiting */
+static const unsigned int DEFAULT_MIN_LIMITFREERELAY = 1;
+
+/** Subject free transactions to priority checking when entering the mempool */
+static const bool DEFAULT_RELAYPRIORITY = false;
 
 /**
  * Filter for transactions that were recently rejected by


### PR DESCRIPTION
It was reported that some free transactions were still getting through even though the operator had set limitfreerelay=0.  