### PR TITLE
Significantly reduce the number of dbcache lookups

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -198,11 +198,14 @@ bool CCoinsViewCache::HaveCoin(const COutPoint &outpoint) const
     return (it != cacheCoins.end() && !it->second.coin.IsSpent());
 }
 
-bool CCoinsViewCache::HaveCoinInCache(const COutPoint &outpoint) const
+bool CCoinsViewCache::HaveCoinInCache(const COutPoint &outpoint, bool &fSpent) const
 {
     READLOCK(cs_utxo);
     CCoinsMap::const_iterator it = cacheCoins.find(outpoint);
-    return it != cacheCoins.end();
+    bool fHave = (it != cacheCoins.end());
+    if (fHave)
+        fSpent = it->second.coin.IsSpent();
+    return fHave;
 }
 
 uint256 CCoinsViewCache::GetBestBlock() const

--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -198,6 +198,31 @@ bool CCoinsViewCache::HaveCoin(const COutPoint &outpoint) const
     return (it != cacheCoins.end() && !it->second.coin.IsSpent());
 }
 
+bool CCoinsViewCache::GetCoinFromDB(const COutPoint &outpoint) const
+{
+    Coin coin;
+    if (!base->GetCoin(outpoint, coin))
+        return false;
+
+    WRITELOCK(cs_utxo);
+    CCoinsMap::iterator ret =
+        cacheCoins
+            .emplace(std::piecewise_construct, std::forward_as_tuple(outpoint), std::forward_as_tuple(std::move(coin)))
+            .first;
+    if (ret->second.coin.IsSpent())
+    {
+        // The parent only has an empty entry for this outpoint; we can consider our
+        // version as fresh.
+        ret->second.flags = CCoinsCacheEntry::FRESH;
+    }
+    cachedCoinsUsage += ret->second.coin.DynamicMemoryUsage();
+
+    if (nBestCoinHeight < ret->second.coin.nHeight)
+        nBestCoinHeight = ret->second.coin.nHeight;
+
+    return !ret->second.coin.IsSpent();
+}
+
 bool CCoinsViewCache::HaveCoinInCache(const COutPoint &outpoint, bool &fSpent) const
 {
     READLOCK(cs_utxo);

--- a/src/coins.h
+++ b/src/coins.h
@@ -293,6 +293,13 @@ public:
         size_t &nChildCachedCoinsUsage);
 
     /**
+     * Check if we have the given utxo on disk and load it into cache.
+     * The semantics are the same as HaveCoin(), but no calls to
+     * the backing CCoinsView are made.
+     */
+    bool GetCoinFromDB(const COutPoint &outpoint) const;
+
+    /**
      * Check if we have the given utxo already loaded in this cache.
      * The semantics are the same as HaveCoin(), but no calls to
      * the backing CCoinsView are made.

--- a/src/coins.h
+++ b/src/coins.h
@@ -301,8 +301,11 @@ public:
 
     /**
      * Check if we have the given utxo already loaded in this cache.
-     * The semantics are the same as HaveCoin(), but no calls to
-     * the backing CCoinsView are made.
+     *
+     * @param[in]  outpoint   A reference to an outpoint in the coin we are checking
+     * @param[out] fSpent     A reference to an bool which indicates if the coin was spent or not
+     *                        NOTE: this value will not be set if the coin does not exist in cache.
+     * @return     bool       A return of true only indicates the coin is in cache, but not if it is spent/unspent
      */
     bool HaveCoinInCache(const COutPoint &outpoint, bool &fSpent) const;
 

--- a/src/coins.h
+++ b/src/coins.h
@@ -297,7 +297,7 @@ public:
      * The semantics are the same as HaveCoin(), but no calls to
      * the backing CCoinsView are made.
      */
-    bool HaveCoinInCache(const COutPoint &outpoint) const;
+    bool HaveCoinInCache(const COutPoint &outpoint, bool &fSpent) const;
 
     /**
      * Return a reference to Coin in the cache, or a pruned one if not found. This is

--- a/src/test/coins_tests.cpp
+++ b/src/test/coins_tests.cpp
@@ -210,7 +210,9 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
             COutPoint out(txids[insecure_rand() % txids.size()], 0);
             int cacheid = insecure_rand() % stack.size();
             stack[cacheid]->Uncache(out);
-            uncached_an_entry |= !stack[cacheid]->HaveCoinInCache(out);
+
+            bool fSpent = false;
+            uncached_an_entry |= !stack[cacheid]->HaveCoinInCache(out, fSpent);
         }
 
         // One every 500 iterations, trim a random cache to zero
@@ -240,7 +242,8 @@ BOOST_AUTO_TEST_CASE(coins_cache_simulation_test)
                 }
                 else
                 {
-                    BOOST_CHECK(stack.back()->HaveCoinInCache(it->first));
+                    bool fSpent = false;
+                    BOOST_CHECK(stack.back()->HaveCoinInCache(it->first, fSpent));
                     found_an_entry = true;
                 }
             }

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -692,7 +692,7 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
                     if (!ss.coins->HaveCoinInCache(txin.prevout, fSpent))
                     {
                         vCoinsToUncache.push_back(txin.prevout);
-                        if (!view.HaveCoin(txin.prevout))
+                        if (!view.GetCoinFromDB(txin.prevout))
                         {
                             fMissingOrSpent = true;
                         }


### PR DESCRIPTION
In txadmission there is a two step process to check if inputs are
missing or spent.  This process first looks in the in memory dbcache
to check if the input is there. But then following that it does
a call to HaveCoin() which checks the in memory cache again before
getting the coin off disk. There is no need either check the cache
again via HaveCoin if the coin is already in the cache.  So in this
commit we only call HaveCoin() if we do not have it already in memory.
This however requires that we return  a flag from HaveCoinInCache() which
tells us if the coin that is in cache has been spent or not.