### PR TITLE
[WIP] Abstract blocks

### DIFF
--- a/src/blockrelay/compactblock.h
+++ b/src/blockrelay/compactblock.h
@@ -119,13 +119,14 @@ public:
     CompactReReqResponse(const CBlock &block, const std::vector<uint32_t> &indexes)
     {
         blockhash = block.GetHash();
-        if (indexes.size() > block.vtx.size())
+        if (indexes.size() > block.numTransactions())
             throw std::invalid_argument("request more transactions than are in a block");
         for (uint32_t i : indexes)
         {
-            if (i >= block.vtx.size())
+            CTransactionRef txref = block.by_pos(i);
+            if (txref == nullptr)
                 throw std::invalid_argument("out of bound tx in rerequest");
-            txn.push_back(*block.vtx.at(i));
+            txn.push_back(*txref);
         }
     }
 

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -41,11 +41,12 @@ CThinBlock::CThinBlock(const CBlock &block, const CBloomFilter &filter) : nSize(
 {
     header = block.GetBlockHeader();
 
-    unsigned int nTx = block.vtx.size();
+    unsigned int nTx = block.numTransactions();
     vTxHashes.reserve(nTx);
-    for (unsigned int i = 0; i < nTx; i++)
+    size_t i = 0;
+    for (const auto &tx : block)
     {
-        const uint256 &hash = block.vtx[i]->GetHash();
+        const uint256 &hash = tx->GetHash();
         vTxHashes.push_back(hash);
 
         // Find the transactions that do not match the filter.
@@ -53,7 +54,8 @@ CThinBlock::CThinBlock(const CBlock &block, const CBloomFilter &filter) : nSize(
         // NOTE: We always add the first tx, the coinbase as it is the one
         //       most often missing.
         if (!filter.contains(hash) || i == 0)
-            vMissingTx.push_back(*block.vtx[i]);
+            vMissingTx.push_back(*tx);
+        i++;
     }
 }
 
@@ -161,7 +163,7 @@ bool CThinBlock::process(CNode *pfrom, std::shared_ptr<CBlockThinRelay> pblock)
 
         nWaitingForTxns = missingCount;
         LOG(THIN, "Thinblock %s waiting for: %d, unnecessary: %d, total txns: %d received txns: %d peer=%s\n",
-            pblock->GetHash().ToString(), nWaitingForTxns, unnecessaryCount, pblock->vtx.size(),
+            pblock->GetHash().ToString(), nWaitingForTxns, unnecessaryCount, pblock->numTransactions(),
             pblock->thinblock->mapMissingTx.size(), pfrom->GetLogName());
     } // end lock orphanpool.cs, mempool.cs
     LOG(THIN, "Current in memory thinblockbytes size is %ld bytes\n", pblock->nCurrentBlockSize);
@@ -208,12 +210,14 @@ CXThinBlock::CXThinBlock(const CBlock &block, const CBloomFilter *filter) : nSiz
     header = block.GetBlockHeader();
     this->collision = false;
 
-    unsigned int nTx = block.vtx.size();
+    unsigned int nTx = block.numTransactions();
     vTxHashes.reserve(nTx);
     std::set<uint64_t> setPartialTxHash;
-    for (unsigned int i = 0; i < nTx; i++)
+
+    size_t i = 0;
+    for (const auto &tx : block)
     {
-        const uint256 hash256 = block.vtx[i]->GetHash();
+        const uint256 hash256 = tx->GetHash();
         uint64_t cheapHash = hash256.GetCheapHash();
         vTxHashes.push_back(cheapHash);
 
@@ -226,7 +230,8 @@ CXThinBlock::CXThinBlock(const CBlock &block, const CBloomFilter *filter) : nSiz
         // NOTE: We always add the first tx, the coinbase as it is the one
         //       most often missing.
         if ((filter && !filter->contains(hash256)) || i == 0)
-            vMissingTx.push_back(*block.vtx[i]);
+            vMissingTx.push_back(*tx);
+        i++;
     }
 }
 
@@ -235,14 +240,15 @@ CXThinBlock::CXThinBlock(const CBlock &block) : nSize(0), collision(false)
     header = block.GetBlockHeader();
     this->collision = false;
 
-    unsigned int nTx = block.vtx.size();
+    unsigned int nTx = block.numTransactions();
     vTxHashes.reserve(nTx);
     std::set<uint64_t> setPartialTxHash;
 
     READLOCK(orphanpool.cs);
