### PR TITLE
Pruning: fix lock order issue and potential deadlock

### DIFF
--- a/src/chain.h
+++ b/src/chain.h
@@ -8,9 +8,9 @@
 #define BITCOIN_CHAIN_H
 
 #include "arith_uint256.h"
-#include "sync.h"
 #include "pow.h"
 #include "primitives/block.h"
+#include "sync.h"
 #include "tinyformat.h"
 #include "uint256.h"
 #include "util.h"

--- a/src/chain.h
+++ b/src/chain.h
@@ -8,6 +8,7 @@
 #define BITCOIN_CHAIN_H
 
 #include "arith_uint256.h"
+#include "sync.h"
 #include "pow.h"
 #include "primitives/block.h"
 #include "tinyformat.h"
@@ -16,6 +17,8 @@
 
 #include <atomic>
 #include <vector>
+
+extern CSharedCriticalSection cs_mapBlockIndex;
 
 class CBlockFileInfo
 {
@@ -334,6 +337,7 @@ public:
     //! Returns true if the validity was changed.
     bool RaiseValidity(enum BlockStatus nUpTo)
     {
+        AssertWriteLockHeld(cs_mapBlockIndex);
         assert(!(nUpTo & ~BLOCK_VALID_MASK)); // Only validity flags allowed.
         if (nStatus & BLOCK_FAILED_MASK)
             return false;

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -2591,11 +2591,15 @@ bool ConnectBlock(const CBlock &block,
                     return AbortNode(state, "Failed to write undo data");
 
                 // update nUndoPos in block index
+                //
+                // We must take the cs_mapBlockIndex after FindUndoPos() in order to maintain
+                // the proper locking order of cs_main -> cs_LastBlockFile -> cs_mapBlockIndex
                 WRITELOCK(cs_mapBlockIndex);
                 pindex->nUndoPos = _pos.nPos;
                 pindex->nStatus |= BLOCK_HAVE_UNDO;
             }
 
+            WRITELOCK(cs_mapBlockIndex);
             pindex->RaiseValidity(BLOCK_VALID_SCRIPTS);
             setDirtyBlockIndex.insert(pindex);
         }

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -2578,7 +2578,6 @@ bool ConnectBlock(const CBlock &block,
 
     // Write undo information to disk
     {
-        WRITELOCK(cs_mapBlockIndex);
         if (pindex->GetUndoPos().IsNull() || !pindex->IsValid(BLOCK_VALID_SCRIPTS))
         {
             if (pindex->GetUndoPos().IsNull())
@@ -2592,6 +2591,7 @@ bool ConnectBlock(const CBlock &block,
                     return AbortNode(state, "Failed to write undo data");
 
                 // update nUndoPos in block index
+                WRITELOCK(cs_mapBlockIndex);
                 pindex->nUndoPos = _pos.nPos;
                 pindex->nStatus |= BLOCK_HAVE_UNDO;
             }


### PR DESCRIPTION
cs_LastBlockFile should be take before cs_mapblockindex.  FindUndoPos()
takes a lock to cs_LastBlockIndex but we were taking cs_mapblockindex
upstream here; we don't really need to take cs_mapblockindex until later
where we modify the index values.

This issue only seems happens when pruning is enabled and we're looking for
files to prune.