### PR TITLE
Rename the secondary commit queue from just q to txCommitQFinal

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -243,7 +243,11 @@ std::queue<CTxInputData> txWaitNextBlockQ GUARDED_BY(csTxInQ);
 // Transactions that have been validated and are waiting to be committed into the mempool
 CWaitableCriticalSection csCommitQ;
 CConditionVariable cvCommitQ GUARDED_BY(csCommitQ);
-std::map<uint256, CTxCommitData> *txCommitQ = nullptr;
+std::map<uint256, CTxCommitData> *txCommitQ GUARDED_BY(csCommitQ) = nullptr;
+// Before the transactions are finally commited to the mempool the txCommitQ pointer is copied
+// to txCommitQFinal so that the lock on txCommitQ can be released and processing can continue.
+CCriticalSection csCommitQFinal;
+std::map<uint256, CTxCommitData> *txCommitQFinal GUARDED_BY(csCommitQFinal) = nullptr;
 
 // Control the execution of the parallel tx validation and serial mempool commit phases
 CThreadCorral txProcessingCorral;

--- a/src/txadmission.h
+++ b/src/txadmission.h
@@ -148,6 +148,8 @@ extern std::queue<CTxInputData> txWaitNextBlockQ;
 extern CWaitableCriticalSection csCommitQ;
 extern CConditionVariable cvCommitQ;
 extern std::map<uint256, CTxCommitData> *txCommitQ;
+extern CCriticalSection csCommitQFinal;
+extern std::map<uint256, CTxCommitData> *txCommitQFinal;
 
 // returns a transaction ref, if it exists in the commitQ
 CTransactionRef CommitQGet(uint256 hash);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1366,6 +1366,16 @@ bool CTxMemPool::addUnchecked(const uint256 &hash, const CTxMemPoolEntry &entry,
     return addUnchecked(hash, entry, setAncestors, fCurrentEstimate);
 }
 
