### PR TITLE
Bump rust to 1.37.0

### DIFF
--- a/depends/packages/rust.mk
+++ b/depends/packages/rust.mk
@@ -1,8 +1,8 @@
 package=rust
-$(package)_version=1.32.0
+$(package)_version=1.37.0
 $(package)_download_path=https://static.rust-lang.org/dist
 $(package)_file_name=rust-$($(package)_version)-x86_64-unknown-linux-gnu.tar.gz
-$(package)_sha256_hash=e024698320d76b74daf0e6e71be3681a1e7923122e3ebd03673fcac3ecc23810
+$(package)_sha256_hash=cb573229bfd32928177c3835fdeb62d52da64806b844bc1095c6225b0665a1cb
 
 define $(package)_stage_cmds
   ./install.sh --destdir=$($(package)_staging_dir) --prefix=$(host_prefix)/native --disable-ldconfig

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -181,6 +181,7 @@ BITCOIN_CORE_H = \
   random.h \
   reverse_iterator.h \
   reverselock.h \
+  rpc/blockchain.h \
   rpc/client.h \
   rpc/protocol.h \
   rpc/server.h \


### PR DESCRIPTION
The minimal supported rust version in next ElectrsCash release will be 1.34.0. Bitcoin Unlimited gitian build currently has 1.32.0.

This bumps the rust version in the gitian build to the latest stable release, which is 1.37.0.