-    for (unsigned int i = 0; i < nTx; i++)
+    size_t i = 0;
+    for (const auto &tx : block)
     {
-        const uint256 hash256 = block.vtx[i]->GetHash();
+        const uint256 hash256 = tx->GetHash();
         uint64_t cheapHash = hash256.GetCheapHash();
         vTxHashes.push_back(cheapHash);
 
@@ -254,12 +260,13 @@ CXThinBlock::CXThinBlock(const CBlock &block) : nSize(0), collision(false)
         if (!((mempool.exists(hash256)) ||
                 (orphanpool.mapOrphanTransactions.find(hash256) != orphanpool.mapOrphanTransactions.end())))
         {
-            vMissingTx.push_back(*block.vtx[i]);
+            vMissingTx.push_back(*tx);
         }
         // We always add the first tx, the coinbase as it is the one
         // most often missing.
         else if (i == 0)
-            vMissingTx.push_back(*block.vtx[i]);
+            vMissingTx.push_back(*tx);
+        i++;
     }
 }
 
@@ -449,11 +456,11 @@ bool CXRequestThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
         }
         else
         {
-            for (unsigned int i = 0; i < block.vtx.size(); i++)
+            for (const auto &tx : block)
             {
-                uint64_t cheapHash = block.vtx[i]->GetHash().GetCheapHash();
+                uint64_t cheapHash = tx->GetHash().GetCheapHash();
                 if (thinRequestBlockTx.setCheapHashesToRequest.count(cheapHash))
-                    vTx.push_back(*block.vtx[i]);
+                    vTx.push_back(*tx);
             }
         }
     }
@@ -727,7 +734,7 @@ bool CXThinBlock::process(CNode *pfrom, std::string strCommand, std::shared_ptr<
 
     nWaitingForTxns = missingCount;
     LOG(THIN, "xthinblock waiting for: %d, unnecessary: %d, total txns: %d received txns: %d\n", nWaitingForTxns,
-        unnecessaryCount, pblock->vtx.size(), thinBlock->mapMissingTx.size());
+        unnecessaryCount, pblock->numTransactions(), thinBlock->mapMissingTx.size());
 
     // If there are any missing hashes or transactions then we request them here.
     // This must be done outside of the mempool.cs lock or may deadlock.
@@ -870,7 +877,7 @@ static bool ReconstructBlock(CNode *pfrom,
         }
 
         // Add this transaction. If the tx is null we still add it as a placeholder to keep the correct ordering.
-        pblock->vtx.emplace_back(ptx);
+        pblock->add(ptx);
     }
     // Now that we've rebuilt the block successfully we can set the XVal flag which is used in
     // ConnectBlock() to determine which if any inputs we can skip the checking of inputs.

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -47,7 +47,7 @@ CBlock CreateGenesisBlock(CScript prefix,
     genesis.nBits = nBits;
     genesis.nNonce = nNonce;
     genesis.nVersion = nVersion;
-    genesis.vtx.push_back(MakeTransactionRef(std::move(txNew)));
+    genesis.add(MakeTransactionRef(std::move(txNew)));
     genesis.hashPrevBlock.SetNull();
     genesis.hashMerkleRoot = BlockMerkleRoot(genesis);
     return genesis;

--- a/src/consensus/merkle.cpp
+++ b/src/consensus/merkle.cpp
@@ -195,24 +195,23 @@ uint256 ComputeMerkleRootFromBranch(const uint256 &leaf, const std::vector<uint2
     return hash;
 }
 
-uint256 BlockMerkleRoot(const CBlock &block, bool *mutated)
+static std::vector<uint256> getLeaves(const CBlock &block)
 {
     std::vector<uint256> leaves;
-    leaves.resize(block.vtx.size());
-    for (size_t s = 0; s < block.vtx.size(); s++)
-    {
-        leaves[s] = block.vtx[s]->GetHash();
-    }
+    leaves.resize(block.numTransactions());
+    size_t s = 0;
+    for (const CTransactionRef &txr : block)
+        leaves[s++] = txr->GetHash();
+    return leaves;
+}
+uint256 BlockMerkleRoot(const CBlock &block, bool *mutated)
+{
+    std::vector<uint256> leaves = getLeaves(block);
     return ComputeMerkleRoot(leaves, mutated);
 }
 
 std::vector<uint256> BlockMerkleBranch(const CBlock &block, uint32_t position)
 {
-    std::vector<uint256> leaves;
-    leaves.resize(block.vtx.size());
-    for (size_t s = 0; s < block.vtx.size(); s++)
-    {
-        leaves[s] = block.vtx[s]->GetHash();
-    }
+    std::vector<uint256> leaves = getLeaves(block);
     return ComputeMerkleBranch(leaves, position);
 }

--- a/src/core_memusage.h
+++ b/src/core_memusage.h
@@ -50,16 +50,7 @@ static inline size_t RecursiveDynamicUsage(const CMutableTransaction &tx)
     return mem;
 }
 
