### PR TITLE
Implementation of variable keycheck mask for CIblt

### DIFF
--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -46,18 +46,10 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
 {
     header = pblock->GetBlockHeader();
     nBlockTxs = pblock->vtx.size();
-    uint64_t grapheneSetVersion = 0;
+    uint64_t grapheneSetVersion = CGrapheneBlock::GetGrapheneSetVersion(version);
 
     if (version >= 2)
         FillShortTxIDSelector();
-
-    if (version < 2)
-        grapheneSetVersion = 0;
-    else
-    {
-        // Currently CGrapheneSet version trails CGrapheneBlock version by 1
-        grapheneSetVersion = version - 1;
-    }
 
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -53,12 +53,8 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
 
     if (version < 2)
         grapheneSetVersion = 0;
-    if (version == 2)
-        grapheneSetVersion = 1;
-    else if (version == 3)
-        grapheneSetVersion = 2;
-    else if (version == 4)
-        grapheneSetVersion = 3;
+    else
+        grapheneSetVersion = version - 1;
 
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -54,7 +54,10 @@ CGrapheneBlock::CGrapheneBlock(const CBlockRef pblock,
     if (version < 2)
         grapheneSetVersion = 0;
     else
+    {
+        // Currently CGrapheneSet version trails CGrapheneBlock version by 1
         grapheneSetVersion = version - 1;
+    }
 
     std::vector<uint256> blockHashes;
     for (auto &tx : pblock->vtx)

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -143,10 +143,12 @@ public:
             throw std::runtime_error("nBlockTxs exceeds threshold for excessive block txs");
         if (!pGrapheneSet)
         {
+            // Currently CGrapheneSet version trails CGrapheneBlock version by 1
+            uint64_t grapheneSetVersion = version - 1;
             if (version > 3)
-                pGrapheneSet = std::make_shared<CGrapheneSet>(CGrapheneSet(version - 1, computeOptimized));
+                pGrapheneSet = std::make_shared<CGrapheneSet>(CGrapheneSet(grapheneSetVersion, computeOptimized));
             else
-                pGrapheneSet = std::make_shared<CGrapheneSet>(CGrapheneSet(version - 1));
+                pGrapheneSet = std::make_shared<CGrapheneSet>(CGrapheneSet(grapheneSetVersion));
         }
         READWRITE(*pGrapheneSet);
     }

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -31,7 +31,7 @@ enum FastFilterSupport
 
 const uint8_t GRAPHENE_FAST_FILTER_SUPPORT = EITHER;
 const uint64_t GRAPHENE_MIN_VERSION_SUPPORTED = 0;
-const uint64_t GRAPHENE_MAX_VERSION_SUPPORTED = 4;
+const uint64_t GRAPHENE_MAX_VERSION_SUPPORTED = 5;
 const unsigned char MIN_MEMPOOL_INFO_BYTES = 8;
 const uint8_t SHORTTXIDS_LENGTH = 8;
 
@@ -144,13 +144,9 @@ public:
         if (!pGrapheneSet)
         {
             if (version > 3)
-                pGrapheneSet = std::make_shared<CGrapheneSet>(CGrapheneSet(3, computeOptimized));
-            else if (version == 3)
-                pGrapheneSet = std::make_shared<CGrapheneSet>(CGrapheneSet(2));
-            else if (version == 2)
-                pGrapheneSet = std::make_shared<CGrapheneSet>(CGrapheneSet(1));
+                pGrapheneSet = std::make_shared<CGrapheneSet>(CGrapheneSet(version - 1, computeOptimized));
             else
-                pGrapheneSet = std::make_shared<CGrapheneSet>(CGrapheneSet(0));
+                pGrapheneSet = std::make_shared<CGrapheneSet>(CGrapheneSet(version - 1));
         }
         READWRITE(*pGrapheneSet);
     }

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -122,6 +122,17 @@ public:
      */
     static bool HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string strCommand, unsigned nHops);
 
+    static inline uint64_t GetGrapheneSetVersion(uint64_t grapheneBlockVersion)
+    {
+        if (grapheneBlockVersion < 2)
+            return 0;
+        else
+        {
+            // Currently CGrapheneSet version trails CGrapheneBlock version by 1
+            return grapheneBlockVersion - 1;
+        }
+    }
+
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
@@ -143,12 +154,12 @@ public:
             throw std::runtime_error("nBlockTxs exceeds threshold for excessive block txs");
         if (!pGrapheneSet)
         {
-            // Currently CGrapheneSet version trails CGrapheneBlock version by 1
-            uint64_t grapheneSetVersion = version - 1;
             if (version > 3)
-                pGrapheneSet = std::make_shared<CGrapheneSet>(CGrapheneSet(grapheneSetVersion, computeOptimized));
+                pGrapheneSet = std::make_shared<CGrapheneSet>(
+                    CGrapheneSet(CGrapheneBlock::GetGrapheneSetVersion(version), computeOptimized));
             else
-                pGrapheneSet = std::make_shared<CGrapheneSet>(CGrapheneSet(grapheneSetVersion));
+                pGrapheneSet =
+                    std::make_shared<CGrapheneSet>(CGrapheneSet(CGrapheneBlock::GetGrapheneSetVersion(version)));
         }
         READWRITE(*pGrapheneSet);
     }

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -432,7 +432,7 @@ uint8_t CGrapheneSet::NChecksumBits(size_t nIbltEntries,
         return 32;
 
     return (uint8_t)std::max((double)MIN_CHECKSUM_BITS,
-        std::log2(nIbltEntries *
-                  (1 - std::pow(1 - fBloomFPR * (nIbltHashFuncs / (double)nIbltEntries), nReceiverUniverseItems))) -
-            std::log2(fUncheckedErrorTol));
+        std::ceil(std::log2(nIbltEntries * (1 - std::pow(1 - fBloomFPR * (nIbltHashFuncs / (double)nIbltEntries),
+                                                    nReceiverUniverseItems))) -
+                                 std::log2(fUncheckedErrorTol)));
 }

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -98,7 +98,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
         nCheckSumBits = MAX_CHECKSUM_BITS;
 
     LOG(GRAPHENE, "using %d checksum bits in IBLT\n", nCheckSumBits);
