### PR TITLE
[WIP] enable simultaneous block processing and mempool admission.

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -227,11 +227,19 @@ CCond cvTxInQ;
 // Finds transactions that may conflict with other pending transactions
 CFastFilter<4 * 1024 * 1024> incomingConflicts GUARDED_BY(csTxInQ);
 
+// Finds transactions that may conflict with transactions being processed (currently only those in a block)
+// This filter is not cleared during the periodic tx mempool commitment.
+CFastFilter<4 * 1024 * 1024> baseConflicts;
+
 // Tranactions that are waiting for validation and are known not to conflict with others
 std::queue<CTxInputData> txInQ GUARDED_BY(csTxInQ);
 
 // Transaction that cannot be processed in this round (may potentially conflict with other tx)
 std::queue<CTxInputData> txDeferQ GUARDED_BY(csTxInQ);
+
+// Transactions that cannot be processed given the current contents of baseConflicts
+// Guarded by csTxInQ
+std::queue<CTxInputData> baseDeferQ;
 
 // Transactions that arrive when the chain is not syncd can be place here at times when we've received
 // the block announcement but havn't yet downloaded the block and updated the tip. In this case there can

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1794,7 +1794,6 @@ UniValue submitminingsolution(const UniValue &params, bool fHelp)
 {
     UniValue rcvd;
     CBlock block;
-    LOCK(cs_main);
 
     if (fHelp || params.size() != 1)
     {
@@ -1814,15 +1813,17 @@ UniValue submitminingsolution(const UniValue &params, bool fHelp)
 
     int64_t id = rcvd["id"].get_int64();
 
-    // Needs LOCK(cs_main); above:
-    if (miningCandidatesMap.count(id) == 1)
     {
-        block = miningCandidatesMap[id].block;
-        miningCandidatesMap.erase(id);
-    }
-    else
-    {
-        return UniValue("id not found");
+        LOCK(cs_main);
+        if (miningCandidatesMap.count(id) == 1)
+        {
+            block = miningCandidatesMap[id].block;
+            miningCandidatesMap.erase(id);
+        }
+        else
+        {
+            return UniValue("id not found");
+        }
     }
 
     UniValue nonce = rcvd["nonce"];

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -3375,7 +3375,7 @@ bool ActivateBestChain(CValidationState &state,
     bool result = true;
     CBlockIndex *pindexMostWork = nullptr;
 
-    TxAdmissionPause txlock;
+    TxFilteredAdmission txlock(pblock);
     LOCK(cs_main);
 
     bool fOneDone = false;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -1053,7 +1053,7 @@ void CWallet::MarkConflicted(const uint256 &hashBlock, const uint256 &hashTx)
 
 void CWallet::SyncTransaction(const CTransactionRef &ptx, const CBlock *pblock, int txIdx)
 {
-    LOCK2(cs_main, cs_wallet);
+    LOCK(cs_wallet);
 
     if (!AddToWalletIfInvolvingMe(ptx, pblock, true, txIdx))
         return; // Not one of ours


### PR DESCRIPTION
This PR enables mempool acceptance during block validation.  It accomplishes this without allowing doublespends in the mempool by creating a fastfilter (fast bloom filter) of all transaction inputs in the block.  If any incoming transaction matches the filter, it's processing is deferred until the block is fully processed.

This significantly increases parallelism but hits mempool contention because CTxMemPool::removeForBlock takes the mempool write lock for its entire duration, stopping transaction validation.  

This is the output of getstat showing the generation of a 10000 tx per 10 second transaction load, during a 280000 tx (~128MB) block mining cycle -- RPC call, construction, RPC response, solution reply, and block acceptance processing.

./bitcoin-cli getstat memPool/txAdded sec10 100
      9997,
      9998,
      9999,
      9914,
      5741,
      0,
      0,
      11200,
      32937,
      9999,
      9999,

You can see that although we have a 20 second pause in tx acceptance, these transactions are queued up and quickly committed once the mempool is released.

So this is "OK" but we can do better by rewriting CTxMemPool::removeForBlock to  achieve finer write lock control.

TODO: handle processing multiple blocks simultaneously
handle a block's tx removing a mempool tx with a dependent tx sitting in the commit Q.  Must flush the commit Q before removing mempool tx.