### PR TITLE
Fix edge condition where we try to connect an invalid chain but need to finish syncing

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -77,19 +77,20 @@ CCriticalSection cs_rpcWarmup;
 CSharedCriticalSection cs_mapBlockIndex;
 BlockMap mapBlockIndex GUARDED_BY(cs_mapBlockIndex);
 
+std::atomic<CBlockIndex *> pindexBestHeader{nullptr};
+std::atomic<CBlockIndex *> pindexBestInvalid{nullptr};
+
 CCriticalSection cs_main;
 CChain chainActive GUARDED_BY(cs_main); // however, chainActive.Tip() is lock free
 // BU variables moved to globals.cpp
 // - moved CCriticalSection cs_main;
 // - moved BlockMap mapBlockIndex;
 // - movedCChain chainActive;
-std::atomic<CBlockIndex *> pindexBestHeader{nullptr};
 CFeeRate minRelayTxFee GUARDED_BY(cs_main) = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
 // The allowed size of the in memory UTXO cache
 int64_t nCoinCacheMaxSize GUARDED_BY(cs_main) = 0;
 /** A cache to store headers that have arrived but can not yet be connected **/
 std::map<uint256, std::pair<CBlockHeader, int64_t> > mapUnConnectedHeaders GUARDED_BY(cs_main);
-CBlockIndex *pindexBestInvalid GUARDED_BY(cs_main) = nullptr;
 /**
  * Every received block is assigned a unique and increasing identifier, so we
  * know which one to give priority in case of a fork.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -98,7 +98,6 @@ extern CCriticalSection cs_mapInboundConnectionTracker;
 
 extern CCriticalSection cs_LastBlockFile;
 
-extern CBlockIndex *pindexBestInvalid;
 extern std::map<uint256, NodeId> mapBlockSource;
 extern std::set<int> setDirtyFileInfo;
 extern uint64_t nBlockSequenceId;

--- a/src/main.h
+++ b/src/main.h
@@ -186,6 +186,9 @@ extern int64_t nMaxTipAge;
 /** Best header we've seen so far (used for getheaders queries' starting points). */
 extern std::atomic<CBlockIndex *> pindexBestHeader;
 
+/** Best Invalid header we've seen so far. */
+extern std::atomic<CBlockIndex *> pindexBestInvalid;
+
 /** Used to determine whether it is time to check the orphan pool for any txns that can be evicted. */
 extern int64_t nLastOrphanCheck;
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2517,7 +2517,15 @@ bool SendMessages(CNode *pto)
         }
 
         // If the chain is not entirely sync'd then look for new blocks to download.
-        if (!IsChainSyncd())
+        //
+        // Also check an edge condition, where we've invalidated a chain and set the pindexBestHeader to the
+        // new most work chain, as a result we may end up just connecting whatever blocks are in setblockindexcandidates
+        // resulting in pindexBestHeader equalling the chainActive.Tip() causing us to stop checking for more blocks to
+        // download (our chain will now not sync until the next block announcement is received). Therefore, if the
+        // best invalid chain work is still greater than our chaintip then we have to keep looking for more blocks
+        // to download.
+        if (!IsChainSyncd() || (pindexBestInvalid.load() && chainActive.Tip() &&
+                                   pindexBestInvalid.load()->nChainWork > chainActive.Tip()->nChainWork))
         {
             TRY_LOCK(cs_main, locked);
             if (locked)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2524,8 +2524,12 @@ bool SendMessages(CNode *pto)
         // download (our chain will now not sync until the next block announcement is received). Therefore, if the
         // best invalid chain work is still greater than our chaintip then we have to keep looking for more blocks
         // to download.
-        if (!IsChainSyncd() || (pindexBestInvalid.load() && chainActive.Tip() &&
-                                   pindexBestInvalid.load()->nChainWork > chainActive.Tip()->nChainWork))
+        //
+        // Use temporaries for the chain tip and best invalid because they are both atomics and either could
+        // be nullified between the two calls.
+        CBlockIndex *pTip = chainActive.Tip();
+        CBlockIndex *pBestInvalid = pindexBestInvalid.load();
+        if (!IsChainSyncd() || (pBestInvalid && pTip && pBestInvalid->nChainWork > pTip->nChainWork))
         {
             TRY_LOCK(cs_main, locked);
             if (locked)


### PR DESCRIPTION
This can under some circumstances prevent us from syncing fully
to the correct chain until we receive the next block announcement.

This was happening in the ctor.py test where we had two chains, one
which was DTOR and one CTOR and then we tried to connect a node
to these two chains and let it sync.  Sometimes it was hanging
because when one chain was marked invalid then we ended up
setting the chaintip to the most work chain. This casues us to
connect all the blocks in the setblockindexcandidates resulting
in the pindexBestHeader being equal to the chainTip.  The final result
is that no more blocks could be downloaded because it appeared that
the chain was fully synced. Another new block announcement would be
needed to get the sync to continue.  This problem is unlikely to
be seen on mainnet, however it could happen with the end result that
our chain sync would fall behind until the next block was mined.