### PR TITLE
move unit tests to temporary directory

### DIFF
--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -41,6 +41,10 @@ extern void noui_connect();
 
 BasicTestingSetup::BasicTestingSetup(const std::string &chainName)
 {
+    // Do not place the data created by these unit tests on top of any existing chain,
+    // by overriding datadir to use a temporary if it isn't already overridden
+    if (mapArgs.count("-datadir") == 0)
+        mapArgs["-datadir"] = GetTempPath().string();
     SHA256AutoDetect();
     ECC_Start();
     SetupEnvironment();


### PR DESCRIPTION
move unit tests to use a temporary directory so they don't overwrite an ongoing regtest