+bool CTxMemPool::_addUnchecked(const uint256 &hash, const CTxMemPoolEntry &entry, bool fCurrentEstimate)
+{
+    AssertWriteLockHeld(cs);
+    setEntries setAncestors;
+    uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
+    std::string dummy;
+    _CalculateMemPoolAncestors(entry, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy);
+    return addUnchecked(hash, entry, setAncestors, fCurrentEstimate);
+}
+
 void CTxMemPool::_UpdateChild(txiter entry, txiter child, bool add)
 {
     setEntries s;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -542,7 +542,7 @@ public:
     template <typename Lambda>
     void forEachThenClear(const Lambda &f)
     {
-        WRITELOCK(cs);
+        AssertWriteLockHeld(cs);
         for (CTxMemPool::indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++)
         {
             f(*it);
@@ -574,6 +574,7 @@ public:
     // addUnchecked can be used to have it call CalculateMemPoolAncestors(), and
     // then invoke the second version.
     bool addUnchecked(const uint256 &hash, const CTxMemPoolEntry &entry, bool fCurrentEstimate = true);
+    bool _addUnchecked(const uint256 &hash, const CTxMemPoolEntry &entry, bool fCurrentEstimate = true);
     bool addUnchecked(const uint256 &hash,
         const CTxMemPoolEntry &entry,
         setEntries &setAncestors,

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -542,6 +542,16 @@ public:
     template <typename Lambda>
     void forEachThenClear(const Lambda &f)
     {
+        WRITELOCK(cs);
+        for (CTxMemPool::indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++)
+        {
+            f(*it);
+        }
+        _clear();
+    }
+    template <typename Lambda>
+    void _forEachThenClear(const Lambda &f)
+    {
         AssertWriteLockHeld(cs);
         for (CTxMemPool::indexed_transaction_set::const_iterator it = mapTx.begin(); it != mapTx.end(); it++)
         {

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -2916,7 +2916,7 @@ static void ResubmitTransactions(CBlock &block)
         }
 
         // Resubmit and clear the mempool
-        mempool.forEachThenClear([](const auto &entry) {
+        mempool._forEachThenClear([](const auto &entry) {
             CTxInputData txd;
             txd.tx = entry.GetSharedTx();
             txd.nodeName = "rollback";

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -2889,6 +2889,67 @@ void UpdateTip(CBlockIndex *pindexNew)
     }
 }
 
+static void ResubmitTransactions(CBlock &block)
+{
+    // To be very safe let's force everything in the mempool to be re-admitted.  This reduces this rare case
+    // quickly to a very common operation mode.  If we do not do this, we must guarantee that all tx coming from
+    // the block get injected into the mempool to ensure that any mempool tx that relies on an input from this
+    // block doesn't get orphaned but remain in the mempool.
+    // The performance of doing it this way is surprisingly ok, even though it seems like more work,
+    // because the readmission code is multithreaded and very efficient, yet the code to slip a tx back into a
+    // dependency chain in the mempool performed terribly.
+    //
+    // We must hold the mempool lock throughout otherwise it would be possible for some txns to slip back into
+    // the mempool from the csCommitQFinal.
+    WRITELOCK(mempool.cs);
+    {
+        // Resubmit the block first
+        for (const auto &ptx : block.vtx)
+        {
+            if (!ptx->IsCoinBase())
+            {
+                CTxInputData txd;
+                txd.tx = ptx;
+                txd.nodeName = "rollback";
+                EnqueueTxForAdmission(txd);
+            }
+        }
+
+        // Resubmit and clear the mempool
+        mempool.forEachThenClear([](const auto &entry) {
+            CTxInputData txd;
+            txd.tx = entry.GetSharedTx();
+            txd.nodeName = "rollback";
+            EnqueueTxForAdmission(txd);
+        });
+
+        // Clear txCommitQ
+        {
+            boost::unique_lock<boost::mutex> lock(csCommitQ);
+            for (auto &kv : *txCommitQ)
+            {
+                CTxInputData txd;
+                txd.tx = kv.second.entry.GetSharedTx();
+                txd.nodeName = "rollback";
+                EnqueueTxForAdmission(txd);
+            }
+            txCommitQ->clear();
+        }
+
+        // Clear txCommitQFinal
+        {
+            LOCK(csCommitQFinal);
+            for (auto &kv : *txCommitQFinal)
+            {
+                CTxInputData txd;
+                txd.tx = kv.second.entry.GetSharedTx();
+                txd.nodeName = "rollback";
+                EnqueueTxForAdmission(txd);
+            }
+            txCommitQFinal->clear();
+        }
+    }
+}
 /** Disconnect chainActive's tip. You probably want to call mempool.removeForReorg and manually re-limit mempool size
  * after this, with cs_main held. */
 bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusParams, const bool fRollBack)
@@ -2942,43 +3003,7 @@ bool DisconnectTip(CValidationState &state, const Consensus::Params &consensusPa
     }
     else
     {
-        // To be very safe let's force everything in the mempool to be re-admitted.  This reduces this rare case
-        // quickly to a very common operation mode.  If we do not do this, we must guarantee that all tx coming from
-        // the block get injected into the mempool to ensure that any mempool tx that relies on an input from this
-        // block doesn't get orphaned but remain in the mempool.
-        // The performance of doing it this way is surprisingly ok, even though it seems like more work,
-        // because the readmission code is multithreaded and very efficient, yet the code to slip a tx back into a
-        // dependency chain in the mempool performed terribly.
-
-        for (const auto &ptx : block.vtx)
-        {
-            if (!ptx->IsCoinBase())
-            {
-                CTxInputData txd;
-                txd.tx = ptx;
-                txd.nodeName = "rollback";
-                EnqueueTxForAdmission(txd);
-            }
-        }
-
-        mempool.forEachThenClear([](const auto &entry) {
-            CTxInputData txd;
-            txd.tx = entry.GetSharedTx();
-            txd.nodeName = "rollback";
-            EnqueueTxForAdmission(txd);
-        });
-
-        {
-            boost::unique_lock<boost::mutex> lock(csCommitQ);
-            for (auto &kv : *txCommitQ)
-            {
-                CTxInputData txd;
-                txd.tx = kv.second.entry.GetSharedTx();
-                txd.nodeName = "rollback";
-                EnqueueTxForAdmission(txd);
-            }
-            txCommitQ->clear();
-        }
+        ResubmitTransactions(block);
     }
 
     return true;


### PR DESCRIPTION
This helps to clarify the purpose of the queue. Aso we make the queue
a global structure with it's own lock so that we can clear the queue
out if needed.

Resubmit the transactions from txCommitQFinal when doing a re-org and
also clear it afterwards. Must maintain good locking order with mempooo.cs
which prevent us from accidentally added txns to the mempool during a reorg.