### PR TITLE
Remove unused rpc onpostcommand

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -46,7 +46,6 @@ static struct CRPCSignals
     boost::signals2::signal<void()> Started;
     boost::signals2::signal<void()> Stopped;
     boost::signals2::signal<void(const CRPCCommand &)> PreCommand;
-    boost::signals2::signal<void(const CRPCCommand &)> PostCommand;
 } g_rpcSignals;
 
 void RPCServer::OnStarted(boost::function<void()> slot) { g_rpcSignals.Started.connect(slot); }
@@ -54,11 +53,6 @@ void RPCServer::OnStopped(boost::function<void()> slot) { g_rpcSignals.Stopped.c
 void RPCServer::OnPreCommand(boost::function<void(const CRPCCommand &)> slot)
 {
     g_rpcSignals.PreCommand.connect(boost::bind(slot, _1));
-}
-
-void RPCServer::OnPostCommand(boost::function<void(const CRPCCommand &)> slot)
-{
-    g_rpcSignals.PostCommand.connect(boost::bind(slot, _1));
 }
 
 class CRPCConvertParam
@@ -547,8 +541,6 @@ UniValue CRPCTable::execute(const std::string &strMethod, const UniValue &prepar
     {
         throw JSONRPCError(RPC_MISC_ERROR, e.what());
     }
-
-    g_rpcSignals.PostCommand(*pcmd);
 }
 
 std::vector<std::string> CRPCTable::listCommands() const

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -532,15 +532,17 @@ UniValue CRPCTable::execute(const std::string &strMethod, const UniValue &prepar
 
     g_rpcSignals.PreCommand(*pcmd);
 
+    UniValue result;
     try
     {
         // Execute
-        return pcmd->actor(params, false);
+        result = pcmd->actor(params, false);
     }
     catch (const std::exception &e)
     {
         throw JSONRPCError(RPC_MISC_ERROR, e.what());
     }
+    return result;
 }
 
 std::vector<std::string> CRPCTable::listCommands() const

--- a/src/rpc/server.h
+++ b/src/rpc/server.h
@@ -27,7 +27,6 @@ namespace RPCServer
 void OnStarted(boost::function<void()> slot);
 void OnStopped(boost::function<void()> slot);
 void OnPreCommand(boost::function<void(const CRPCCommand &)> slot);
-void OnPostCommand(boost::function<void(const CRPCCommand &)> slot);
 }
 
 class CBlockIndex;


### PR DESCRIPTION
this PR also fixed the compiler warning for returning nothing at the end of a non void function