### PR TITLE
Declare aux variable only if we are actually using it.

### DIFF
--- a/src/test/utilprocess_tests.cpp
+++ b/src/test/utilprocess_tests.cpp
@@ -25,8 +25,8 @@ BOOST_AUTO_TEST_CASE(this_process_path_test)
 static bool bin_exists(const std::string &path) { return boost::filesystem::exists(path); }
 BOOST_AUTO_TEST_CASE(subprocess_return_code)
 {
-    auto dummy_callb = [](const std::string &) {};
 #if (BOOST_OS_LINUX && (BOOST_VERSION >= 106500))
+    auto dummy_callb = [](const std::string &) {};
 
     if (!bin_exists("/bin/true") || !bin_exists("/bin/false"))
     {
@@ -54,10 +54,10 @@ BOOST_AUTO_TEST_CASE(subprocess_return_code)
 
 BOOST_AUTO_TEST_CASE(subprocess_stdout)
 {
+#if (BOOST_OS_LINUX && (BOOST_VERSION >= 106500))
     std::vector<std::string> callback_lines;
     auto callb = [&callback_lines](const std::string &line) { callback_lines.push_back(line); };
 
-#if (BOOST_OS_LINUX && (BOOST_VERSION >= 106500))
     if (!bin_exists("/bin/echo"))
     {
         std::cerr << "Skipping test " << __func__ << std::endl;
@@ -73,9 +73,9 @@ BOOST_AUTO_TEST_CASE(subprocess_stdout)
 
 BOOST_AUTO_TEST_CASE(subprocess_terminate)
 {
+#if (BOOST_OS_LINUX && (BOOST_VERSION >= 106500))
     auto dummy_callb = [](const std::string &) {};
 
-#if (BOOST_OS_LINUX && (BOOST_VERSION >= 106500))
     if (!bin_exists("/bin/sleep"))
     {
         std::cerr << "Skipping test " << __func__ << std::endl;
@@ -107,8 +107,8 @@ BOOST_AUTO_TEST_CASE(subprocess_terminate)
 
 BOOST_AUTO_TEST_CASE(subprocess_non_existing_path)
 {
-    auto dummy_callb = [](const std::string &) {};
 #if (BOOST_OS_LINUX && (BOOST_VERSION >= 106500))
+    auto dummy_callb = [](const std::string &) {};
     const std::string path = "/nonexistingpath";
     if (bin_exists(path))
     {


### PR DESCRIPTION
This will fix a bunch of warnings intrifuced by #1802

```
test/utilprocess_tests.cpp: In member function 'void utilprocess_tests::subprocess_return_code::test_method()':
test/utilprocess_tests.cpp:28:10: warning: variable 'dummy_callb' set but not used [-Wunused-but-set-variable]
     auto dummy_callb = [](const std::string &) {};
          ^
test/utilprocess_tests.cpp: In member function 'void utilprocess_tests::subprocess_stdout::test_method()':
test/utilprocess_tests.cpp:58:10: warning: variable 'callb' set but not used [-Wunused-but-set-variable]
     auto callb = [&callback_lines](const std::string &line) { callback_lines.push_back(line); };
          ^
test/utilprocess_tests.cpp: In member function 'void utilprocess_tests::subprocess_terminate::test_method()':
test/utilprocess_tests.cpp:76:10: warning: variable 'dummy_callb' set but not used [-Wunused-but-set-variable]
     auto dummy_callb = [](const std::string &) {};
          ^
test/utilprocess_tests.cpp: In member function 'void utilprocess_tests::subprocess_non_existing_path::test_method()':
test/utilprocess_tests.cpp:110:10: warning: variable 'dummy_callb' set but not used [-Wunused-but-set-variable]
     auto dummy_callb = [](const std::string &) {};
          ^
```