### PR TITLE
[qa] Enable electrum tests if binary has been built

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -46,7 +46,7 @@ if sourcePath != outOfSourceBuildPath:
     sys.path.append(outOfSourceBuildPath)
 
 from tests_config import *
-from test_classes import RpcTest, Disabled, Skip
+from test_classes import RpcTest, Disabled, Skip, WhenElectrumFound
 
 BOLD = ("","")
 if os.name == 'posix':
@@ -246,8 +246,8 @@ testScripts = [ RpcTest(t) for t in [
     'sighashmatch',
     'getlogcategories',
     'getrawtransaction',
-    Disabled('electrum_basics', "Needs to be skipped if electrs is not built"),
-    Disabled('electrum_reorg', "Needs to be skipped if electrs is not built")
+    WhenElectrumFound('electrum_basics'),
+    WhenElectrumFound('electrum_reorg'),
 ] ]
 
 testScriptsExt = [ RpcTest(t) for t in [

--- a/qa/pull-tester/test_classes.py
+++ b/qa/pull-tester/test_classes.py
@@ -125,6 +125,19 @@ def Skip(test_name, platforms, reason):
     rpctest.skip(platforms, reason)
     return rpctest
 
+def WhenElectrumFound(test_name):
+    '''
+    Keeps test enabled when electrum binary is found. Disables it if not.
+    '''
+    import os
+    electrs_path = os.path.join(
+        os.path.dirname(os.environ["BITCOIND"]),
+        "electrs")
+
+    if os.path.exists(electrs_path):
+        return test_name
+
+    return Disabled(test_name, "Electrum server not built")
 
 if __name__ == "__main__":
     import doctest


### PR DESCRIPTION
Enables electrum tests if the `electrs` binary exists in the same
directory as `bitcoind`.

Addresses this comment https://github.com/BitcoinUnlimited/BitcoinUnlimited/pull/1866#discussion_r313351054