### PR TITLE
Terminate rpc-tests.y if there's no test to run.

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -391,6 +391,10 @@ def runtests():
                     trimmed_tests_to_run.append(t)
             tests_to_run = trimmed_tests_to_run
 
+        # if all specified tests are disabled just quit
+        if len(tests_to_run) == 0:
+            quit()
+
         if len(tests_to_run) > 1 and run_parallel:
             # Populate cache
             subprocess.check_output([RPC_TESTS_DIR + 'create_cache.py'] + [flags]+


### PR DESCRIPTION
In case a user specified a bunch of tests to run explicitly by
passing them to rpc_tests.py via command line, abort the script in
case all of the specified tests are disabled.

E.g. If you try to execute:

```
qa/pull-tester/rpc-tests.py p2p-fullblocktest.py
```

this is the actual output w/o this patch:

```
Disabled testscript p2p-fullblocktest.py (reason: TODO)
Traceback (most recent call last):
  File "qa/pull-tester/rpc-tests.py", line 614, in <module>
    runtests()
  File "qa/pull-tester/rpc-tests.py", line 400, in runtests
    max_len_name = len(max(tests_to_run, key=len))
ValueError: max() arg is an empty sequence
```