### PR TITLE
Refactor the setting of the cache configurations

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1070,16 +1070,12 @@ bool AppInit2(Config &config, thread_group &threadGroup)
     }
 
     // Return the initial values for the various in memory caches.
-    int64_t nBlockDBCache = 0;
-    int64_t nBlockUndoDBCache = 0;
-    int64_t nBlockTreeDBCache = 0;
-    int64_t nCoinDBCache = 0;
-    GetCacheConfiguration(nBlockDBCache, nBlockUndoDBCache, nBlockTreeDBCache, nCoinDBCache, nCoinCacheMaxSize);
+    CacheConfig cacheConfig = SetCacheConfiguration();
     LOGA("Cache configuration:\n");
-    LOGA("* Using %.1fMiB for block database\n", nBlockDBCache * (1.0 / 1024 / 1024));
-    LOGA("* Using %.1fMiB for block undo database\n", nBlockUndoDBCache * (1.0 / 1024 / 1024));
-    LOGA("* Using %.1fMiB for block index database\n", nBlockTreeDBCache * (1.0 / 1024 / 1024));
-    LOGA("* Using %.1fMiB for chain state database\n", nCoinDBCache * (1.0 / 1024 / 1024));
+    LOGA("* Using %.1fMiB for block database\n", cacheConfig.nBlockDBCache * (1.0 / 1024 / 1024));
+    LOGA("* Using %.1fMiB for block undo database\n", cacheConfig.nBlockUndoDBCache * (1.0 / 1024 / 1024));
+    LOGA("* Using %.1fMiB for block index database\n", cacheConfig.nBlockTreeDBCache * (1.0 / 1024 / 1024));
+    LOGA("* Using %.1fMiB for chain state database\n", cacheConfig.nCoinDBCache * (1.0 / 1024 / 1024));
     LOGA("* Using %.1fMiB for in-memory UTXO set\n", nCoinCacheMaxSize * (1.0 / 1024 / 1024));
 
     bool fLoaded = false;
@@ -1103,10 +1099,11 @@ bool AppInit2(Config &config, thread_group &threadGroup)
                 delete pblockdb;
 
                 uiInterface.InitMessage(_("Opening Block database..."));
-                InitializeBlockStorage(nBlockTreeDBCache, nBlockDBCache, nBlockUndoDBCache);
+                InitializeBlockStorage(
+                    cacheConfig.nBlockTreeDBCache, cacheConfig.nBlockDBCache, cacheConfig.nBlockUndoDBCache);
 
                 uiInterface.InitMessage(_("Opening UTXO database..."));
-                pcoinsdbview = new CCoinsViewDB(nCoinDBCache, false, fReindex);
+                pcoinsdbview = new CCoinsViewDB(cacheConfig.nCoinDBCache, false, fReindex);
                 pcoinscatcher = new CCoinsViewErrorCatcher(pcoinsdbview);
                 uiInterface.InitMessage(_("Opening Coins Cache database..."));
                 pcoinsTip = new CCoinsViewCache(pcoinscatcher);

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -56,24 +56,27 @@ static const int64_t nMaxCoinsDBCache = 8;
 uint64_t GetAvailableMemory();
 /** Get the total physical memory */
 uint64_t GetTotalSystemMemory();
+
+struct CacheConfig
+{
+    int64_t nBlockDBCache;
+    int64_t nBlockUndoDBCache;
+    int64_t nBlockTreeDBCache;
+    int64_t nCoinDBCache;
+
+    CacheConfig() : nBlockDBCache(0), nBlockUndoDBCache(0), nBlockTreeDBCache(0), nCoinDBCache(0) {}
+};
+
 /** Get the sizes for each of the caches. This is done during init.cpp on startup but also
  *  later, during dynamic sizing of the coins cache, when need to know the initial startup values.
  */
-void GetCacheConfiguration(int64_t &_nBlockDBCache,
-    int64_t &_nBlockUndoDBcache,
-    int64_t &_nBlockTreeDBCache,
-    int64_t &_nCoinDBCache,
-    int64_t &_nCoinCacheMaxSize,
-    bool fDefault = false);
-/** Calculate the various cache sizes. This is primarily used in GetCacheConfiguration() however during
+CacheConfig SetCacheConfiguration(bool fDefault = false);
+
+/** Calculate the various cache sizes. This is primarily used in SetCacheConfiguration() however during
  *  dynamic sizing of the coins cache we also need to use this function directly.
  */
-void CacheSizeCalculations(int64_t _nTotalCache,
-    int64_t &_nBlockDBCache,
-    int64_t &_nBlockUndoDBcache,
-    int64_t &_nBlockTreeDBCache,
-    int64_t &_nCoinDBCache,
-    int64_t &_nCoinCacheMaxSize);
+CacheConfig CacheSizeCalculations(int64_t _nTotalCache);
+
 /** This function is called during FlushStateToDisk.  The coins cache is dynamically sized before any
  *  checking is done for cache flushing and trimming
  */


### PR DESCRIPTION
Simplify and clarify the code by using a struct to store the
config settings which can then be used as a return value.

Change GetCacheConfiguration() to SetCacheConfiguration()