-    uint32_t keycheckMask = 0xffffffff >> (MAX_CHECKSUM_BITS - nCheckSumBits);
+    uint32_t keycheckMask = MAX_CHECKSUM_MASK >> (MAX_CHECKSUM_BITS - nCheckSumBits);
     pSetIblt = std::make_shared<CIblt>(CIblt(nIbltCells, ibltSalt, ibltVersion, keycheckMask));
 
     std::map<uint64_t, uint256> mapCheapHashes;

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -31,13 +31,7 @@ CGrapheneSet::CGrapheneSet(size_t _nReceiverUniverseItems,
     // Below is the parameter "n" from the graphene paper
     uint64_t nItems = _itemHashes.size();
 
-    uint64_t ibltVersion;
-    if (version < 2)
-        ibltVersion = 0;
-    else if (version < 4)
-        ibltVersion = 1;
-    else
-        ibltVersion = 2;
+    uint64_t ibltVersion = CGrapheneSet::GetCIbltVersion(version);
 
     FastRandomContext insecure_rand(fDeterministic);
 

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -169,6 +169,16 @@ public:
         pSetIblt = nullptr;
     }
 
+    static inline uint64_t GetCIbltVersion(uint64_t grapheneSetVersion)
+    {
+        if (grapheneSetVersion < 2)
+            return 0;
+        else if (grapheneSetVersion < 4)
+            return 1;
+        else
+            return 2;
+    }
+
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
@@ -201,14 +211,7 @@ public:
             READWRITE(*pSetFilter);
         }
         if (!pSetIblt)
-        {
-            if (version < 2)
-                pSetIblt = std::make_shared<CIblt>(CIblt(0));
-            else if (version < 4)
-                pSetIblt = std::make_shared<CIblt>(CIblt(1));
-            else
-                pSetIblt = std::make_shared<CIblt>(CIblt(2));
-        }
+            pSetIblt = std::make_shared<CIblt>(CIblt(CGrapheneSet::GetCIbltVersion(version)));
         READWRITE(*pSetIblt);
     }
 };

--- a/src/iblt.cpp
+++ b/src/iblt.cpp
@@ -80,7 +80,7 @@ CIblt::CIblt()
     n_hash = 1;
     is_modified = false;
     version = 0;
-    keycheckMask = 0xffffffff;
+    keycheckMask = MAX_CHECKSUM_MASK;
 }
 
 CIblt::CIblt(uint64_t _version)
@@ -88,20 +88,20 @@ CIblt::CIblt(uint64_t _version)
     salt = 0;
     n_hash = 1;
     is_modified = false;
-    keycheckMask = 0xffffffff;
+    keycheckMask = MAX_CHECKSUM_MASK;
 
     CIblt::version = _version;
 }
 
 CIblt::CIblt(size_t _expectedNumEntries, uint64_t _version)
-    : salt(0), n_hash(0), is_modified(false), keycheckMask(0xffffffff)
+    : salt(0), n_hash(0), is_modified(false), keycheckMask(MAX_CHECKSUM_MASK)
 {
     CIblt::version = _version;
     CIblt::resize(_expectedNumEntries);
 }
 
 CIblt::CIblt(size_t _expectedNumEntries, uint32_t _salt, uint64_t _version)
