### PR TITLE
[WIP] mempool: Increase transaction insertion time resolution

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -227,7 +227,7 @@ void entryToJSON(UniValue &info, const CTxMemPoolEntry &e)
     info.pushKV("size", (int)e.GetTxSize());
     info.pushKV("fee", ValueFromAmount(e.GetFee()));
     info.pushKV("modifiedfee", ValueFromAmount(e.GetModifiedFee()));
-    info.pushKV("time", e.GetTime());
+    info.pushKV("time", e.GetTimeMicros() / 1000000); // FIXME: just pass increased resolution as float maybe?
     info.pushKV("height", (int)e.GetHeight());
     info.pushKV("startingpriority", e.GetPriority(e.GetHeight()));
     info.pushKV("currentpriority", e.GetPriority(chainActive.Height()));

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -760,7 +760,7 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
         }
 
         // Create a commit data entry
-        CTxMemPoolEntry entry(tx, nFees, GetTime(), dPriority, chainActive.Height(), pool.HasNoInputsOf(*tx),
+        CTxMemPoolEntry entry(tx, nFees, GetTimeMicros(), dPriority, chainActive.Height(), pool.HasNoInputsOf(*tx),
             inChainInputValue, fSpendsCoinbase, nSigOps, lp);
 
         nSize = entry.GetTxSize();

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -83,7 +83,7 @@ private:
     CAmount nFee; //! Cached to avoid expensive parent-transaction lookups
     size_t nModSize; //! ... and modified size for priority
     size_t nUsageSize; //! ... and total memory usage
-    int64_t nTime; //! Local time when entering the mempool
+    int64_t nTimeMicros; //! Local time when entering the mempool
     double entryPriority; //! Priority when entering the mempool
     unsigned int entryHeight; //! Chain height when entering the mempool
     bool hadNoDependencies; //! Not dependent on any other txs when it entered the mempool
@@ -115,7 +115,7 @@ public:
     CTxMemPoolEntry();
     CTxMemPoolEntry(const CTransactionRef &_tx,
         const CAmount &_nFee,
-        int64_t _nTime,
+        int64_t _nTimeMicros,
         double _entryPriority,
         unsigned int _entryHeight,
         bool poolHasNoInputsOf,
@@ -134,7 +134,7 @@ public:
     double GetPriority(unsigned int currentHeight) const;
     const CAmount &GetFee() const { return nFee; }
     size_t GetTxSize() const { return this->tx->GetTxSize(); }
-    int64_t GetTime() const { return nTime; }
+    int64_t GetTimeMicros() const { return nTimeMicros; }
     unsigned int GetHeight() const { return entryHeight; }
     bool WasClearAtEntry() const { return hadNoDependencies; }
     unsigned int GetSigOpCount() const { return sigOpCount; }
@@ -242,7 +242,7 @@ public:
 
         if (f1 == f2)
         {
-            return a.GetTime() >= b.GetTime();
+            return a.GetTimeMicros() >= b.GetTimeMicros();
         }
         return f1 < f2;
     }
@@ -278,7 +278,10 @@ public:
 class CompareTxMemPoolEntryByEntryTime
 {
 public:
-    bool operator()(const CTxMemPoolEntry &a, const CTxMemPoolEntry &b) const { return a.GetTime() < b.GetTime(); }
+    bool operator()(const CTxMemPoolEntry &a, const CTxMemPoolEntry &b) const
+    {
+        return a.GetTimeMicros() < b.GetTimeMicros();
+    }
 };
 
 class CompareTxMemPoolEntryByAncestorFee
@@ -330,7 +333,7 @@ struct TxMempoolInfo
     CTransactionRef tx;
 
     /** The time the transaction entered the mempool */
-    int64_t nTime;
+    int64_t nTimeMicros;
 
     /** The feerate of the transaction */
     CFeeRate feeRate;


### PR DESCRIPTION
This likely needs a discussion whether it is actually wanted first.

This will be helpful to have more detail when keeping track of double-
spend proofs and similar.

It increases the time resolution for the insertion time of a TX into
the mempool from seconds to microseconds resolution. Which is
probably overkill but doesn't really hurt either.

TODO: Needs a test still.