### PR TITLE
Make nCoinCacheMaxSize atomic.  

### DIFF
--- a/src/blockstorage/blockstorage.cpp
+++ b/src/blockstorage/blockstorage.cpp
@@ -592,7 +592,7 @@ bool FlushStateToDiskInternal(CValidationState &state,
     size_t cacheSize = pcoinsTip->DynamicMemoryUsage();
     static int64_t nSizeAfterLastFlush = 0;
     // The cache is close to the limit. Try to flush and trim.
-    bool fCacheCritical = ((mode == FLUSH_STATE_IF_NEEDED) && (cacheSize > nCoinCacheMaxSize)) ||
+    bool fCacheCritical = ((mode == FLUSH_STATE_IF_NEEDED) && (cacheSize > (size_t)nCoinCacheMaxSize)) ||
                           (cacheSize - nSizeAfterLastFlush > (int64_t)nMaxCacheIncreaseSinceLastFlush);
     // It's been a while since we wrote the block index to disk. Do this frequently, so we don't need to redownload
     // after a crash.

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -80,6 +80,9 @@ BlockMap mapBlockIndex GUARDED_BY(cs_mapBlockIndex);
 std::atomic<CBlockIndex *> pindexBestHeader{nullptr};
 std::atomic<CBlockIndex *> pindexBestInvalid{nullptr};
 
+// The max allowed size of the in memory UTXO cache.
+std::atomic<int64_t> nCoinCacheMaxSize{0};
+
 CCriticalSection cs_main;
 CChain chainActive GUARDED_BY(cs_main); // however, chainActive.Tip() is lock free
 // BU variables moved to globals.cpp
@@ -87,8 +90,6 @@ CChain chainActive GUARDED_BY(cs_main); // however, chainActive.Tip() is lock fr
 // - moved BlockMap mapBlockIndex;
 // - movedCChain chainActive;
 CFeeRate minRelayTxFee GUARDED_BY(cs_main) = CFeeRate(DEFAULT_MIN_RELAY_TX_FEE);
-// The allowed size of the in memory UTXO cache
-int64_t nCoinCacheMaxSize GUARDED_BY(cs_main) = 0;
 /** A cache to store headers that have arrived but can not yet be connected **/
 std::map<uint256, std::pair<CBlockHeader, int64_t> > mapUnConnectedHeaders GUARDED_BY(cs_main);
 /**

--- a/src/main.h
+++ b/src/main.h
@@ -174,7 +174,6 @@ extern bool fIsBareMultisigStd;
 extern unsigned int nBytesPerSigOp;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
-extern int64_t nCoinCacheMaxSize;
 /** A fee rate smaller than this is considered zero fee (for relaying, mining and transaction creation) */
 extern CFeeRate minRelayTxFee;
 /** Absolute maximum transaction fee (in satoshis) used by wallet and mempool (rejects high fee in sendrawtransaction)

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -221,7 +221,7 @@ void ThreadCommitToMempool()
 
                 // The flush to disk above is only periodic therefore we need to check if we need to trim
                 // any excess from the cache.
-                if (pcoinsTip->DynamicMemoryUsage() > nCoinCacheMaxSize)
+                if (pcoinsTip->DynamicMemoryUsage() > (size_t)nCoinCacheMaxSize)
                     pcoinsTip->Trim(nCoinCacheMaxSize * .95);
             }
 

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -23,6 +23,9 @@ class uint256;
 
 static const bool DEFAULT_TXINDEX = false;
 
+//! The max allowed size of the in memory UTXO cache which can also be dynamically adjusted
+//! (if it has been configured) based on the current availability of memory.
+extern std::atomic<int64_t> nCoinCacheMaxSize;
 //! -dbcache default (MiB)
 static const int64_t nDefaultDbCache = 500;
 //! max. -dbcache in (MiB)
@@ -63,7 +66,6 @@ void GetCacheConfiguration(int64_t &_nBlockDBCache,
     int64_t &_nBlockUndoDBcache,
     int64_t &_nBlockTreeDBCache,
     int64_t &_nCoinDBCache,
-    int64_t &_nCoinCacheMaxSize,
     bool fDefault = false);
 /** Calculate the various cache sizes. This is primarily used in GetCacheConfiguration() however during
  *  dynamic sizing of the coins cache we also need to use this function directly.
@@ -72,8 +74,7 @@ void CacheSizeCalculations(int64_t _nTotalCache,
     int64_t &_nBlockDBCache,
     int64_t &_nBlockUndoDBcache,
     int64_t &_nBlockTreeDBCache,
-    int64_t &_nCoinDBCache,
-    int64_t &_nCoinCacheMaxSize);
+    int64_t &_nCoinDBCache);
 /** This function is called during FlushStateToDisk.  The coins cache is dynamically sized before any
  *  checking is done for cache flushing and trimming
  */


### PR DESCRIPTION
It gets accessed in other places but isn't locked.  It would typically require cs_main, but we don't want or need to take cs_main in txadmission.cpp where nCoinCacheMaxSize is often checked in ThreadCommitToMempool()