### PR TITLE
Prevent deadlock of CPU miner and TX commit thread

### DIFF
--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -613,24 +613,16 @@ static bool ProcessBlockFound(const CBlock *pblock, const CChainParams &chainpar
     // Inform about the new block
     GetMainSignals().BlockFound(pblock->GetHash());
 
+    // In we are mining our own block or not running in parallel for any reason
+    // we must terminate any block validation threads that are currently running,
+    // Unless they have more work than our own block or are processing a chain
+    // that has more work than our block.
+    PV->StopAllValidationThreads(pblock->GetBlockHeader().nBits);
 
-    {
-        // We take a cs_main lock here even though it will also be aquired in ProcessNewBlock.  We want
-        // to make sure we give priority to our own blocks.  This is in order to prevent any other Parallel
-        // Blocks to validate when we've just mined one of our own blocks.
-        LOCK(cs_main);
-
-        // In we are mining our own block or not running in parallel for any reason
-        // we must terminate any block validation threads that are currently running,
-        // Unless they have more work than our own block or are processing a chain
-        // that has more work than our block.
-        PV->StopAllValidationThreads(pblock->GetBlockHeader().nBits);
-
-        // Process this block the same as if we had received it from another node
-        CValidationState state;
-        if (!ProcessNewBlock(state, chainparams, nullptr, pblock, true, nullptr, false))
-            return error("BitcoinMiner: ProcessNewBlock, block not accepted");
-    }
+    // Process this block the same as if we had received it from another node
+    CValidationState state;
+    if (!ProcessNewBlock(state, chainparams, nullptr, pblock, true, nullptr, false))
+        return error("BitcoinMiner: ProcessNewBlock, block not accepted");
 
     return true;
 }


### PR DESCRIPTION
This concerns the rarely used BU CPU miner.

The `cs_main` lock must not be taken before `ProcessNewBlock(..)`, as this
might then cause `ActivateBestChain(..)` to mutually deadlock with the tx
mempool commit thread. `ActivateBestChain(..)` might get stuck while
acquiring the `TxAdmissionPause` RAII that uses the TX processing
"thread corral", while the TX commit thread uses `cs_main` and the
thread corral the other way around.

Thanks to @gandrewstone and @ptschip for further input on this.