### PR TITLE
Implementation of mempool synchronization

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -217,6 +217,7 @@ testScripts = [ RpcTest(t) for t in [
     'mempool_limit',
     'mempool_persist',
     'mempool_validate',
+    'mempoolsync',
     'httpbasics',
     'multi_rpc',
     'zapwallettxes',

--- a/qa/rpc-tests/getlogcategories.py
+++ b/qa/rpc-tests/getlogcategories.py
@@ -45,10 +45,10 @@ class GetLogCategories (BitcoinTestFramework):
         self.is_network_split = False
 
     def run_test (self):
-        exp0 = "coindb tor addrman libevent http rpc partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks cmpctblock electrum"
-        exp1 = "libevent http partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks cmpctblock electrum"
-        exp2 = "libevent http partitioncheck bench prune reindex mempoolrej parallel rand req bloom estimatefee dbase selectcoins zmq qt ibd respend weakblocks cmpctblock electrum"
-        exp3 = "libevent http partitioncheck bench prune reindex mempoolrej parallel req bloom estimatefee dbase selectcoins respend weakblocks cmpctblock electrum"
+        exp0 = "coindb tor addrman libevent http rpc partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks cmpctblock electrum mempoolsync"
+        exp1 = "libevent http partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks cmpctblock electrum mempoolsync"
+        exp2 = "libevent http partitioncheck bench prune reindex mempoolrej parallel rand req bloom estimatefee dbase selectcoins zmq qt ibd respend weakblocks cmpctblock electrum mempoolsync"
+        exp3 = "libevent http partitioncheck bench prune reindex mempoolrej parallel req bloom estimatefee dbase selectcoins respend weakblocks cmpctblock electrum mempoolsync"
         exp4 = exp1
         exp5 = exp0
         exp6 = ""

--- a/qa/rpc-tests/mempoolsync.py
+++ b/qa/rpc-tests/mempoolsync.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+import time
+
+
+class MempoolSyncTest(BitcoinTestFramework):
+    def __init__(self, test_assertion='success'):
+        self.rep = False
+
+    def set_test_params(self):
+        self.num_nodes = 3
+
+    def setup_network(self, split=False):
+        node_opts = [
+            "-rpcservertimeout=0",
+            "-debug=mempoolsync",
+            "-net.syncMempoolWithPeers=1",
+            "-net.randomlyDontInv=100",
+            "-excessiveblocksize=6000000",
+            "-blockprioritysize=6000000",
+            "-blockmaxsize=6000000"]
+
+        self.nodes = [
+            start_node(0, self.options.tmpdir, node_opts),
+            start_node(1, self.options.tmpdir, node_opts),
+            start_node(2, self.options.tmpdir, node_opts)
+        ]
+
+        interconnect_nodes(self.nodes)
+        self.is_network_split = False
+        self.sync_all()
+
+    def run_test(self):
+        chain_height = self.nodes[0].getblockcount()
+        assert_equal(chain_height, 200)
+
+        logging.info("Mine a single block to get out of IBD")
+        self.nodes[0].generate(1)
+        self.sync_all()
+
+        logging.info("Send 10 transactions from node0 (to its own address)")
+        addr = self.nodes[0].getnewaddress()
+        for i in range(10):
+            self.nodes[0].sendtoaddress(addr, Decimal("10"))
+
+        logging.info("Send 10 transactions from node1 (to its own address)")
+        addr = self.nodes[1].getnewaddress()
+        for i in range(10):
+            self.nodes[1].sendtoaddress(addr, Decimal("10"))
+
+        logging.info("Send 10 transactions from node2 (to its own address)")
+        addr = self.nodes[2].getnewaddress()
+        for i in range(10):
+            self.nodes[2].sendtoaddress(addr, Decimal("10"))
+
+        waitFor(180, lambda: len(self.nodes[0].getrawmempool()) == 30)
+        waitFor(180, lambda: len(self.nodes[1].getrawmempool()) == 30)
+        waitFor(180, lambda: len(self.nodes[2].getrawmempool()) == 30)
+
+if __name__ == '__main__':
+    MempoolSyncTest().main()

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -112,6 +112,7 @@ BITCOIN_CORE_H = \
   blockrelay/compactblock.h \
   blockrelay/graphene.h \
   blockrelay/graphene_set.h \
+  blockrelay/mempool_sync.h \
   blockrelay/thinblock.h \
   blockstorage/blockleveldb.h \
   blockstorage/blockstorage.h \
@@ -265,6 +266,7 @@ libbitcoin_server_a_SOURCES = \
   blockrelay/compactblock.cpp \
   blockrelay/graphene.cpp \
   blockrelay/graphene_set.cpp \
+  blockrelay/mempool_sync.cpp \
   blockrelay/thinblock.cpp \
   blockstorage/blockleveldb.cpp \
   blockstorage/sequential_files.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -107,6 +107,7 @@ BITCOIN_TESTS =\
   test/dbwrapper_tests.cpp \
   test/main_tests.cpp \
   test/mempool_tests.cpp \
+  test/mempool_sync_tests.cpp \
   test/merkle_tests.cpp \
   test/miner_tests.cpp \
   test/multisig_tests.cpp \

--- a/src/blockrelay/mempool_sync.cpp
+++ b/src/blockrelay/mempool_sync.cpp
@@ -502,32 +502,9 @@ CNode *SelectMempoolSyncPeer(std::vector<CNode *> vNodesCopy)
         return nullptr;
 }
 
-void ClearDisconnectedFromMempoolSyncMaps()    
+void ClearDisconnectedFromMempoolSyncMaps(NodeId nodeid)    
 {
     LOCK(cs_mempoolsync);
-
-    std::set<NodeId> toRemove;
-    for (auto idPair : mempoolSyncRequested)
-    {
-        if (!connmgr->FindNodeFromId(idPair.first))
-            toRemove.insert(idPair.first);
-    }
-
-    for (auto idPair : mempoolSyncResponded)
-    {
-        if (!connmgr->FindNodeFromId(idPair.first))
-            toRemove.insert(idPair.first);
-    }
-
-    if (toRemove.size() > 0)
-        LOG(MPOOLSYNC, "Mempool sync removing %d disconnected peers from sync maps\n", toRemove.size());
-
-    for (auto nId : toRemove)
-    {
-        if (mempoolSyncRequested.count(nId) > 0)
-            mempoolSyncRequested.erase(nId);
-
-        if (mempoolSyncResponded.count(nId) > 0)
-            mempoolSyncResponded.erase(nId);
-    }
+    mempoolSyncRequested.erase(nodeid);
+    mempoolSyncResponded.erase(nodeid);
 }

--- a/src/blockrelay/mempool_sync.cpp
+++ b/src/blockrelay/mempool_sync.cpp
@@ -1,0 +1,540 @@
+// Copyright (c) 2018-2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "blockrelay/mempool_sync.h"
+#include "connmgr.h"
+#include "dosman.h"
+#include "net.h"
+#include "nodestate.h"
+#include "txadmission.h"
+#include "txmempool.h"
+#include "txorphanpool.h"
+#include "util.h"
+#include "utiltime.h"
+#include "xversionkeys.h"
+
+#include <random>
+
+extern CTxMemPool mempool;
+extern CTweak<uint64_t> syncMempoolWithPeers;
+extern CTweak<uint64_t> mempoolSyncMinVersionSupported;
+extern CTweak<uint64_t> mempoolSyncMaxVersionSupported;
+extern CCriticalSection cs_mempoolsync;
+extern uint64_t lastMempoolSyncClear;
+
+CMempoolSyncInfo::CMempoolSyncInfo(uint64_t _nTxInMempool,
+    uint64_t _nRemainingMempoolBytes,
+    uint64_t _shorttxidk0,
+    uint64_t _shorttxidk1,
+    uint64_t _nSatoshiPerK)
+    : nTxInMempool(_nTxInMempool), nRemainingMempoolBytes(_nRemainingMempoolBytes), shorttxidk0(_shorttxidk0),
+      shorttxidk1(_shorttxidk1), nSatoshiPerK(_nSatoshiPerK)
+{
+}
+CMempoolSyncInfo::CMempoolSyncInfo()
+{
+    this->nTxInMempool = 0;
+    this->nRemainingMempoolBytes = 0;
+    this->shorttxidk0 = 0;
+    this->shorttxidk1 = 0;
+    this->nSatoshiPerK = 0;
+}
+
+CMempoolSync::CMempoolSync(std::vector<uint256> mempoolTxHashes,
+    uint64_t nReceiverMemPoolTx,
+    uint64_t nSenderMempoolPlusBlock,
+    uint64_t shorttxidk0,
+    uint64_t shorttxidk1,
+    uint64_t _version)
+{
+    uint64_t grapheneSetVersion = CMempoolSync::GetGrapheneSetVersion(version);
+    version = _version;
+    nSenderMempoolTxs = 0;
+    nSenderMempoolTxs = mempoolTxHashes.size();
+
+    pGrapheneSet = std::make_shared<CGrapheneSet>(CGrapheneSet(nReceiverMemPoolTx, nSenderMempoolPlusBlock,
+        mempoolTxHashes, shorttxidk0, shorttxidk1, grapheneSetVersion, IBLT_ENTROPY, COMPUTE_OPTIMIZED, false));
+}
+
+CMempoolSync::~CMempoolSync() { pGrapheneSet = nullptr; }
+bool HandleMempoolSyncRequest(CDataStream &vRecv, CNode *pfrom)
+{
+    LOG(MPOOLSYNC, "Handling mempool sync request from peer %s\n", pfrom->GetLogName());
+    CMempoolSyncInfo mempoolinfo;
+    CInv inv;
+    vRecv >> inv >> mempoolinfo;
+    NodeId nodeId = pfrom->GetId();
+
+    // Message consistency checking
+    if (!(inv.type == MSG_MEMPOOLSYNC))
+    {
+        dosMan.Misbehaving(pfrom, 100);
+        return error("invalid GET_MEMPOOLSYNC message type=%u\n", inv.type);
+    }
+
+    // Requester should only contact peers that support mempool sync
+    if (!syncMempoolWithPeers.Value())
+    {
+        dosMan.Misbehaving(pfrom, 100);
+        return error("Mempool sync requested from peer %s but not supported\n", pfrom->GetLogName());
+    }
+
+    // Requester must limit request frequency
+    {
+        LOCK(cs_mempoolsync);
+
+        if (mempoolSyncResponded.count(nodeId) > 0 &&
+            ((GetStopwatchMicros() - mempoolSyncResponded[nodeId].lastUpdated) <
+                MEMPOOLSYNC_FREQ_US - MEMPOOLSYNC_FREQ_GRACE_US))
+        {
+            dosMan.Misbehaving(pfrom, 100);
+            return error("Mempool sync requested less than %d mu seconds ago from peer %s\n", MEMPOOLSYNC_FREQ_US,
+                pfrom->GetLogName());
+        }
+
+        // Record request
+        mempoolSyncResponded[nodeId] =
+            CMempoolSyncState(GetStopwatchMicros(), mempoolinfo.shorttxidk0, mempoolinfo.shorttxidk1, false);
+    }
+
+    if (inv.type == MSG_MEMPOOLSYNC)
+    {
+        LOG(MPOOLSYNC, "Mempool currently holds %d transactions\n", mempool.size());
+
+        std::vector<uint256> mempoolTxHashes;
+        // cycle through mempool txs in order of ancestor_score
+        {
+            READLOCK(mempool.cs_txmempool);
+
+            int64_t nRemainingMempoolBytes = mempoolinfo.nRemainingMempoolBytes;
+            typename CTxMemPool::indexed_transaction_set::index<ancestor_score>::type::iterator it =
+                mempool.mapTx.get<ancestor_score>().begin();
+            for (; it != mempool.mapTx.get<ancestor_score>().end() && nRemainingMempoolBytes > 0; ++it)
+            {
+                size_t nTxSize = it->GetTx().GetTxSize();
+                int64_t nFee = it->GetFee();
+                CFeeRate feeRate(nFee, nTxSize);
+
+                // Skip tx if fee rate is too low
+                if (feeRate.GetFeePerK() < (int)mempoolinfo.nSatoshiPerK)
+                    continue;
+
+                mempoolTxHashes.push_back(it->GetTx().GetHash());
+                nRemainingMempoolBytes -= nTxSize;
+            }
+        }
+
+        if (mempoolTxHashes.size() == 0)
+        {
+            LOG(MPOOLSYNC, "Mempool is empty; aborting mempool sync with peer %s\n", pfrom->GetLogName());
+            return true;
+        }
+
+        // Assemble mempool sync object
+        uint64_t nBothMempools = mempoolTxHashes.size() + mempoolinfo.nTxInMempool;
+        CMempoolSync mempoolSync(mempoolTxHashes, mempoolinfo.nTxInMempool, nBothMempools, mempoolinfo.shorttxidk0,
+            mempoolinfo.shorttxidk1, NegotiateMempoolSyncVersion(pfrom));
+
+        pfrom->PushMessage(NetMsgType::MEMPOOLSYNC, mempoolSync);
+        LOG(MPOOLSYNC, "Sent mempool sync to peer %s using version %d\n", pfrom->GetLogName(), mempoolSync.version);
+    }
+    else
+    {
+        dosMan.Misbehaving(pfrom, 100);
+
+        return false;
+    }
+
+    return true;
+}
+
+/**
+ * Handle an incoming mempool synchronization payload
+ */
+bool CMempoolSync::ReceiveMempoolSync(CDataStream &vRecv, CNode *pfrom, std::string strCommand)
+{
+    // Deserialize mempool sync payload
+    CMempoolSync tmp;
+    vRecv >> tmp;
+    auto mempoolSync = std::make_shared<CMempoolSync>(std::forward<CMempoolSync>(tmp));
+    NodeId nodeId = pfrom->GetId();
+
+    LOG(MPOOLSYNC, "Received mempool sync from peer %s\n", pfrom->GetLogName());
+
+    // Do not process unrequested mempool sync.
+    {
+        LOCK(cs_mempoolsync);
+
+        if (!(mempoolSyncRequested.count(nodeId) == 1))
+        {
+            dosMan.Misbehaving(pfrom, 10);
+            return error("Received unrequested mempool sync from peer %s\n", pfrom->GetLogName());
+        }
+
+        // Do not proceed if this request has already been processed
+        if (mempoolSyncRequested[nodeId].completed)
+        {
+            dosMan.Misbehaving(pfrom, 100);
+            return error(
+                "Received mempool sync from peer %s but synchronization has already completed", pfrom->GetLogName());
+        }
+    }
+
+    return mempoolSync->process(pfrom);
+}
+
+bool CMempoolSync::process(CNode *pfrom)
+{
+    NodeId nodeId = pfrom->GetId();
+    std::set<uint256> passingTxHashes;
+    std::map<uint64_t, uint256> mapPartialTxHash;
+    std::set<uint64_t> setHashesToRequest;
+
+    std::vector<uint256> mempoolTxHashes;
+    GetMempoolTxHashes(mempoolTxHashes);
+
+    // Collect cheap hashes
+    {
+        LOCK(cs_mempoolsync);
+
+        for (const uint256 &hash : mempoolTxHashes)
+        {
+            uint64_t cheapHash = GetShortID(mempoolSyncRequested[nodeId].shorttxidk0,
+                mempoolSyncRequested[nodeId].shorttxidk1, hash, SHORT_ID_VERSION);
+            mapPartialTxHash.insert(std::make_pair(cheapHash, hash));
+        }
+    }
+
+    try
+    {
+        std::vector<uint64_t> blockCheapHashes = pGrapheneSet->Reconcile(mapPartialTxHash);
+
+        // Sort out what hashes we have from the complete set of cheapHashes
+        for (size_t i = 0; i < blockCheapHashes.size(); i++)
+        {
+            uint64_t cheapHash = blockCheapHashes[i];
+
+            const auto &elem = mapPartialTxHash.find(cheapHash);
+            if (elem == mapPartialTxHash.end())
+                setHashesToRequest.insert(cheapHash);
+        }
+    }
+    catch (const std::runtime_error &e)
+    {
+        LOG(MPOOLSYNC, "Mempool sync failed for peer %s. Graphene set could not be reconciled: %s\n",
+            pfrom->GetLogName(), e.what());
+    }
+
+    LOG(MPOOLSYNC, "Mempool sync received: %d total txns, waiting for: %d from peer %s\n", nSenderMempoolTxs,
+        setHashesToRequest.size(), pfrom->GetLogName());
+
+    // If there are any missing transactions then we request them here.
+    if (setHashesToRequest.size() > 0)
+    {
+        CRequestMempoolSyncTx mempoolSyncTx(setHashesToRequest);
+        pfrom->PushMessage(NetMsgType::GET_MEMPOOLSYNCTX, mempoolSyncTx);
+        LOG(MPOOLSYNC, "Requesting to sync %d missing transactions from %s\n", setHashesToRequest.size(),
+            pfrom->GetLogName());
+
+        return true;
+    }
+
+    // If there are no transactions to request, then synchronization is complete
+    {
+        LOCK(cs_mempoolsync);
+
+        mempoolSyncRequested[nodeId].completed = true;
+    }
+
+    LOG(MPOOLSYNC, "Completeing mempool sync with %s; no missing transactions\n", pfrom->GetLogName());
+
+    return true;
+}
+
+bool CRequestMempoolSyncTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
+{
+    CRequestMempoolSyncTx reqMempoolSyncTx;
+    vRecv >> reqMempoolSyncTx;
+    NodeId nodeId = pfrom->GetId();
+
+    // Message consistency checking
+    if (reqMempoolSyncTx.setCheapHashesToRequest.empty())
+    {
+        dosMan.Misbehaving(pfrom, 100);
+        return error("Incorrectly constructed getmemsynctx received.  Banning peer=%s", pfrom->GetLogName());
+    }
+
+    // A response was received for a request that was not made
+    std::vector<CTransactionRef> vTx;
+    {
+        LOCK(cs_mempoolsync);
+
+        if (mempoolSyncResponded.count(nodeId) == 0)
+        {
+            dosMan.Misbehaving(pfrom, 10);
+            return error("Received getmemsynctx from peer %s but mempool sync is not in progress", pfrom->GetLogName());
+        }
+
+        // Already processed requested transactions
+        if (mempoolSyncResponded[nodeId].completed)
+        {
+            dosMan.Misbehaving(pfrom, 100);
+            return error(
+                "Received getmemsynctx from peer %s but mempool sync has already completed", pfrom->GetLogName());
+        }
+
+        LOG(MPOOLSYNC, "Received getmemsynctx from peer=%s requesting %d transactions\n", pfrom->GetLogName(),
+            reqMempoolSyncTx.setCheapHashesToRequest.size());
+
+        std::vector<uint256> mempoolTxHashes;
+        GetMempoolTxHashes(mempoolTxHashes);
+
+        // Locate transactions requested
+        // Note that only those still in the mempool will be located
+        for (auto &hash : mempoolTxHashes)
+        {
+            uint64_t cheapHash = GetShortID(mempoolSyncResponded[nodeId].shorttxidk0,
+                mempoolSyncResponded[nodeId].shorttxidk1, hash, SHORT_ID_VERSION);
+
+            if (reqMempoolSyncTx.setCheapHashesToRequest.count(cheapHash) == 0)
+                continue;
+
+            // Check mempool first
+            auto txRef = mempool.get(hash);
+            if (txRef != nullptr)
+                vTx.push_back(txRef);
+
+            // Then CommitQ
+            txRef = CommitQGet(hash);
+            if (txRef != nullptr)
+                vTx.push_back(txRef);
+
+            // Finally orphanpool
+            {
+                READLOCK(orphanpool.cs_orphanpool);
+
+                std::map<uint256, CTxOrphanPool::COrphanTx>::iterator iter =
+                    orphanpool.mapOrphanTransactions.find(hash);
+                if (iter != orphanpool.mapOrphanTransactions.end())
+                {
+                    vTx.push_back(iter->second.ptx);
+                }
+            }
+        }
+    }
+
+    LOG(MPOOLSYNC, "Sending %d mempool sync transactions to peer=%s\n", vTx.size(), pfrom->GetLogName());
+
+    // Assemble missing transaction object
+    CMempoolSyncTx mempoolSyncTx(vTx);
+    pfrom->PushMessage(NetMsgType::MEMPOOLSYNCTX, mempoolSyncTx);
+
+    // We should not receive any future messages related to this synchronization round
+    {
+        LOCK(cs_mempoolsync);
+
+        mempoolSyncResponded[nodeId].completed = true;
+    }
+
+    return true;
+}
+
+bool CMempoolSyncTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
+{
+    std::string strCommand = NetMsgType::MEMPOOLSYNCTX;
+    CMempoolSyncTx mempoolSyncTx;
+    vRecv >> mempoolSyncTx;
+    NodeId nodeId = pfrom->GetId();
+
+    {
+        LOCK(cs_mempoolsync);
+
+        // Do not process unrequested memsynctx.
+        if (mempoolSyncRequested.count(nodeId) == 0)
+        {
+            dosMan.Misbehaving(pfrom, 10);
+            return error("Received memsynctx from peer %s but mempool sync is not in progress", pfrom->GetLogName());
+        }
+
+        // Already received requested transactions
+        if (mempoolSyncRequested[nodeId].completed)
+        {
+            dosMan.Misbehaving(pfrom, 100);
+            return error(
+                "Received memsynctx from peer %s but transactions have already been sent", pfrom->GetLogName());
+        }
+    }
+
+    LOG(MPOOLSYNC, "Received memsynctx from peer=%s; adding %d transactions to mempool\n", pfrom->GetLogName(),
+        mempoolSyncTx.vTx.size());
+
+    // Add transactions to mempool
+    for (const auto &tx : mempoolSyncTx.vTx)
+    {
+        CTxInputData inputData;
+        inputData.tx = tx;
+        inputData.nodeId = pfrom->id;
+        EnqueueTxForAdmission(inputData);
+    }
+
+    LOG(MPOOLSYNC, "Recovered %d txs from peer=%s via mempool sync\n", mempoolSyncTx.vTx.size(), pfrom->GetLogName());
+
+    // We should not receive any future messages related to this round of synchronization
+    {
+        LOCK(cs_mempoolsync);
+
+        mempoolSyncRequested[nodeId].completed = true;
+    }
+
+    return true;
+}
+
+void GetMempoolTxHashes(std::vector<uint256> &mempoolTxHashes)
+{
+    {
+        boost::unique_lock<boost::mutex> lock(csCommitQ);
+        for (auto &kv : *txCommitQ)
+        {
+            mempoolTxHashes.push_back(kv.first);
+        }
+    }
+
+    {
+        READLOCK(orphanpool.cs_orphanpool);
+        for (auto &kv : orphanpool.mapOrphanTransactions)
+        {
+            mempoolTxHashes.push_back(kv.first);
+        }
+    }
+
+    std::vector<uint256> memPoolHashes;
+    mempool.queryHashes(memPoolHashes);
+
+    for (const uint256 &hash : memPoolHashes)
+    {
+        mempoolTxHashes.push_back(hash);
+    }
+}
+
+CMempoolSyncInfo GetMempoolSyncInfo()
+{
+    // We need the number of transactions in the mempool and orphanpools but also the number
+    // in the txCommitQ that have been processed and valid, and which will be in the mempool shortly.
+    uint64_t nCommitQ = 0;
+    {
+        boost::unique_lock<boost::mutex> lock(csCommitQ);
+        nCommitQ = txCommitQ->size();
+    }
+
+    uint64_t nTxInMempool = mempool.size() + orphanpool.GetOrphanPoolSize() + nCommitQ;
+    uint64_t nMempoolMaxTxBytes = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
+    uint64_t nSatoshiPerK = minRelayTxFee.GetFeePerK();
+
+    // Form SipHash keys
+    uint64_t seed = GetRand(std::numeric_limits<uint64_t>::max());
+    CDataStream stream(SER_NETWORK, PROTOCOL_VERSION);
+    stream << seed;
+    CSHA256 hasher;
+    hasher.Write((unsigned char *)&(*stream.begin()), stream.end() - stream.begin());
+    uint256 shorttxidhash;
+    hasher.Finalize(shorttxidhash.begin());
+    uint64_t shorttxidk0 = shorttxidhash.GetUint64(0);
+    uint64_t shorttxidk1 = shorttxidhash.GetUint64(1);
+
+    // Calculate how many bytes of space remain in the mempool
+    uint64_t nRemainingMempoolTxBytes = nMempoolMaxTxBytes;
+    {
+        READLOCK(mempool.cs_txmempool);
+        for (const CTxMemPoolEntry &e : mempool.mapTx)
+        {
+            nRemainingMempoolTxBytes += e.GetTx().GetTxSize();
+        }
+    }
+
+    return CMempoolSyncInfo(nTxInMempool, nRemainingMempoolTxBytes, shorttxidk0, shorttxidk1, nSatoshiPerK);
+}
+
+uint64_t NegotiateMempoolSyncVersion(CNode *pfrom)
+{
+    uint64_t peerMin = pfrom->nMempoolSyncMinVersionSupported;
+    uint64_t selfMin = mempoolSyncMinVersionSupported.Value();
+    uint64_t peerMax = pfrom->nMempoolSyncMaxVersionSupported;
+    uint64_t selfMax = mempoolSyncMaxVersionSupported.Value();
+
+    uint64_t upper = (uint64_t)std::min(peerMax, selfMax);
+    uint64_t lower = (uint64_t)std::max(peerMin, selfMin);
+
+    if (lower > upper)
+        throw std::runtime_error("Sender and receiver support incompatible mempool sync versions");
+
+    return upper;
+}
+
+CNode *SelectMempoolSyncPeer(std::vector<CNode *> vNodesCopy)
+{
+    std::vector<CNode *> vSyncableNodes;
+
+    for (auto node : vNodesCopy)
+    {
+        // Skip if mempool sync is not supported
+        if (!node->canSyncMempoolWithPeers)
+            continue;
+
+        // Skip if version cannot be negotiated
+        try
+        {
+            NegotiateMempoolSyncVersion(node);
+        }
+        catch (std::runtime_error &e)
+        {
+            continue;
+        }
+
+        CNodeStateAccessor state(nodestate, node->GetId());
+        int nCommonHeight = state->pindexLastCommonBlock ? state->pindexLastCommonBlock->nHeight : -1;
+        int nSyncHeight = state->pindexBestKnownBlock ? state->pindexBestKnownBlock->nHeight : -1;
+
+        // Skip if node is in IBD
+        if ((nCommonHeight < chainActive.Tip()->nHeight - 10) && (nSyncHeight < chainActive.Tip()->nHeight - 10))
+            continue;
+
+        vSyncableNodes.push_back(node);
+    }
+
+    // Randomly select node with whom to request mempoolsync
+    if (vSyncableNodes.size() > 0)
+        return vSyncableNodes[GetRandInt(vSyncableNodes.size())];
+    else
+        return nullptr;
+}
+
+void ClearDisconnectedFromMempoolSyncMaps()    
+{
+    LOCK(cs_mempoolsync);
+
+    std::set<NodeId> toRemove;
+    for (auto idPair : mempoolSyncRequested)
+    {
+        if (!connmgr->FindNodeFromId(idPair.first))
+            toRemove.insert(idPair.first);
+    }
+
+    for (auto idPair : mempoolSyncResponded)
+    {
+        if (!connmgr->FindNodeFromId(idPair.first))
+            toRemove.insert(idPair.first);
+    }
+
+    if (toRemove.size() > 0)
+        LOG(MPOOLSYNC, "Mempool sync removing %d disconnected peers from sync maps\n", toRemove.size());
+
+    for (auto nId : toRemove)
+    {
+        if (mempoolSyncRequested.count(nId) > 0)
+            mempoolSyncRequested.erase(nId);
+
+        if (mempoolSyncResponded.count(nId) > 0)
+            mempoolSyncResponded.erase(nId);
+    }
+}

--- a/src/blockrelay/mempool_sync.h
+++ b/src/blockrelay/mempool_sync.h
@@ -196,6 +196,6 @@ void GetMempoolTxHashes(std::vector<uint256> &mempoolTxHashes);
 CMempoolSyncInfo GetMempoolSyncInfo();
 uint64_t NegotiateMempoolSyncVersion(CNode *pfrom);
 CNode *SelectMempoolSyncPeer(std::vector<CNode *> vNodesCopy);
-void ClearDisconnectedFromMempoolSyncMaps();
+void ClearDisconnectedFromMempoolSyncMaps(NodeId nodeid);
 
 #endif // BITCOIN_MEMPOOL_SYNC_H

--- a/src/blockrelay/mempool_sync.h
+++ b/src/blockrelay/mempool_sync.h
@@ -1,0 +1,201 @@
+// Copyright (c) 2018-2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_MEMPOOL_SYNC_H
+#define BITCOIN_MEMPOOL_SYNC_H
+
+#include "blockrelay/blockrelay_common.h"
+#include "blockrelay/graphene.h"
+#include "consensus/consensus.h"
+#include "net.h"
+#include "utiltime.h"
+
+const uint64_t DEFAULT_MEMPOOL_SYNC_MIN_VERSION_SUPPORTED = 0;
+const uint64_t DEFAULT_MEMPOOL_SYNC_MAX_VERSION_SUPPORTED = 0;
+// arbitrary entropy passed to CGrapheneSet an used for IBLT
+const uint32_t IBLT_ENTROPY = 13;
+// any value greater than 2 will use SipHash
+const uint64_t SHORT_ID_VERSION = 2;
+// frequency of synchronization (per peer) in microseconds
+const int64_t MEMPOOLSYNC_FREQ_US = 30 * 1e6;
+const int64_t MEMPOOLSYNC_FREQ_GRACE_US = 5 * 1e6;
+// frequency that CMempoolSyncState maps are cleared in microseconds
+const int64_t MEMPOOLSYNC_CLEAR_FREQ_US = 3600 * 1e6;
+// Use CVariableFastFilter if true, otherwise use CBloomFilter
+const bool COMPUTE_OPTIMIZED = true;
+
+/** State of mempool sync for a given peer. Can be used to track either responses or requests. */
+class CMempoolSyncState
+{
+public:
+    /** Microseconds since this peer last responded / requested sync. */
+    uint64_t lastUpdated;
+    /** SipHash keys as determined by sync requester. */
+    uint64_t shorttxidk0;
+    uint64_t shorttxidk1;
+    /** Flag indicating that all appropriate messages have been received from peer.*/
+    bool completed;
+
+public:
+    CMempoolSyncState(uint64_t _lastUpdated, uint64_t _shorttxidk0, uint64_t _shorttxidk1, bool _completed)
+        : lastUpdated(_lastUpdated), shorttxidk0(_shorttxidk0), shorttxidk1(_shorttxidk1), completed(_completed)
+    {
+    }
+    CMempoolSyncState() : lastUpdated(GetStopwatchMicros()), shorttxidk0(0), shorttxidk1(0), completed(false) {}
+};
+
+extern std::map<NodeId, CMempoolSyncState> mempoolSyncRequested;
+extern std::map<NodeId, CMempoolSyncState> mempoolSyncResponded;
+
+/** Mempool sync related metadata sent from requester to responder.*/
+class CMempoolSyncInfo
+{
+public:
+    /** Number of transactions in requester's mempool. */
+    uint64_t nTxInMempool;
+    /** The number of bytes of space remaining in requester's mempool. */
+    uint64_t nRemainingMempoolBytes;
+    /** SipHash keys to be used for generating cheap hashes. */
+    uint64_t shorttxidk0;
+    uint64_t shorttxidk1;
+    /** The minimum number of satoshi's per KB for transactions accommodated by requester. */
+    uint64_t nSatoshiPerK;
+
+public:
+    CMempoolSyncInfo(uint64_t nTxInMempool,
+        uint64_t nRemainingMempoolBytes,
+        uint64_t shorttxidk0,
+        uint64_t shorttxidk1,
+        uint64_t nSatoshiPerK);
+    CMempoolSyncInfo();
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action)
+    {
+        READWRITE(nTxInMempool);
+        READWRITE(nRemainingMempoolBytes);
+        READWRITE(shorttxidk0);
+        READWRITE(shorttxidk1);
+        READWRITE(nSatoshiPerK);
+    }
+};
+
+/** Mempool sync payload sent to requester by responder. */
+class CMempoolSync
+{
+public:
+    /** Number of transactions in the requester's mempool. */
+    uint64_t nSenderMempoolTxs;
+    /** Graphene set containing transactions from responder's mempool. */
+    std::shared_ptr<CGrapheneSet> pGrapheneSet;
+    /** Negotiated mempool sync version. */
+    uint64_t version;
+
+public:
+    CMempoolSync(std::vector<uint256> mempoolTxHashes,
+        uint64_t nReceiverMemPoolTx,
+        uint64_t nSenderMempoolPlusBlock,
+        uint64_t shorttxidk0,
+        uint64_t shorttxidk1,
+        uint64_t _version);
+    CMempoolSync() : nSenderMempoolTxs(0), pGrapheneSet(nullptr), version(0) {}
+    CMempoolSync(uint64_t _version) : nSenderMempoolTxs(0), pGrapheneSet(nullptr) {}
+    ~CMempoolSync();
+
+    static inline uint64_t GetGrapheneSetVersion(uint64_t grapheneBlockVersion) { return 4; }
+    /**
+     * Handle an incoming MempoolSync
+     * @param[in]  vRecv        The raw binary message
+     * @param[in]  pFrom        The node the message was from
+     * @param[in]  strCommand   The message kind
+     * @return True if handling succeeded
+     */
+    static bool ReceiveMempoolSync(CDataStream &vRecv, CNode *pfrom, std::string strCommand);
+    bool process(CNode *pfrom);
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action)
+    {
+        READWRITE(COMPACTSIZE(version));
+        READWRITE(nSenderMempoolTxs);
+        if (nSenderMempoolTxs > (maxMessageSizeMultiplier * excessiveBlockSize / MIN_TX_SIZE))
+            throw std::runtime_error("nSenderMempoolTxs exceeds threshold for excessive block txs");
+        if (!pGrapheneSet)
+        {
+            pGrapheneSet = std::make_shared<CGrapheneSet>(
+                CGrapheneSet(CMempoolSync::GetGrapheneSetVersion(version), COMPUTE_OPTIMIZED));
+        }
+        READWRITE(*pGrapheneSet);
+    }
+
+    bool process(CNode *pfrom, std::string strCommand, std::shared_ptr<CBlockThinRelay> pblock);
+};
+
+/** Payload of cheap hashes corresponding to transactions missing from requester. */
+class CRequestMempoolSyncTx
+{
+public:
+    std::set<uint64_t> setCheapHashesToRequest; // map of missing transactions
+
+public:
+    CRequestMempoolSyncTx(std::set<uint64_t> &_setCheapHashesToRequest)
+        : setCheapHashesToRequest(_setCheapHashesToRequest){};
+    CRequestMempoolSyncTx() {}
+    /**
+     * Handle an incoming request for missing graphene block transactions
+     * @param[in] vRecv        The raw binary message
+     * @param[in] pFrom        The node the message was from
+     * @return True if handling succeeded
+     */
+    static bool HandleMessage(CDataStream &vRecv, CNode *pfrom);
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action)
+    {
+        READWRITE(setCheapHashesToRequest);
+    }
+};
+
+/** Payload of transactions corresponding to cheap hashes requested by requester. */
+class CMempoolSyncTx
+{
+public:
+    /** Missing transactions. */
+    std::vector<CTransactionRef> vTx;
+
+public:
+    CMempoolSyncTx(std::vector<CTransactionRef> &_vTx) : vTx(_vTx){};
+    CMempoolSyncTx(){};
+
+    /**
+     * Handle receiving a list of missing mempool sync transactions from a prior request
+     * @param[in] vRecv        The raw binary message
+     * @param[in] pFrom        The node the message was from
+     * @return True if handling succeeded
+     */
+    static bool HandleMessage(CDataStream &vRecv, CNode *pfrom);
+
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action)
+    {
+        READWRITE(vTx);
+    }
+};
+
+bool HandleMempoolSyncRequest(CDataStream &vRecv, CNode *pfrom);
+void GetMempoolTxHashes(std::vector<uint256> &mempoolTxHashes);
+CMempoolSyncInfo GetMempoolSyncInfo();
+uint64_t NegotiateMempoolSyncVersion(CNode *pfrom);
+CNode *SelectMempoolSyncPeer(std::vector<CNode *> vNodesCopy);
+void ClearDisconnectedFromMempoolSyncMaps();
+
+#endif // BITCOIN_MEMPOOL_SYNC_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 #include "arith_uint256.h"
 #include "blockrelay/blockrelay_common.h"
 #include "blockrelay/graphene.h"
