### PR TITLE
 Fix a compiler warning obtained when native compiling on a 32 bit linux box

### DIFF
--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1002,7 +1002,7 @@ void CTxMemPool::check(const CCoinsViewCache *pcoins) const
         // Check children against mapNextTx
         CTxMemPool::setEntries setChildrenCheck;
         std::map<COutPoint, CInPoint>::const_iterator iter = mapNextTx.lower_bound(COutPoint(it->GetTx().GetHash(), 0));
-        int64_t childSizes = 0;
+        uint64_t childSizes = 0;
         for (; iter != mapNextTx.end() && iter->first.hash == it->GetTx().GetHash(); ++iter)
         {
             txiter childit = mapTx.find(iter->second.ptx->GetHash());


### PR DESCRIPTION
This is based on #1836 and #1838 to avoid useless travis failure. hence this PR should be merged *after* the aforementioned PRs.

The only significant commit is 9589ced.