### PR TITLE
Using cashaddr econding by default for addresses.

### DIFF
--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1260,8 +1260,9 @@ bool AppInit2(Config &config, thread_group &threadGroup)
 #ifdef ENABLE_WALLET
 
     // Encoded addresses using cashaddr instead of base58
-    // Activates by default on Jan, 14
-    config.SetCashAddrEncoding(GetBoolArg("-usecashaddr", GetAdjustedTime() > 1515900000));
+    // The default behaviour is to use this encoding. This will help
+    // to avoid confusion with other currencies the base58 encoding
+    config.SetCashAddrEncoding(GetBoolArg("-usecashaddr", true));
 
     if (fDisableWallet)
     {


### PR DESCRIPTION
There's no semantic change in this commit since the prev code use
the cashaddr encoding if MTP-11 is greater than 1515900000 (i.e. Jan 14 2018)