### PR TITLE
CPU Miner Enhancements -- Follow-up to #1904

### DIFF
--- a/src/miner.h
+++ b/src/miner.h
@@ -154,7 +154,7 @@ UniValue SubmitBlock(CBlock &block);
 UniValue mkblocktemplate(const UniValue &params,
     int64_t coinbaseSize = -1,
     CBlock *pblockOut = nullptr,
-    boost::shared_ptr<CReserveScript> coinbaseScript = boost::shared_ptr<CReserveScript>());
+    const CScript &coinbaseScript = CScript());
 
 // Force block template recalculation the next time a template is requested
 void SignalBlockTemplateChange();

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1774,7 +1774,7 @@ UniValue getminingcandidate(const UniValue &params, bool fHelp)
             HelpExampleCli("getminingcandidate", "null bchtest:qq9rw090p2eu9drv6ptztwx4ghpftwfa0gyqvlvx2q"));
     }
 
-    boost::shared_ptr<CReserveScript> coinbaseScript;
+    CScript coinbaseScript;
     std::string destStr;
 
     // we accept: param1, param2 or just param1 by itself or null,param2 to only specify param2
@@ -1805,8 +1805,7 @@ UniValue getminingcandidate(const UniValue &params, bool fHelp)
         {
             throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, strprintf("Error: Invalid address \"%s\"", destStr));
         }
-        coinbaseScript = boost::shared_ptr<CReserveScript>(new CReserveScript());
-        coinbaseScript->reserveScript = GetScriptForDestination(destination);
+        coinbaseScript = GetScriptForDestination(destination);
     }
 
     mkblocktemplate(UniValue(UniValue::VARR), coinbaseSize, &candid.block, coinbaseScript);


### PR DESCRIPTION
This is a follow-up to PR #1904 .

As discussed in PR #1904, it was a bad idea to pass down a `shared_ptr<CReserveScript>` to `mkblocktemplate` from the `getminingcandidate` RPC handler. Doing it that way was not terribly useful behavior and was just needlessly noisy to read.

(The only reason we might want to do it that way would have been if we wanted to call `KeepKey()` on the `CReserveScript` reference returned from the wallet -- but we never did that -- so it was pointless to use a `shared_ptr`).

So, in the interests of more readable/simpler code, this PR passes down a simple `const CScript &` (optional argument) to `mkblocktemplate`.

Also in this PR: Updated the comments and return the correct RPC error messages for the two error cases involving the wallet:

- wallet not compiled in -> "No coinbase script available (mining requires a wallet)"
- wallet has no keypool keys -> "Error: Keypool ran out, please call keypoolrefill first"

Previously the code actually reversed those two error messages: It would return the error for no more keys if no wallet support compiled-in, and return the "no wallet support" error message for when the keypool ran out of keys!