+#include "blockrelay/mempool_sync.h"
 #include "blockrelay/thinblock.h"
 #include "blockstorage/blockstorage.h"
 #include "blockstorage/sequential_files.h"
@@ -143,6 +144,9 @@ void InitializeNode(const CNode *pnode)
 
 void FinalizeNode(NodeId nodeid)
 {
+    // Clean up the sync maps
+    ClearDisconnectedFromMempoolSyncMaps(nodeid);
+
     // Clear thintype block data if we have any.
     thinrelay.ClearAllBlocksToReconstruct(nodeid);
     thinrelay.ClearAllBlocksInFlight(nodeid);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2288,7 +2288,7 @@ void ThreadMessageHandler()
         {
             // select node from whom to request mempool sync
             CNode *syncPeer = SelectMempoolSyncPeer(vNodesCopy);
-            if (!(syncPeer == nullptr))
+            if (syncPeer && IsChainNearlySyncd())
                 requester.RequestMempoolSync(syncPeer);
         }
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2292,10 +2292,6 @@ void ThreadMessageHandler()
                 requester.RequestMempoolSync(syncPeer);
         }
 
-        // Periodically clear mempool sync maps in case peers have disconnected
-        if (GetStopwatchMicros() - lastMempoolSyncClear > MEMPOOLSYNC_CLEAR_FREQ_US)
-            ClearDisconnectedFromMempoolSyncMaps();
-
         for (CNode *pnode : vNodesCopy)
         {
             if (pnode->fDisconnect)

--- a/src/net.h
+++ b/src/net.h
@@ -370,6 +370,12 @@ public:
     /** This node's max acceptable sum of all descendant transaction sizes.  Used to decide whether this node will
      * accept a particular transaction. */
     size_t nLimitDescendantSize = BCH_DEFAULT_DESCENDANT_SIZE_LIMIT * 1000;
+    // Does this node support mempool synchronization?
+    bool canSyncMempoolWithPeers;
+    // Minimum supported mempool synchronization version
+    uint64_t nMempoolSyncMinVersionSupported;
+    // Maximum supported mempool synchronization version
+    uint64_t nMempoolSyncMaxVersionSupported;
 
     // This is shared-locked whenever messages are processed.
     // Take it exclusive-locked to finish all ongoing processing

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -51,6 +51,12 @@ const char *GRAPHENETX = "grblktx";
 const char *GET_GRAPHENETX = "get_grblktx";
 const char *GET_GRAPHENE = "get_grblk";
 // BUIPXXX Graphene - end section
+// Mempool sync - begin section
+const char *MEMPOOLSYNC = "memsync";
+const char *MEMPOOLSYNCTX = "memsynctx";
+const char *GET_MEMPOOLSYNC = "get_memsync";
+const char *GET_MEMPOOLSYNCTX = "getmemsynctx";
+// Mempool sync - end section
 const char *XPEDITEDREQUEST = "req_xpedited";
 const char *XPEDITEDBLK = "Xb";
 const char *XPEDITEDTxn = "Xt";

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -179,6 +179,22 @@ extern const char *GET_GRAPHENETX;
  * The get_graphene message transmits a single serialized get_grblk.
  */
 extern const char *GET_GRAPHENE;
+/**
+ * The mempoolsync message transmits a single serialized get_memsync.
+ */
+extern const char *MEMPOOLSYNC;
+/**
+ * The mempoolsynctx message transmits a single serialized get_memsynctx.
+ */
+extern const char *MEMPOOLSYNCTX;
+/**
+ * The get_mempoolsync message transmits a single serialized get_memsync.
+ */
+extern const char *GET_MEMPOOLSYNC;
+/**
+ * The get_mempoolsynctx message transmits a single serialized get_memsynctx.
+ */
+extern const char *GET_MEMPOOLSYNCTX;
 
 /**
  * The getaddr message requests an addr message from the receiving node,
@@ -481,6 +497,8 @@ enum
     // With the introduction of compact block, this is being deprecated in favor of using the get_thin p2p
     // message, which solves the conflict with MSG_THINBLOCK and MSG_CMPCT_BLOCK.
     MSG_THINBLOCK = MSG_CMPCT_BLOCK,
+    // Uses Graphene set reconciliation to syncronize mempools between two peers.
+    MSG_MEMPOOLSYNC,
 };
 
 #endif // BITCOIN_PROTOCOL_H

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -27,6 +27,7 @@ successful receipt, "requester.Rejected(...)" to indicate a bad object (request 
 #ifndef REQUEST_MANAGER_H
 #define REQUEST_MANAGER_H
 
+#include "blockrelay/mempool_sync.h"
 #include "net.h"
 #include "nodestate.h"
 #include "stat.h"
@@ -44,6 +45,10 @@ static const unsigned int DEFAULT_MIN_TX_REQUEST_RETRY_INTERVAL = 5 * 1000 * 100
 extern unsigned int blkReqRetryInterval;
 extern unsigned int MIN_BLK_REQUEST_RETRY_INTERVAL;
 static const unsigned int DEFAULT_MIN_BLK_REQUEST_RETRY_INTERVAL = 5 * 1000 * 1000;
+// Which peers have mempool synchronization in-flight?
+extern std::map<NodeId, CMempoolSyncState> mempoolSyncRequested;
+extern uint64_t lastMempoolSync;
+extern CCriticalSection cs_mempoolsync;
 
 class CNode;
 
@@ -232,6 +237,9 @@ public:
 
     // This gets called from RequestNextBlocksToDownload
     void FindNextBlocksToDownload(CNode *node, unsigned int count, std::vector<CBlockIndex *> &vBlocks);
+
+    // Request to synchronize mempool with peer pto
+    void RequestMempoolSync(CNode *pto);
 
     // Returns a bool indicating whether we requested this block.
     void MarkBlockAsInFlight(NodeId nodeid, const uint256 &hash);

--- a/src/test/mempool_sync_tests.cpp
+++ b/src/test/mempool_sync_tests.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2018-2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include "blockrelay/mempool_sync.h"
+#include "serialize.h"
+#include "streams.h"
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+#include <cassert>
+#include <iostream>
+
+BOOST_FIXTURE_TEST_SUITE(mempool_sync_tests, BasicTestingSetup)
+
+BOOST_AUTO_TEST_CASE(mempool_sync_can_serde)
+{
+    uint64_t sync_version = DEFAULT_MEMPOOL_SYNC_MAX_VERSION_SUPPORTED;
+    uint64_t nReceiverMemPoolTx = 0;
+    uint64_t nSenderMempoolPlusBlock = 1;
+    uint64_t shorttxidk0 = 7;
+    uint64_t shorttxidk1 = 11;
+
+    CBlock block;
+    CTransaction tx;
+    CDataStream stream(
+        ParseHex("01000000010b26e9b7735eb6aabdf358bab62f9816a21ba9ebdb719d5299e88607d722c190000000008b4830450220070aca4"
+                 "4506c5cef3a16ed519d7c3c39f8aab192c4e1c90d065f37b8a4af6141022100a8e160b856c2d43d27d8fba71e5aef6405b864"
+                 "3ac4cb7cb3c462aced7f14711a0141046d11fee51b0e60666d5049a9101a72741df480b96ee26488a4d3466b95c9a40ac5eee"
+                 "f87e10a5cd336c19a84565f80fa6c547957b7700ff4dfbdefe76036c339ffffffff021bff3d11000000001976a91404943fdd"
+                 "508053c75000106d3bc6e2754dbcff1988ac2f15de00000000001976a914a266436d2965547608b9e15d9032a7b9d64fa4318"
+                 "8ac00000000"),
+        SER_DISK, CLIENT_VERSION);
+    stream >> tx;
+    std::vector<uint256> senderMempoolTxHashes;
+    std::vector<uint256> receiverMempoolTxHashes;
+    senderMempoolTxHashes.push_back(tx.GetHash());
+    CMempoolSync senderMempoolSync(
+        senderMempoolTxHashes, nReceiverMemPoolTx, nSenderMempoolPlusBlock, shorttxidk0, shorttxidk1, sync_version);
+    CMempoolSync receiverMempoolSync(sync_version);
+    CDataStream ss(SER_DISK, 0);
+
+    ss << senderMempoolSync;
+    ss >> receiverMempoolSync;
+
+    receiverMempoolSync.pGrapheneSet->Reconcile(receiverMempoolTxHashes);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/util.h
+++ b/src/util.h
@@ -198,7 +198,8 @@ enum
     WB = 0x40000000, // weak blocks
     CMPCT = 0x80000000, // compact blocks
 
-    ELECTRUM = 0x100000000
+    ELECTRUM = 0x100000000,
+    MPOOLSYNC = 0x200000000
 };
 
 namespace Logging
@@ -222,7 +223,7 @@ To add a new log category:
             {REQ, "req"}, {BLOOM, "bloom"}, {LCK, "lck"}, {PROXY, "proxy"}, {DBASE, "dbase"},                   \
             {SELECTCOINS, "selectcoins"}, {ESTIMATEFEE, "estimatefee"}, {QT, "qt"}, {IBD, "ibd"},               \
             {GRAPHENE, "graphene"}, {RESPEND, "respend"}, {WB, "weakblocks"}, {CMPCT, "cmpctblock"},            \
-            {ELECTRUM, "electrum"},                                                                             \
+            {ELECTRUM, "electrum"}, {MPOOLSYNC, "mempoolsync"},                                                 \
         {                                                                                                       \
             ZMQ, "zmq"                                                                                          \
         }                                                                                                       \

--- a/src/xversionkeys.dat
+++ b/src/xversionkeys.dat
@@ -32,6 +32,10 @@ KEY i BU_XTHIN_VERSION                          0x0002                   0x0003 
 KEY i BU_GRAPHENE_FAST_FILTER_PREF              0x0002                   0x0004         u64c
 # Graphene high / low (inclusive) version numbers
 KEY i BU_GRAPHENE_MIN_VERSION_SUPPORTED         0x0002                   0x0005         u64c
+# Mempool sync preferences
+KEY i BU_MEMPOOL_SYNC                           0x0002                   0x0006         u64c
+KEY i BU_MEMPOOL_SYNC_MIN_VERSION_SUPPORTED     0x0002                   0x0007         u64c
+KEY i BU_MEMPOOL_SYNC_MAX_VERSION_SUPPORTED     0x0002                   0x0008         u64c
 
 # Communicate mempool unconfirmed preferences to connected nodes.  This allows those nodes to send transactions when they will be accepted.
 KEY i BU_MEMPOOL_ANCESTOR_COUNT_LIMIT           0x0002                   0x0009         u64c


### PR DESCRIPTION
This PR provides an implementation of mempool synchronization using Graphene set reconciliation primitives. The overall approach is for peers to pull synchronization objects from other peers at regular intervals (currently once every 30 seconds). Each interval, the requesting peer randomly chooses a peer from whom to request synchronization. When a responding peer receives a mempool sync request, he makes a best effort to send to the requester all transactions in his mempool that are missing from the requester's mempool. Synchronization is not necessarily symmetric: peer `A` can sync with the mempool of `B`, but `B` need not necessarily sync with `A`. 

For DoS prevention, each peer will accept a synchronization request from any other peer at most once every 25 seconds. For any given synchronization session that is in-flight, the responding peer will accept exactly one request for missing transactions. Similarly, each requesting peer will accept exactly one missing transaction response per synchronization request. Any messages exceeding the above limits will result in an increase in the ban counter for the offending peer. 

Validation includes rpc and manual testing. The rpc test sets up 3 nodes and turns off normal transaction propagation between them. Each peer generates a batch of transactions and conducts mempool sync with its neighbors. The test passes if all mempools contain all transactions after 180 seconds or less. For manual testing, @sickpig setup an edge node on mainnet running mempool sync. On my machine locally, I setup an internal node also running mempool sync and connecting exclusively to the edge node. Normal transaction propagation was disabled between edge and internal nodes. Attached is a plot of the transaction counts in the mempools of each node over a 1 day period. The lines are nearly identical, indicating close synchronization between the two mempools. 
<img width="579" alt="sync_test" src="https://user-images.githubusercontent.com/1005112/65324924-8926ea00-db7b-11e9-90b1-e3577563c684.png">
