### PR TITLE
clear mempool during blockchain rewinds

### DIFF
--- a/qa/rpc-tests/invalidateblock.py
+++ b/qa/rpc-tests/invalidateblock.py
@@ -116,7 +116,7 @@ class InvalidateTest(BitcoinTestFramework):
         self.nodes[0].invalidateblock(block)
         mp = self.nodes[0].getrawmempool()
         assert(tx1hash in mp)
-        # tx2 won't be in the mempool because of its nLockTime (see fee sniping)
+        # tx2 probably won't be in the mempool because of the probabilistic setting of nLockTime (see fee sniping)
 
         # Next set up 2 dependent tx as above.  Rollback and make sure both are removed from the mempool.
         block2 = self.nodes[0].generate(1)[0]

--- a/qa/rpc-tests/invalidateblock.py
+++ b/qa/rpc-tests/invalidateblock.py
@@ -89,6 +89,43 @@ class InvalidateTest(BitcoinTestFramework):
 
         self.testChainSyncWithLongerInvalid()
 
+        self.testMempoolDuringInvalidate()
+
+    def testMempoolDuringInvalidate(self):
+        """ This test checks dependent transactions committed and in the mempool during block invalidates and verifies that the dependent one does not
+            stay in the mempool if the dependency is removed.
+        """
+        # start this test connected
+        connect_nodes_bi(self.nodes,1,2)
+        # Get something to spend
+        nBlocks = self.nodes[0].getblockcount()
+        self.nodes[0].generate(101-nBlocks)
+        nBlocks = 101
+
+        sync_blocks(self.nodes)
+
+        # Set up 2 dependent tx, 1 committed the other in mempool.  invalidate the committed block and make sure that we don't end up
+        # with tx 2 alone in the mempool.
+        addr = self.nodes[1].getnewaddress()
+        tx1hash = self.nodes[0].sendtoaddress(addr, 20)
+        waitFor(10, lambda: self.nodes[0].getmempoolinfo()["size"] > 0)
+        block = self.nodes[0].generate(1)[0]
+        waitFor(5, lambda: self.nodes[1].getblockcount() == nBlocks+1)
+        tx2hash = self.nodes[1].sendtoaddress(addr, 10)  # This must be dependent on the prior send because node 1 has no other money
+        waitFor(10, lambda: self.nodes[0].getmempoolinfo()["size"] == 1)
+        self.nodes[0].invalidateblock(block)
+        mp = self.nodes[0].getrawmempool()
+        assert(tx1hash in mp)
+        # tx2 won't be in the mempool because of its nLockTime (see fee sniping)
+
+        # Next set up 2 dependent tx as above.  Rollback and make sure both are removed from the mempool.
+        block2 = self.nodes[0].generate(1)[0]
+        self.nodes[1].abandontransaction(tx2hash) # clean up the old tx because wallet won't attempt resend for awhile
+        tx3hash = self.nodes[1].sendtoaddress(addr, 11)
+        waitFor(10, lambda: self.nodes[0].getmempoolinfo()["size"] == 1)
+        self.nodes[0].rollbackchain(101)
+        time.sleep(1)  # sleep is unreliable but in this case we are waiting for something to NOT happen so no choice.
+        assert(self.nodes[0].getmempoolinfo()["size"] == 0)  # After a rollback mempool should be emptied.
 
     def testChainSyncWithLongerInvalid(self):
         print("verify that IBD continues on a separate chain after a block is invalidated")
@@ -145,4 +182,5 @@ def Test():
     "debug":["net","blk","thin","mempool","req","bench","evict"], # "lck"
     "blockprioritysize":2000000  # we don't want any transactions rejected due to insufficient fees...
      }
-    t.main(["--nocleanup","--noshutdown", "--tmppfx=/ramdisk/test"],bitcoinConf,None)
+    flags = standardFlags()
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -1152,7 +1152,7 @@ def findBitcoind():
 def standardFlags():
     flags = [] # ["--nocleanup", "--noshutdown"]
     if os.path.isdir("/ramdisk/test"):
-        flags.append("--tmppfx=/ramdisk/test")
+        flags.append("--tmpdir=/ramdisk/test/t")
     binpath = findBitcoind()
     flags.append("--srcdir=%s" % binpath)
     return flags

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -538,6 +538,29 @@ public:
     CTxMemPool(const CFeeRate &_minReasonableRelayFee);
     ~CTxMemPool();
 
