### PR TITLE
fix ping latency time to use stopwatch time

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -665,7 +665,7 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes)
                     LOG(THIN | GRAPHENE, "Receive Queue: pushed %s to the front of the queue\n", strFirstMsgCommand);
                 }
             }
-            // BU: end
+            msg.nStopwatch = GetStopwatchMicros();
             msg.nTime = GetTimeMicros();
             messageHandlerCondition.notify_one();
         }

--- a/src/net.h
+++ b/src/net.h
@@ -256,6 +256,7 @@ public:
     unsigned int nDataPos;
 
     int64_t nTime; // calendar time (in microseconds) of message receipt.
+    int64_t nStopwatch; // stopwatch time in microseconds of message receipt.  Used to calculate round trip latency.
 
     // default constructor builds an empty message object to accept assignment of real messages
     CNetMessage() : hdrbuf(0, 0), hdr({0, 0, 0, 0}), vRecv(0, 0)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -384,13 +384,13 @@ static void enableCompactBlocks(CNode *pfrom)
     }
 }
 
-bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, int64_t nTimeReceived)
+bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, int64_t nStopwatchTimeReceived)
 {
     int64_t receiptTime = GetTime();
     const CChainParams &chainparams = Params();
     RandAddSeedPerfmon();
     unsigned int msgSize = vRecv.size(); // BU for statistics
-    UpdateRecvStats(pfrom, strCommand, msgSize, nTimeReceived);
+    UpdateRecvStats(pfrom, strCommand, msgSize, nStopwatchTimeReceived);
     LOG(NET, "received: %s (%u bytes) peer=%s\n", SanitizeString(strCommand), msgSize, pfrom->GetLogName());
     if (mapArgs.count("-dropmessagestest") && GetRand(atoi(mapArgs["-dropmessagestest"])) == 0)
     {
@@ -1795,7 +1795,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
 
     else if (strCommand == NetMsgType::PONG)
     {
-        int64_t pingUsecEnd = nTimeReceived;
+        int64_t pingUsecEnd = nStopwatchTimeReceived;
         uint64_t nonce = 0;
         size_t nAvail = vRecv.in_avail();
         bool bPingFinished = false;
@@ -2081,7 +2081,7 @@ bool ProcessMessages(CNode *pfrom)
         bool fRet = false;
         try
         {
-            fRet = ProcessMessage(pfrom, strCommand, vRecv, msg.nTime);
+            fRet = ProcessMessage(pfrom, strCommand, vRecv, msg.nStopwatch);
             if (shutdown_threads.load() == true)
             {
                 return false;

--- a/src/net_processing.h
+++ b/src/net_processing.h
@@ -13,8 +13,13 @@
 bool ProcessMessages(CNode *pfrom);
 
 
-/** Process a single protocol messages received from a given node */
-bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, int64_t nTimeReceived);
+/** Process a single protocol messages received from a given node
+    @param pfrom The node this message originated from
+    @param strCommand The message type
+    @param vRecv The message contents
+    @param nStopwatchTimeReceived Stopwatch time in microseconds indicating when this message was received
+*/
+bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, int64_t nStopwatchTimeReceived);
 
 /**
  * Send queued protocol messages to be sent to a give node.

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(version_tests)
     dummyNode1.nVersion = 0;
     int nVersion = MIN_PEER_PROTO_VERSION;
     vRecv1 << nVersion << nServices << nTime << addrMe;
-    ProcessMessage(&dummyNode1, NetMsgType::VERSION, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::VERSION, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode1);
     BOOST_CHECK(dummyNode1.nVersion);
     BOOST_CHECK(!dosMan.IsBanned(addr1));
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(version_tests)
     dummyNode1a.nVersion = 0;
     nVersion = MIN_PEER_PROTO_VERSION - 1;
     vRecv1 << nVersion << nServices << nTime << addrMe;
-    ProcessMessage(&dummyNode1a, NetMsgType::VERSION, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1a, NetMsgType::VERSION, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode1a);
     BOOST_CHECK(dummyNode1a.nVersion);
     BOOST_CHECK(dosMan.IsBanned(addr1));
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE(version_tests)
     CNode dummyNode2(INVALID_SOCKET, addr2, "", true);
     dummyNode2.nVersion = MIN_PEER_PROTO_VERSION;
     vRecv1 << nVersion << nServices << nTime << addrMe;
-    ProcessMessage(&dummyNode2, NetMsgType::VERSION, vRecv1, GetTime());
+    ProcessMessage(&dummyNode2, NetMsgType::VERSION, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode2);
     BOOST_CHECK(dummyNode2.nVersion);
     BOOST_CHECK(dummyNode2.fDisconnect);
@@ -191,7 +191,7 @@ BOOST_AUTO_TEST_CASE(version_tests)
     dosMan.ClearBanned();
     CNode dummyNode3(INVALID_SOCKET, addr3, "", true);
     dummyNode3.nVersion = 0;
-    ProcessMessage(&dummyNode3, NetMsgType::PING, vRecv1, GetTime());
+    ProcessMessage(&dummyNode3, NetMsgType::PING, vRecv1,  GetStopwatchMicros());
     SendMessages(&dummyNode3);
     BOOST_CHECK(!dummyNode3.nVersion);
     BOOST_CHECK(dummyNode3.fDisconnect);
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(verack_tests)
     dummyNode1.state_outgoing = ConnectionStateOutgoing::SENT_VERSION;
     dummyNode1.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode1.tVersionSent = GetTime(); // should not cause ban if VERSION was sent
-    ProcessMessage(&dummyNode1, NetMsgType::VERACK, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::VERACK, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode1);
     BOOST_CHECK(dummyNode1.tVersionSent >= 0);
     BOOST_CHECK_EQUAL(dummyNode1.state_outgoing, ConnectionStateOutgoing::READY);
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(verack_tests)
 
     // Receive VERACK but no VERSION sent
     dummyNode1.tVersionSent = -1; // should cause disconnect
-    ProcessMessage(&dummyNode1, NetMsgType::VERACK, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::VERACK, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode1);
     BOOST_CHECK(dummyNode1.tVersionSent < 0);
     BOOST_CHECK(dummyNode1.fDisconnect);
@@ -230,7 +230,7 @@ BOOST_AUTO_TEST_CASE(verack_tests)
     dummyNode2.state_incoming = ConnectionStateIncoming::READY; // should cause disconnect if VERSION was already sent
     dummyNode2.state_outgoing = ConnectionStateOutgoing::READY; // should cause disconnect if VERSION was already sent
     dummyNode2.tVersionSent = GetTime();
-    ProcessMessage(&dummyNode2, NetMsgType::VERACK, vRecv1, GetTime());
+    ProcessMessage(&dummyNode2, NetMsgType::VERACK, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode2);
     BOOST_CHECK(dummyNode2.successfullyConnected());
     BOOST_CHECK(dummyNode2.fDisconnect);
@@ -247,7 +247,7 @@ BOOST_AUTO_TEST_CASE(verack_tests)
     dummyNode3.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode3.tVersionSent = nStartTime;
     SetMockTime(nStartTime + VERACK_TIMEOUT + 1); // VERACK should not cause disconnect even if timeout exceeded
-    ProcessMessage(&dummyNode3, NetMsgType::VERACK, vRecv1, GetTime());
+    ProcessMessage(&dummyNode3, NetMsgType::VERACK, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode3);
     BOOST_CHECK(dummyNode3.tVersionSent >= 0);
     BOOST_CHECK(!dosMan.IsBanned(addr3));
@@ -262,7 +262,7 @@ BOOST_AUTO_TEST_CASE(verack_tests)
     vRecv1 << (uint64_t)12345; // ping nonce
     {
         READLOCK(dummyNode4.csMsgSerializer);
-        ProcessMessage(&dummyNode4, NetMsgType::PING, vRecv1, GetTime());
+        ProcessMessage(&dummyNode4, NetMsgType::PING, vRecv1, GetStopwatchMicros());
     }
     BOOST_CHECK(!dummyNode4.fDisconnect);
 
@@ -275,7 +275,7 @@ BOOST_AUTO_TEST_CASE(verack_tests)
     vRecv1 << (uint64_t)12345; // ping nonce
     {
         READLOCK(dummyNode4.csMsgSerializer);
-        ProcessMessage(&dummyNode4a, NetMsgType::PING, vRecv1, GetTime());
+        ProcessMessage(&dummyNode4a, NetMsgType::PING, vRecv1, GetStopwatchMicros());
     }
     BOOST_CHECK(dummyNode4a.fDisconnect);
 }
@@ -292,7 +292,7 @@ BOOST_AUTO_TEST_CASE(bu_version_tests)
     dummyNode1.state_outgoing = ConnectionStateOutgoing::READY;
     dummyNode1.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode1.addrFromPort = 0;
-    ProcessMessage(&dummyNode1, NetMsgType::BUVERSION, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::BUVERSION, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode1);
     BOOST_CHECK_EQUAL(dummyNode1.state_incoming, ConnectionStateIncoming::READY);
     BOOST_CHECK_EQUAL(dummyNode1.state_outgoing, ConnectionStateOutgoing::READY);
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(bu_version_tests)
     dummyNode1.state_incoming = ConnectionStateIncoming::CONNECTED_WAIT_VERSION;
     dummyNode1.state_outgoing = ConnectionStateOutgoing::READY;
     dummyNode1.addrFromPort = 0;
-    ProcessMessage(&dummyNode1, NetMsgType::BUVERACK, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::BUVERACK, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode1);
     BOOST_CHECK_EQUAL(dummyNode1.state_incoming, ConnectionStateIncoming::CONNECTED_WAIT_VERSION);
     BOOST_CHECK(dosMan.IsBanned(addr1));
@@ -313,7 +313,7 @@ BOOST_AUTO_TEST_CASE(bu_version_tests)
     dummyNode2.state_outgoing = ConnectionStateOutgoing::READY;
     dummyNode2.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNode2.addrFromPort = 8333; // we don't ban as the port can also be set from xversion
-    ProcessMessage(&dummyNode2, NetMsgType::BUVERSION, vRecv1, GetTime());
+    ProcessMessage(&dummyNode2, NetMsgType::BUVERSION, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode2);
     BOOST_CHECK(dummyNode2.addrFromPort);
     BOOST_CHECK(!dosMan.IsBanned(addr2));
@@ -329,14 +329,14 @@ BOOST_AUTO_TEST_CASE(bu_verack_tests)
     dummyNode1.state_incoming = ConnectionStateIncoming::READY;
     dummyNode1.state_outgoing = ConnectionStateOutgoing::READY;
     dummyNode1.nVersion = MIN_PEER_PROTO_VERSION;
-    ProcessMessage(&dummyNode1, NetMsgType::BUVERACK, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::BUVERACK, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode1);
     BOOST_CHECK(dummyNode1.state_outgoing == ConnectionStateOutgoing::READY);
     BOOST_CHECK(!dosMan.IsBanned(addr1));
 
     // Receive BUVERACK but no BUVERSION sent
     dummyNode1.state_outgoing = ConnectionStateOutgoing::CONNECTED;
-    ProcessMessage(&dummyNode1, NetMsgType::BUVERACK, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::BUVERACK, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode1);
     BOOST_CHECK(dummyNode1.state_outgoing == ConnectionStateOutgoing::CONNECTED);
     BOOST_CHECK(dosMan.IsBanned(addr1));
@@ -358,19 +358,19 @@ BOOST_AUTO_TEST_CASE(inv_tests)
     dummyNode1.state_outgoing = ConnectionStateOutgoing::READY;
     dummyNode1.nVersion = MIN_PEER_PROTO_VERSION;
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetStopwatchMicros());
 
     SendMessages(&dummyNode1); // sending five messages below MAX_INV_SZ should not cause ban
     BOOST_CHECK(vInv.size() <= MAX_INV_SZ);
@@ -384,22 +384,22 @@ BOOST_AUTO_TEST_CASE(inv_tests)
     dummyNode1.state_outgoing = ConnectionStateOutgoing::READY;
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode1); // send four messages should not cause ban
     BOOST_CHECK(vInv.size() > MAX_INV_SZ);
     BOOST_CHECK(!dosMan.IsBanned(addr1));
 
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode1); // send a fifth message will cause a ban
     BOOST_CHECK(vInv.size() > MAX_INV_SZ);
     BOOST_CHECK(dosMan.IsBanned(addr1));
@@ -426,21 +426,21 @@ BOOST_AUTO_TEST_CASE(inv_tests)
     dummyNode3.state_outgoing = ConnectionStateOutgoing::READY;
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode3, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode3, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode3, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode3, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode3, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode3, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode3, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode3, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode3); // send four messages should not cause ban
     BOOST_CHECK(!dosMan.IsBanned(addr3));
 
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode3, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode3, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode3); // send a fifth message should cause ban
     BOOST_CHECK(dosMan.IsBanned(addr3));
 
@@ -465,22 +465,22 @@ BOOST_AUTO_TEST_CASE(inv_tests)
     dummyNode5.state_outgoing = ConnectionStateOutgoing::READY;
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode5, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode5, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode5, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode5, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode5, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode5, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode5, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode5, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode5); // send four messages should not cause ban
     BOOST_CHECK(!dosMan.IsBanned(addr5));
 
     vRecv1.clear();
     vRecv1 << vInv;
-    ProcessMessage(&dummyNode5, NetMsgType::INV, vRecv1, GetTime());
+    ProcessMessage(&dummyNode5, NetMsgType::INV, vRecv1, GetStopwatchMicros());
     SendMessages(&dummyNode5); // send a fifth message should cause ban
     BOOST_CHECK(dosMan.IsBanned(addr5));
 }
@@ -522,7 +522,7 @@ BOOST_AUTO_TEST_CASE(compactblock_tests)
         dummyNode.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNode.state_incoming = ConnectionStateIncoming::READY;
         dummyNode.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNode, NetMsgType::GETBLOCKTXN, vRecv1, GetTime());
+        ProcessMessage(&dummyNode, NetMsgType::GETBLOCKTXN, vRecv1, GetStopwatchMicros());
         SendMessages(&dummyNode);
         BOOST_CHECK(dosMan.IsBanned(addr1));
         dosMan.ClearBanned();
@@ -548,7 +548,7 @@ BOOST_AUTO_TEST_CASE(compactblock_tests)
         dummyNode.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNode.state_incoming = ConnectionStateIncoming::READY;
         dummyNode.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNode, NetMsgType::GETBLOCKTXN, vRecv1, GetTime());
+        ProcessMessage(&dummyNode, NetMsgType::GETBLOCKTXN, vRecv1, GetStopwatchMicros());
         SendMessages(&dummyNode);
         BOOST_CHECK(dosMan.IsBanned(addr1));
         dosMan.ClearBanned();
@@ -574,7 +574,7 @@ BOOST_AUTO_TEST_CASE(compactblock_tests)
         dummyNode.state_incoming = ConnectionStateIncoming::READY;
         dummyNode.state_outgoing = ConnectionStateOutgoing::READY;
         auto pblock = thinrelay.SetBlockToReconstruct(&dummyNode, TestBlock1().GetHash());
-        ProcessMessage(&dummyNode, NetMsgType::BLOCKTXN, vRecv1, GetTime());
+        ProcessMessage(&dummyNode, NetMsgType::BLOCKTXN, vRecv1, GetStopwatchMicros());
         SendMessages(&dummyNode);
         BOOST_CHECK(dosMan.IsBanned(addr1));
         dosMan.ClearBanned();
@@ -596,7 +596,7 @@ BOOST_AUTO_TEST_CASE(compactblock_tests)
         dummyNode.state_incoming = ConnectionStateIncoming::READY;
         dummyNode.state_outgoing = ConnectionStateOutgoing::READY;
         auto pblock = thinrelay.SetBlockToReconstruct(&dummyNode, TestBlock1().GetHash());
-        ProcessMessage(&dummyNode, NetMsgType::BLOCKTXN, vRecv1, GetTime());
+        ProcessMessage(&dummyNode, NetMsgType::BLOCKTXN, vRecv1, GetStopwatchMicros());
         SendMessages(&dummyNode);
         BOOST_CHECK(dosMan.IsBanned(addr1));
         dosMan.ClearBanned();
@@ -647,7 +647,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNodeA.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNodeA.state_incoming = ConnectionStateIncoming::READY;
         dummyNodeA.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNodeA, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetTime());
+        ProcessMessage(&dummyNodeA, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetStopwatchMicros());
         BOOST_CHECK(!dummyNodeA.fDisconnect); // node should not be disconnected
     }
 
@@ -662,7 +662,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNodeB.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNodeB.state_incoming = ConnectionStateIncoming::READY;
         dummyNodeB.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNodeB, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetTime());
+        ProcessMessage(&dummyNodeB, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetStopwatchMicros());
         BOOST_CHECK(dummyNodeB.fDisconnect); // node should be disconnected
     }
 
@@ -678,7 +678,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNodeC.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNodeC.state_incoming = ConnectionStateIncoming::READY;
         dummyNodeC.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNodeC, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetTime());
+        ProcessMessage(&dummyNodeC, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetStopwatchMicros());
         BOOST_CHECK(!dummyNodeC.fDisconnect); // node should not be disconnected
     }
 
@@ -698,7 +698,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNodeD.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNodeD.state_incoming = ConnectionStateIncoming::READY;
         dummyNodeD.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNodeD, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetTime());
+        ProcessMessage(&dummyNodeD, NetMsgType::FILTERSIZEXTHIN, vRecv1, GetStopwatchMicros());
         BOOST_CHECK(dummyNodeD.fDisconnect); // node should be disconnected
     }
 
@@ -718,7 +718,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNode1.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNode1.state_incoming = ConnectionStateIncoming::READY;
         dummyNode1.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNode1, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
+        ProcessMessage(&dummyNode1, NetMsgType::XTHINBLOCK, vRecv1, GetStopwatchMicros());
         SendMessages(&dummyNode1);
         BOOST_CHECK(xthin.vMissingTx.size() == 0);
         BOOST_CHECK(dosMan.IsBanned(addr1));
@@ -738,7 +738,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNode1a.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNode1a.state_incoming = ConnectionStateIncoming::READY;
         dummyNode1a.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNode1a, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
+        ProcessMessage(&dummyNode1a, NetMsgType::XTHINBLOCK, vRecv1, GetStopwatchMicros());
         SendMessages(&dummyNode1a);
         BOOST_CHECK(!xthin.vMissingTx[0].IsCoinBase());
         BOOST_CHECK(dosMan.IsBanned(addr1));
@@ -760,7 +760,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNode1b.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNode1b.state_incoming = ConnectionStateIncoming::READY;
         dummyNode1b.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNode1b, NetMsgType::XTHINBLOCK, vRecv1, GetTime());
+        ProcessMessage(&dummyNode1b, NetMsgType::XTHINBLOCK, vRecv1, GetStopwatchMicros());
         SendMessages(&dummyNode1b);
         BOOST_CHECK(!CheckBlockHeader(xthin.header, state, true));
         BOOST_CHECK(dosMan.IsBanned(addr1));
@@ -780,7 +780,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNode2.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNode2.state_incoming = ConnectionStateIncoming::READY;
         dummyNode2.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNode2, NetMsgType::THINBLOCK, vRecv2, GetTime());
+        ProcessMessage(&dummyNode2, NetMsgType::THINBLOCK, vRecv2, GetStopwatchMicros());
         SendMessages(&dummyNode2);
         BOOST_CHECK(thin.vMissingTx.size() == 0);
         BOOST_CHECK(dosMan.IsBanned(addr2));
@@ -800,7 +800,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNode2a.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNode2a.state_incoming = ConnectionStateIncoming::READY;
         dummyNode2a.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNode2a, NetMsgType::THINBLOCK, vRecv2, GetTime());
+        ProcessMessage(&dummyNode2a, NetMsgType::THINBLOCK, vRecv2, GetStopwatchMicros());
         SendMessages(&dummyNode2a);
         BOOST_CHECK(!thin.vMissingTx[0].IsCoinBase());
         BOOST_CHECK(dosMan.IsBanned(addr2));
@@ -820,7 +820,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNode2b.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNode2b.state_incoming = ConnectionStateIncoming::READY;
         dummyNode2b.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNode2b, NetMsgType::THINBLOCK, vRecv2, GetTime());
+        ProcessMessage(&dummyNode2b, NetMsgType::THINBLOCK, vRecv2, GetStopwatchMicros());
         SendMessages(&dummyNode2b);
         BOOST_CHECK(!CheckBlockHeader(thin.header, state, true));
         BOOST_CHECK(dosMan.IsBanned(addr2));
@@ -849,7 +849,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNode3.state_incoming = ConnectionStateIncoming::READY;
         dummyNode3.state_outgoing = ConnectionStateOutgoing::READY;
         auto pblock = thinrelay.SetBlockToReconstruct(&dummyNode3, nullhash);
-        ProcessMessage(&dummyNode3, NetMsgType::XBLOCKTX, vRecv3, GetTime());
+        ProcessMessage(&dummyNode3, NetMsgType::XBLOCKTX, vRecv3, GetStopwatchMicros());
         SendMessages(&dummyNode3);
         BOOST_CHECK(nullhash.IsNull());
         BOOST_CHECK(dosMan.IsBanned(addr3));
@@ -877,7 +877,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNode3a.state_incoming = ConnectionStateIncoming::READY;
         dummyNode3a.state_outgoing = ConnectionStateOutgoing::READY;
         auto pblock = thinrelay.SetBlockToReconstruct(&dummyNode3a, block3.GetHash());
-        ProcessMessage(&dummyNode3a, NetMsgType::XBLOCKTX, vRecv3, GetTime());
+        ProcessMessage(&dummyNode3a, NetMsgType::XBLOCKTX, vRecv3, GetStopwatchMicros());
         SendMessages(&dummyNode3a);
         BOOST_CHECK(vTxEmpty.size() == 0);
         BOOST_CHECK(dosMan.IsBanned(addr3));
@@ -900,7 +900,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNode4.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNode4.state_incoming = ConnectionStateIncoming::READY;
         dummyNode4.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNode4, NetMsgType::GET_XBLOCKTX, vRecv4, GetTime());
+        ProcessMessage(&dummyNode4, NetMsgType::GET_XBLOCKTX, vRecv4, GetStopwatchMicros());
         SendMessages(&dummyNode4);
         BOOST_CHECK(nullhash.IsNull());
         BOOST_CHECK(dosMan.IsBanned(addr4));
@@ -921,7 +921,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNode4a.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNode4a.state_incoming = ConnectionStateIncoming::READY;
         dummyNode4a.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNode4a, NetMsgType::GET_XBLOCKTX, vRecv4, GetTime());
+        ProcessMessage(&dummyNode4a, NetMsgType::GET_XBLOCKTX, vRecv4, GetStopwatchMicros());
         SendMessages(&dummyNode4a);
         BOOST_CHECK(setHashesToRequest.empty());
         BOOST_CHECK(dosMan.IsBanned(addr4));
@@ -945,7 +945,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNode5.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNode5.state_incoming = ConnectionStateIncoming::READY;
         dummyNode5.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNode5, NetMsgType::GET_XTHIN, vRecv5, GetTime());
+        ProcessMessage(&dummyNode5, NetMsgType::GET_XTHIN, vRecv5, GetStopwatchMicros());
         SendMessages(&dummyNode5);
         BOOST_CHECK(nullhash.IsNull());
         BOOST_CHECK(dosMan.IsBanned(addr5));
@@ -966,7 +966,7 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         dummyNode5a.nVersion = MIN_PEER_PROTO_VERSION;
         dummyNode5a.state_incoming = ConnectionStateIncoming::READY;
         dummyNode5a.state_outgoing = ConnectionStateOutgoing::READY;
-        ProcessMessage(&dummyNode5a, NetMsgType::GET_XTHIN, vRecv5, GetTime());
+        ProcessMessage(&dummyNode5a, NetMsgType::GET_XTHIN, vRecv5, GetStopwatchMicros());
         SendMessages(&dummyNode5a);
         BOOST_CHECK(inv2.type != MSG_THINBLOCK && inv2.type != MSG_XTHINBLOCK);
         BOOST_CHECK(dosMan.IsBanned(addr5));

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -262,7 +262,7 @@ void UpdateSendStats(CNode *pfrom, const char *strCommand, int msgSize, int64_t 
     }
 }
 
-void UpdateRecvStats(CNode *pfrom, const std::string &strCommand, int msgSize, int64_t nTimeReceived)
+void UpdateRecvStats(CNode *pfrom, const std::string &strCommand, int msgSize, int64_t nStopwatchTimeReceived)
 {
     recvAmt += msgSize;
     std::string name = "net/recv/msg/" + strCommand;

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -256,7 +256,7 @@ extern CCriticalSection cs_mapInboundConnectionTracker;
 // statistics
 void UpdateSendStats(CNode *pfrom, const char *strCommand, int msgSize, int64_t nTime);
 
-void UpdateRecvStats(CNode *pfrom, const std::string &strCommand, int msgSize, int64_t nTimeReceived);
+void UpdateRecvStats(CNode *pfrom, const std::string &strCommand, int msgSize, int64_t nStopwatchTimeReceived);
 // txn mempool statistics
 extern CStatHistory<unsigned int> txAdded;
 extern CStatHistory<uint64_t, MinValMax<uint64_t> > poolSize;


### PR DESCRIPTION
Without this fix, the ping times are not properly calculated.  The effect of this is to show bad data in the qt debug window and in an RPC call.