### PR TITLE
Time cleanup

### DIFF
--- a/src/bench/rollingbloom.cpp
+++ b/src/bench/rollingbloom.cpp
@@ -24,9 +24,9 @@ static void RollingBloom(benchmark::State& state)
         data[2] = count >> 16;
         data[3] = count >> 24;
         if (countnow == nEntriesPerGeneration) {
-            int64_t b = GetTimeMicros();
+            int64_t b = GetStopwatchMicros();
             filter.insert(data);
-            int64_t e = GetTimeMicros();
+            int64_t e = GetStopwatchMicros();
             std::cout << "RollingBloom-refresh,1," << (e-b)*0.000001 << "," << (e-b)*0.000001 << "," << (e-b)*0.000001 << "\n";
             countnow = 0;
         } else {

--- a/src/blockstorage/blockstorage.cpp
+++ b/src/blockstorage/blockstorage.cpp
@@ -570,7 +570,7 @@ bool FlushStateToDiskInternal(CValidationState &state,
     static int64_t nLastWrite = 0;
     static int64_t nLastFlush = 0;
     static int64_t nLastSetChain = 0;
-    int64_t nNow = GetTimeMicros();
+    int64_t nNow = GetStopwatchMicros();
     // Avoid writing/flushing immediately after startup.
     if (nLastWrite == 0)
     {

--- a/src/net.h
+++ b/src/net.h
@@ -222,7 +222,8 @@ public:
     bool fRelayTxes;
     int64_t nLastSend;
     int64_t nLastRecv;
-    int64_t nTimeConnected;
+    int64_t nTimeConnected; /** Calendar time this node was connected */
+    uint64_t nStopwatchConnected; /** Stopwatch time this node was connected (in uSec) */
     int64_t nTimeOffset;
     std::string addrName;
     int nVersion;
@@ -254,7 +255,7 @@ public:
     CDataStream vRecv; // received message data
     unsigned int nDataPos;
 
-    int64_t nTime; // time (in microseconds) of message receipt.
+    int64_t nTime; // calendar time (in microseconds) of message receipt.
 
     // default constructor builds an empty message object to accept assignment of real messages
     CNetMessage() : hdrbuf(0, 0), hdr({0, 0, 0, 0}), vRecv(0, 0)
@@ -378,63 +379,66 @@ public:
     int nRecvVersion;
 
     // BU connection de-prioritization
-    //! Total bytes sent and received
+    //* Total bytes sent and received
     uint64_t nActivityBytes;
 
     int64_t nLastSend;
     int64_t nLastRecv;
-    int64_t nTimeConnected;
+    int64_t nTimeConnected; /** Calendar time this node was connected */
+    uint64_t nStopwatchConnected; /** Stopwatch time this node was connected */
     int64_t nTimeOffset;
-    //! The address of the remote peer
+    /** The address of the remote peer */
     CAddress addr;
 
-    //! set to true if this node is ok with no message checksum
+    /** set to true if this node is ok with no message checksum */
     bool skipChecksum;
 
-    //! The address the remote peer advertised in its version message
+    /** The address the remote peer advertised in its version message */
     CAddress addrFrom_advertised;
 
     std::string addrName;
     const char *currentCommand; // if in the middle of the send, this is the command type
-    //! The the remote peer sees us as this address (may be different than our IP due to NAT)
+    /** The the remote peer sees us as this address (may be different than our IP due to NAT) */
     CService addrLocal;
     int nVersion;
 
-    //! The state of informing the remote peer of our version information
+    /** The state of informing the remote peer of our version information */
     ConnectionStateOutgoing state_outgoing;
 
-    //! The state of being informed by the remote peer of his version information
+    /** The state of being informed by the remote peer of his version information */
     ConnectionStateIncoming state_incoming;
 
-    //! used to make processing serial when version handshake is taking place
+    /** used to make processing serial when version handshake is taking place */
     CCriticalSection csSerialPhase;
 
-    //! the intial xversion message sent in the handshake
+    /** the intial xversion message sent in the handshake */
     CCriticalSection cs_xversion;
     CXVersionMessage xVersion;
 
-    //! strSubVer is whatever byte array we read from the wire. However, this field is intended
-    //! to be printed out, displayed to humans in various forms and so on. So we sanitize it and
-    //! store the sanitized version in cleanSubVer. The original should be used when dealing with
-    //! the network or wire types and the cleaned string used when displayed or logged.
+    /** strSubVer is whatever byte array we read from the wire. However, this field is intended
+        to be printed out, displayed to humans in various forms and so on. So we sanitize it and
+        store the sanitized version in cleanSubVer. The original should be used when dealing with
+        the network or wire types and the cleaned string used when displayed or logged.
+    */
     std::string strSubVer, cleanSubVer;
 
-    //! This peer can bypass DoS banning.
+    /** This peer can bypass DoS banning. */
     bool fWhitelisted;
-    //! If true this node is being used as a short lived feeler.
+    /** If true this node is being used as a short lived feeler. */
     bool fFeeler;
     bool fOneShot;
     bool fClient;
 
-    //! after BIP159
+    /** after BIP159 */
     bool m_limited_node;
 
-    //! If true a remote node initiated the connection.  If false, we initiated.
-    //! The protocol is slightly asymmetric:
-    //! initial version exchange
-    //! stop ADDR flooding in preparation for a network-wide eclipse attack
-    //! stop connection slot attack via eviction of stale (connected but no data) inbound connections
-    //! stop fingerprinting by seeding fake addresses and checking for them later by ignoring outbound getaddr
+    /** If true a remote node initiated the connection.  If false, we initiated.
+        The protocol is slightly asymmetric:
+        initial version exchange
+        stop ADDR flooding in preparation for a network-wide eclipse attack
+        stop connection slot attack via eviction of stale (connected but no data) inbound connections
+        stop fingerprinting by seeding fake addresses and checking for them later by ignoring outbound getaddr
+    */
     bool fInbound;
     bool fAutoOutbound; // any outbound node not connected with -addnode, connect-thinblock or -connect
     bool fNetworkNode; // any outbound node

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -569,7 +569,7 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, CBlockRef p
     try
     {
         uint64_t nSizeBlock = pblock->GetBlockSize();
-        int64_t startTime = GetTimeMicros();
+        int64_t startTime = GetStopwatchMicros();
         CValidationState state;
 
         // Indicate that the block was fully received. At this point we have either a block or a fully reconstructed
@@ -600,12 +600,12 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, CBlockRef p
         {
             LargestBlockSeen(nSizeBlock); // update largest block seen
 
-            double nValidationTime = (double)(GetTimeMicros() - startTime) / 1000000.0;
+            double nValidationTime = (double)(GetStopwatchMicros() - startTime) / 1000000.0;
             if ((strCommand != NetMsgType::BLOCK) &&
                 (IsThinBlocksEnabled() || IsGrapheneBlockEnabled() || IsCompactBlocksEnabled()))
             {
                 LOG(THIN | GRAPHENE | CMPCT, "Processed Block %s reconstructed from (%s) in %.2f seconds, peer=%s\n",
-                    inv.hash.ToString(), strCommand, (double)(GetTimeMicros() - startTime) / 1000000.0,
+                    inv.hash.ToString(), strCommand, (double)(GetStopwatchMicros() - startTime) / 1000000.0,
                     pfrom->GetLogName());
 
                 if (strCommand == NetMsgType::GRAPHENEBLOCK || strCommand == NetMsgType::GRAPHENETX)
@@ -618,7 +618,7 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, CBlockRef p
             else
             {
                 LOG(THIN | GRAPHENE | CMPCT, "Processed Regular Block %s in %.2f seconds, peer=%s\n",
-                    inv.hash.ToString(), (double)(GetTimeMicros() - startTime) / 1000000.0, pfrom->GetLogName());
+                    inv.hash.ToString(), (double)(GetStopwatchMicros() - startTime) / 1000000.0, pfrom->GetLogName());
             }
         }
 

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -966,7 +966,8 @@ void RPCConsole::updateNodeDetail(const CNodeCombinedStats *stats)
         stats->nodeStats.nLastRecv ? GUIUtil::formatDurationStr(GetTime() - stats->nodeStats.nLastRecv) : tr("never"));
     ui->peerBytesSent->setText(FormatBytes(stats->nodeStats.nSendBytes));
     ui->peerBytesRecv->setText(FormatBytes(stats->nodeStats.nRecvBytes));
-    ui->peerConnTime->setText(GUIUtil::formatDurationStr(GetTime() - stats->nodeStats.nTimeConnected));
+    ui->peerConnTime->setText(
+        GUIUtil::formatDurationStr((GetStopwatchMicros() - stats->nodeStats.nStopwatchConnected) / 1000000));
     ui->peerPingTime->setText(GUIUtil::formatPingTime(stats->nodeStats.dPingTime));
     ui->peerPingWait->setText(GUIUtil::formatPingTime(stats->nodeStats.dPingWait));
     ui->timeoffset->setText(GUIUtil::formatTimeOffset(stats->nodeStats.nTimeOffset));

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -80,7 +80,7 @@ public:
     CInv obj;
     bool rateLimited;
     bool fProcessing; // object was received but is still being processed
-    int64_t lastRequestTime; // In microseconds, 0 means no request
+    int64_t lastRequestTime; // In stopwatch time microseconds, 0 means no request
     unsigned int outstandingReqs;
     ObjectSourceList availableFrom;
     unsigned int priority;
@@ -101,7 +101,7 @@ public:
 struct QueuedBlock
 {
     uint256 hash;
-    int64_t nTime; //! Time of "getdata" request in microseconds.
+    int64_t nTime; // Stopwatch time of "getdata" request in microseconds.
 };
 struct CRequestManagerNodeState
 {

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -811,7 +811,7 @@ void AdjustCoinCacheSize()
 
 #ifdef WIN32
     static int64_t nLastDbAdjustment = 0;
-    int64_t nNow = GetTimeMicros();
+    int64_t nNow = GetStopwatchMicros();
 
     if (nLastDbAdjustment == 0)
     {

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1611,7 +1611,7 @@ bool LoadMempool(void)
 
 bool DumpMempool(void)
 {
-    int64_t start = GetTimeMicros();
+    int64_t start = GetStopwatchMicros();
 
     std::map<uint256, CAmount> mapDeltas;
     std::vector<TxMempoolInfo> vInfo;
@@ -1625,7 +1625,7 @@ bool DumpMempool(void)
         vInfo = mempool.AllTxMempoolInfo();
     }
 
-    int64_t mid = GetTimeMicros();
+    int64_t mid = GetStopwatchMicros();
 
     try
     {
@@ -1653,7 +1653,7 @@ bool DumpMempool(void)
         FileCommit(file.Get());
         file.fclose();
         RenameOver(GetDataDir() / "mempool.dat.new", GetDataDir() / "mempool.dat");
-        int64_t last = GetTimeMicros();
+        int64_t last = GetStopwatchMicros();
         LOGA("Dumped mempool: %gs to copy, %gs to dump\n", (mid - start) * 0.000001, (last - mid) * 0.000001);
     }
     catch (const std::exception &e)

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -50,6 +50,12 @@ int64_t GetTimeMillis()
 
 int64_t GetTimeMicros()
 {
+    int64_t mocktime = nMockTime.load(std::memory_order_relaxed);
+    if (mocktime)
+    {
+        return mocktime * 1000000;
+    }
+
     int64_t now = (boost::posix_time::microsec_clock::universal_time() -
                       boost::posix_time::ptime(boost::gregorian::date(1970, 1, 1)))
                       .total_microseconds();
@@ -80,13 +86,11 @@ uint64_t GetStopwatch()
 /** Return a time useful for the debug log */
 int64_t GetLogTimeMicros()
 {
-    int64_t mocktime = nMockTime.load(std::memory_order_relaxed);
-    if (mocktime)
-    {
-        return mocktime * 1000000;
-    }
-
-    return GetTimeMicros();
+    int64_t now = (boost::posix_time::microsec_clock::universal_time() -
+                      boost::posix_time::ptime(boost::gregorian::date(1970, 1, 1)))
+                      .total_microseconds();
+    assert(now > 0);
+    return now;
 }
 
 void MilliSleep(int64_t n)

--- a/src/utiltime.cpp
+++ b/src/utiltime.cpp
@@ -38,8 +38,9 @@ int64_t GetTime()
 void SetMockTime(int64_t nMockTimeIn) { nMockTime.store(nMockTimeIn, std::memory_order_relaxed); }
 int64_t GetTimeMillis()
 {
-    if (nMockTime)
-        return nMockTime * 1000;
+    int64_t mocktime = nMockTime.load(std::memory_order_relaxed);
+    if (mocktime)
+        return mocktime * 1000;
 
     int64_t now = (boost::posix_time::microsec_clock::universal_time() -
                       boost::posix_time::ptime(boost::gregorian::date(1970, 1, 1)))
@@ -65,9 +66,9 @@ int64_t GetTimeMicros()
 
 
 #ifdef WIN32
-uint64_t GetStopwatch() { return 1000 * GetTimeMicros(); }
+uint64_t GetStopwatch() { return 1000 * GetLogTimeMicros(); }
 #elif MAC_OSX
-uint64_t GetStopwatch() { return 1000 * GetTimeMicros(); }
+uint64_t GetStopwatch() { return 1000 * GetLogTimeMicros(); }
 #else
 uint64_t GetStopwatch()
 {

--- a/src/utiltime.h
+++ b/src/utiltime.h
@@ -10,13 +10,31 @@
 #include <stdint.h>
 #include <string>
 
+/** Returns the calendar time in seconds since the epoch, or @nMockTime if mock time is enabled during testing */
 int64_t GetTime();
+/** Returns the calendar time in milliseconds since the epoch, or @nMockTime*1000 if mock time is enabled during testing
+ */
 int64_t GetTimeMillis();
+/** Returns the calendar time in microseconds since the epoch, or @nMockTime*10^6 if mock time is enabled during testing
+ */
 int64_t GetTimeMicros();
+
+/** Returns the calendar time in microseconds since the epoch.  Not affected by mock time during testing. */
 int64_t GetLogTimeMicros();
+
+/** Sets a fake time value, which is very useful for testing */
 void SetMockTime(int64_t nMockTimeIn);
+
+/** Sleep for n milliseconds */
 void MilliSleep(int64_t n);
-uint64_t GetStopwatch(); // Returns a monotonically increasing time for interval measurement (in nSec)
+
+/** Returns a monotonically increasing time for interval measurement (in nSec).  This number is unrelated to calendar
+time and is not affected by mock time during test */
+uint64_t GetStopwatch();
+/** Returns a monotonically increasing time for interval measurement (in uSec).  This number is unrelated to calendar
+time and is not affected by mock time during test */
+inline uint64_t GetStopwatchMicros() { return GetStopwatch() / 1000; }
+/** Convert seconds since the epoch to a string */
 std::string DateTimeStrFormat(const char *pszFormat, int64_t nTime);
 
 #endif // BITCOIN_UTILTIME_H

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -1914,7 +1914,7 @@ bool ConnectBlockPrevalidations(const CBlock &block,
     const CChainParams &chainparams,
     bool fJustCheck)
 {
-    int64_t nTimeStart = GetTimeMicros();
+    int64_t nTimeStart = GetStopwatchMicros();
 
     // Check it again in case a previous version let a bad block in
     if (!CheckBlock(block, state, !fJustCheck, !fJustCheck))
@@ -1926,7 +1926,7 @@ bool ConnectBlockPrevalidations(const CBlock &block,
     uint256 hashPrevBlock = pindex->pprev == nullptr ? uint256() : pindex->pprev->GetBlockHash();
     assert(hashPrevBlock == view.GetBestBlock());
 
-    int64_t nTime1 = GetTimeMicros();
+    int64_t nTime1 = GetStopwatchMicros();
     nTimeCheck += nTime1 - nTimeStart;
     LOG(BENCH, "    - Sanity checks: %.2fms [%.2fs]\n", 0.001 * (nTime1 - nTimeStart), nTimeCheck * 0.000001);
 
@@ -1983,7 +1983,7 @@ bool ConnectBlockPrevalidations(const CBlock &block,
         }
     }
 
-    int64_t nTime2 = GetTimeMicros();
+    int64_t nTime2 = GetStopwatchMicros();
     nTimeForks += nTime2 - nTime1;
     LOG(BENCH, "    - Fork checks: %.2fms [%.2fs]\n", 0.001 * (nTime2 - nTime1), nTimeForks * 0.000001);
 
@@ -2031,7 +2031,7 @@ bool ConnectBlockDependencyOrdering(const CBlock &block,
     std::vector<std::pair<uint256, CDiskTxPos> > &vPos)
 {
     nFees = 0;
-    int64_t nTime2 = GetTimeMicros();
+    int64_t nTime2 = GetStopwatchMicros();
     LOG(BLK, "Dependency ordering for %s MTP: %d\n", block.GetHash().ToString(), pindex->GetMedianTimePast());
 
     // Start enforcing BIP68 (sequence locks) and BIP112 (CHECKSEQUENCEVERIFY)
@@ -2209,13 +2209,13 @@ bool ConnectBlockDependencyOrdering(const CBlock &block,
         }
     }
 
-    int64_t nTime3 = GetTimeMicros();
+    int64_t nTime3 = GetStopwatchMicros();
     nTimeConnect += nTime3 - nTime2;
     LOG(BENCH, "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs]\n", (unsigned)block.vtx.size(),
         0.001 * (nTime3 - nTime2), 0.001 * (nTime3 - nTime2) / block.vtx.size(),
         nInputs <= 1 ? 0 : 0.001 * (nTime3 - nTime2) / (nInputs - 1), nTimeConnect * 0.000001);
 
-    int64_t nTime4 = GetTimeMicros();
+    int64_t nTime4 = GetStopwatchMicros();
     nTimeVerify += nTime4 - nTime2;
     LOG(BENCH, "    - Verify %u txins: %.2fms (%.3fms/txin) [%.2fs]\n", nInputs - 1, 0.001 * (nTime4 - nTime2),
         nInputs <= 1 ? 0 : 0.001 * (nTime4 - nTime2) / (nInputs - 1), nTimeVerify * 0.000001);
@@ -2237,7 +2237,7 @@ bool ConnectBlockCanonicalOrdering(const CBlock &block,
     std::vector<std::pair<uint256, CDiskTxPos> > &vPos)
 {
     nFees = 0;
-    int64_t nTime2 = GetTimeMicros();
+    int64_t nTime2 = GetStopwatchMicros();
     LOG(BLK, "Canonical ordering for %s MTP: %d\n", block.GetHash().ToString(), pindex->GetMedianTimePast());
 
     // Start enforcing BIP68 (sequence locks) and BIP112 (CHECKSEQUENCEVERIFY)
@@ -2448,13 +2448,13 @@ bool ConnectBlockCanonicalOrdering(const CBlock &block,
         }
     }
 
-    int64_t nTime3 = GetTimeMicros();
+    int64_t nTime3 = GetStopwatchMicros();
     nTimeConnect += nTime3 - nTime2;
     LOG(BENCH, "      - Connect %u transactions: %.2fms (%.3fms/tx, %.3fms/txin) [%.2fs]\n", (unsigned)block.vtx.size(),
         0.001 * (nTime3 - nTime2), 0.001 * (nTime3 - nTime2) / block.vtx.size(),
         nInputs <= 1 ? 0 : 0.001 * (nTime3 - nTime2) / (nInputs - 1), nTimeConnect * 0.000001);
 
-    int64_t nTime4 = GetTimeMicros();
+    int64_t nTime4 = GetStopwatchMicros();
     nTimeVerify += nTime4 - nTime2;
     LOG(BENCH, "    - Verify %u txins: %.2fms (%.3fms/txin) [%.2fs]\n", nInputs - 1, 0.001 * (nTime4 - nTime2),
         nInputs <= 1 ? 0 : 0.001 * (nTime4 - nTime2) / (nInputs - 1), nTimeVerify * 0.000001);
@@ -2552,7 +2552,7 @@ bool ConnectBlock(const CBlock &block,
     if (fJustCheck)
         return true;
 
-    int64_t nTime4 = GetTimeMicros();
+    int64_t nTime4 = GetStopwatchMicros();
 
     /*****************************************************************************************************************
      *                         Start update of UTXO, if this block wins the validation race *
@@ -2608,7 +2608,7 @@ bool ConnectBlock(const CBlock &block,
     // add this block to the view's block chain (the main UTXO in memory cache)
     view.SetBestBlock(pindex->GetBlockHash());
 
-    int64_t nTime5 = GetTimeMicros();
+    int64_t nTime5 = GetStopwatchMicros();
     nTimeIndex += nTime5 - nTime4;
     LOG(BENCH, "    - Index writing: %.2fms [%.2fs]\n", 0.001 * (nTime5 - nTime4), nTimeIndex * 0.000001);
 
@@ -2617,7 +2617,7 @@ bool ConnectBlock(const CBlock &block,
     GetMainSignals().UpdatedTransaction(hashPrevBestCoinBase);
     hashPrevBestCoinBase = block.vtx[0]->GetHash();
 
-    int64_t nTime6 = GetTimeMicros();
+    int64_t nTime6 = GetStopwatchMicros();
     nTimeCallbacks += nTime6 - nTime5;
     LOG(BENCH, "    - Callbacks: %.2fms [%.2fs]\n", 0.001 * (nTime6 - nTime5), nTimeCallbacks * 0.000001);
 
@@ -2875,7 +2875,7 @@ bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusPa
     if (!ReadBlockFromDisk(block, pindexDelete, consensusParams))
         return AbortNode(state, "DisconnectTip(): Failed to read block");
     // Apply the block atomically to the chain state.
-    int64_t nStart = GetTimeMicros();
+    int64_t nStart = GetStopwatchMicros();
     {
         CCoinsViewCache view(pcoinsTip);
         if (DisconnectBlock(block, pindexDelete, view) != DISCONNECT_OK)
@@ -2883,7 +2883,7 @@ bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusPa
         bool result = view.Flush();
         assert(result);
     }
-    LOG(BENCH, "- Disconnect block: %.2fms\n", (GetTimeMicros() - nStart) * 0.001);
+    LOG(BENCH, "- Disconnect block: %.2fms\n", (GetStopwatchMicros() - nStart) * 0.001);
     // Write the chain state to disk, if necessary.
     if (!FlushStateToDisk(state, FLUSH_STATE_IF_NEEDED))
         return false;
@@ -2958,7 +2958,7 @@ bool ConnectTip(CValidationState &state,
         return false;
 
     // Read block from disk.
-    int64_t nTime1 = GetTimeMicros();
+    int64_t nTime1 = GetStopwatchMicros();
     CBlock block;
     if (!pblock)
     {
@@ -2967,7 +2967,7 @@ bool ConnectTip(CValidationState &state,
         pblock = &block;
     }
     // Apply the block atomically to the chain state.
-    int64_t nTime2 = GetTimeMicros();
+    int64_t nTime2 = GetStopwatchMicros();
     nTimeReadFromDisk += nTime2 - nTime1;
     int64_t nTime3;
     LOG(BENCH, "  - Load block from disk: %.2fms [%.2fs]\n", (nTime2 - nTime1) * 0.001, nTimeReadFromDisk * 0.000001);
@@ -2984,26 +2984,26 @@ bool ConnectTip(CValidationState &state,
             }
             return false;
         }
-        int64_t nStart = GetTimeMicros();
+        int64_t nStart = GetStopwatchMicros();
         bool result = view.Flush();
         nBlockSizeAtChainTip.store(pblock->GetBlockSize());
         assert(result);
-        LOG(BENCH, "      - Update Coins %.3fms\n", GetTimeMicros() - nStart);
+        LOG(BENCH, "      - Update Coins %.3fms\n", GetStopwatchMicros() - nStart);
 
         mapBlockSource.erase(pindexNew->GetBlockHash());
-        nTime3 = GetTimeMicros();
+        nTime3 = GetStopwatchMicros();
         nTimeConnectTotal += nTime3 - nTime2;
         LOG(BENCH, "  - Connect total: %.2fms [%.2fs]\n", (nTime3 - nTime2) * 0.001, nTimeConnectTotal * 0.000001);
     }
 
-    int64_t nTime4 = GetTimeMicros();
+    int64_t nTime4 = GetStopwatchMicros();
     nTimeFlush += nTime4 - nTime3;
     LOG(BENCH, "  - Flush: %.2fms [%.2fs]\n", (nTime4 - nTime3) * 0.001, nTimeFlush * 0.000001);
     // Write the chain state to disk, if necessary, and only during IBD, reindex, or importing.
     if (!IsChainNearlySyncd() || fReindex || fImporting)
         if (!FlushStateToDisk(state, FLUSH_STATE_IF_NEEDED))
             return false;
-    int64_t nTime5 = GetTimeMicros();
+    int64_t nTime5 = GetStopwatchMicros();
     nTimeChainState += nTime5 - nTime4;
     LOG(BENCH, "  - Writing chainstate: %.2fms [%.2fs]\n", (nTime5 - nTime4) * 0.001, nTimeChainState * 0.000001);
 
@@ -3026,7 +3026,7 @@ bool ConnectTip(CValidationState &state,
         txIdx++;
     }
 
-    int64_t nTime6 = GetTimeMicros();
+    int64_t nTime6 = GetStopwatchMicros();
     nTimePostConnect += nTime6 - nTime5;
     nTimeTotal += nTime6 - nTime1;
     LOG(BENCH, "  - Connect postprocess: %.2fms [%.2fs]\n", (nTime6 - nTime5) * 0.001, nTimePostConnect * 0.000001);
@@ -3451,7 +3451,7 @@ bool ProcessNewBlock(CValidationState &state,
     CDiskBlockPos *dbp,
     bool fParallel)
 {
-    int64_t start = GetTimeMicros();
+    int64_t start = GetStopwatchMicros();
     LOG(THIN, "Processing new block %s from peer %s.\n", pblock->GetHash().ToString(),
         pfrom ? pfrom->GetLogName() : "myself");
     // Preliminary checks
@@ -3520,7 +3520,7 @@ bool ProcessNewBlock(CValidationState &state,
             return false;
     }
 
-    int64_t end = GetTimeMicros();
+    int64_t end = GetStopwatchMicros();
     if (Logging::LogAcceptCategory(BENCH))
     {
         uint64_t maxTxSizeLocal = 0;


### PR DESCRIPTION
use stopwatch time for any interval timing.  Apply mock time consistently across calendar time functions, except for logging time.  Add doc comments.