### PR TITLE
[electrum] electrs v0.7 -> ElectrsCash v1.0

### DIFF
--- a/qa/rpc-tests/test_framework/electrumutil.py
+++ b/qa/rpc-tests/test_framework/electrumutil.py
@@ -12,7 +12,7 @@ def compare(node, key, expected, is_debug_data = False):
     info = node.getelectruminfo()
     if is_debug_data:
         info = info['debuginfo']
-        key = "electrs_" + key
+        key = "electrscash_" + key
     logging.debug("expecting %s == %s from %s", key, expected, info)
     if key not in info:
         return False
@@ -27,8 +27,9 @@ def bitcoind_electrum_args():
             "-electrum.monitoring.port=" + str(random.randint(40000, 60000))]
 
 class ElectrumConnection:
-    def __init__(self):
+    def __init__(self, timeout_seconds = 60.0):
         self.s = socket.create_connection(("127.0.0.1", ELECTRUM_PORT))
+        self.s.settimeout(timeout_seconds)
         self.f = self.s.makefile('r')
         self.id = 0
 

--- a/src/electrum/electrs.cpp
+++ b/src/electrum/electrs.cpp
@@ -12,6 +12,8 @@
 
 #include <boost/filesystem.hpp>
 
+constexpr char ELECTRSCASH_BIN[] = "electrscash";
+
 static std::string monitoring_port() { return GetArg("-electrum.monitoring.port", "4224"); }
 static std::string monitoring_host() { return GetArg("-electrum.monitoring.host", "127.0.0.1"); }
 static std::string rpc_host() { return GetArg("-electrum.host", "127.0.0.1"); }
@@ -63,7 +65,7 @@ std::string electrs_path()
     boost::filesystem::path bitcoind_dir(this_process_path());
     bitcoind_dir = bitcoind_dir.remove_filename();
 
-    auto default_path = bitcoind_dir / "electrs";
+    auto default_path = bitcoind_dir / ELECTRSCASH_BIN;
     const std::string path = GetArg("-electrum.exec", default_path.string());
 
     if (path.empty())
@@ -108,12 +110,12 @@ std::vector<std::string> electrs_args(int rpcport, const std::string &network)
     args.push_back("--jsonrpc-import");
 
     // Where to store electrs database files.
-    const std::string defaultDir = (GetDataDir() / "electrs").string();
+    const std::string defaultDir = (GetDataDir() / ELECTRSCASH_BIN).string();
     args.push_back("--db-dir=" + GetArg("-electrum.dir", defaultDir));
 
     // Tell electrs what network we're on
     const std::map<std::string, std::string> netmapping = {
-        {"main", "mainnet"}, {"test", "testnet"}, {"regtest", "regtest"}};
+        {"main", "bitcoin"}, {"test", "testnet"}, {"regtest", "regtest"}};
     if (!netmapping.count(network))
     {
         std::stringstream ss;

--- a/src/electrum/electrumrpcinfo.h
+++ b/src/electrum/electrumrpcinfo.h
@@ -9,7 +9,7 @@
 
 namespace electrum
 {
-static constexpr const char *INDEX_HEIGHT_KEY = "electrs_index_height";
+static constexpr const char *INDEX_HEIGHT_KEY = "electrscash_index_height";
 class ElectrumRPCInfo
 {
 public:


### PR DESCRIPTION

Changes (from the [RELEASE-NOTES](https://github.com/BitcoinUnlimited/ElectrsCash/blob/master/RELEASE-NOTES.md))
* Cache capacity is now defined in megabytes, rather than number of entries.
* Support Rust >=1.34
* Use configure_me instead of clap to support config files, environment variables and man pages 
* Revert LTO build (to fix deterministic build)
* Allow stopping bulk indexing via SIGINT/SIGTERM
* Cache list of transaction IDs for blocks
* Prefix Prometheus metrics with 'electrscash_'