-    : n_hash(0), is_modified(false), keycheckMask(0xffffffff)
+    : n_hash(0), is_modified(false), keycheckMask(MAX_CHECKSUM_MASK)
 {
     CIblt::version = _version;
     CIblt::salt = _salt;
@@ -145,7 +145,7 @@ void CIblt::resize(size_t _expectedNumEntries)
 
     // set hash seeds from salt
     for (size_t i = 0; i < n_hash; i++)
-        mapHashIdxSeeds[i] = salt % (0xffffffff - n_hash) + i;
+        mapHashIdxSeeds[i] = salt % (MAX_CHECKSUM_MASK - n_hash) + i;
 
     // reduce probability of failure by increasing by overhead factor
     size_t nEntries = (size_t)(_expectedNumEntries * OptimalOverhead(_expectedNumEntries));

--- a/src/iblt.h
+++ b/src/iblt.h
@@ -41,6 +41,7 @@ SOFTWARE.
 //
 
 const uint64_t IBLT_MAX_VERSION_SUPPORTED = 2;
+const uint32_t MAX_CHECKSUM_MASK = 0xffffffff;
 
 class BaseHashTableEntry
 {
@@ -188,7 +189,7 @@ public:
             std::vector<HashTableEntryStaticChk> hashTableChk;
             if (ser_action.ForRead())
             {
-                keycheckMask = 0xffffffff;
+                keycheckMask = MAX_CHECKSUM_MASK;
                 READWRITE(hashTableChk);
                 for (auto entryChk : hashTableChk)
                 {

--- a/src/iblt.h
+++ b/src/iblt.h
@@ -183,6 +183,12 @@ public:
         {
             READWRITE(keycheckMask);
             READWRITE(hashTable);
+            // Ensure that keyChecks do not exceed keycheckMask
+            if (ser_action.ForRead())
+            {
+                for (auto entry : hashTable)
+                    entry.keyCheck = entry.keyCheck & keycheckMask;
+            }
         }
         else
         {

--- a/src/iblt.h
+++ b/src/iblt.h
@@ -60,20 +60,27 @@ class HashTableEntry : public BaseHashTableEntry
 {
 public:
     uint64_t keyCheck64;
+    uint64_t count64;
 
     ADD_SERIALIZE_METHODS;
 
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream &s, Operation ser_action)
     {
-        READWRITE(count);
         READWRITE(keySum);
 
         if (!ser_action.ForRead())
+        {
             keyCheck64 = (uint64_t)keyCheck;
+            count64 = (uint64_t)count;
+        }
         READWRITE(COMPACTSIZE(keyCheck64));
+        READWRITE(COMPACTSIZE(count64));
         if (ser_action.ForRead())
+        {
             keyCheck = (uint32_t)keyCheck64;
+            count = (uint64_t)count64;
+        }
 
         READWRITE(valueSum);
     }

--- a/src/test/graphene_tests.cpp
+++ b/src/test/graphene_tests.cpp
@@ -27,15 +27,7 @@ size_t ProjectedGrapheneSizeBytes(uint64_t version, uint64_t nBlockTxs, uint64_t
     FastRandomContext insecure_rand(true);
     auto fpr = [nExcessTxs](int a) { return a / float(nExcessTxs); };
 
-    uint64_t ibltVersion;
-    if (version < 2)
-        ibltVersion = 0;
-    else if (version < 4)
-        ibltVersion = 1;
-    else
-        ibltVersion = 2;
-
-    CIblt iblt(nSymDiff, ibltVersion);
+    CIblt iblt(nSymDiff, CGrapheneSet::GetCIbltVersion(version));
     size_t ibltBytes = ::GetSerializeSize(iblt, SER_NETWORK, PROTOCOL_VERSION) - SERIALIZATION_OVERHEAD;
 
     size_t filterBytes;

--- a/src/test/graphene_tests.cpp
+++ b/src/test/graphene_tests.cpp
@@ -19,15 +19,23 @@
 #include <iostream>
 #include <iomanip>
 
-#define MAX_GRAPHENE_SET_VERSION 1
+#define MAX_GRAPHENE_SET_VERSION 4
 
-size_t ProjectedGrapheneSizeBytes(uint64_t nBlockTxs, uint64_t nExcessTxs, uint64_t nSymDiff, bool computeOptimized=false)
+size_t ProjectedGrapheneSizeBytes(uint64_t version, uint64_t nBlockTxs, uint64_t nExcessTxs, uint64_t nSymDiff, bool computeOptimized=false)
 {
     const int SERIALIZATION_OVERHEAD = 11;
     FastRandomContext insecure_rand(true);
     auto fpr = [nExcessTxs](int a) { return a / float(nExcessTxs); };
 
-    CIblt iblt(nSymDiff, 0);
+    uint64_t ibltVersion;
+    if (version < 2)
+        ibltVersion = 0;
+    else if (version < 4)
+        ibltVersion = 1;
+    else
+        ibltVersion = 2;
+
+    CIblt iblt(nSymDiff, ibltVersion);
     size_t ibltBytes = ::GetSerializeSize(iblt, SER_NETWORK, PROTOCOL_VERSION) - SERIALIZATION_OVERHEAD;
 
     size_t filterBytes;
@@ -58,6 +66,7 @@ BOOST_FIXTURE_TEST_SUITE(graphene_tests, BasicTestingSetup)
 
 BOOST_AUTO_TEST_CASE(graphene_set_encodes_and_decodes)
 {
+    uint64_t version = MAX_GRAPHENE_SET_VERSION;
     uint256 senderArr[] = {
         SerializeHash(3), SerializeHash(1), SerializeHash(2), SerializeHash(7), SerializeHash(11), SerializeHash(4)};
     std::vector<uint256> senderItems(senderArr, senderArr + sizeof(senderArr) / sizeof(uint256));
@@ -67,12 +76,12 @@ BOOST_AUTO_TEST_CASE(graphene_set_encodes_and_decodes)
 
     // unordered graphene sets
     {
-        CGrapheneSet senderGrapheneSet(6, 6, senderItems, 0, 0, 0, 0, false, false, true);
+        CGrapheneSet senderGrapheneSet(6, 6, senderItems, 0, 0, version, 0, false, false, true);
         std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
         std::vector<uint64_t> senderCheapHashes;
         for (uint256 item : senderItems)
-            senderCheapHashes.push_back(item.GetCheapHash());
+            senderCheapHashes.push_back(senderGrapheneSet.GetShortID(item));
 
         std::sort(senderCheapHashes.begin(), senderCheapHashes.end(), [](uint64_t i1, uint64_t i2) { return i1 < i2; });
         std::sort(reconciledCheapHashes.begin(), reconciledCheapHashes.end(),
@@ -84,12 +93,12 @@ BOOST_AUTO_TEST_CASE(graphene_set_encodes_and_decodes)
 
     // ordered graphene sets
     {
-        CGrapheneSet senderGrapheneSet(6, 6, senderItems, 0, 0, 0, 0, false, true, true);
+        CGrapheneSet senderGrapheneSet(6, 6, senderItems, 0, 0, version, 0, false, true, true);
         std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
         std::vector<uint64_t> senderCheapHashes;
         for (uint256 item : senderItems)
-            senderCheapHashes.push_back(item.GetCheapHash());
+            senderCheapHashes.push_back(senderGrapheneSet.GetShortID(item));
 
         BOOST_CHECK_EQUAL_COLLECTIONS(reconciledCheapHashes.begin(), reconciledCheapHashes.end(),
             senderCheapHashes.begin(), senderCheapHashes.end());
@@ -100,17 +109,16 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_multiple_sizes)
 {
     size_t nItemList[] = {1, 10, 50, 500, 5000, 10000};
     int nNumHashes = 0;
+    uint64_t version = MAX_GRAPHENE_SET_VERSION;
     for (size_t nItems : nItemList)
     {
         std::vector<uint256> senderItems;
-        std::vector<uint64_t> senderCheapHashes;
         std::vector<uint256> baseReceiverItems;
         for (size_t i = 1; i <= nItems; i++)
         {
             nNumHashes++;
             const uint256 &hash = GetHash(nNumHashes);
             senderItems.push_back(hash);
-            senderCheapHashes.push_back(hash.GetCheapHash());
             baseReceiverItems.push_back(hash);
         }
 
@@ -124,8 +132,12 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_multiple_sizes)
             }
 
             CGrapheneSet senderGrapheneSet(
-                receiverItems.size(), receiverItems.size(), senderItems, 0, 0, 0, 0, false, true, true);
+                receiverItems.size(), receiverItems.size(), senderItems, 0, 0, version, 0, false, true, true);
             std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
+
+            std::vector<uint64_t> senderCheapHashes;
+            for (auto &hash : senderItems)
+                senderCheapHashes.push_back(senderGrapheneSet.GetShortID(hash));
 
             BOOST_CHECK_EQUAL_COLLECTIONS(reconciledCheapHashes.begin(), reconciledCheapHashes.end(),
                 senderCheapHashes.begin(), senderCheapHashes.end());
@@ -141,8 +153,12 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_multiple_sizes)
             }
 
             CGrapheneSet senderGrapheneSet(
-                receiverItems.size(), receiverItems.size(), senderItems, 0, 0, 0, 0, false, true, true);
+                receiverItems.size(), receiverItems.size(), senderItems, 0, 0, version, 0, false, true, true);
             std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
+
+            std::vector<uint64_t> senderCheapHashes;
+            for (auto &hash : senderItems)
+                senderCheapHashes.push_back(senderGrapheneSet.GetShortID(hash));
 
             BOOST_CHECK_EQUAL_COLLECTIONS(reconciledCheapHashes.begin(), reconciledCheapHashes.end(),
                 senderCheapHashes.begin(), senderCheapHashes.end());
@@ -152,9 +168,11 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_multiple_sizes)
 
 BOOST_AUTO_TEST_CASE(graphene_set_finds_brute_force_opt_for_small_blocks)
 {
-    CGrapheneSet grapheneSet(0);
+    uint64_t version = MAX_GRAPHENE_SET_VERSION;
+    CGrapheneSet grapheneSet(version);
 
-    int n = (int)std::floor(APPROX_ITEMS_THRESH / 2);
+    uint16_t approx_items_thresh = version >= 4 ? APPROX_ITEMS_THRESH_REDUCE_CHECK : APPROX_ITEMS_THRESH;   
+    int n = (int)std::floor(approx_items_thresh / 2);
     int mu = 100;
     int m = (int)std::floor(n / 8) + mu;
 
@@ -163,8 +181,8 @@ BOOST_AUTO_TEST_CASE(graphene_set_finds_brute_force_opt_for_small_blocks)
     int a = 1;
     for (a = 1; a < m - mu; a++)
     {
-        size_t totalBytes = ProjectedGrapheneSizeBytes(n, m - mu, a);
-        size_t totalBytesOpt = ProjectedGrapheneSizeBytes(n, m - mu, a, true);
+        size_t totalBytes = ProjectedGrapheneSizeBytes(version, n, m - mu, a);
+        size_t totalBytesOpt = ProjectedGrapheneSizeBytes(version, n, m - mu, a, true);
 
         BOOST_CHECK_EQUAL(totalBytes, totalBytesOpt);
 
@@ -180,37 +198,46 @@ BOOST_AUTO_TEST_CASE(graphene_set_finds_brute_force_opt_for_small_blocks)
 
 BOOST_AUTO_TEST_CASE(graphene_set_finds_approx_opt_for_large_blocks)
 {
-    int n = 4 * APPROX_ITEMS_THRESH;
+    uint64_t version = MAX_GRAPHENE_SET_VERSION;
+    uint16_t approx_items_thresh = version >= 4 ? APPROX_ITEMS_THRESH_REDUCE_CHECK : APPROX_ITEMS_THRESH;   
+    int n = 4 * approx_items_thresh;
     int mu = 1000;
-    int m = APPROX_ITEMS_THRESH + mu;
-    CGrapheneSet grapheneSet(0);
-    auto approxSymDiff = [n]() {
+    int m = approx_items_thresh + mu;
+    CGrapheneSet grapheneSet(version);
+    double optSymDiff = grapheneSet.OptimalSymDiff(n, m, m - mu, 0);
+    double fpr = CGrapheneSet::BloomFalsePositiveRate(optSymDiff, m - mu);
+    uint8_t checksumBits = CGrapheneSet::NChecksumBits(n * CIblt::OptimalOverhead(n), CIblt::OptimalNHash(n), m, fpr, UNCHECKED_ERROR_TOL);
+    auto approxSymDiff = [n, checksumBits]() {
         return std::max(
-            1.0, std::round(FILTER_CELL_SIZE * n / (8 * IBLT_CELL_SIZE * IBLT_DEFAULT_OVERHEAD * LN2SQUARED)));
+            1.0, std::round(FILTER_CELL_SIZE * n / ((checksumBits + 8 * IBLT_FIXED_CELL_SIZE) * IBLT_DEFAULT_OVERHEAD * LN2SQUARED)));
     };
 
-    BOOST_CHECK_EQUAL(approxSymDiff(), grapheneSet.OptimalSymDiff(n, m, m - mu, 0));
+    BOOST_CHECK_EQUAL(approxSymDiff(), optSymDiff);
 }
 
 BOOST_AUTO_TEST_CASE(graphene_set_approx_opt_close_to_optimal)
 {
-    int n = APPROX_ITEMS_THRESH;
-    int mu = 100;
-    int m = (int)std::ceil(n / APPROX_EXCESS_RATE) + mu;
-    CGrapheneSet grapheneSet(0);
+    for (uint64_t version=0; version < MAX_GRAPHENE_SET_VERSION; version++)
+    {
+        int n = version >= 4 ? APPROX_ITEMS_THRESH_REDUCE_CHECK : APPROX_ITEMS_THRESH;
+        int mu = 100;
+        int m = (int)std::ceil(n / APPROX_EXCESS_RATE) + mu;
+        CGrapheneSet grapheneSet(version);
 
-    float totalBytesApprox = (float)ProjectedGrapheneSizeBytes(n, m - mu, grapheneSet.ApproxOptimalSymDiff(n));
-    float totalBytesBrute =
-        (float)ProjectedGrapheneSizeBytes(n, m - mu, grapheneSet.BruteForceSymDiff(n, m, m - mu, 0));
-    float totalBytesBruteOpt =
-        (float)ProjectedGrapheneSizeBytes(n, m - mu, grapheneSet.BruteForceSymDiff(n, m, m - mu, 0), true);
+        float totalBytesApprox = (float)ProjectedGrapheneSizeBytes(version, n, m - mu, grapheneSet.ApproxOptimalSymDiff(n));
+        float totalBytesBrute =
+            (float)ProjectedGrapheneSizeBytes(version, n, m - mu, grapheneSet.BruteForceSymDiff(n, m, m - mu, MAX_CHECKSUM_BITS));
+        float totalBytesBruteOpt =
+            (float)ProjectedGrapheneSizeBytes(version, n, m - mu, grapheneSet.BruteForceSymDiff(n, m, m - mu, MAX_CHECKSUM_BITS), true);
 
-    BOOST_CHECK_CLOSE(totalBytesApprox, totalBytesBrute, 15);
-    BOOST_CHECK_CLOSE(totalBytesApprox, totalBytesBruteOpt, 15);
+        BOOST_CHECK_CLOSE(totalBytesApprox, totalBytesBrute, 15);
+        BOOST_CHECK_CLOSE(totalBytesApprox, totalBytesBruteOpt, 15);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(graphene_set_decodes_empty_intersection)
 {
+    uint64_t version = MAX_GRAPHENE_SET_VERSION;
     uint256 senderArr[] = {SerializeHash(-7), SerializeHash(-2), SerializeHash(-4), SerializeHash(-1),
         SerializeHash(-5), SerializeHash(-11), SerializeHash(3), SerializeHash(1), SerializeHash(2), SerializeHash(7),
         SerializeHash(11), SerializeHash(4)};
@@ -221,12 +248,12 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_empty_intersection)
         SerializeHash(-5), SerializeHash(-11)};
     std::vector<uint256> receiverItems(receiverArr, receiverArr + sizeof(receiverArr) / sizeof(uint256));
 
-    CGrapheneSet senderGrapheneSet(6, 12, senderItems, 0, 0, 0, 0, false, true, true);
+    CGrapheneSet senderGrapheneSet(6, 12, senderItems, 0, 0, version, 0, false, true, true);
     std::vector<uint64_t> reconciledCheapHashes = senderGrapheneSet.Reconcile(receiverItems);
 
     std::vector<uint64_t> senderCheapHashes;
     for (uint256 item : senderItems)
-        senderCheapHashes.push_back(item.GetCheapHash());
+        senderCheapHashes.push_back(senderGrapheneSet.GetShortID(item));
 
     BOOST_CHECK_EQUAL_COLLECTIONS(
         reconciledCheapHashes.begin(), reconciledCheapHashes.end(), senderCheapHashes.begin(), senderCheapHashes.end());
@@ -234,17 +261,18 @@ BOOST_AUTO_TEST_CASE(graphene_set_decodes_empty_intersection)
 
 BOOST_AUTO_TEST_CASE(graphene_set_can_serde)
 {
+    uint64_t version = MAX_GRAPHENE_SET_VERSION;
     std::vector<uint256> senderItems;
     CDataStream ss(SER_DISK, 0);
 
     senderItems.push_back(SerializeHash(3));
-    CGrapheneSet sentGrapheneSet(1, 1, senderItems, 0, 0, 0, 0, false, false, true);
-    CGrapheneSet receivedGrapheneSet(0);
+    CGrapheneSet sentGrapheneSet(1, 1, senderItems, 0, 0, version, 0, false, false, true);
+    CGrapheneSet receivedGrapheneSet(version);
 
     ss << sentGrapheneSet;
     ss >> receivedGrapheneSet;
 
-    BOOST_CHECK_EQUAL(receivedGrapheneSet.Reconcile(senderItems)[0], senderItems[0].GetCheapHash());
+    BOOST_CHECK_EQUAL(receivedGrapheneSet.Reconcile(senderItems)[0], sentGrapheneSet.GetShortID(senderItems[0]));
 }
 
 BOOST_AUTO_TEST_CASE(graphene_set_version_check)
@@ -279,12 +307,13 @@ BOOST_AUTO_TEST_CASE(item_rank_encodes_and_decodes)
 
 BOOST_AUTO_TEST_CASE(compute_optimized_graphene_set_can_serde)
 {
+    uint64_t version = MAX_GRAPHENE_SET_VERSION;
     std::vector<uint256> senderItems;
     CDataStream ss(SER_DISK, 0);
 
     senderItems.push_back(SerializeHash(3));
-    CGrapheneSet sentGrapheneSet(1, 1, senderItems, 0, 0, 3, 0, true, false, true);
-    CGrapheneSet receivedGrapheneSet(3, true);
+    CGrapheneSet sentGrapheneSet(1, 1, senderItems, 0, 0, version, 0, true, false, true);
+    CGrapheneSet receivedGrapheneSet(version, true);
 
     ss << sentGrapheneSet;
     ss >> receivedGrapheneSet;
@@ -327,7 +356,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_cpu_check)
 
     auto sipStart = std::chrono::high_resolution_clock::now();
     CGrapheneSet sipGrapheneSet(
-        receiverItems.size(), receiverItems.size(), senderItems, 0, 0, 2, 0, false, false, true);
+        receiverItems.size(), receiverItems.size(), senderItems, 0, 0, MAX_GRAPHENE_SET_VERSION, 0, false, false, true);
     sipGrapheneSet.Reconcile(receiverItems);
     auto sipFinish = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> sipElapsed = sipFinish - sipStart;
@@ -335,7 +364,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_cpu_check)
 
     auto fastStart = std::chrono::high_resolution_clock::now();
     CGrapheneSet fastGrapheneSet(
-        receiverItems.size(), receiverItems.size(), senderItems, 0, 0, 3, 0, true, false, true);
+        receiverItems.size(), receiverItems.size(), senderItems, 0, 0, MAX_GRAPHENE_SET_VERSION, 0, true, false, true);
     fastGrapheneSet.Reconcile(receiverItems);
     auto fastFinish = std::chrono::high_resolution_clock::now();
     std::chrono::duration<double> fastElapsed = fastFinish - fastStart;
@@ -344,7 +373,7 @@ BOOST_AUTO_TEST_CASE(graphene_set_cpu_check)
 
 BOOST_AUTO_TEST_CASE(graphene_block_can_serde)
 {
-
+    uint64_t version = GRAPHENE_MAX_VERSION_SUPPORTED;
     // regular graphene block
     {
         CBlock block;
@@ -360,7 +389,7 @@ BOOST_AUTO_TEST_CASE(graphene_block_can_serde)
         stream >> tx;
         const CTransactionRef ptx = MakeTransactionRef(tx);
         block.vtx.push_back(ptx);
-        CGrapheneBlock senderGrapheneBlock(MakeBlockRef(block), 5, 6, 4, false);
+        CGrapheneBlock senderGrapheneBlock(MakeBlockRef(block), 5, 6, version, false);
         CGrapheneBlock receiverGrapheneBlock(4);
         CDataStream ss(SER_DISK, 0);
 
@@ -383,7 +412,7 @@ BOOST_AUTO_TEST_CASE(graphene_block_can_serde)
         stream >> tx;
         const CTransactionRef ptx = MakeTransactionRef(tx);
         block.vtx.push_back(ptx);
-        CGrapheneBlock senderGrapheneBlock(MakeBlockRef(block), 5, 6, 4, true);
+        CGrapheneBlock senderGrapheneBlock(MakeBlockRef(block), 5, 6, version, true);
         CGrapheneBlock receiverGrapheneBlock(4, true);
         CDataStream ss(SER_DISK, 0);
 
@@ -392,5 +421,12 @@ BOOST_AUTO_TEST_CASE(graphene_block_can_serde)
     }
 }
 
+BOOST_AUTO_TEST_CASE(nchecksumbits_gives_correct_value)
+{
+    double tol = 1 / std::pow(2, 11); 
+    uint8_t bits = CGrapheneSet::NChecksumBits(10, 2, 1, 0.5, tol);
+
+    BOOST_CHECK_EQUAL(bits, 11);
+}
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/iblt_tests.cpp
+++ b/src/test/iblt_tests.cpp
@@ -7,6 +7,7 @@
 
 #include "hashwrapper.h"
 #include "iblt.h"
+#include "serialize.h"
 #include "test/test_bitcoin.h"
 #include "utilstrencodings.h"
 
@@ -24,243 +25,288 @@ std::vector<uint8_t> PseudoRandomValue(uint32_t n)
 
 BOOST_FIXTURE_TEST_SUITE(iblt_tests, BasicTestingSetup)
 
+BOOST_AUTO_TEST_CASE(iblt_variable_checksum_gives_smaller_encoding)
+{
+    uint64_t version = 2;
+    uint32_t salt = 1;
+    size_t n = 1;
+
+    CIblt full(n, version);
+    full.insert(0, IBLT_NULL_VALUE);
+    size_t full_size = ::GetSerializeSize(full, SER_NETWORK, PROTOCOL_VERSION);
+    CIblt masked1(n, salt, version, 0x0000ffff);
+    masked1.insert(0, IBLT_NULL_VALUE);
+    size_t masked1_size = ::GetSerializeSize(masked1, SER_NETWORK, PROTOCOL_VERSION);
+    CIblt masked2(n, salt, version, 0x000000ff);
+    masked2.insert(0, IBLT_NULL_VALUE);
+    size_t masked2_size = ::GetSerializeSize(masked2, SER_NETWORK, PROTOCOL_VERSION);
+
+    BOOST_CHECK(full_size > masked1_size);
+    BOOST_CHECK(masked1_size > masked2_size);
+}
+
 BOOST_AUTO_TEST_CASE(iblt_handles_small_quantities)
 {
-    uint64_t version = 0;
-	bool allPassed = true;
-	for (size_t nItems=1;nItems < 100;nItems++)
-	{
-		CIblt t(nItems, version);
+    uint64_t versions[2] = {1, 2}; 
+    for (uint64_t version : versions)
+    {
+        bool allPassed = true;
+        for (size_t nItems=1;nItems < 100;nItems++)
+        {
+            CIblt t(nItems, version);
 
-		for (size_t i=0;i < nItems;i++)
-			t.insert(i, IBLT_NULL_VALUE);
+            for (size_t i=0;i < nItems;i++)
+                t.insert(i, IBLT_NULL_VALUE);
 
-		std::set<std::pair<uint64_t, std::vector<uint8_t> > > entries;
-		allPassed = allPassed && t.listEntries(entries, entries);
-	}
+            std::set<std::pair<uint64_t, std::vector<uint8_t> > > entries;
+            allPassed = allPassed && t.listEntries(entries, entries);
+        }
 
-	BOOST_CHECK(allPassed);
+        BOOST_CHECK(allPassed);
+    }
 }
 
 BOOST_AUTO_TEST_CASE(iblt_arbitrary_salt)
 {
     uint32_t salt = 17;
-    uint64_t version = 1;
-    size_t nItems = 2;
-    CIblt t(nItems, salt, version);
+    uint64_t versions[2] = {1, 2}; 
+    for (uint64_t version : versions)
+    {
+        size_t nItems = 2;
+        CIblt t(nItems, salt, version);
 
-    t.insert(0, ParseHex("00000000"));
-    t.insert(1, ParseHex("00000001"));
-    bool gotResult;
-    std::vector<uint8_t> result;
+        t.insert(0, ParseHex("00000000"));
+        t.insert(1, ParseHex("00000001"));
+        bool gotResult;
+        std::vector<uint8_t> result;
 
-    gotResult = t.get(0, result);
-    BOOST_CHECK(gotResult && result == ParseHex("00000000"));
+        gotResult = t.get(0, result);
+        BOOST_CHECK(gotResult && result == ParseHex("00000000"));
 
-    gotResult = t.get(1, result);
-    BOOST_CHECK(gotResult && result == ParseHex("00000001"));
+        gotResult = t.get(1, result);
+        BOOST_CHECK(gotResult && result == ParseHex("00000001"));
+    }
 }
 
 BOOST_AUTO_TEST_CASE(iblt_salted_reset)
 {
     size_t nHash = 1;
     uint32_t salt = 17;
-    uint64_t version = 1;
-    bool gotResult;
-    std::vector<uint8_t> result;
-    CIblt t(nHash, salt, version);
+    uint64_t versions[2] = {1, 2}; 
+    for (uint64_t version : versions)
+    {
+        bool gotResult;
+        std::vector<uint8_t> result;
+        CIblt t(nHash, salt, version);
 
-    t.insert(0, ParseHex("00000000"));
-    gotResult = t.get(0, result);
-    BOOST_CHECK(gotResult && result == ParseHex("00000000"));
+        t.insert(0, ParseHex("00000000"));
+        gotResult = t.get(0, result);
+        BOOST_CHECK(gotResult && result == ParseHex("00000000"));
 
-    t.reset();
-    t.resize(20);
-    t.insert(1, ParseHex("00000001"));
-    t.insert(11, ParseHex("00000011"));
+        t.reset();
+        t.resize(20);
+        t.insert(1, ParseHex("00000001"));
+        t.insert(11, ParseHex("00000011"));
 
-    gotResult = t.get(1, result);
-    BOOST_CHECK(gotResult && result == ParseHex("00000001"));
+        gotResult = t.get(1, result);
+        BOOST_CHECK(gotResult && result == ParseHex("00000001"));
+    }
 }
 
 BOOST_AUTO_TEST_CASE(iblt_reset)
 {
-    CIblt t;
-    t.insert(0, ParseHex("00000000"));
-    bool gotResult;
-    std::vector<uint8_t> result;
-    gotResult = t.get(21, result);
-    BOOST_CHECK(!gotResult);  // anything could have been inserted into a zero length IBLT
+    uint64_t versions[2] = {1, 2}; 
+    for (uint64_t version : versions)
+    {
+        CIblt t(version);
+        t.insert(0, ParseHex("00000000"));
+        bool gotResult;
+        std::vector<uint8_t> result;
+        gotResult = t.get(21, result);
+        BOOST_CHECK(!gotResult);  // anything could have been inserted into a zero length IBLT
 
-    t.reset();
-    t.resize(20);
-    t.insert(0, ParseHex("00000000"));
-    t.insert(1, ParseHex("00000001"));
-    t.insert(11, ParseHex("00000011"));
+        t.reset();
+        t.resize(20);
+        t.insert(0, ParseHex("00000000"));
+        t.insert(1, ParseHex("00000001"));
+        t.insert(11, ParseHex("00000011"));
 
-    gotResult = t.get(0, result);
-    BOOST_CHECK(gotResult && result == ParseHex("00000000"));
+        gotResult = t.get(0, result);
+        BOOST_CHECK(gotResult && result == ParseHex("00000000"));
 
-    t.reset();
+        t.reset();
 
-    gotResult = t.get(0, result);
-    BOOST_CHECK(gotResult && (result.size()==0));
+        gotResult = t.get(0, result);
+        BOOST_CHECK(gotResult && (result.size()==0));
 
-    t.resize(40);
+        t.resize(40);
 
-    t.insert(0, ParseHex("00000000"));
-    t.insert(1, ParseHex("00000001"));
-    t.insert(11, ParseHex("00000011"));
+        t.insert(0, ParseHex("00000000"));
+        t.insert(1, ParseHex("00000001"));
+        t.insert(11, ParseHex("00000011"));
 
-    gotResult = t.get(0, result);
-    BOOST_CHECK(gotResult && result == ParseHex("00000000"));
+        gotResult = t.get(0, result);
+        BOOST_CHECK(gotResult && result == ParseHex("00000000"));
+    }
 }
 
 BOOST_AUTO_TEST_CASE(iblt_erases_properly)
 {
-    uint64_t version = 0;
-    CIblt t(20, version);
-    t.insert(0, ParseHex("00000000"));
-    t.insert(1, ParseHex("00000001"));
-    t.insert(11, ParseHex("00000011"));
-
-    bool gotResult;
-    std::vector<uint8_t> result;
-    gotResult = t.get(0, result);
-    BOOST_CHECK(gotResult && result == ParseHex("00000000"));
-    gotResult = t.get(11, result);
-    BOOST_CHECK(gotResult && result == ParseHex("00000011"));
-
-    t.erase(0, ParseHex("00000000"));
-    t.erase(1, ParseHex("00000001"));
-    gotResult = t.get(1, result);
-    BOOST_CHECK(gotResult && result.empty());
-    t.erase(11, ParseHex("00000011"));
-    gotResult = t.get(11, result);
-    BOOST_CHECK(gotResult && result.empty());
-
-    t.insert(0, ParseHex("00000000"));
-    t.insert(1, ParseHex("00000001"));
-    t.insert(11, ParseHex("00000011"));
-
-    for (int i = 100; i < 115; i++)
+    uint64_t versions[2] = {1, 2}; 
+    for (uint64_t version : versions)
     {
-        t.insert(i, ParseHex("aabbccdd"));
-    }
+        CIblt t(20, version);
+        t.insert(0, ParseHex("00000000"));
+        t.insert(1, ParseHex("00000001"));
+        t.insert(11, ParseHex("00000011"));
 
-    gotResult = t.get(101, result);
-    BOOST_CHECK(gotResult && result == ParseHex("aabbccdd"));
-    gotResult = t.get(200, result);
-    BOOST_CHECK(gotResult && result.empty());
+        bool gotResult;
+        std::vector<uint8_t> result;
+        gotResult = t.get(0, result);
+        BOOST_CHECK(gotResult && result == ParseHex("00000000"));
+        gotResult = t.get(11, result);
+        BOOST_CHECK(gotResult && result == ParseHex("00000011"));
+
+        t.erase(0, ParseHex("00000000"));
+        t.erase(1, ParseHex("00000001"));
+        gotResult = t.get(1, result);
+        BOOST_CHECK(gotResult && result.empty());
+        t.erase(11, ParseHex("00000011"));
+        gotResult = t.get(11, result);
+        BOOST_CHECK(gotResult && result.empty());
+
+        t.insert(0, ParseHex("00000000"));
+        t.insert(1, ParseHex("00000001"));
+        t.insert(11, ParseHex("00000011"));
+
+        for (int i = 100; i < 115; i++)
+        {
+            t.insert(i, ParseHex("aabbccdd"));
+        }
+
+        gotResult = t.get(101, result);
+        BOOST_CHECK(gotResult && result == ParseHex("aabbccdd"));
+        gotResult = t.get(200, result);
+        BOOST_CHECK(gotResult && result.empty());
+    }
 }
 
 BOOST_AUTO_TEST_CASE(iblt_handles_overload)
 {
-    uint64_t version = 0;
-    CIblt t(20, version);
+    uint64_t versions[2] = {1, 2}; 
+    for (uint64_t version : versions)
+    {
+        CIblt t(20, version);
 
-    // 1,000 values in an IBLT that has room for 20,
-    // all lookups should fail.
-    for (int i = 0; i < 1000; i++)
-    {
-        t.insert(i, PseudoRandomValue(i));
-    }
-    bool gotResult;
-    std::vector<uint8_t> result;
-    for (int i = 0; i < 1000; i += 97)
-    {
-        gotResult = t.get(i, result);
-        BOOST_CHECK(!gotResult && result.empty());
-    }
+        // 1,000 values in an IBLT that has room for 20,
+        // all lookups should fail.
+        for (int i = 0; i < 1000; i++)
+        {
+            t.insert(i, PseudoRandomValue(i));
+        }
+        bool gotResult;
+        std::vector<uint8_t> result;
+        for (int i = 0; i < 1000; i += 97)
+        {
+            gotResult = t.get(i, result);
+            BOOST_CHECK(!gotResult && result.empty());
+        }
 
-    // erase all but 20:
-    for (int i = 20; i < 1000; i++)
-    {
-        t.erase(i, PseudoRandomValue(i));
-    }
-    for (int i = 0; i < 20; i++)
-    {
-        gotResult = t.get(i, result);
-        BOOST_CHECK(gotResult && result == PseudoRandomValue(i));
+        // erase all but 20:
+        for (int i = 20; i < 1000; i++)
+        {
+            t.erase(i, PseudoRandomValue(i));
+        }
+        for (int i = 0; i < 20; i++)
+        {
+            gotResult = t.get(i, result);
+            BOOST_CHECK(gotResult && result == PseudoRandomValue(i));
+        }
     }
 }
 
 BOOST_AUTO_TEST_CASE(iblt_lists_entries_properly)
 {
-    uint64_t version = 0;
-    std::set<std::pair<uint64_t, std::vector<uint8_t> > > expected;
-    CIblt t(20, version);
-    for (int i = 0; i < 20; i++)
+    uint64_t versions[2] = {1, 2}; 
+    for (uint64_t version : versions)
     {
-        t.insert(i, PseudoRandomValue(i * 2));
-        expected.insert(std::make_pair(i, PseudoRandomValue(i * 2)));
+        std::set<std::pair<uint64_t, std::vector<uint8_t> > > expected;
+        CIblt t(20, version);
+        for (int i = 0; i < 20; i++)
+        {
+            t.insert(i, PseudoRandomValue(i * 2));
+            expected.insert(std::make_pair(i, PseudoRandomValue(i * 2)));
+        }
+        std::set<std::pair<uint64_t, std::vector<uint8_t> > > entries;
+        bool fAllFound = t.listEntries(entries, entries);
+        BOOST_CHECK(fAllFound && entries == expected);
     }
-    std::set<std::pair<uint64_t, std::vector<uint8_t> > > entries;
-    bool fAllFound = t.listEntries(entries, entries);
-    BOOST_CHECK(fAllFound && entries == expected);
 }
 
 BOOST_AUTO_TEST_CASE(iblt_performs_subtraction_properly)
 {
-    uint64_t version = 0;
-    CIblt t1(11, version);
-    CIblt t2(11, version);
-
-    for (int i = 0; i < 195; i++)
+    uint64_t versions[2] = {1, 2}; 
+    for (uint64_t version : versions)
     {
-        t1.insert(i, PseudoRandomValue(i));
+        CIblt t1(11, version);
+        CIblt t2(11, version);
+
+        for (int i = 0; i < 195; i++)
+        {
+            t1.insert(i, PseudoRandomValue(i));
+        }
+        for (int i = 5; i < 200; i++)
+        {
+            t2.insert(i, PseudoRandomValue(i));
+        }
+
+        CIblt diff = t1 - t2;
+
+        // Should end up with 10 differences, 5 positive and 5 negative:
+        std::set<std::pair<uint64_t, std::vector<uint8_t> > > expectedPositive;
+        std::set<std::pair<uint64_t, std::vector<uint8_t> > > expectedNegative;
+        for (int i = 0; i < 5; i++)
+        {
+            expectedPositive.insert(std::make_pair(i, PseudoRandomValue(i)));
+            expectedNegative.insert(std::make_pair(195 + i, PseudoRandomValue(195 + i)));
+        }
+        std::set<std::pair<uint64_t, std::vector<uint8_t> > > positive;
+        std::set<std::pair<uint64_t, std::vector<uint8_t> > > negative;
+        bool allDecoded = diff.listEntries(positive, negative);
+        BOOST_CHECK(allDecoded);
+        BOOST_CHECK(positive == expectedPositive);
+        BOOST_CHECK(negative == expectedNegative);
+
+        positive.clear();
+        negative.clear();
+        allDecoded = (t2 - t1).listEntries(positive, negative);
+        BOOST_CHECK(allDecoded);
+        BOOST_CHECK(positive == expectedNegative); // Opposite subtraction, opposite results
+        BOOST_CHECK(negative == expectedPositive);
+
+
+        CIblt emptyIBLT(11, version);
+        std::set<std::pair<uint64_t, std::vector<uint8_t> > > emptySet;
+
+        // Test edge cases for empty IBLT:
+        allDecoded = emptyIBLT.listEntries(emptySet, emptySet);
+        BOOST_CHECK(allDecoded);
+        BOOST_CHECK(emptySet.empty());
+
+        positive.clear();
+        negative.clear();
+        allDecoded = (diff - emptyIBLT).listEntries(positive, negative);
+        BOOST_CHECK(allDecoded);
+        BOOST_CHECK(positive == expectedPositive);
+        BOOST_CHECK(negative == expectedNegative);
+
+        positive.clear();
+        negative.clear();
+        allDecoded = (emptyIBLT - diff).listEntries(positive, negative);
+        BOOST_CHECK(allDecoded);
+        BOOST_CHECK(positive == expectedNegative); // Opposite subtraction, opposite results
+        BOOST_CHECK(negative == expectedPositive);
     }
-    for (int i = 5; i < 200; i++)
-    {
-        t2.insert(i, PseudoRandomValue(i));
-    }
-
-    CIblt diff = t1 - t2;
-
-    // Should end up with 10 differences, 5 positive and 5 negative:
-    std::set<std::pair<uint64_t, std::vector<uint8_t> > > expectedPositive;
-    std::set<std::pair<uint64_t, std::vector<uint8_t> > > expectedNegative;
-    for (int i = 0; i < 5; i++)
-    {
-        expectedPositive.insert(std::make_pair(i, PseudoRandomValue(i)));
-        expectedNegative.insert(std::make_pair(195 + i, PseudoRandomValue(195 + i)));
-    }
-    std::set<std::pair<uint64_t, std::vector<uint8_t> > > positive;
-    std::set<std::pair<uint64_t, std::vector<uint8_t> > > negative;
-    bool allDecoded = diff.listEntries(positive, negative);
-    BOOST_CHECK(allDecoded);
-    BOOST_CHECK(positive == expectedPositive);
-    BOOST_CHECK(negative == expectedNegative);
-
-    positive.clear();
-    negative.clear();
-    allDecoded = (t2 - t1).listEntries(positive, negative);
-    BOOST_CHECK(allDecoded);
-    BOOST_CHECK(positive == expectedNegative); // Opposite subtraction, opposite results
-    BOOST_CHECK(negative == expectedPositive);
-
-
-    CIblt emptyIBLT(11, version);
-    std::set<std::pair<uint64_t, std::vector<uint8_t> > > emptySet;
-
-    // Test edge cases for empty IBLT:
-    allDecoded = emptyIBLT.listEntries(emptySet, emptySet);
-    BOOST_CHECK(allDecoded);
-    BOOST_CHECK(emptySet.empty());
-
-    positive.clear();
-    negative.clear();
-    allDecoded = (diff - emptyIBLT).listEntries(positive, negative);
-    BOOST_CHECK(allDecoded);
-    BOOST_CHECK(positive == expectedPositive);
-    BOOST_CHECK(negative == expectedNegative);
-
-    positive.clear();
-    negative.clear();
-    allDecoded = (emptyIBLT - diff).listEntries(positive, negative);
-    BOOST_CHECK(allDecoded);
-    BOOST_CHECK(positive == expectedNegative); // Opposite subtraction, opposite results
-    BOOST_CHECK(negative == expectedPositive);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR introduces a variable size keyCheck field for the HashTableEntry class used by CIblt. The reason for this change is that [recent research](https://github.com/bissias/graphene-experiments/blob/master/jupyter/min_checksum_IBLT.ipynb) has shown that most IBLTs do not need to use all 32 bits of the keyCheck field. Therefore, it is typically possible to reduce the overall size of the Graphene block by giving the keyCheck field variable size.

