### PR TITLE
[rpc] Fix electrum monitor parsing of long ints

### DIFF
--- a/src/electrum/electrs.cpp
+++ b/src/electrum/electrs.cpp
@@ -98,7 +98,7 @@ std::vector<std::string> electrs_args(int rpcport, const std::string &network)
     return args;
 }
 
-std::map<std::string, int> fetch_electrs_info()
+std::map<std::string, int64_t> fetch_electrs_info()
 {
     if (!GetBoolArg("-electrum", false))
     {
@@ -108,7 +108,7 @@ std::map<std::string, int> fetch_electrs_info()
     std::stringstream infostream = http_get(monitoring_host(), std::stoi(monitoring_port()), "/");
 
     const std::regex keyval("^([a-z_]+)\\s(\\d+)\\s*$");
-    std::map<std::string, int> info;
+    std::map<std::string, int64_t> info;
     std::string line;
     std::smatch match;
     while (std::getline(infostream, line, '\n'))
@@ -117,7 +117,14 @@ std::map<std::string, int> fetch_electrs_info()
         {
             continue;
         }
-        info[match[1].str()] = std::stoi(match[2].str());
+        try
+        {
+            info[match[1].str()] = std::stol(match[2].str());
+        }
+        catch (const std::exception &e)
+        {
+            LOG(ELECTRUM, "%s error: %s", __func__, e.what());
+        }
     }
     return info;
 }

--- a/src/electrum/electrs.h
+++ b/src/electrum/electrs.h
@@ -16,7 +16,7 @@ namespace electrum {
 std::string electrs_path();
 std::vector<std::string> electrs_args(int rpcport, const std::string& network);
 
-std::map<std::string, int> fetch_electrs_info();
+std::map<std::string, int64_t> fetch_electrs_info();
 
 } // ns electrum
 

--- a/src/electrum/electrumrpcinfo.cpp
+++ b/src/electrum/electrumrpcinfo.cpp
@@ -11,7 +11,7 @@
 
 namespace electrum
 {
-static int64_t get_index_height(const std::map<std::string, int> &info)
+static int64_t get_index_height(const std::map<std::string, int64_t> &info)
 {
     auto height_it = info.find(INDEX_HEIGHT_KEY);
     if (height_it == end(info))
@@ -64,7 +64,7 @@ void ElectrumRPCInfo::ThrowHelp()
 int ElectrumRPCInfo::ActiveTipHeight() const { return chainActive.Height(); }
 bool ElectrumRPCInfo::IsInitialBlockDownload() const { return ::IsInitialBlockDownload(); }
 bool ElectrumRPCInfo::IsRunning() const { return ElectrumServer::Instance().IsRunning(); }
-std::map<std::string, int> ElectrumRPCInfo::FetchElectrsInfo() const { return fetch_electrs_info(); }
+std::map<std::string, int64_t> ElectrumRPCInfo::FetchElectrsInfo() const { return fetch_electrs_info(); }
 std::string ElectrumRPCInfo::GetStatus(int64_t index_height) const
 {
     if (!this->IsRunning())

--- a/src/electrum/electrumrpcinfo.h
+++ b/src/electrum/electrumrpcinfo.h
@@ -24,7 +24,7 @@ protected:
     virtual int ActiveTipHeight() const;
     virtual bool IsInitialBlockDownload() const;
     virtual bool IsRunning() const;
-    virtual std::map<std::string, int> FetchElectrsInfo() const;
+    virtual std::map<std::string, int64_t> FetchElectrsInfo() const;
 
 private:
     std::string GetStatus(int64_t index_height) const;

--- a/src/test/electrumrpcinfo_tests.cpp
+++ b/src/test/electrumrpcinfo_tests.cpp
@@ -17,12 +17,12 @@ public:
     bool ibd = false;
     bool isrunning = false;
     int height = 0;
-    std::map<std::string, int> info;
+    std::map<std::string, int64_t> info;
 
     int ActiveTipHeight() const override { return height; }
     bool IsInitialBlockDownload() const override { return ibd; }
     bool IsRunning() const override { return isrunning; }
-    std::map<std::string, int> FetchElectrsInfo() const override { return info; }
+    std::map<std::string, int64_t> FetchElectrsInfo() const override { return info; }
 };
 
 BOOST_FIXTURE_TEST_SUITE(electrumrpcinfo_tests, BasicTestingSetup)
@@ -83,6 +83,15 @@ BOOST_AUTO_TEST_CASE(info_indexheight)
     rpc.info = {{INDEX_HEIGHT_KEY, 100}};
     status = rpc.GetElectrumInfo();
     BOOST_CHECK_EQUAL(100, status["index_height"].get_int());
+}
+
+BOOST_AUTO_TEST_CASE(info_can_handle_longint)
+{
+    ElectrumRPCInfoMOC rpc;
+
+    rpc.info = {{INDEX_HEIGHT_KEY, std::numeric_limits<int64_t>::max()}};
+    UniValue status = rpc.GetElectrumInfo();
+    BOOST_CHECK_EQUAL(std::numeric_limits<int64_t>::max(), status["index_height"].get_int64());
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes issue where the `electrumrpc` rpc call would throw on std::stoi due to runtime info containing long integers.