### PR TITLE
Fix a bunch of warnings

### DIFF
--- a/src/bitcoin-miner.cpp
+++ b/src/bitcoin-miner.cpp
@@ -338,7 +338,7 @@ static UniValue CpuMineBlock(unsigned int searchDuration, const UniValue &params
     if (!found)
     {
         const auto elapsed = GetTimeMillis() - start;
-        printf("Checked %d possibilities in %lld secs, %3.3f MH/s\n", nChecked, elapsed / 1000,
+        printf("Checked %d possibilities in %ld secs, %3.3f MH/s\n", nChecked, elapsed / 1000,
             (nChecked / 1e6) / (elapsed / 1e3));
         return ret;
     }

--- a/src/test/bitmanip_tests.cpp
+++ b/src/test/bitmanip_tests.cpp
@@ -52,7 +52,7 @@ BOOST_AUTO_TEST_CASE(bit_count) {
     }
 
     // Check random values against a naive implementation.
-    for (int i = 0; i < COUNT; i++) {
+    for (size_t i = 0; i < COUNT; i++) {
         uint32_t v = insecure_rand();
         CheckBitCount(v, countBitsNaive(v));
     }


### PR DESCRIPTION
Namely:


```
../src/test/bitmanip_tests.cpp: In member function ‘void bitmanip_tests::bit_count::test_method()’:
../src/test/bitmanip_tests.cpp:55:23: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     for (int i = 0; i < COUNT; i++) {
                          ~~^~~~~~~
```

```
../../src/bitcoin-miner.cpp: In function ‘UniValue CpuMineBlock(unsigned int, const UniValue&, bool&, const RandFunc&)’:
../../src/bitcoin-miner.cpp:342:47: warning: format ‘%lld’ expects argument of type ‘long long int’, but argument 3 has type ‘long int’ [-Wformat=]
         printf("Checked %d possibilities in %lld secs, %3.3f MH/s\n", nChecked, elapsed / 1000,
                                                                                 ~~~~~~~~~~~~~~
             (nChecked / 1e6) / (elapsed / 1e3));
                                               ^
```