### PR TITLE
Release the noderef upon disconnect.

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1132,9 +1132,10 @@ void CleanupDisconnectedNodes()
                 // close socket and cleanup
                 pnode->CloseSocketDisconnect();
 
-                // hold in disconnected pool until all refs are released
-                if (pnode->fNetworkNode || pnode->fInbound)
-                    pnode->Release();
+                // Release this one reference.
+                pnode->Release();
+
+                // hold in disconnected pool until all other refs are released
                 vNodesDisconnected.push_back(pnode);
             }
         }


### PR DESCRIPTION
It doesn't matter what node type it is, and futhermore the we
could have non-network outbound peers so we need to make sure
we're release all the refs for those as well.