### PR TITLE
Fixed compile error for --enable-debug on non-Linux

### DIFF
--- a/src/sync.cpp
+++ b/src/sync.cpp
@@ -21,9 +21,9 @@ void PrintLockContention(const char *pszName, const char *pszFile, unsigned int 
 #endif /* DEBUG_LOCKCONTENTION */
 
 #ifdef DEBUG_LOCKORDER
-#include <sys/syscall.h>
 
 #ifdef __linux__
+#include <sys/syscall.h>
 uint64_t getTid(void)
 {
     // "native" thread id used so the number correlates with what is shown in gdb
@@ -31,10 +31,15 @@ uint64_t getTid(void)
     return tid;
 }
 #else
+#include <functional>
 uint64_t getTid(void)
 {
-    uint64_t tid = boost::lexical_cast<uint64_t>(boost::this_thread::get_id());
-    return tid;
+    // Note: there is no guaranteed way to turn the thread-id into an int
+    // since it's an opaque type. Just about the only operation it supports
+    // is std::hash (so that thread id's may be placed in maps).
+    // So we just do this.
+    static std::hash<std::thread::id> hasher;
+    return uint64_t(hasher(std::this_thread::get_id()));
 }
 #endif
 


### PR DESCRIPTION
On BSD and Darwin and other non-Linux, `--enable-debug` compilation
was producing the following error:

```

  sync.cpp:36:27: error: no member named 'lexical_cast' in namespace 'boost'
      uint64_t tid = boost::lexical_cast<uint64_t>(boost::this_thread::get_id());
                   ~~~~~~~^
  sync.cpp:36:40: error: unexpected type name 'uint64_t': expected expression
      uint64_t tid = boost::lexical_cast<uint64_t>(boost::this_thread::get_id());
                                       ^
  2 errors generated.

```

Additionally, I am not even sure the `#include <sys/syscall.h>` would be kosher with 
Windows compilation either in this case.

I tried fixing this by `#include`ing the requisite lexical_cast header for
boost, but that produced a runtime error due to an uncaught exception on
Darwin (bad_lexical_cast) -- presumably the thread-id on Darwin cannot
be lexically cast to int.

This is not surprising: There is no guaranteed way to turn a std::thread::id 
(or boost::thread::id) into an int save for hashing it using std::hash.  So we do that 
for the non-linux case, and compilation succeeds and bitcoind runs ok.