### PR TITLE
[qa] add rpc call gettxpos

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -246,7 +246,8 @@ testScripts = [ RpcTest(t) for t in [
     'getlogcategories',
     'getrawtransaction',
     Disabled('electrum_basics', "Needs to be skipped if electrs is not built"),
-    Disabled('electrum_reorg', "Needs to be skipped if electrs is not built")
+    Disabled('electrum_reorg', "Needs to be skipped if electrs is not built"),
+    'gettxpos',
 ] ]
 
 testScriptsExt = [ RpcTest(t) for t in [

--- a/qa/rpc-tests/gettxpos.py
+++ b/qa/rpc-tests/gettxpos.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright (c) 2019 The Bitcoin Unlimited developers
+"""
+Tests to check if basic electrum server integration works
+"""
+from test_framework.util import assert_equal
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.loginit import logging
+from test_framework.nodemessages import CBlock, FromHex
+
+
+class ElectrumBasicTests(BitcoinTestFramework):
+
+    def __init__(self):
+        super().__init__()
+        self.setup_clean_chain = True
+        self.num_nodes = 1
+
+    def run_test(self):
+        n = self.nodes[0]
+        n.set("consensus.enableCanonicalTxOrder=1")
+        n.generate(200)
+
+        for i in range(1, 100):
+            n.sendtoaddress(n.getnewaddress(), 1)
+
+        block = n.generate(1)
+        block = FromHex(CBlock(), n.getblock(block[0], False))
+
+        for i in range(0, len(block.vtx)):
+            res = n.gettxpos(block.vtx[i].calc_sha256(),
+                    block.calc_sha256())
+            assert_equal(i, res['position'])
+
+
+    def setup_network(self, dummy = None):
+        self.nodes = self.setup_nodes()
+
+if __name__ == '__main__':
+    ElectrumBasicTests().main()

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -361,6 +361,7 @@ test/thinblock_tests.cpp
 test/thinblock_util_tests.cpp
 test/timedata_tests.cpp
 test/transaction_tests.cpp
+test/txlookup_tests.cpp
 test/txvalidationcache_tests.cpp
 test/uahf_test.cpp
 test/uint256_tests.cpp
@@ -369,6 +370,8 @@ test/util_tests.cpp
 test/utilhttp_tests.cpp
 test/utilprocess_tests.cpp
 test/versionbits_tests.cpp
+txlookup.cpp
+txlookup.h
 wallet/crypter.cpp
 wallet/crypter.h
 wallet/db.cpp

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -200,6 +200,7 @@ BITCOIN_CORE_H = \
   torcontrol.h \
   txadmission.h \
   txdb.h \
+  txlookup.h \
   txmempool.h \
   txorphanpool.h \
   ui_interface.h \
@@ -304,6 +305,7 @@ libbitcoin_server_a_SOURCES = \
   torcontrol.cpp \
   txadmission.cpp \
   txdb.cpp \
+  txlookup.cpp \
   txmempool.cpp \
   txorphanpool.cpp \
   tweak.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -127,6 +127,7 @@ BITCOIN_TESTS =\
   test/thinblock_util_tests.cpp \
   test/timedata_tests.cpp \
   test/transaction_tests.cpp \
+  test/txlookup_tests.cpp \
   test/txvalidationcache_tests.cpp \
   test/versionbits_tests.cpp \
   test/genversionbits_tests.cpp \

--- a/src/respend/test/respenddetector_tests.cpp
+++ b/src/respend/test/respenddetector_tests.cpp
@@ -3,11 +3,10 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 #include "respend/respenddetector.h"
-#include "key.h"
-#include "random.h"
+#include "primitives/transaction.h"
 #include "respend/respendaction.h"
-#include "script/standard.h"
 #include "test/test_bitcoin.h"
+#include "test/testutil.h"
 #include "txmempool.h"
 
 #include <boost/test/unit_test.hpp>
@@ -55,22 +54,6 @@ public:
     CTxMemPool mempool;
     std::shared_ptr<DummyRespendAction> dummyaction;
 };
-
-CMutableTransaction CreateRandomTx()
-{
-    CKey key;
-    key.MakeNewKey(true);
-
-    CMutableTransaction tx;
-    tx.vin.resize(1);
-    tx.vin[0].prevout.n = 0;
-    tx.vin[0].prevout.hash = GetRandHash();
-    tx.vin[0].scriptSig << OP_1;
-    tx.vout.resize(1);
-    tx.vout[0].nValue = 1 * CENT;
-    tx.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
-    return tx;
-}
 
 } // ns anon
 

--- a/src/test/testutil.cpp
+++ b/src/test/testutil.cpp
@@ -10,5 +10,24 @@
 #endif
 
 #include "fs.h"
