### PR TITLE
[port] Use black magic for popcount

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -136,7 +136,7 @@ script:
     - export CONTINUE=1
     - if [ $SECONDS -gt 1980 ]; then export CONTINUE=0; fi  # Likely the depends build took very long
     - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/script_a.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
-    - if [ $SECONDS -gt 2000 -a "$RUN_TESTS"="true" ]; then export CONTINUE=0; fi  # Likely the build took very long
+    - if [ $SECONDS -gt 2100 -a "$RUN_TESTS"="true" ]; then export CONTINUE=0; echo "$SECONDS"; fi  # Likely the build took very long
     - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/script_b.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
 
 after_script:

--- a/configure.ac
+++ b/configure.ac
@@ -653,6 +653,8 @@ AC_CHECK_DECLS([bswap_16, bswap_32, bswap_64],,,
                  #include <byteswap.h>
                  #endif])
 
+AC_CHECK_DECLS([ __builtin_popcount])
+
 dnl Check for MSG_NOSIGNAL
 AC_MSG_CHECKING(for MSG_NOSIGNAL)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/socket.h>]],

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -107,6 +107,7 @@ BITCOIN_CORE_H = \
   base58.h \
   bandb.h \
   banentry.h \
+  bitmanip.h \
   blockrelay/blockrelay_common.h \
   blockrelay/compactblock.h \
   blockrelay/graphene.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -66,6 +66,7 @@ BITCOIN_TESTS =\
   test/base58_tests.cpp \
   test/base64_tests.cpp \
   test/bip32_tests.cpp \
+  test/bitmanip_tests.cpp \
   test/bloom_tests.cpp \
   test/checkblock_tests.cpp \
   test/checkdatasig_tests.cpp \

--- a/src/bitmanip.h
+++ b/src/bitmanip.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2019 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_UTIL_BITMANIP_H
+#define BITCOIN_UTIL_BITMANIP_H
+
+#include <config/bitcoin-config.h>
+
+#include <cstdint>
+
+inline uint32_t countBits(uint32_t v) {
+#if HAVE_DECL___BUILTIN_POPCOUNT
+    return __builtin_popcount(v);
+#else
+    /**
+     * Computes the number of bits set in each group of 8bits then uses a
+     * multiplication to sum all of them in the 8 most significant bits and
+     * return these.
+     * More detailed explanation can be found at
+     * https://www.playingwithpointers.com/blog/swar.html
+     */
+    v = v - ((v >> 1) & 0x55555555);
+    v = (v & 0x33333333) + ((v >> 2) & 0x33333333);
+    return (((v + (v >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24;
+#endif
+}
+
+#endif // BITCOIN_UTIL_BITMANIP_H

--- a/src/test/bitmanip_tests.cpp
+++ b/src/test/bitmanip_tests.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2019 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <test/test_bitcoin.h>
+#include <test/test_random.h>
+#include <bitmanip.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(bitmanip_tests, BasicTestingSetup)
+
+static void CheckBitCount(uint32_t value, uint32_t expected_count) {
+    // Count are rotation invariant.
+    for (int i = 0; i < 32; i++) {
+        BOOST_CHECK_EQUAL(countBits(value), expected_count);
+        value = (value << 1) | (value >> 31);
+    }
+}
+
+static uint32_t countBitsNaive(uint32_t value) {
+    uint32_t ret = 0;
+    while (value != 0) {
+        ret += (value & 0x01);
+        value >>= 1;
+    }
+
+    return ret;
+}
+
+const size_t COUNT=4096;
+
+BOOST_AUTO_TEST_CASE(bit_count) {
+    // Check various known values.
+    CheckBitCount(0, 0);
+    CheckBitCount(1, 1);
+    CheckBitCount(0xffffffff, 32);
+    CheckBitCount(0x01234567, 12);
+    CheckBitCount(0x12345678, 13);
+    CheckBitCount(0xfedcba98, 20);
+    CheckBitCount(0x5a55aaa5, 16);
+    CheckBitCount(0xdeadbeef, 24);
+
+    for (uint32_t i = 2; i != 0; i <<= 1) {
+        // Check two bit set for all combinations.
+        CheckBitCount(i | 0x01, 2);
+    }
+
+    // Check many small values against a naive implementation.
+    for (uint32_t v = 0; v <= 0xfff; v++) {
+        CheckBitCount(v, countBitsNaive(v));
+    }
+
+    // Check random values against a naive implementation.
+    for (int i = 0; i < COUNT; i++) {
+        uint32_t v = insecure_rand();
+        CheckBitCount(v, countBitsNaive(v));
+    }
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Or compiler intrinsic if these are supported.
The black magic algorithm is from 'Owen Anderson <resistor@mac.com>', as far as I know.

This is a port of:

- reviews.bitcoinabc.org/D2148
- reviews.bitcoinabc.org/D3738

~~This PR is built on top of #1901 and #1907~~

This is a prereq for porting Schnorr multi sig from ABC.