### PR TITLE
[travis] fix unit tests execution

### DIFF
--- a/.travis/script_a.sh
+++ b/.travis/script_a.sh
@@ -44,9 +44,6 @@ END_FOLD
 
 BEGIN_FOLD make
 DOCKER_EXEC make $MAKEJOBS $GOAL || ( echo "Build failure. Verbose build follows." && DOCKER_EXEC make $GOAL V=1 ; false ) ;
-if [ "$RUN_TESTS" = "true" ] && { [ "$HOST" = "i686-w64-mingw32" ] || [ "$HOST" = "x86_64-w64-mingw32" ]; }; then
-  travis_wait 50 DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1;
-fi
 END_FOLD
 
 cd ${TRAVIS_BUILD_DIR} || (echo "could not enter travis build dir $TRAVIS_BUILD_DIR"; exit 1)

--- a/.travis/script_b.sh
+++ b/.travis/script_b.sh
@@ -13,7 +13,7 @@ cd "build" || (echo "could not enter distdir build"; exit 1)
 
 BEGIN_FOLD unit-tests
 if [ "$RUN_TESTS" = "true" ] && ! { [ "$HOST" = "i686-w64-mingw32" ] || [ "$HOST" = "x86_64-w64-mingw32" ]; }; then
-  DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1;
+  travis_wait 50 DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1;
 fi
 END_FOLD
 


### PR DESCRIPTION
We used to execute unit tests (make check) twice, both in script_a.sh
and script_b.sh. Removed 'make check' execution from the former.