### PR TITLE
Ban SV peers by checking the user agent string in order to prevent the orphan pool filling up

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -486,8 +486,11 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             pfrom->cleanSubVer = SanitizeString(pfrom->strSubVer);
 
             // ban SV peers
-            if (pfrom->strSubVer.find("Bitcoin SV") != std::string::npos)
+            if (pfrom->strSubVer.find("Bitcoin SV") != std::string::npos ||
+                pfrom->strSubVer.find("(SV;") != std::string::npos)
+            {
                 dosMan.Misbehaving(pfrom, 100);
+            }
         }
         if (!vRecv.empty())
             vRecv >> pfrom->nStartingHeight;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -484,6 +484,10 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         {
             vRecv >> LIMITED_STRING(pfrom->strSubVer, MAX_SUBVERSION_LENGTH);
             pfrom->cleanSubVer = SanitizeString(pfrom->strSubVer);
+
+            // ban SV peers
+            if (pfrom->strSubVer.find("Bitcoin SV") != std::string::npos)
+                dosMan.Misbehaving(pfrom, 100);
         }
         if (!vRecv.empty())
             vRecv >> pfrom->nStartingHeight;


### PR DESCRIPTION
While this is not entirely the best thing we could do it does prevent
current SV peers from connecting and filling our orphan cache. A longer
term solution would be to use a new service bit but that would
require a multi implementation co-ordination which would take a while
to implement. But at least for the short term the current solution
offers immediate relief from the barrage of orphans we sometimes
receive.