### PR TITLE
Disable eletrumserver unit tests if boost version is lower than 1.65

### DIFF
--- a/src/test/electrumserver_tests.cpp
+++ b/src/test/electrumserver_tests.cpp
@@ -12,7 +12,7 @@ BOOST_FIXTURE_TEST_SUITE(electrumserver_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(isrunning)
 {
-#if BOOST_OS_LINUX
+#if (BOOST_OS_LINUX && (BOOST_VERSION >= 106500))
     if (!boost::filesystem::exists("/bin/sleep"))
     {
         std::cout << "Skipping " << __func__ << std::endl;

--- a/src/test/utilprocess_tests.cpp
+++ b/src/test/utilprocess_tests.cpp
@@ -26,7 +26,7 @@ static bool bin_exists(const std::string &path) { return boost::filesystem::exis
 BOOST_AUTO_TEST_CASE(subprocess_return_code)
 {
     auto dummy_callb = [](const std::string &) {};
-#if BOOST_OS_LINUX
+#if (BOOST_OS_LINUX && (BOOST_VERSION >= 106500))
 
     if (!bin_exists("/bin/true") || !bin_exists("/bin/false"))
     {
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(subprocess_stdout)
     std::vector<std::string> callback_lines;
     auto callb = [&callback_lines](const std::string &line) { callback_lines.push_back(line); };
 
-#if BOOST_OS_LINUX
+#if (BOOST_OS_LINUX && (BOOST_VERSION >= 106500))
     if (!bin_exists("/bin/echo"))
     {
         std::cerr << "Skipping test " << __func__ << std::endl;
@@ -74,7 +74,8 @@ BOOST_AUTO_TEST_CASE(subprocess_stdout)
 BOOST_AUTO_TEST_CASE(subprocess_terminate)
 {
     auto dummy_callb = [](const std::string &) {};
-#if BOOST_OS_LINUX
+
+#if (BOOST_OS_LINUX && (BOOST_VERSION >= 106500))
     if (!bin_exists("/bin/sleep"))
     {
         std::cerr << "Skipping test " << __func__ << std::endl;
@@ -107,7 +108,7 @@ BOOST_AUTO_TEST_CASE(subprocess_terminate)
 BOOST_AUTO_TEST_CASE(subprocess_non_existing_path)
 {
     auto dummy_callb = [](const std::string &) {};
-#if BOOST_OS_LINUX
+#if (BOOST_OS_LINUX && (BOOST_VERSION >= 106500))
     const std::string path = "/nonexistingpath";
     if (bin_exists(path))
     {


### PR DESCRIPTION
With boost library that comes with Ubuntu 16.04 (1.58) running unit
tests related to the electrs process lead to this kind of errors:

```
Entering test suite "Bitcoin Test Suite"
Entering test suite "electrumserver_tests"
Entering test case "isrunning"
unknown location(0): fatal error in "isrunning": child was killed; pid:
26922; uid: 1003; exit value: 2
test/electrumserver_tests.cpp(23): last checkpoint
Leaving test case "isrunning"; testing time: 17834mks
```

This is due to the way older version of boost deal with SIGCHLD.