### PR TITLE
Remove cs_main lock when syncing with wallets

### DIFF
--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -270,16 +270,10 @@ void CommitTxToMempool()
     }
 
 #ifdef ENABLE_WALLET
+    for (auto &it : *q)
     {
-        // cs_main is taken again in SyncWithWallets but must be locked before csCommitQ
-        // to maintain correct locking order.
-        LOCK(cs_main);
-
-        for (auto &it : *q)
-        {
-            CTxCommitData &data = it.second;
-            SyncWithWallets(data.entry.GetSharedTx(), nullptr, -1);
-        }
+        CTxCommitData &data = it.second;
+        SyncWithWallets(data.entry.GetSharedTx(), nullptr, -1);
     }
 #endif
     q->clear();


### PR DESCRIPTION
This is not longer needed to maintain locking order becasue
we no longer need to maintain locking order with the commitQ because
further upstream we swapped pointer and are now dealing with a
queue that is separate from the commitQ.