### PR TITLE
Remove initializtion of nLastBlockSize in the requestManager constructor

### DIFF
--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -100,7 +100,6 @@ CRequestManager::CRequestManager()
 {
     inFlight = 0;
     nOutbound = 0;
-    nLastBlockSize = 0;
 
     sendIter = mapTxnInfo.end();
     sendBlkIter = mapBlkInfo.end();


### PR DESCRIPTION
nLastBlockSize is actually a global variable used in the miner. This
initializtion accidentaally slipped in by PR #1785