### PR TITLE
[port] make CheckMinimalPush available to codebase

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -508,43 +508,6 @@ bool CheckPubKeyEncoding(const valtype &vchPubKey, unsigned int flags, ScriptErr
     return true;
 }
 
-bool static CheckMinimalPush(const valtype &data, opcodetype opcode)
-{
-    // Excludes OP_1NEGATE, OP_1-16 since they are by definition minimal
-    DbgAssert(0 <= opcode && opcode <= OP_PUSHDATA4, return true);
-    if (data.size() == 0)
-    {
-        // Should have used OP_0.
-        return opcode == OP_0;
-    }
-    else if (data.size() == 1 && data[0] >= 1 && data[0] <= 16)
-    {
-        // Should have used OP_1 .. OP_16.
-        return false;
-    }
-    else if (data.size() == 1 && data[0] == 0x81)
-    {
-        // Should have used OP_1NEGATE.
-        return false;
-    }
-    else if (data.size() <= 75)
-    {
-        // Must have used a direct push (opcode indicating number of bytes pushed + those bytes).
-        return opcode == data.size();
-    }
-    else if (data.size() <= 255)
-    {
-        // Must have used OP_PUSHDATA.
-        return opcode == OP_PUSHDATA1;
-    }
-    else if (data.size() <= 65535)
-    {
-        // Must have used OP_PUSHDATA2.
-        return opcode == OP_PUSHDATA2;
-    }
-    return true;
-}
-
 static inline bool IsOpcodeDisabled(opcodetype opcode, uint32_t flags)
 {
     switch (opcode)

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -274,6 +274,48 @@ const char *GetOpName(opcodetype opcode)
     }
 }
 
+bool CheckMinimalPush(const std::vector<uint8_t> &data, opcodetype opcode)
+{
+    // Excludes OP_1NEGATE, OP_1-16 since they are by definition minimal.
+    // Returns true if the passed code is legal with respect to minimal push
+    // by definition.
+    if (0 <= opcode && opcode <= OP_PUSHDATA4)
+    {
+        return true;
+    }
+    if (data.size() == 0)
+    {
+        // Should have used OP_0.
+        return opcode == OP_0;
+    }
+    else if (data.size() == 1 && data[0] >= 1 && data[0] <= 16)
+    {
+        // Should have used OP_1 .. OP_16.
+        return false;
+    }
+    else if (data.size() == 1 && data[0] == 0x81)
+    {
+        // Should have used OP_1NEGATE.
+        return false;
+    }
+    else if (data.size() <= 75)
+    {
+        // Must have used a direct push (opcode indicating number of bytes pushed + those bytes).
+        return opcode == data.size();
+    }
+    else if (data.size() <= 255)
+    {
+        // Must have used OP_PUSHDATA.
+        return opcode == OP_PUSHDATA1;
+    }
+    else if (data.size() <= 65535)
+    {
+        // Must have used OP_PUSHDATA2.
+        return opcode == OP_PUSHDATA2;
+    }
+    return true;
+}
+
 bool CScriptNum::IsMinimallyEncoded(const std::vector<uint8_t> &vch, const size_t nMaxNumSize)
 {
     if (vch.size() > nMaxNumSize)

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -276,10 +276,11 @@ const char *GetOpName(opcodetype opcode)
 
 bool CheckMinimalPush(const std::vector<uint8_t> &data, opcodetype opcode)
 {
+    // Returns true if the passed code is legal with respect to minimal push by definition.
+
     // Excludes OP_1NEGATE, OP_1-16 since they are by definition minimal.
-    // Returns true if the passed code is legal with respect to minimal push
-    // by definition.
-    if (0 <= opcode && opcode <= OP_PUSHDATA4)
+    // Any other opcodes outside of this range have nothing to do with data push so are pedantically "minimal".
+    if ((OP_0 > opcode) || (opcode > OP_PUSHDATA4))
     {
         return true;
     }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -202,6 +202,12 @@ enum opcodetype
 
 const char *GetOpName(opcodetype opcode);
 
+/**
+ * Check whether the given stack element data would be minimally pushed using
+ * the given opcode.
+ */
+bool CheckMinimalPush(const std::vector<uint8_t> &data, opcodetype opcode);
+
 class scriptnum_error : public std::runtime_error
 {
 public:


### PR DESCRIPTION
Besides the script evaluator, it can be useful in other script parsers to find out whether a given push was minimal or not.

This is a port of https://reviews.bitcoinabc.org/D3872

This is part of a series of ports which will implement [minimal data](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/2019-11-15-minimaldata.md).