+#include "key.h"
+#include "primitives/transaction.h"
+#include "random.h"
+#include "script/standard.h"
 
 fs::path GetTempPath() { return fs::temp_directory_path(); }
+CMutableTransaction CreateRandomTx()
+{
+    CKey key;
+    key.MakeNewKey(true);
+
+    CMutableTransaction tx;
+    tx.vin.resize(1);
+    tx.vin[0].prevout.n = 0;
+    tx.vin[0].prevout.hash = GetRandHash();
+    tx.vin[0].scriptSig << OP_1;
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 1 * CENT;
+    tx.vout[0].scriptPubKey = GetScriptForDestination(key.GetPubKey().GetID());
+    return tx;
+}

--- a/src/test/testutil.h
+++ b/src/test/testutil.h
@@ -11,6 +11,9 @@
 
 #include "fs.h"
 
+class CMutableTransaction;
+
 fs::path GetTempPath();
+CMutableTransaction CreateRandomTx();
 
 #endif // BITCOIN_TEST_TESTUTIL_H

--- a/src/test/txlookup_tests.cpp
+++ b/src/test/txlookup_tests.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include "txlookup.h"
+#include "test/test_bitcoin.h"
+#include "test/testutil.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(txlookup_tests, BasicTestingSetup);
+
+BOOST_AUTO_TEST_CASE(non_ctor_lookup)
+{
+    CBlock block;
+    for (size_t i = 0; i < 100; ++i)
+    {
+        block.vtx.push_back(MakeTransactionRef(CreateRandomTx()));
+    }
+
+    for (size_t i = 0; i < 100; i += 10)
+    {
+        BOOST_CHECK_EQUAL(i, FindTxPosition(block, block.vtx[i]->GetHash(), false));
+    }
+}
+
+BOOST_AUTO_TEST_CASE(ctor_lookup)
+{
+    CBlock block;
+    for (size_t i = 0; i < 100; ++i)
+    {
+        block.vtx.push_back(MakeTransactionRef(CreateRandomTx()));
+    }
+    std::sort(
+        begin(block.vtx) + 1, end(block.vtx), [](const auto &a, const auto &b) { return a->GetHash() < b->GetHash(); });
+
+    for (size_t i = 0; i < 100; i += 10)
+    {
+        BOOST_CHECK_EQUAL(i, FindTxPosition(block, block.vtx[i]->GetHash(), true));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/txlookup.cpp
+++ b/src/txlookup.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "txlookup.h"
+#include "primitives/block.h"
+#include "uint256.h"
+
+#include <algorithm>
+
+
+static int64_t slow_pos_lookup(const CBlock &block, const uint256 &tx)
+{
+    for (size_t i = 0; i < block.vtx.size(); ++i)
+    {
+        if (block.vtx[i]->GetHash() == tx)
+        {
+            return i;
+        }
+    }
+    return TX_NOT_FOUND;
+}
+
+static int64_t ctor_pos_lookup(const CBlock &block, const uint256 &tx)
+{
+    // Coinbase is not sorted and thus needs special treatment
+    if (block.vtx[0]->GetHash() == tx)
+    {
+        return 0;
+    }
+
+    auto compare = [](auto &blocktx, const uint256 &lookuptx) { return blocktx->GetHash() < lookuptx; };
+
+    auto it = std::lower_bound(begin(block.vtx) + 1, end(block.vtx), tx, compare);
+
+    if (it == end(block.vtx))
+    {
+        return TX_NOT_FOUND;
+    }
+    return std::distance(begin(block.vtx), it);
+}
+
+
+/// Finds the position of a transaction in a block.
+/// \param ctor Optimized lookup if it's known that block has CTOR ordering
+/// \return
+int64_t FindTxPosition(const CBlock &block, const uint256 &txhash, bool ctor_optimized)
+{
+    if (block.vtx.size() == 0)
+    {
+        // invalid block
+        return TX_NOT_FOUND;
+    }
+    return ctor_optimized ? ctor_pos_lookup(block, txhash) : slow_pos_lookup(block, txhash);
+}

--- a/src/txlookup.h
+++ b/src/txlookup.h
@@ -1,0 +1,19 @@
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_TXLOOKUP_H
+
+#include <cstdint>
+
+static const int64_t TX_NOT_FOUND = -1;
+
+class CBlock;
+class uint256;
+
+/// Finds the position of a transaction in a block.
+/// \param ctor Optimized lookup if it's known that block has CTOR ordering
+/// \return position in block, or negative value on error
+int64_t FindTxPosition(const CBlock &block, const uint256 &txhash, bool ctor_optimized);
+
+#endif


### PR DESCRIPTION
RPC call for finding the transaction position within a block.

Motivation for this RPC call is to improve electrum server performance. Currently, for finding the transaction position, electrs fetches the full block from `bitcoind` -- and it does this for every transaction merkle proof it creates.