-static inline size_t RecursiveDynamicUsage(const CBlock &block)
-{
-    size_t mem = memusage::DynamicUsage(block.vtx);
-    for (const auto &tx : block.vtx)
-    {
-        mem += memusage::DynamicUsage(tx) + RecursiveDynamicUsage(*tx);
-    }
-    return mem;
-}
-
+static inline size_t RecursiveDynamicUsage(const CBlock &block) { return block.RecursiveDynamicUsage(); }
 static inline size_t RecursiveDynamicUsage(const CBlockLocator &locator)
 {
     return memusage::DynamicUsage(locator.vHave);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -333,7 +333,7 @@ bool GetTransaction(const uint256 &hash,
         CBlock block;
         if (ReadBlockFromDisk(block, pindexSlow, consensusParams))
         {
-            for (const auto &tx : block.vtx)
+            for (const auto &tx : block)
             {
                 if (tx->GetHash() == hash)
                 {

--- a/src/merkleblock.cpp
+++ b/src/merkleblock.cpp
@@ -19,13 +19,14 @@ CMerkleBlock::CMerkleBlock(const CBlock &block, CBloomFilter &filter)
     vector<bool> vMatch;
     vector<uint256> vHashes;
 
-    vMatch.reserve(block.vtx.size());
-    vHashes.reserve(block.vtx.size());
+    vMatch.reserve(block.numTransactions());
+    vHashes.reserve(block.numTransactions());
 
-    for (unsigned int i = 0; i < block.vtx.size(); i++)
+    size_t i = 0;
+    for (const auto &tx : block)
     {
-        const uint256 &hash = block.vtx[i]->GetHash();
-        if (filter.IsRelevantAndUpdate(block.vtx[i]))
+        const uint256 &hash = tx->GetHash();
+        if (filter.IsRelevantAndUpdate(tx))
         {
             vMatch.push_back(true);
             vMatchedTxn.push_back(make_pair(i, hash));
@@ -33,6 +34,7 @@ CMerkleBlock::CMerkleBlock(const CBlock &block, CBloomFilter &filter)
         else
             vMatch.push_back(false);
         vHashes.push_back(hash);
+        i++;
     }
 
     txn = CPartialMerkleTree(vHashes, vMatch);
@@ -45,17 +47,19 @@ CMerkleBlock::CMerkleBlock(const CBlock &block, const std::set<uint256> &txids)
     vector<bool> vMatch;
     vector<uint256> vHashes;
 
-    vMatch.reserve(block.vtx.size());
-    vHashes.reserve(block.vtx.size());
+    vMatch.reserve(block.numTransactions());
+    vHashes.reserve(block.numTransactions());
 
-    for (unsigned int i = 0; i < block.vtx.size(); i++)
+    size_t i = 0;
+    for (const auto &tx : block)
     {
-        const uint256 &hash = block.vtx[i]->GetHash();
+        const uint256 &hash = tx->GetHash();
         if (txids.count(hash))
             vMatch.push_back(true);
         else
             vMatch.push_back(false);
         vHashes.push_back(hash);
+        i++;
     }
 
     txn = CPartialMerkleTree(vHashes, vMatch);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -222,8 +222,12 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                                     typedef std::pair<unsigned int, uint256> PairType;
                                     for (PairType &pair : merkleBlock.vMatchedTxn)
                                     {
-                                        pfrom->txsSent += 1;
-                                        pfrom->PushMessage(NetMsgType::TX, block.vtx[pair.first]);
+                                        CTransactionRef txref = block.by_pos(pair.first);
+                                        if (txref != nullptr)
+                                        {
+                                            pfrom->PushMessage(NetMsgType::TX, txref);
+                                            pfrom->txsSent += 1;
+                                        }
                                     }
                                 }
                                 // else

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -442,7 +442,7 @@ void CParallelValidation::ClearOrphanCache(const CBlockRef pblock)
             vPreviousBlock.clear();
 
             // Erase orphans from the current block that were already received.
-            for (auto &tx : pblock->vtx)
+            for (const auto &tx : *pblock)
             {
                 uint256 hash = tx->GetHash();
                 vPreviousBlock.push_back(hash);

--- a/src/primitives/block.cpp
+++ b/src/primitives/block.cpp
@@ -5,24 +5,26 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "primitives/block.h"
+#include <iostream>
 
+#include "core_memusage.h"
 #include "crypto/common.h"
 #include "hashwrapper.h"
+#include "memusage.h"
+#include "serialize.h"
+#include "streams.h"
 #include "tinyformat.h"
 #include "utilstrencodings.h"
-
 uint256 CBlockHeader::GetHash() const { return SerializeHash(*this); }
 std::string CBlock::ToString() const
 {
     std::stringstream s;
     s << strprintf(
-        "CBlock(hash=%s, ver=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, vtx=%u)\n",
+        "CBlock(hash=%s, ver=%d, hashPrevBlock=%s, hashMerkleRoot=%s, nTime=%u, nBits=%08x, nNonce=%u, ntx=%u)\n",
         GetHash().ToString(), nVersion, hashPrevBlock.ToString(), hashMerkleRoot.ToString(), nTime, nBits, nNonce,
         vtx.size());
-    for (unsigned int i = 0; i < vtx.size(); i++)
-    {
-        s << "  " << vtx[i]->ToString() << "\n";
-    }
+    for (CTransactionRef txref : *this)
+        s << "  " << txref->ToString() << "\n";
     return s.str();
 }
 
@@ -32,3 +34,22 @@ uint64_t CBlock::GetBlockSize() const
         nBlockSize = ::GetSerializeSize(*this, SER_NETWORK, PROTOCOL_VERSION);
     return nBlockSize;
 }
+
+size_t CBlock::RecursiveDynamicUsage() const
+{
+    size_t mem = memusage::DynamicUsage(vtx);
+    for (const auto &tx : vtx)
+    {
+        mem += memusage::DynamicUsage(tx) + ::RecursiveDynamicUsage(*tx);
+    }
+    return mem;
+}
+
+struct NumericallyLessTxHashComparator
+{
+public:
+    bool operator()(const CTransactionRef &a, const CTransactionRef &b) const { return a->GetHash() < b->GetHash(); }
+};
+
+
+void CBlock::sortLTOR() { std::sort(vtx.begin() + 1, vtx.end(), NumericallyLessTxHashComparator()); }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -118,7 +118,7 @@ UniValue blockToJSON(const CBlock &block, const CBlockIndex *blockindex, bool tx
     UniValue txs(UniValue::VARR);
     if (listTxns)
     {
-        for (const auto &tx : block.vtx)
+        for (const auto &tx : block)
         {
             if (txDetails)
             {
@@ -135,7 +135,7 @@ UniValue blockToJSON(const CBlock &block, const CBlockIndex *blockindex, bool tx
     }
     else
     {
-        result.pushKV("txcount", (uint64_t)block.vtx.size());
+        result.pushKV("txcount", (uint64_t)block.numTransactions());
     }
     result.pushKV("time", block.GetBlockTime());
     result.pushKV("mediantime", (int64_t)blockindex->GetMedianTimePast());

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -437,7 +437,7 @@ static UniValue MkFullMiningCandidateJson(std::set<std::string> setClientRules,
     UniValue transactions(UniValue::VARR);
     map<uint256, int64_t> setTxIndex;
     int i = 0;
-    for (const auto &it : pblock->vtx)
+    for (const auto &it : *pblock)
     {
         const CTransaction &tx = *it;
         uint256 txHash = tx.GetHash();
@@ -508,7 +508,7 @@ static UniValue MkFullMiningCandidateJson(std::set<std::string> setClientRules,
     result.pushKV("previousblockhash", pblock->hashPrevBlock.GetHex());
     result.pushKV("transactions", transactions);
     result.pushKV("coinbaseaux", aux);
-    result.pushKV("coinbasevalue", (int64_t)pblock->vtx[0]->vout[0].nValue);
+    result.pushKV("coinbasevalue", (int64_t)pblock->coinbase()->vout[0].nValue);
     result.pushKV("longpollid", chainActive.Tip()->GetBlockHash().GetHex() + i64tostr(nTransactionsUpdatedLast));
     result.pushKV("target", hashTarget.GetHex());
     result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast() + 1);

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -386,7 +386,7 @@ UniValue getrawblocktransactions(const UniValue &params, bool fHelp)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");
 
     UniValue resultSet(UniValue::VOBJ);
-    for (auto tx : block.vtx)
+    for (const auto &tx : block)
     {
         if (has_protocol)
         {
@@ -565,7 +565,7 @@ UniValue getrawtransactionssince(const UniValue &params, bool fHelp)
             throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");
         }
         UniValue blockResults(UniValue::VOBJ);
-        for (auto tx : block.vtx)
+        for (const auto &tx : block)
         {
             if (has_protocol)
             {
@@ -667,7 +667,7 @@ UniValue gettxoutproof(const UniValue &params, bool fHelp)
         throw JSONRPCError(RPC_INTERNAL_ERROR, "Can't read block from disk");
 
     unsigned int ntxFound = 0;
-    for (const auto &tx : block.vtx)
+    for (const auto &tx : block)
         if (setTxids.count(tx->GetHash()))
             ntxFound++;
     if (ntxFound != setTxids.size())
@@ -736,7 +736,7 @@ UniValue gettxoutproofs(const UniValue &params, bool fHelp)
     bool ntxFound = false;
     for (const auto &txid : setTxids)
     {
-        for (const auto &tx : block.vtx)
+        for (const auto &tx : block)
         {
             if (setTxids.count(tx->GetHash()))
             {

--- a/src/test/compactblocks_tests.cpp
+++ b/src/test/compactblocks_tests.cpp
@@ -41,15 +41,14 @@ static CBlock TestBlock()
     tx.vout.resize(1);
     tx.vout[0].nValue = 42;
 
-    block.vtx.resize(3);
-    block.vtx[0] = MakeTransactionRef(tx);
+    block.add(MakeTransactionRef(tx));
     block.nVersion = 42;
     block.hashPrevBlock = GetRandHash();
     block.nBits = 0x207fffff;
 
     tx.vin[0].prevout.hash = GetRandHash();
     tx.vin[0].prevout.n = 0;
-    block.vtx[1] = MakeTransactionRef(tx);
+    block.add(MakeTransactionRef(tx));
 
     tx.vin.resize(10);
     for (size_t i = 0; i < tx.vin.size(); i++)
@@ -57,7 +56,7 @@ static CBlock TestBlock()
         tx.vin[i].prevout.hash = GetRandHash();
         tx.vin[i].prevout.n = 0;
     }
-    block.vtx[2] = MakeTransactionRef(tx);
+    block.add(MakeTransactionRef(tx));
 
     bool mutated;
     block.hashMerkleRoot = BlockMerkleRoot(block, &mutated);

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -561,7 +561,7 @@ BOOST_AUTO_TEST_CASE(compactblock_tests)
         CompactReReqResponse response1;
         response1.blockhash.SetNull();
         response1.txn.resize(1);
-        response1.txn[0] = *TestBlock1().vtx[1];
+        response1.txn[0] = *TestBlock1().by_pos(1);
 
         CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
         stream << response1;
@@ -835,7 +835,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
     dosMan.ClearBanned();
     nullhash.SetNull();
     std::vector<CTransaction> vtx;
-    for (auto &tx : block3.vtx)
+    for (auto &tx : block3)
         vtx.push_back(*tx);
 
     CXThinBlockTx xblocktx(nullhash, vtx);

--- a/src/test/graphene_tests.cpp
+++ b/src/test/graphene_tests.cpp
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(graphene_block_can_serde)
             SER_DISK, CLIENT_VERSION);
         stream >> tx;
         const CTransactionRef ptx = MakeTransactionRef(tx);
-        block.vtx.push_back(ptx);
+        block.add(ptx);
         CGrapheneBlock senderGrapheneBlock(MakeBlockRef(block), 5, 6, 4, false);
         CGrapheneBlock receiverGrapheneBlock(4);
         CDataStream ss(SER_DISK, 0);
@@ -367,7 +367,7 @@ BOOST_AUTO_TEST_CASE(graphene_block_can_serde)
         ss << senderGrapheneBlock;
         ss >> receiverGrapheneBlock;
     }
-    
+
     // compute optimized graphene block
     {
         CBlock block;
@@ -382,7 +382,7 @@ BOOST_AUTO_TEST_CASE(graphene_block_can_serde)
             SER_DISK, CLIENT_VERSION);
         stream >> tx;
         const CTransactionRef ptx = MakeTransactionRef(tx);
-        block.vtx.push_back(ptx);
+        block.add(ptx);
         CGrapheneBlock senderGrapheneBlock(MakeBlockRef(block), 5, 6, 4, true);
         CGrapheneBlock receiverGrapheneBlock(4, true);
         CDataStream ss(SER_DISK, 0);

--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -446,10 +446,10 @@ BOOST_AUTO_TEST_CASE(MempoolAncestorIndexingTest)
     CheckSort<ancestor_score>(pool, sortedOrder);
 
     /* after tx6 is mined, tx7 should move up in the sort */
-    std::vector<CTransactionRef> vtx;
-    vtx.push_back(MakeTransactionRef(tx6));
+    CBlock block;
+    block.add(MakeTransactionRef(tx6));
     std::list<CTransactionRef> dummy;
-    pool.removeForBlock(vtx, 1, dummy, false);
+    pool.removeForBlock(block, 1, dummy, false);
 
     sortedOrder.erase(sortedOrder.begin() + 1);
     // Ties are broken by hash
@@ -590,13 +590,13 @@ BOOST_AUTO_TEST_CASE(MempoolSizeLimitTest)
     pool.addUnchecked(tx5.GetHash(), entry.Fee(1000LL).FromTx(tx5, &pool));
     pool.addUnchecked(tx7.GetHash(), entry.Fee(9000LL).FromTx(tx7, &pool));
 
-    std::vector<CTransactionRef> vtx;
+    CBlock block;
     std::list<CTransactionRef> conflicts;
     SetMockTime(42);
     SetMockTime(42 + CTxMemPool::ROLLING_FEE_HALFLIFE);
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), maxFeeRateRemoved.GetFeePerK() + 1000);
     // ... we should keep the same min fee until we get a block
-    pool.removeForBlock(vtx, 1, conflicts);
+    pool.removeForBlock(block, 1, conflicts);
     SetMockTime(42 + 2 * CTxMemPool::ROLLING_FEE_HALFLIFE);
     BOOST_CHECK_EQUAL(pool.GetMinFee(1).GetFeePerK(), (maxFeeRateRemoved.GetFeePerK() + 1000) / 2);
     // ... then feerate should drop 1/2 each halflife

--- a/src/test/pmt_tests.cpp
+++ b/src/test/pmt_tests.cpp
@@ -51,14 +51,14 @@ BOOST_AUTO_TEST_CASE(pmt_test1)
         {
             CMutableTransaction tx;
             tx.nLockTime = j; // actual transaction data doesn't matter; just make the nLockTime's unique
-            block.vtx.push_back(MakeTransactionRef(std::move(tx)));
+            block.add(MakeTransactionRef(std::move(tx)));
         }
 
         // calculate actual merkle root and height
         uint256 merkleRoot1 = BlockMerkleRoot(block);
         std::vector<uint256> vTxid(nTx, uint256());
         for (unsigned int j = 0; j < nTx; j++)
-            vTxid[j] = block.vtx[j]->GetHash();
+            vTxid[j] = block.by_pos(j)->GetHash();
         int nHeight = 1, nTx_ = nTx;
         while (nTx_ > 1)
         {

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     CFeeRate baseRate(basefee, ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION));
 
     // Create a fake block
-    std::vector<CTransactionRef> block;
+    CBlock block;
     int blocknum = 0;
 
     // Loop through 200 blocks
@@ -87,12 +87,12 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
             {
                 CTransactionRef ptx = mpool.get(txHashes[9 - h].back());
                 if (ptx)
-                    block.push_back(ptx);
+                    block.add(ptx);
                 txHashes[9 - h].pop_back();
             }
         }
         mpool.removeForBlock(block, ++blocknum, dummyConflicted);
-        block.clear();
+        block.SetNull();
         if (blocknum == 30)
         {
             // At this point we should need to combine 5 buckets to get enough data points
@@ -188,12 +188,12 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         {
             CTransactionRef ptx = mpool.get(txHashes[j].back());
             if (ptx)
-                block.push_back(ptx);
+                block.add(ptx);
             txHashes[j].pop_back();
         }
     }
     mpool.removeForBlock(block, 265, dummyConflicted);
-    block.clear();
+    block.SetNull();
     for (int i = 1; i < 10; i++)
     {
         BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() > origFeeEst[i - 1] - deltaFee);
@@ -217,11 +217,11 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
                                              .FromTx(tx, &mpool));
                 CTransactionRef ptx = mpool.get(hash);
                 if (ptx)
-                    block.push_back(ptx);
+                    block.add(ptx);
             }
         }
         mpool.removeForBlock(block, ++blocknum, dummyConflicted);
-        block.clear();
+        block.SetNull();
     }
     for (int i = 1; i < 10; i++)
     {

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -88,12 +88,6 @@ TestingSetup::~TestingSetup()
     fs::remove_all(pathTemp);
 }
 
-struct NumericallyLessTxHashComparator
-{
-public:
-    bool operator()(const CTransactionRef &a, const CTransactionRef &b) const { return a->GetHash() < b->GetHash(); }
-};
-
 TestChain100Setup::TestChain100Setup() : TestingSetup(CBaseChainParams::REGTEST)
 {
     // Generate a 100-block chain:
@@ -103,7 +97,7 @@ TestChain100Setup::TestChain100Setup() : TestingSetup(CBaseChainParams::REGTEST)
     {
         std::vector<CMutableTransaction> noTxns;
         CBlock b = CreateAndProcessBlock(noTxns, scriptPubKey);
-        coinbaseTxns.push_back(*b.vtx[0]);
+        coinbaseTxns.push_back(*b.coinbase());
     }
 }
 
@@ -117,15 +111,19 @@ CBlock TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransa
     const CChainParams &chainparams = Params();
     std::unique_ptr<CBlockTemplate> pblocktemplate(new CBlockTemplate());
     pblocktemplate = BlockAssembler(chainparams).CreateNewBlock(scriptPubKey);
-    CBlock &block = pblocktemplate->block;
+    CBlockHeader &blockheader = pblocktemplate->block;
+
+    CBlock block(blockheader);
 
     // Replace mempool-selected txns with just coinbase plus passed-in txns:
-    block.vtx.resize(1);
+    CTransactionRef cb = pblocktemplate->block.coinbase();
+    block.setCoinbase(cb);
     for (const CMutableTransaction &tx : txns)
-        block.vtx.push_back(MakeTransactionRef(tx));
+        block.add(MakeTransactionRef(tx));
 
     // enfore LTOR ordering of transactions
-    std::sort(block.vtx.begin() + 1, block.vtx.end(), NumericallyLessTxHashComparator());
+    block.sortLTOR();
+    // std::sort(block.begin() + 1, block.end(), NumericallyLessTxHashComparator());
 
     // IncrementExtraNonce creates a valid coinbase and merkleRoot
     unsigned int extraNonce = 0;

--- a/src/test/thinblock_tests.cpp
+++ b/src/test/thinblock_tests.cpp
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(thinblock_test)
     BOOST_CHECK_EQUAL(9, xthinblock1.vMissingTx.size());
 
     /* insert txid in block */
-    const uint256 hash_in_block = block.vtx[1]->GetHash();
+    const uint256 hash_in_block = block.by_pos(1)->GetHash();
     filter.insert(hash_in_block);
     CThinBlock thinblock2(block, filter);
     CXThinBlock xthinblock2(block, &filter);
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(thinblock_test)
 
     /*collision test*/
     BOOST_CHECK(!xthinblock2.collision);
-    block.vtx.push_back(block.vtx[1]); // duplicate tx
+    block.add(block.by_pos(1)); // duplicate tx
     filter.clear();
     CXThinBlock xthinblock3(block, &filter);
     BOOST_CHECK(xthinblock3.collision);
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(thinblock_test)
     BOOST_CHECK(xthinblock5.vMissingTx.size() >= 8 && xthinblock5.vMissingTx.size() <= 9);
 
     /* insert txid in block */
-    const uint256 hash_in_block1 = block.vtx[1]->GetHash();
+    const uint256 hash_in_block1 = block.by_pos(1)->GetHash();
     filter1.insert(hash_in_block1);
     CThinBlock thinblock6(block1, filter1);
     CXThinBlock xthinblock6(block1, &filter1);
@@ -178,7 +178,7 @@ BOOST_AUTO_TEST_CASE(thinblock_test)
 
     /*collision test*/
     BOOST_CHECK(!xthinblock6.collision);
-    block.vtx.push_back(block1.vtx[1]); // duplicate tx
+    block.add(block1.by_pos(1)); // duplicate tx
     filter1.clear();
     CXThinBlock xthinblock7(block, &filter1);
     BOOST_CHECK(xthinblock7.collision);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -792,7 +792,7 @@ void CTxMemPool::_removeConflicts(const CTransaction &tx, std::list<CTransaction
 // If a transaction has an ancestor, it is placed on a deferred map: ancestor->descendant list.
 // Whenever a tx is removed from the mempool, any of its descendants are placed back onto the
 // queue of tx that are removable.
-void CTxMemPool::removeForBlock(const std::vector<CTransactionRef> &vtx,
+void CTxMemPool::removeForBlock(const CBlock &block,
     unsigned int nBlockHeight,
     std::list<CTransactionRef> &conflicts,
     bool fCurrentEstimate)
@@ -806,7 +806,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef> &vtx,
     DeferredMap deferred;
     std::queue<txiter> ready;
 
-    for (const auto &tx : vtx)
+    for (const auto &tx : block)
     {
         setEntries descendants;
         uint256 hash = tx->GetHash();
@@ -881,7 +881,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef> &vtx,
     }
 
     // Remove conflicting tx
-    for (const auto &tx : vtx)
+    for (const auto &tx : block)
     {
         _removeConflicts(*tx, conflicts);
         _ClearPrioritisation(tx->GetHash());

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -560,7 +560,7 @@ public:
     void removeForReorg(const CCoinsViewCache *pcoins, unsigned int nMemPoolHeight, int flags);
     void removeConflicts(const CTransaction &tx, std::list<CTransactionRef> &removed);
     void _removeConflicts(const CTransaction &tx, std::list<CTransactionRef> &removed);
-    void removeForBlock(const std::vector<CTransactionRef> &vtx,
+    void removeForBlock(const CBlock &block,
         unsigned int nBlockHeight,
         std::list<CTransactionRef> &conflicted,
         bool fCurrentEstimate = true);

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -538,7 +538,8 @@ extern void UnlimitedLogBlock(const CBlock &block, const std::string &hash, uint
     if (blockReceiptLog) {
         long int byteLen = block.GetBlockSize();
         CBlockHeader bh = block.GetBlockHeader();
-        fprintf(blockReceiptLog, "%" PRIu64 ",%" PRIu64 ",%ld,%ld,%s\n", receiptTime, (uint64_t)bh.nTime, byteLen, block.vtx.size(), hash.c_str());
+        fprintf(blockReceiptLog, "%" PRIu64 ",%" PRIu64 ",%ld,%ld,%s\n", receiptTime, (uint64_t)bh.nTime, byteLen,
+                block.numTransactions(), hash.c_str());
         fflush(blockReceiptLog);
     }
 #endif
@@ -601,7 +602,7 @@ bool static ScanHash(const CBlockHeader *pblock, uint32_t &nNonce, uint256 *phas
 static bool ProcessBlockFound(const CBlock *pblock, const CChainParams &chainparams)
 {
     LOGA("%s\n", pblock->ToString());
-    LOGA("generated %s\n", FormatMoney(pblock->vtx[0]->vout[0].nValue));
+    LOGA("generated %s\n", FormatMoney(pblock->coinbase()->vout[0].nValue));
 
     // Found a solution
     {
@@ -695,7 +696,7 @@ void static BitcoinMiner(const CChainParams &chainparams)
             CBlock *pblock = &pblocktemplate->block;
             IncrementExtraNonce(pblock, nExtraNonce);
 
-            LOGA("Running BitcoinMiner with %u transactions in block (%u bytes)\n", pblock->vtx.size(),
+            LOGA("Running BitcoinMiner with %u transactions in block (%u bytes)\n", pblock->numTransactions(),
                 pblock->GetBlockSize());
 
             //
@@ -1696,16 +1697,14 @@ static void AddMiningCandidate(CMiningCandidate &candid, int64_t id)
     miningCandidatesMap[id] = candid;
 }
 
+// FIXME: isn't this code dup of merkle.cpp or merkleblock.cpp?
 std::vector<uint256> GetMerkleProofBranches(CBlock *pblock)
 {
     std::vector<uint256> ret;
     std::vector<uint256> leaves;
-    int len = pblock->vtx.size();
 
-    for (int i = 0; i < len; i++)
-    {
-        leaves.push_back(pblock->vtx[i].get()->GetHash());
-    }
+    for (const auto &tx : *pblock)
+        leaves.push_back(tx->GetHash());
 
     ret = ComputeMerkleBranch(leaves, 0);
     return ret;
@@ -1728,7 +1727,7 @@ static UniValue MkMiningCandidateJson(CMiningCandidate &candid)
     ret.pushKV("prevhash", block.hashPrevBlock.GetHex());
 
     {
-        const CTransaction *tran = block.vtx[0].get();
+        const CTransactionRef &tran = block.coinbase();
         ret.pushKV("coinbase", EncodeHexTx(*tran));
     }
 
@@ -1858,7 +1857,7 @@ UniValue submitminingsolution(const UniValue &params, bool fHelp)
     if (!cbhex.isNull())
     {
         if (DecodeHexTx(coinbase, cbhex.get_str()))
-            block.vtx[0] = MakeTransactionRef(std::move(coinbase));
+            block.setCoinbase(MakeTransactionRef(std::move(coinbase)));
         else
         {
             throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "coinbase decode failed");
@@ -1868,7 +1867,7 @@ UniValue submitminingsolution(const UniValue &params, bool fHelp)
     // MerkleRoot:
     {
         std::vector<uint256> merkleProof = GetMerkleProofBranches(&block);
-        uint256 t = block.vtx[0]->GetHash();
+        uint256 t = block.coinbase()->GetHash();
         block.hashMerkleRoot = CalculateMerkleRoot(t, merkleProof);
     }
 

--- a/src/validation/verifydb.cpp
+++ b/src/validation/verifydb.cpp
@@ -92,7 +92,7 @@ bool CVerifyDB::VerifyDB(const CChainParams &chainparams, CCoinsView *coinsview,
                 pindexFailure = pindex;
             }
             else
-                nGoodTransactions += block.vtx.size();
+                nGoodTransactions += block.numTransactions();
         }
         if (ShutdownRequested())
             return true;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1432,7 +1432,7 @@ int CWallet::ScanForWalletTransactions(CBlockIndex *pindexStart, bool fUpdate)
             CBlock block;
             ReadBlockFromDisk(block, pindex, Params().GetConsensus());
             int txIdx = 0;
-            for (const auto &ptx : block.vtx)
+            for (const auto &ptx : block)
             {
                 if (AddToWalletIfInvolvingMe(ptx, &block, fUpdate, txIdx))
                     ret++;


### PR DESCRIPTION
This change abstracts the implementation details of a CBlock's
transaction set, which is currently simply a
`std::vector<CTransactionRef>` away from a CBlock's interface.
This will allow the internal representation of a CBlock to be
more easily changed for different storage models and container
types (such as a Merklix-aware binary tree, or a `mmap()`ed on disk
representation, potentially aiding an implementation of BUIP120
as well). It should also help to prepare for further potential
changes to BCH down the road (such as Merklix trees in general) as well as
making dealing with transaction order (CTOR) easier and more
localized.

This is rather at the proposal stage as well, therefore the [WIP] marker.