### PR TITLE
[Electrum] Support passing arguments to electrs

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -720,7 +720,10 @@ static void addElectrumOptions(AllowedArgs &allowedArgs)
         .addArg("electrum.dir", requiredStr, "Data directory for electrum database")
         .addArg("electrum.port", requiredStr, "Port electrum RPC listens on (default: mainnet 50001, testnet: 60001")
         .addArg("electrum.host", requiredStr, "Host electrum RPC listens on (default: 127.0.0.1)")
-        .addArg("electrum.addr.limit", requiredStr, "Max txs to look up per address (default: 500)")
+        .addArg("electrum.rawarg", optionalStr,
+            "Raw argument to pass directly to underlying electrum daemon "
+            "(example: -electrum.rawarg=\"--server-banner=\\\"Welcome to my server!\\\"\"). "
+            "This option can be specified multiple times.")
         .addDebugArg("electrum.exec", requiredStr, "Path to electrum daemon executable")
         .addDebugArg("electrum.monitoring.port", requiredStr, "Port to bind monitoring service")
         .addDebugArg("electrum.monitoring.host", requiredStr, "Host to bind monitoring service")

--- a/src/test/electrs_tests.cpp
+++ b/src/test/electrs_tests.cpp
@@ -42,4 +42,20 @@ BOOST_AUTO_TEST_CASE(issue_1700)
     BOOST_CHECK(electrs_args_has("--electrum-rpc-addr=127.0.0.1:60001", "test"));
 }
 
+BOOST_AUTO_TEST_CASE(rawargs)
+{
+    BOOST_CHECK(electrs_args_has("--txid-limit=500"));
+    BOOST_CHECK(!electrs_args_has("--txid-limit=42"));
+
+    // Test that we override txid-limit and append server-banner
+    mapMultiArgs["-electrum.rawarg"].push_back("--txid-limit=42");
+    mapMultiArgs["-electrum.rawarg"].push_back("--server-banner=\"Hello World!\"");
+
+    BOOST_CHECK(!electrs_args_has("--txid-limit=500"));
+    BOOST_CHECK(electrs_args_has("--txid-limit=42"));
+    BOOST_CHECK(electrs_args_has("--server-banner=\"Hello World!\""));
+
+    mapMultiArgs.clear();
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Adds new (multi) argument electrum.rawarg, which directly passes the
value as an argument to electrscash.

This adds support for configuring the server in any way possible,
such as adding custom server banner, tweaking cache options, etc.
without having to reimplement every option in BU.