### PR TITLE
Add UpdateBlockAvailability() to Thinblocks and CompactBlocks

### DIFF
--- a/src/blockrelay/compactblock.cpp
+++ b/src/blockrelay/compactblock.cpp
@@ -159,6 +159,7 @@ bool CompactBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     }
 
     CInv inv(MSG_BLOCK, compactBlock->header.GetHash());
+    requester.UpdateBlockAvailability(pfrom->GetId(), inv.hash);
     LOG(CMPCT, "received compact block %s from peer %s of %d bytes\n", inv.hash.ToString(), pfrom->GetLogName(),
         compactBlock->GetSize());
 

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -95,6 +95,7 @@ bool CThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     }
 
     CInv inv(MSG_BLOCK, thinBlock->header.GetHash());
+    requester.UpdateBlockAvailability(pfrom->GetId(), inv.hash);
     LOG(THIN, "received thinblock %s from peer %s of %d bytes\n", inv.hash.ToString(), pfrom->GetLogName(),
         thinBlock->GetSize());
 


### PR DESCRIPTION
When we handle messages for Xthins and Graphene we update the block
availailability. Although technically we don't need this until we
allow unannounced thintype blocks, it's good to have this in place
so we don't have issues in the future when/if we enable that feature
and also it keeps the code symmetrical with graphene/xthins.