### PR TITLE
Bump electrs to v0.7.0

### DIFF
--- a/contrib/electrs/build_electrs.py
+++ b/contrib/electrs/build_electrs.py
@@ -5,8 +5,8 @@ import os
 import sys
 import shutil
 GIT_REPO = "https://github.com/dagurval/electrs.git"
-GIT_BRANCH = "v0.6.1bu"
-EXPECT_HEAD = "175c1d161b5d30c60a20b5b9922e65fd05e6b59c"
+GIT_BRANCH = "v0.7.0bu"
+EXPECT_HEAD = "5d37e7fe52e5cd81c00f269ad09dd32a835ff808"
 
 ROOT_DIR = os.path.realpath(
         os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))


### PR DESCRIPTION
Bump electrs version. This version adds backward compatibility with Rust 1.32 (which is what BU uses) and fixes #1767. I have tested gitian build on this branch. [Full changelog](https://github.com/dagurval/electrs/blob/master/RELEASE-NOTES.md).