### PR TITLE
A few small fixes to trimming the coincache during IBD or after txadmission

### DIFF
--- a/src/blockstorage/blockstorage.cpp
+++ b/src/blockstorage/blockstorage.cpp
@@ -689,7 +689,8 @@ bool FlushStateToDiskInternal(CValidationState &state,
             size_t nTrimSize = nCoinCacheMaxSize * .90;
             if (nCoinCacheMaxSize - nMaxCacheIncreaseSinceLastFlush > nTrimSize)
             {
-                nTrimSize = nCoinCacheMaxSize - nMaxCacheIncreaseSinceLastFlush;
+                if (nCoinCacheMaxSize > (int64_t)nMaxCacheIncreaseSinceLastFlush)
+                    nTrimSize = nCoinCacheMaxSize - nMaxCacheIncreaseSinceLastFlush;
             }
             pcoinsTip->Trim(nTrimSize);
         }

--- a/src/blockstorage/blockstorage.cpp
+++ b/src/blockstorage/blockstorage.cpp
@@ -592,7 +592,7 @@ bool FlushStateToDiskInternal(CValidationState &state,
     size_t cacheSize = pcoinsTip->DynamicMemoryUsage();
     static int64_t nSizeAfterLastFlush = 0;
     // The cache is close to the limit. Try to flush and trim.
-    bool fCacheCritical = ((mode == FLUSH_STATE_IF_NEEDED) && (cacheSize > nCoinCacheMaxSize * 0.995)) ||
+    bool fCacheCritical = ((mode == FLUSH_STATE_IF_NEEDED) && (cacheSize > nCoinCacheMaxSize)) ||
                           (cacheSize - nSizeAfterLastFlush > (int64_t)nMaxCacheIncreaseSinceLastFlush);
     // It's been a while since we wrote the block index to disk. Do this frequently, so we don't need to redownload
     // after a crash.
@@ -681,7 +681,7 @@ bool FlushStateToDiskInternal(CValidationState &state,
         // trim extra so that we don't flush as often during IBD.
         if (IsChainNearlySyncd() && !fReindex && !fImporting)
         {
-            pcoinsTip->Trim(nCoinCacheMaxSize);
+            pcoinsTip->Trim(nCoinCacheMaxSize * .95);
         }
         else
         {

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -317,12 +317,6 @@ void CCoinsViewCache::Trim(size_t nTrimSize) const
     static uint64_t nTrimHeightDelta = nBestCoinHeight * 0.80; // This is where we attempt to do our first trim
     uint64_t nTrimHeight = nBestCoinHeight - nTrimHeightDelta;
 
-    // if we've already walked the nTrimHeight all the way back as far as we can go and there is nothing to trim
-    // then no need to check further.  This should be the typical state after a block sync is completed and there is
-    // enough dbcache to hold all the coins from recent transactions in memory.
-    if (nTrimHeight == 0 && _DynamicMemoryUsage() <= nTrimSize)
-        return;
-
     // Begin first Trim loop. This loop will trim coins from cache by the coin height, removing the oldest coins first.
     // This has been proven to improve sync performance significantly for nodes that can not hold the entire dbcache
     // in memory.

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -218,9 +218,11 @@ void ThreadCommitToMempool()
 
                 CValidationState state;
                 FlushStateToDisk(state, FLUSH_STATE_PERIODIC);
-                // The flush to disk above is only periodic therefore we need to continuously trim any excess from the
-                // cache.
-                pcoinsTip->Trim(nCoinCacheMaxSize);
+
+                // The flush to disk above is only periodic therefore we need to check if we need to trim
+                // any excess from the cache.
+                if (pcoinsTip->DynamicMemoryUsage() > nCoinCacheMaxSize)
+                    pcoinsTip->Trim(nCoinCacheMaxSize * .95);
             }
 
             mempool.check(pcoinsTip);


### PR DESCRIPTION
A few small items that need tweaking since we've now moved to a different model for entering txns to the mempool which was causing us to trim after every push to the mempool, when the dbcache was full. 

Also this also solves an edge condition, with very small dbcaches usually used only in testing', where the trim size can underflow causing nothing to be trimmed.