### PR TITLE
[WIP] Output a message every 10 iterations of the wallet tests

### DIFF
--- a/src/wallet/test/wallet_tests.cpp
+++ b/src/wallet/test/wallet_tests.cpp
@@ -79,6 +79,9 @@ BOOST_AUTO_TEST_CASE(coin_selection_tests)
     // test multiple times to allow for differences in the shuffle order
     for (int i = 0; i < RUN_TESTS; i++)
     {
+        if (RUN_TESTS % 10 == 0)
+            BOOST_TEST_MESSAGE("Wallet test iteration: " << i);
+
         empty_wallet();
 
         // with an empty wallet we can't even pay one cent


### PR DESCRIPTION
These tests often cause travis runs to hang because they take
so long and no output has been returned to Travis for 10 mins. By
printing out a message every so often we should have fewer of these
timeouts on Travis.