+    /** Atomically (with respect to the mempool) call f on each mempool entry, and then clear the mempool */
+    template <typename Lambda>
+    void forEachThenClear(const Lambda &f)
+    {
+        WRITELOCK(cs);
+        for (CTxMemPool::indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++)
+        {
+            f(*it);
+        }
+        _clear();
+    }
+
+    /** Atomically (with respect to the mempool) call f on each mempool entry */
+    template <typename Lambda>
+    void forEach(const Lambda &f)
+    {
+        WRITELOCK(cs);
+        for (CTxMemPool::indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++)
+        {
+            f(*it);
+        }
+    }
+
     /**
      * If sanity-checking is turned on, check makes sure the pool is
      * consistent (does not contain two transactions that spend the same inputs,

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1794,7 +1794,6 @@ UniValue submitminingsolution(const UniValue &params, bool fHelp)
 {
     UniValue rcvd;
     CBlock block;
-    LOCK(cs_main);
 
     if (fHelp || params.size() != 1)
     {
@@ -1814,15 +1813,17 @@ UniValue submitminingsolution(const UniValue &params, bool fHelp)
 
     int64_t id = rcvd["id"].get_int64();
 
-    // Needs LOCK(cs_main); above:
-    if (miningCandidatesMap.count(id) == 1)
     {
-        block = miningCandidatesMap[id].block;
-        miningCandidatesMap.erase(id);
-    }
-    else
-    {
-        return UniValue("id not found");
+        LOCK(cs_main);
+        if (miningCandidatesMap.count(id) == 1)
+        {
+            block = miningCandidatesMap[id].block;
+            miningCandidatesMap.erase(id);
+        }
+        else
+        {
+            return UniValue("id not found");
+        }
     }
 
     UniValue nonce = rcvd["nonce"];

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -2931,7 +2931,9 @@ bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusPa
     }
 
     // Clear mempool if rolling back the chain using the "rollbackchain" rpc command, otherwise clear and
-    // place all tx back into the admission queue.
+    // place all tx back into the admission queue. "Rollbackchain" is used for significant manually triggered
+    // reorganizations, such as switching between forks, so it makes no sense to keep the transactions because
+    // they will likely be invalid or already confirmed on the other fork.
     if (fRollBack)
     {
         mempool.clear();
@@ -2968,7 +2970,7 @@ bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusPa
 
         {
             boost::unique_lock<boost::mutex> lock(csCommitQ);
-            for (auto& kv: *txCommitQ)
+            for (auto &kv : *txCommitQ)
             {
                 CTxInputData txd;
                 txd.tx = kv.second.entry.GetSharedTx();

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -2930,10 +2930,24 @@ bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusPa
         SyncWithWallets(ptx, nullptr, -1);
     }
 
-    // Resurrect mempool transactions from the disconnected block but do not do this step if we are
-    // rolling back the chain using the "rollbackchain" rpc command.
-    if (!fRollBack)
+    // Clear mempool if rolling back the chain using the "rollbackchain" rpc command, otherwise clear and
+    // place all tx back into the admission queue.
+    if (fRollBack)
     {
+        mempool.clear();
+        boost::unique_lock<boost::mutex> lock(csCommitQ);
+        txCommitQ->clear();
+    }
+    else
+    {
+        // To be very safe let's force everything in the mempool to be re-admitted.  This reduces this rare case
+        // quickly to a very common operation mode.  If we do not do this, we must guarantee that all tx coming from
+        // the block get injected into the mempool to ensure that any mempool tx that relies on an input from this
+        // block doesn't get orphaned but remain in the mempool.
+        // The performance of doing it this way is surprisingly ok, even though it seems like more work,
+        // because the readmission code is multithreaded and very efficient, yet the code to slip a tx back into a
+        // dependency chain in the mempool performed terribly.
+
         for (const auto &ptx : block.vtx)
         {
             if (!ptx->IsCoinBase())
@@ -2943,6 +2957,25 @@ bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusPa
                 txd.nodeName = "rollback";
                 EnqueueTxForAdmission(txd);
             }
+        }
+
+        mempool.forEachThenClear([](const auto &entry) {
+            CTxInputData txd;
+            txd.tx = entry.GetSharedTx();
+            txd.nodeName = "rollback";
+            EnqueueTxForAdmission(txd);
+        });
+
+        {
+            boost::unique_lock<boost::mutex> lock(csCommitQ);
+            for (auto& kv: *txCommitQ)
+            {
+                CTxInputData txd;
+                txd.tx = kv.second.entry.GetSharedTx();
+                txd.nodeName = "rollback";
+                EnqueueTxForAdmission(txd);
+            }
+            txCommitQ->clear();
         }
     }
 


### PR DESCRIPTION
clear mempool during blockchain rewinds so that the more efficient admisssion code can re-accept txs and narrow locking in submit mining solution rpc