### PR TITLE
Use a set to ensure we don't double count peers

### DIFF
--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -17,46 +17,41 @@ bool IsCompactBlocksEnabled();
 // Update the counters for how many peers we have connected.
 void ThinTypeRelay::AddPeers(CNode *pfrom)
 {
+    LOCK(cs_addpeers);
     if (pfrom)
     {
         if (pfrom->nServices & NODE_XTHIN)
-            nThinBlockPeers++;
+            setThinBlockPeers.insert(pfrom->GetId());
         if (pfrom->nServices & NODE_GRAPHENE)
-            nGraphenePeers++;
+            setGraphenePeers.insert(pfrom->GetId());
     }
+    nThinBlockPeers = setThinBlockPeers.size();
+    nGraphenePeers = setGraphenePeers.size();
 }
 void ThinTypeRelay::AddCompactBlockPeer(CNode *pfrom)
 {
+    LOCK(cs_addpeers);
     if (pfrom && pfrom->fSupportsCompactBlocks)
-        nCompactBlockPeers++;
+    {
+        setCompactBlockPeers.insert(pfrom->GetId());
+    }
+    nCompactBlockPeers = setCompactBlockPeers.size();
 }
 void ThinTypeRelay::RemovePeers(CNode *pfrom)
 {
+    LOCK(cs_addpeers);
     if (pfrom)
     {
         if (pfrom->nServices & NODE_XTHIN)
-            nThinBlockPeers--;
+            setThinBlockPeers.erase(pfrom->GetId());
         if (pfrom->nServices & NODE_GRAPHENE)
-            nGraphenePeers--;
+            setGraphenePeers.erase(pfrom->GetId());
         if (pfrom->fSupportsCompactBlocks)
-            nCompactBlockPeers--;
-
-        if (nThinBlockPeers < 0)
-        {
-            nThinBlockPeers = 0;
-            LOG(THIN | GRAPHENE | CMPCT, "WARNING: nThinBlockPeers was less than zero");
-        }
-        if (nGraphenePeers < 0)
-        {
-            nGraphenePeers = 0;
-            LOG(THIN | GRAPHENE | CMPCT, "WARNING: nGraphenePeers was less than zero");
-        }
-        if (nCompactBlockPeers < 0)
-        {
-            nCompactBlockPeers = 0;
-            LOG(THIN | GRAPHENE | CMPCT, "WARNING: nCompactBlockPeers was less than zero");
-        }
+            setCompactBlockPeers.erase(pfrom->GetId());
     }
+    nThinBlockPeers = setThinBlockPeers.size();
+    nGraphenePeers = setGraphenePeers.size();
+    nCompactBlockPeers = setCompactBlockPeers.size();
 }
 
 // Preferential Block Relay Timer:

--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -17,7 +17,23 @@ bool IsCompactBlocksEnabled();
 // Update the counters for how many peers we have connected.
 void ThinTypeRelay::AddPeers(CNode *pfrom)
 {
+    uint32_t nNodes = 0;
+    {
+        LOCK(cs_vNodes);
+        nNodes = vNodes.size();
+    }
+
     LOCK(cs_addpeers);
+
+    // Don't allow the set sizes to grow unbounded.  They should never be greater
+    // than the number of peers connected.  If this should happen we'll just stop
+    // adding them and return, but if running a debug build we'll assert.
+    DbgAssert(setThinBlockPeers.size() <= nNodes, return );
+    DbgAssert(setGraphenePeers.size() <= nNodes, return );
+    if (setThinBlockPeers.size() > nNodes || setGraphenePeers.size() > nNodes)
+        return;
+
+    // Update the counters
     if (pfrom)
     {
         if (pfrom->nServices & NODE_XTHIN)
@@ -30,7 +46,21 @@ void ThinTypeRelay::AddPeers(CNode *pfrom)
 }
 void ThinTypeRelay::AddCompactBlockPeer(CNode *pfrom)
 {
+    uint32_t nNodes = 0;
+    {
+        LOCK(cs_vNodes);
+        nNodes = vNodes.size();
+    }
+
     LOCK(cs_addpeers);
+
+    // Don't allow the set sizes to grow unbounded.  They should never be greater
+    // than the number of peers connected.  If this should happen we'll just stop
+    // adding them and return, but if running a debug build we'll assert.
+    DbgAssert(setCompactBlockPeers.size() <= nNodes, return );
+    if (setCompactBlockPeers.size() > nNodes)
+        return;
+
     if (pfrom && pfrom->fSupportsCompactBlocks)
     {
         setCompactBlockPeers.insert(pfrom->GetId());

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -44,7 +44,12 @@ private:
     // attack surface.
     size_t MAX_THINTYPE_BLOCKS_IN_FLIGHT = 6;
 
-    // Counters for how many of each peer are currently connected.
+    // Counters for how many of each peer are currently connected.  We use the set to store the
+    // nodeid so that we can then get a unique count of peers with with to update the atomic counters.
+    CCriticalSection cs_addpeers;
+    std::set<NodeId> setThinBlockPeers;
+    std::set<NodeId> setGraphenePeers;
+    std::set<NodeId> setCompactBlockPeers;
     std::atomic<int32_t> nThinBlockPeers{0};
     std::atomic<int32_t> nGraphenePeers{0};
     std::atomic<int32_t> nCompactBlockPeers{0};

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -931,6 +931,11 @@ void CRequestManager::SendRequests()
                                     next.node->Release();
                                 }
                             }
+
+                            // Now that we've completed setting up our request for this transaction
+                            // we're done with this node, for this item, and can release and delete it.
+                            next.node->Release();
+                            next.node = nullptr;
                         }
 
                         inFlight++;

--- a/src/test/requestmanager_tests.cpp
+++ b/src/test/requestmanager_tests.cpp
@@ -101,6 +101,12 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     dummyNodeNone.state_outgoing = ConnectionStateOutgoing::READY;
     dummyNodeNone.id = 4;
 
+    // Add to vNodes
+    vNodes.push_back(&dummyNodeXthin);
+    vNodes.push_back(&dummyNodeGraphene);
+    vNodes.push_back(&dummyNodeCmpct);
+    vNodes.push_back(&dummyNodeNone);
+
     // Initialize Nodes
     GetNodeSignals().InitializeNode(&dummyNodeXthin);
     GetNodeSignals().InitializeNode(&dummyNodeGraphene);
@@ -949,5 +955,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     // Final cleanup: Unset mocktime
     SetMockTime(0);
     requester.MapBlocksInFlightClear();
+
+    // remove from vNodes
+    vNodes.erase(remove(vNodes.begin(), vNodes.end(), &dummyNodeGraphene), vNodes.end());
+    vNodes.erase(remove(vNodes.begin(), vNodes.end(), &dummyNodeNone), vNodes.end());
+    vNodes.erase(remove(vNodes.begin(), vNodes.end(), &dummyNodeCmpct), vNodes.end());
+    vNodes.erase(remove(vNodes.begin(), vNodes.end(), &dummyNodeXthin), vNodes.end());
 }
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
We can receive multiple VERSION or SENDCMPCT messages which can
cause us to double count those peer types. By using a set
we can easily filter out the duplicates.