### PR TITLE
Update guiutil.cpp service flags list

### DIFF
--- a/src/qt/guiutil.cpp
+++ b/src/qt/guiutil.cpp
@@ -992,6 +992,9 @@ QString formatServicesStr(quint64 mask, const QStringList &additionalServices)
             case NODE_CF:
                 strList.append("CF");
                 break;
+            case NODE_NETWORK_LIMITED:
+                strList.append("LIMITED");
+                break;
             default:
                 strList.append(QString("%1[%2]").arg("UNKNOWN").arg(check));
             }


### PR DESCRIPTION
NODE_NETWORK_LIMITED was added by #1647 but we forgot to
keep update the utility used by QT to translate from
bitmask to service flag name.