### PR TITLE
CPU Miner Enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ script:
     - export CONTINUE=1
     - if [ $SECONDS -gt 1980 ]; then export CONTINUE=0; fi  # Likely the depends build took very long
     - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/script_a.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
-    - if [ $SECONDS -gt 2000 -a "$RUN_TESTS"="true"]; then export CONTINUE=0; fi  # Likely the build took very long
+    - if [ $SECONDS -gt 2000 -a "$RUN_TESTS"="true" ]; then export CONTINUE=0; fi  # Likely the build took very long
     - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/script_b.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
 
 after_script:

--- a/src/miner.h
+++ b/src/miner.h
@@ -151,7 +151,10 @@ int64_t UpdateTime(CBlockHeader *pblock, const Consensus::Params &consensusParam
 UniValue SubmitBlock(CBlock &block);
 /** Make a block template to send to miners. */
 // implemented in mining.cpp
-UniValue mkblocktemplate(const UniValue &params, int64_t coinbaseSize = -1, CBlock *pblockOut = nullptr);
+UniValue mkblocktemplate(const UniValue &params,
+    int64_t coinbaseSize = -1,
+    CBlock *pblockOut = nullptr,
+    boost::shared_ptr<CReserveScript> coinbaseScript = boost::shared_ptr<CReserveScript>());
 
 // Force block template recalculation the next time a template is requested
 void SignalBlockTemplateChange();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -568,6 +568,13 @@ int64_t GetArg(const std::string &strArg, int64_t nDefault)
     return nDefault;
 }
 
+double GetDoubleArg(const std::string &strArg, double dDefault)
+{
+    if (mapArgs.count(strArg))
+        return atof(mapArgs[strArg].c_str()); // returns 0.0 on conversion failure
+    return dDefault;
+}
+
 bool GetBoolArg(const std::string &strArg, bool fDefault)
 {
     if (mapArgs.count(strArg))

--- a/src/util.h
+++ b/src/util.h
@@ -454,6 +454,15 @@ std::string GetArg(const std::string &strArg, const std::string &strDefault);
 int64_t GetArg(const std::string &strArg, int64_t nDefault);
 
 /**
+ * Return double argument or default value
+ *
+ * @param strArg Argument to get (e.g. "-foo")
+ * @param default (e.g. 3.14)
+ * @return command-line argument (0.0 if invalid number) or default value
+ */
+double GetDoubleArg(const std::string &strArg, double dDefault);
+
+/**
  * Return boolean argument or default value
  *
  * @param strArg Argument to get (e.g. "-foo")


### PR DESCRIPTION
#### Description

I have been mining testnet lately (hashrate seems to be mostly CPU now anyway on testnet, with the occasional ASIC miner showing up to rain blocks for 12 hours before leaving abruptly).

As such, I have been using the `bitcoin-miner` program quite a bit and I wanted to add a few features to it to make it more useful for everybody.  I already am running this modified version on my setup and it's working great, but I figure I'd give back and share my "advances" with others.

This PR adds the following:

- `-maxdifficulty=<float>` command-line argument to `bitcoin-miner`. With this option, the miner doesn't bother mining if difficulty is too high. It's pointless to mine with a CPU when difficulty is too high (extra wear & tear on the hardware).  Whenever difficulty is > `maxdifficulty` it just sleeps for `duration` seconds (-duration is already an existing argument which defaults to 30), checking again later with the daemon for a difficulty drop.

- `-address=<Address>` command-line argument to `bitcoin-miner`. This required RPC support on the server-side.  Basically it does what you would expect -- can mine to any address rather than requiring an address in the daemon wallet.

- RPC support to `getminingcandidate` to support specifying an address. This is an optional argument and required a little bit of parameter passing into `unlimited.cpp` and `mining.cpp` `mkblocktemplate` (see PR).

- Minor performance/efficiency:    Added a mechanism for all threads to realize when prevBlockHash has changed.  When 1 thread finds a block or detects a block change, all threads now know about it. This fixes the situation whereby some threads continued mining on top of old/stale blocks. With this fix, the threads share a global variable (atomically updated) which captures the prev block "cheap hash" as well as the nBits of the latest block template.  If any threads detect this variable has been updated,  they abort working on their current block template as soon as they can and ask the RPC server for a new block right away to not waste time mining on top of a block that is not at chainTip.

- Small performance nit in `bitcoin-miner.cpp` 's `ScanHash` function to not waste CPU cycles needlessly returning from the function every 4096 tries (only to immediately and unconditionally re-enter the function and resume from where it left off).

#### Questions I had and other notes

I had to modify `mining.cpp::mkblocktemplate` a little bit to support:

1. Accepting a `coinbaseScript` argument (if not supplied, does the old codepath of generating wallet address).
2. As before, it must cache its arguments to decide if it should return the same old template or make a new one..  as such, I added some logic to the big `if` statement in `mkblocktemplate` which decides if it should invalidate the cached block template or return a new one -- I hope I got it right. Please look at that section and let me know...
3. This PR actually fixes a weird bug in that `getminingcandidate` would always fail if compiled without wallet support (because it always unconditionally tried to generate to a wallet address, and it would fail if no wallet support) -- so now at least there is a codepath for running `getminingcandidate` without wallet support.

---

#### ~~Note: if you accept this PR, please squash it as it's a noisy one with many small commits.~~

(EDIT: I already squashed this into 1 commit -- can be squash-merged or merge-merged either work now).

If you decide you accept this feature, please let me know if anything needs to be modified here. Thanks!