### PR TITLE
Fix incorrect validation state when connecting many blocks

### DIFF
--- a/qa/rpc-tests/ctor.py
+++ b/qa/rpc-tests/ctor.py
@@ -27,7 +27,7 @@ class CtorTest (BitcoinTestFramework):
         initialize_chain_clean(self.options.tmpdir, 7, bitcoinConfDict, wallets)
 
     def setup_network(self, split=False):
-        self.nodes = start_nodes(4, self.options.tmpdir)
+        self.nodes = start_nodes(4, self.options.tmpdir,[["-debug"],["-debug"],["-debug"],["-debug"]])
         # Now interconnect the nodes
         connect_nodes_full(self.nodes[:3])
         connect_nodes_bi(self.nodes,2,3)
@@ -89,8 +89,8 @@ class CtorTest (BitcoinTestFramework):
         try:
             invalid = next(x for x in ct if x["status"] == "invalid")
         except Exception as e:
-            pdb.set_trace()
             print(str(e))
+            AssertionError("CTOR node did not reject the block: " + str(e))
         assert_equal(invalid["height"], 102)
 
         # Now generate a CTOR block
@@ -182,7 +182,7 @@ class CtorTest (BitcoinTestFramework):
         for i in range(5):
             connect_nodes_bi(self.nodes,4,i)
 
-        self.nodes.append(start_node(5, self.options.tmpdir))
+        self.nodes.append(start_node(5, self.options.tmpdir, ["-debug"]))
         self.nodes[5].set("consensus.enableCanonicalTxOrder=0")
         waitFor(5, lambda: "False" in str(self.nodes[5].get("consensus.enableCanonicalTxOrder")))
 

--- a/qa/rpc-tests/ctor.py
+++ b/qa/rpc-tests/ctor.py
@@ -56,7 +56,7 @@ class CtorTest (BitcoinTestFramework):
             self.nodes[0].sendtoaddress(a, 5)
 
         # now send tx to myself that must reuse coins because I don't have enough
-        for i in range(1,20):
+        for i in range(1, 20):
             try:
                 self.nodes[0].sendtoaddress(addr[0], 21-i)
             except JSONRPCException as e: # an exception you don't catch is a testing error
@@ -83,14 +83,15 @@ class CtorTest (BitcoinTestFramework):
         assert_equal(self.nodes[1].getblockcount(), 102)
 
         # check that a CTOR node rejected the block
+        waitFor(30, lambda: "invalid" in str(self.nodes[2].getchaintips()))
         ct = self.nodes[2].getchaintips()
         tip = next(x for x in ct if x["status"] == "active")
         assert_equal(tip["height"], 101)
         try:
             invalid = next(x for x in ct if x["status"] == "invalid")
         except Exception as e:
-            print(str(e))
-            AssertionError("CTOR node did not reject the block: " + str(e))
+            print(str(ct))
+            AssertionError("Incorrect chain status: " + str(e))
         assert_equal(invalid["height"], 102)
 
         # Now generate a CTOR block

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -596,19 +596,7 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, CBlockRef p
             ProcessNewBlock(state, chainparams, pfrom, pblock.get(), forceProcessing, nullptr, false);
         }
 
-        int nDoS;
-        if (state.IsInvalid(nDoS))
-        {
-            LOGA("Invalid block due to %s\n", state.GetRejectReason().c_str());
-            if (!strCommand.empty())
-            {
-                pfrom->PushMessage("reject", strCommand, state.GetRejectCode(),
-                    state.GetRejectReason().substr(0, MAX_REJECT_MESSAGE_LENGTH), inv.hash);
-                if (nDoS > 0)
-                    dosMan.Misbehaving(pfrom, nDoS);
-            }
-        }
-        else
+        if (!state.IsInvalid())
         {
             LargestBlockSeen(nSizeBlock); // update largest block seen
 

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -607,20 +607,6 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, CBlockRef p
                 if (nDoS > 0)
                     dosMan.Misbehaving(pfrom, nDoS);
             }
-
-            // the current fork is bad due to this block so reset the best header to the best fully-validated block
-            // so we can download another fork of headers (and blocks).
-            LOCK(cs_main);
-            CBlockIndex *mostWork = FindMostWorkChain();
-            CBlockIndex *tip = chainActive.Tip();
-            if (mostWork && tip && (mostWork->nChainWork > tip->nChainWork))
-            {
-                pindexBestHeader = mostWork;
-            }
-            else
-            {
-                pindexBestHeader = tip;
-            }
         }
         else
         {

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -3208,6 +3208,8 @@ bool ActivateBestChainStep(CValidationState &state,
                 }
             }
         }
+        if (fInvalidFound)
+            break; // stop processing more blocks if the last one was invalid.
 
         // Notify the UI with the new block tip information.
         if (pindexMostWork->nHeight >= nHeight && pindexNewTip != nullptr && pindexLastNotify != pindexNewTip)

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -1320,6 +1320,15 @@ bool InvalidateBlock(CValidationState &state, const Consensus::Params &consensus
     InvalidChainFound(pindex);
     // Now mark every block index on every chain that contains pindex as child of invalid
     MarkAllContainingChainsInvalid(pindex);
+
+    // Since this block has been invalidated and removed from setBlockIndexCandidates
+    // then reset the best header to the current most work chain.
+    CBlockIndex *mostWork = FindMostWorkChain();
+    if (mostWork)
+    {
+        pindexBestHeader = mostWork;
+    }
+
     mempool.removeForReorg(pcoinsTip, chainActive.Tip()->nHeight + 1, STANDARD_LOCKTIME_VERIFY_FLAGS);
     uiInterface.NotifyBlockTip(IsInitialBlockDownload(), pindex->pprev);
     return true;
@@ -2655,6 +2664,14 @@ void InvalidBlockFound(CBlockIndex *pindex, const CValidationState &state)
 
         // Now mark every block index on every chain that contains pindex as child of invalid
         MarkAllContainingChainsInvalid(pindex);
+
+        // Since this block has been invalidated and removed from setBlockIndexCandidates
+        // then reset the best header to the current most work chain.
+        CBlockIndex *mostWork = FindMostWorkChain();
+        if (mostWork)
+        {
+            pindexBestHeader = mostWork;
+        }
     }
 }
 

--- a/src/validation/validation.h
+++ b/src/validation/validation.h
@@ -134,7 +134,8 @@ bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusPa
 bool ActivateBestChain(CValidationState &state,
     const CChainParams &chainparams,
     const CBlock *pblock = nullptr,
-    bool fParallel = false);
+    bool fParallel = false,
+    CNode *pfrom = nullptr);
 
 /**
  * Process an incoming block. This only returns after the best known valid


### PR DESCRIPTION
If we try to connect an invalid block and then subsequently try
to connect a valid one in the same ActivateBestChainStep() loop
then we end up with an incorrect validation state which then causes
us to set out pindexBestHeader to the wrong value , at the point
when we are wrapping up the parallel validation thread.  What we
need to do is ensure that each time we loop through and attempt
to connect a block , that we have a fresh validation state.

Futhermore in ActivateBestChain() where we "remember" the invalid
state that was returned in the bool "result" , we have to reset
that to true if any subsequent block is sucessfully connected
otherwise we will also potentially return an unsucessful result
when in fact we were finally successful.