### PR TITLE
Initialize the dbcache size and nCoinCacheMaxSize for the unit tests

### DIFF
--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -73,6 +73,13 @@ TestingSetup::TestingSetup(const std::string &chainName) : BasicTestingSetup(cha
     bool worked = InitBlockIndex(chainparams);
     assert(worked);
 
+    // Initial dbcache settings so that the automatic cache setting don't kick in and allow
+    // us to accidentally use up our RAM on Travis, and also so that we are not prevented from flushing the
+    // dbcache if the need arises in the unit tests (dbcache must be less than the DEFAULT_HIGH_PERF_MEM_CUTOFF
+    // to allow all cache entries to be flushed).
+    SoftSetArg("-dbcache", std::to_string(5));
+    nCoinCacheMaxSize.store(5000000);
+
     // Make sure there are 3 script check threads running for each queue
     SoftSetArg("-par", std::to_string(3));
     PV.reset(new CParallelValidation());


### PR DESCRIPTION
In test_bitcoin.cpp initialize these values. This prevents us from
accidentally using up RAM during unit tests runs and also fixes
a bug in the txvalidationcache tests which was preventing us from
flushing the dbcache at the start of the test run.