### PR TITLE
[Qt] Add transaction rate trend graph in debug dialog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,7 @@ libbitcoinconsensus.pc
 # IDE files
 *.sublime-project
 *.sublime-workspace
+
+# Visual Studio 2015/2017/2019 cache/options directory
+.vs/
+src/.vs/

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -279,6 +279,8 @@ qt/transactiondescdialog.h
 qt/transactiondesc.h
 qt/transactionfilterproxy.cpp
 qt/transactionfilterproxy.h
+qt/transactiongraphwidget.cpp
+qt/transactiongraphwidget.h
 qt/transactionrecord.cpp
 qt/transactionrecord.h
 qt/transactiontablemodel.cpp

--- a/src/Makefile.qt.include
+++ b/src/Makefile.qt.include
@@ -153,6 +153,7 @@ QT_MOC_CPP = \
   qt/moc_transactiondesc.cpp \
   qt/moc_transactiondescdialog.cpp \
   qt/moc_transactionfilterproxy.cpp \
+  qt/moc_transactiongraphwidget.cpp \
   qt/moc_transactiontablemodel.cpp \
   qt/moc_transactionview.cpp \
   qt/moc_utilitydialog.cpp \
@@ -226,6 +227,7 @@ BITCOIN_QT_H = \
   qt/transactiondesc.h \
   qt/transactiondescdialog.h \
   qt/transactionfilterproxy.h \
+  qt/transactiongraphwidget.h \
   qt/transactionrecord.h \
   qt/transactiontablemodel.h \
   qt/transactionview.h \
@@ -313,6 +315,7 @@ BITCOIN_QT_CPP = \
   qt/rpcconsole.cpp \
   qt/splashscreen.cpp \
   qt/trafficgraphwidget.cpp \
+  qt/transactiongraphwidget.cpp \
   qt/utilitydialog.cpp
 
 if TARGET_WINDOWS

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -69,9 +69,6 @@ public:
     //! Return the dynamic memory usage of the mempool
     size_t getMempoolDynamicUsage() const;
 
-    //! BU: Return the transactions per second that are accepted into the mempool
-    double getTransactionsPerSecond() const;
-
     quint64 getTotalBytesRecv() const;
     quint64 getTotalBytesSent() const;
 
@@ -120,7 +117,7 @@ Q_SIGNALS:
     void orphanPoolSizeChanged(long count);
     void alertsChanged(const QString &warnings);
     void bytesChanged(quint64 totalBytesIn, quint64 totalBytesOut);
-    void transactionsPerSecondChanged(double tansactionsPerSecond); // BU:
+    void transactionsPerSecondChanged(double smoothedTps, double instantaneousTps, double peakTps);
     void thinBlockPropagationStatsChanged(const ThinBlockQuickStats &thin);
     void compactBlockPropagationStatsChanged(const CompactBlockQuickStats &compact);
     void grapheneBlockPropagationStatsChanged(const GrapheneQuickStats &graphene);

--- a/src/qt/clientmodel.h
+++ b/src/qt/clientmodel.h
@@ -105,6 +105,7 @@ private:
 
     QTimer *pollTimer1;
     QTimer *pollTimer2;
+    QTimer *pollTimer3;
 
     void subscribeToCoreSignals();
     void unsubscribeFromCoreSignals();
@@ -131,6 +132,7 @@ Q_SIGNALS:
 public Q_SLOTS:
     void updateTimer1();
     void updateTimer2();
+    void updateTimerTransactionRate();
     void updateNumConnections(int numConnections);
     void updateAlert();
     void updateBanlist();

--- a/src/qt/forms/debugwindow.ui
+++ b/src/qt/forms/debugwindow.ui
@@ -1061,6 +1061,1139 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tab_tps">
+      <attribute name="title">
+       <string>&amp;Transaction Rate</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout_6">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_6">
+         <item>
+          <widget class="TransactionGraphWidget" name="transactionGraph" native="true">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_7">
+           <item>
+            <widget class="QSlider" name="sldTpsGraphRange">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+             <property name="maximum">
+              <number>104</number>
+             </property>
+             <property name="pageStep">
+              <number>1</number>
+             </property>
+             <property name="value">
+              <number>104</number>
+             </property>
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="lblTpsGraphRange">
+             <property name="minimumSize">
+              <size>
+               <width>100</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_8">
+         <item>
+          <widget class="QGroupBox" name="groupBoxInstantaneous">
+           <property name="title">
+            <string>Instantaneous Rate (1s)</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_7">
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_8">
+              <item>
+               <widget class="QLabel" name="labelInstantaneousPeaks">
+                <property name="text">
+                 <string>Peak</string>
+                </property>
+                <property name="font">
+                  <font>
+                    <weight>75</weight>
+                    <bold>true</bold>
+                  </font>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_9">
+              <item>
+               <widget class="Line" name="line_InstantaneousPeakRuntime">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>10</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="palette">
+                 <palette>
+                  <active>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </active>
+                  <inactive>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </inactive>
+                  <disabled>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </disabled>
+                 </palette>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="labelInstantaneousPeakRuntime">
+                <property name="text">
+                 <string>Runtime</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="instantaneousPeakRuntime">
+                <property name="minimumSize">
+                 <size>
+                  <width>50</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_10">
+              <item>
+               <widget class="Line" name="line_InstantaneousPeakSampled">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>10</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="palette">
+                 <palette>
+                  <active>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </active>
+                  <inactive>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </inactive>
+                  <disabled>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </disabled>
+                 </palette>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="labelInstantaneousPeakSampled">
+                <property name="text">
+                 <string>24-Hours</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="instantaneousPeakSampled">
+                <property name="minimumSize">
+                 <size>
+                  <width>50</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_11">
+              <item>
+               <widget class="Line" name="line_InstantaneousPeakDisplayed">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>10</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="palette">
+                 <palette>
+                  <active>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </active>
+                  <inactive>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </inactive>
+                  <disabled>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </disabled>
+                 </palette>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="labelInstantaneousPeakDisplayed">
+                <property name="text">
+                 <string>Displayed</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="instantaneousPeakDisplayed">
+                <property name="minimumSize">
+                 <size>
+                  <width>50</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_12">
+              <item>
+               <widget class="QLabel" name="InstantaneousAverages">
+                <property name="text">
+                 <string>Average</string>
+                </property>
+                <property name="font">
+                  <font>
+                    <weight>75</weight>
+                    <bold>true</bold>
+                  </font>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_13">
+              <item>
+               <widget class="Line" name="line_InstantaneousAvgRuntime">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>10</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="palette">
+                 <palette>
+                  <active>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </active>
+                  <inactive>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </inactive>
+                  <disabled>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </disabled>
+                 </palette>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="labelInstantaneousAvgRuntime">
+                <property name="text">
+                 <string>Runtime</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="instantaneousAvgRuntime">
+                <property name="minimumSize">
+                 <size>
+                  <width>50</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_14">
+              <item>
+               <widget class="Line" name="line_InstantaneousAvgSampled">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>10</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="palette">
+                 <palette>
+                  <active>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </active>
+                  <inactive>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </inactive>
+                  <disabled>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </disabled>
+                 </palette>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="labelInstantaneousAvgSampled">
+                <property name="text">
+                 <string>24-Hours</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="instantaneousAvgSampled">
+                <property name="minimumSize">
+                 <size>
+                  <width>50</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_15">
+              <item>
+               <widget class="Line" name="line_InstantaneousAvgDisplayed">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>10</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="palette">
+                 <palette>
+                  <active>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </active>
+                  <inactive>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </inactive>
+                  <disabled>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>255</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </disabled>
+                 </palette>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="labelInstantaneousAvgDisplayed">
+                <property name="text">
+                 <string>Displayed</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="instantaneousAvgDisplayed">
+                <property name="minimumSize">
+                 <size>
+                  <width>50</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>407</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupBoxSmoothed">
+           <property name="title">
+            <string>Smoothed Rate (60s)</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_9">
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_16">
+              <item>
+               <widget class="QLabel" name="labelSmoothedPeaks">
+                <property name="text">
+                 <string>Peak</string>
+                </property>
+                <property name="font">
+                  <font>
+                    <weight>75</weight>
+                    <bold>true</bold>
+                  </font>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_17">
+              <item>
+               <widget class="Line" name="line_SmoothedPeakRuntime">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>10</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="palette">
+                 <palette>
+                  <active>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </active>
+                  <inactive>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </inactive>
+                  <disabled>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </disabled>
+                 </palette>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="labelSmoothedPeakRuntime">
+                <property name="text">
+                 <string>Runtime</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="smoothedPeakRuntime">
+                <property name="minimumSize">
+                 <size>
+                  <width>50</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_18">
+              <item>
+               <widget class="Line" name="line_SmoothedPeakSampled">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>10</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="palette">
+                 <palette>
+                  <active>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </active>
+                  <inactive>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </inactive>
+                  <disabled>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </disabled>
+                 </palette>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="labelSmoothedPeakSampled">
+                <property name="text">
+                 <string>24-Hours</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="smoothedPeakSampled">
+                <property name="minimumSize">
+                 <size>
+                  <width>50</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_19">
+              <item>
+               <widget class="Line" name="line_SmoothedPeakDisplayed">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>10</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="palette">
+                 <palette>
+                  <active>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </active>
+                  <inactive>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </inactive>
+                  <disabled>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </disabled>
+                 </palette>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="labelSmoothedPeakDisplayed">
+                <property name="text">
+                 <string>Displayed</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="smoothedPeakDisplayed">
+                <property name="minimumSize">
+                 <size>
+                  <width>50</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_20">
+              <item>
+               <widget class="QLabel" name="labelSmoothedAverages">
+                <property name="text">
+                 <string>Average</string>
+                </property>
+                <property name="font">
+                  <font>
+                    <weight>75</weight>
+                    <bold>true</bold>
+                  </font>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_21">
+              <item>
+               <widget class="Line" name="line_SmoothedAvgRuntime">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>10</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="palette">
+                 <palette>
+                  <active>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </active>
+                  <inactive>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </inactive>
+                  <disabled>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </disabled>
+                 </palette>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="labelSmoothedAvgRuntime">
+                <property name="text">
+                 <string>Runtime</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="smoothedAvgRuntime">
+                <property name="minimumSize">
+                 <size>
+                  <width>50</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_22">
+              <item>
+               <widget class="Line" name="line_SmoothedAvgSampled">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>10</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="palette">
+                 <palette>
+                  <active>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </active>
+                  <inactive>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </inactive>
+                  <disabled>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </disabled>
+                 </palette>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="labelSmoothedAvgSampled">
+                <property name="text">
+                 <string>24-Hours</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="smoothedAvgSampled">
+                <property name="minimumSize">
+                 <size>
+                  <width>50</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_23">
+              <item>
+               <widget class="Line" name="line_SmoothedAvgDisplayed">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>10</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="palette">
+                 <palette>
+                  <active>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </active>
+                  <inactive>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </inactive>
+                  <disabled>
+                   <colorrole role="Light">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>0</red>
+                      <green>255</green>
+                      <blue>0</blue>
+                     </color>
+                    </brush>
+                   </colorrole>
+                  </disabled>
+                 </palette>
+                </property>
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="labelSmoothedAvgDisplayed">
+                <property name="text">
+                 <string>Displayed</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="smoothedAvgDisplayed">
+                <property name="minimumSize">
+                 <size>
+                  <width>50</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_6">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>407</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="tab_peers">
       <attribute name="title">
        <string>&amp;Peers</string>
@@ -1169,11 +2302,11 @@
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
          </property>
-         <property name="textFormat">
-          <enum>Qt::RichText</enum>
-         </property>
          <property name="text">
           <string>Select a peer to view detailed information.</string>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::RichText</enum>
          </property>
          <property name="alignment">
           <set>Qt::AlignHCenter|Qt::AlignTop</set>
@@ -1626,6 +2759,12 @@
    <slots>
     <slot>clear()</slot>
    </slots>
+  </customwidget>
+  <customwidget>
+   <class>TransactionGraphWidget</class>
+   <extends>QWidget</extends>
+   <header>transactiongraphwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -400,7 +400,8 @@ void RPCConsole::setClientModel(ClientModel *model)
 
         connect(model, SIGNAL(mempoolSizeChanged(long, size_t)), this, SLOT(setMempoolSize(long, size_t)));
         connect(model, SIGNAL(orphanPoolSizeChanged(long)), this, SLOT(setOrphanPoolSize(long)));
-        connect(model, SIGNAL(transactionsPerSecondChanged(double)), this, SLOT(setTransactionsPerSecond(double)));
+        connect(model, SIGNAL(transactionsPerSecondChanged(double, double, double)), this,
+            SLOT(setTransactionsPerSecond(double, double, double)));
         connect(model, SIGNAL(thinBlockPropagationStatsChanged(const ThinBlockQuickStats &)), this,
             SLOT(setThinBlockPropagationStats(const ThinBlockQuickStats &)));
         connect(model, SIGNAL(compactBlockPropagationStatsChanged(const CompactBlockQuickStats &)), this,
@@ -669,15 +670,18 @@ void RPCConsole::setMempoolSize(long numberOfTxs, size_t dynUsage)
 }
 
 void RPCConsole::setOrphanPoolSize(long numberOfTxs) { ui->orphanPoolNumberTxs->setText(QString::number(numberOfTxs)); }
-void RPCConsole::setTransactionsPerSecond(double nTxPerSec)
+QString FormatTps(double tps)
 {
     // Format the output
-    if (nTxPerSec < 100)
-        ui->transactionsPerSecond->setText(
-            QString::number(nTxPerSec, 'f', 2) + "  (peak: " + QString::number(mempool.GetPeakRate(), 'f', 2) + ")");
+    if (tps < 100)
+        return QString::number(tps, 'f', 2);
     else
-        ui->transactionsPerSecond->setText(QString::number((uint64_t)nTxPerSec) + "  (peak: " +
-                                           QString::number((uint64_t)mempool.GetPeakRate()) + ")");
+        return QString::number((uint64_t)tps);
+}
+
+void RPCConsole::setTransactionsPerSecond(double smoothedTps, double instantaneousTps, double peakTps)
+{
+    ui->transactionsPerSecond->setText(FormatTps(smoothedTps) + "  (peak: " + FormatTps(peakTps) + ")");
 }
 
 void RPCConsole::setThinBlockPropagationStats(const ThinBlockQuickStats &thin)

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -101,7 +101,7 @@ public Q_SLOTS:
     /** Set number of transactions in ophan pool in the UI */
     void setOrphanPoolSize(long numberOfTxs);
     /** Set tx's per second in the UI */
-    void setTransactionsPerSecond(double nTxPerSec);
+    void setTransactionsPerSecond(double smoothedTps, double instantaneousTps, double peakTps);
     /** Set block propagation statistics in the UI */
     void setThinBlockPropagationStats(const ThinBlockQuickStats &thin);
     /** Set block propagation statistics in the UI */

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -69,6 +69,8 @@ private Q_SLOTS:
     void on_openDebugLogfileButton_clicked();
     /** change the time range of the network traffic graph */
     void on_sldGraphRange_valueChanged(int value);
+    /** change the time range of the transaction rate graph */
+    void on_sldTpsGraphRange_valueChanged(int value);
     /** update traffic statistics */
     void updateTrafficStats(quint64 totalBytesIn, quint64 totalBytesOut);
     void resizeEvent(QResizeEvent *event);
@@ -134,6 +136,7 @@ private:
     static QString FormatBytes(quint64 bytes);
     void startExecutor();
     void setTrafficGraphRange(int mins);
+    void setTransactionGraphRange(int mins);
     /** show detailed information on ui about selected node */
     void updateNodeDetail(const CNodeCombinedStats *stats);
 

--- a/src/qt/transactiongraphwidget.cpp
+++ b/src/qt/transactiongraphwidget.cpp
@@ -1,0 +1,376 @@
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "transactiongraphwidget.h"
+#include "clientmodel.h"
+#include "txmempool.h" // for TX_RATE_RESOLUTION_MILLIS
+
+#include <QColor>
+#include <QPainter>
+
+#include <cmath>
+
+/* Minutes to milliseconds conversion factor */
+static const long MINUTES_TO_MILLIS = 60 * 1000;
+/* Maximum sample window of 1 day, in milliseconds */
+static const long MAXIMUM_SAMPLE_WINDOW_MILLIS = 24 * 60 * MINUTES_TO_MILLIS;
+/* Sample rate, derived from the signal frequency used to update the TPS label on the debug ui */
+static const long SAMPLE_RATE_MILLIS = TX_RATE_RESOLUTION_MILLIS;
+/* Keep no more than this many samples in memory (older samples will be purged) */
+static const long MAXIMUM_SAMPLES_TO_KEEP = MAXIMUM_SAMPLE_WINDOW_MILLIS / SAMPLE_RATE_MILLIS;
+
+/* Always display at least 1 tps range on the y-axis */
+static const float MINIMUM_DISPLAY_YVALUE = 1.0f;
+
+/* Maximum redraw frequency */
+static const long MAXIMUM_REDRAW_RATE_MILLIS = 500;
+/* Minimum redraw frequency */
+static const long MINIMUM_REDRAW_RATE_MILLIS = 5000;
+
+static const int XMARGIN = 10;
+static const int YMARGIN = 10;
+
+TransactionGraphWidget::TransactionGraphWidget(QWidget *parent)
+    : QWidget(parent), nMinutes(1440), nRedrawRateMillis(SAMPLE_RATE_MILLIS), fDisplayMax(MINIMUM_DISPLAY_YVALUE),
+      fInstantaneousTpsPeak_Runtime(0.0f), fInstantaneousTpsPeak_Sampled(0.0f), fInstantaneousTpsPeak_Displayed(0.0f),
+      fInstantaneousTpsAverage_Runtime(0.0f), fInstantaneousTpsAverage_Sampled(0.0f),
+      fInstantaneousTpsAverage_Displayed(0.0f), fSmoothedTpsPeak_Runtime(0.0f), fSmoothedTpsPeak_Sampled(0.0f),
+      fSmoothedTpsPeak_Displayed(0.0f), fSmoothedTpsAverage_Runtime(0.0f), fSmoothedTpsAverage_Sampled(0.0f),
+      fSmoothedTpsAverage_Displayed(0.0f), nTotalSamplesRuntime(0L), vInstantaneousSamples(), vSmoothedSamples(),
+      clientModel(0)
+{
+}
+
+long TransactionGraphWidget::getSamplesInDisplayWindow() const
+{
+    return (nMinutes * MINUTES_TO_MILLIS) / SAMPLE_RATE_MILLIS;
+}
+
+void TransactionGraphWidget::setClientModel(ClientModel *model)
+{
+    clientModel = model;
+    if (model)
+    {
+        connect(model, SIGNAL(transactionsPerSecondChanged(double, double, double)), this,
+            SLOT(setTransactionsPerSecond(double, double, double)));
+    }
+}
+
+void TransactionGraphWidget::paintPath(QPainterPath &avgPath, QPainterPath &peakPath)
+{
+    int h = height() - YMARGIN * 2, w = width() - XMARGIN * 2;
+    int x = XMARGIN + w, yAvg, yPeak;
+    int samplesInWindow = getSamplesInDisplayWindow();
+    int sampleCount = samplesInWindow;
+    if (sampleCount > vInstantaneousSamples.size())
+        sampleCount = vInstantaneousSamples.size();
+
+    if (sampleCount > 0)
+    {
+        // Computes the maximum and average of all sample points which fall under the same pixel
+        avgPath.moveTo(x, YMARGIN + h);
+        peakPath.moveTo(x, YMARGIN + h);
+        int lastX = -1, countX = 0;
+        float peakY = 0.0f, avgY = 0.0f;
+        for (int i = 0; i < sampleCount; i++)
+        {
+            float valPeak = vInstantaneousSamples.at(i);
+            float valAvg = vSmoothedSamples.at(i);
+            x = XMARGIN + w - w * i / samplesInWindow;
+            if (x == lastX)
+            {
+                // Update running average for this pixel
+                countX++;
+                avgY = avgY + ((valAvg - avgY) / countX);
+
+                // Update maximum value for this pixel
+                if (valPeak > peakY)
+                    peakY = valPeak;
+
+                continue;
+            }
+
+            // first time through don't draw the line as it is priming the variables
+            if (lastX != -1)
+            {
+                // draw the path for the last set of samples that map to a single pixel
+                yAvg = YMARGIN + h - (int)(h * avgY / fDisplayMax);
+                avgPath.lineTo(lastX, yAvg);
+                yPeak = YMARGIN + h - (int)(h * peakY / fDisplayMax);
+                peakPath.lineTo(lastX, yPeak);
+            }
+
+            // reset values for the new x pixel
+            lastX = x;
+            peakY = valPeak;
+            avgY = valAvg;
+            countX = 1;
+        }
+
+        // The last sample(s) won't be drawn inside the loop due to the way we draw the previous
+        // x-pixel value when the next x-pixel is detected.  This is necessary to support aggregation
+        // of multiple samples that map to the same x-pixel.  So we need to draw the last sample(s) here
+        yAvg = YMARGIN + h - (int)(h * avgY / fDisplayMax);
+        avgPath.lineTo(x, yAvg);
+        yPeak = YMARGIN + h - (int)(h * peakY / fDisplayMax);
+        peakPath.lineTo(x, yPeak);
+
+        // close the figure to the bottom of the graph
+        avgPath.lineTo(x, YMARGIN + h);
+        peakPath.lineTo(x, YMARGIN + h);
+    }
+}
+
+void TransactionGraphWidget::paintEvent(QPaintEvent *)
+{
+    QPainter painter(this);
+    painter.fillRect(rect(), Qt::black);
+
+    QColor axisCol(Qt::gray);
+    int h = height() - YMARGIN * 2;
+    painter.setPen(axisCol);
+    painter.drawLine(XMARGIN, YMARGIN + h, width() - XMARGIN, YMARGIN + h);
+
+    // decide what order of magnitude we are
+    int base = floor(log10(fDisplayMax));
+    float val = pow(10.0f, base);
+
+    const QString units = tr("tps");
+    const float yMarginText = 2.0;
+
+    // draw major-axis lines
+    painter.setPen(axisCol);
+    for (float y = val; y < fDisplayMax; y += val)
+    {
+        // draw label text for all major-axis lines
+        painter.drawText(XMARGIN, YMARGIN + h - h * y / fDisplayMax - yMarginText,
+            QString("%1 %2").arg(QString().setNum(y, 'f', 2)).arg(units));
+
+        int yy = YMARGIN + h - h * y / fDisplayMax;
+        painter.drawLine(XMARGIN, yy, width() - XMARGIN, yy);
+    }
+
+    // if we drew 3 or fewer lines, break them up at the next lower order of magnitude
+    if (fDisplayMax / val <= 3.0f)
+    {
+        axisCol = axisCol.darker();
+        val = pow(10.0f, base - 1);
+        painter.setPen(axisCol);
+        int count = 1;
+        for (float y = val; y < fDisplayMax; y += val, count++)
+        {
+            // don't overwrite lines drawn above
+            if (count % 10 == 0)
+                continue;
+
+            // draw label text for the middle minor-axis line
+            if (count % 5 == 0)
+                painter.drawText(XMARGIN, YMARGIN + h - h * y / fDisplayMax - yMarginText,
+                    QString("%1 %2").arg(QString().setNum(y, 'f', 2)).arg(units));
+
+            int yy = YMARGIN + h - h * y / fDisplayMax;
+            painter.drawLine(XMARGIN, yy, width() - XMARGIN, yy);
+        }
+    }
+
+    if (!vInstantaneousSamples.empty())
+    {
+        // first draw max in the sample aggregation
+        QPainterPath pAvg, pMax;
+        paintPath(pAvg, pMax);
+
+        // draw the peak
+        painter.fillPath(pMax, QColor(255, 255, 0, 128));
+        painter.setPen(Qt::yellow);
+        painter.drawPath(pMax);
+
+        // draw the average
+        painter.fillPath(pAvg, QColor(0, 255, 0, 128));
+        painter.setPen(Qt::green);
+        painter.drawPath(pAvg);
+    }
+}
+
+/*
+  Computes the arithmetic mean based on the current mean at n-1, adding a new sample
+  NOTE: newSampleCount includes the new sample to be added
+*/
+double AddToArithmeticMean(double currentMean, long newSampleCount, double newSample)
+{
+    return currentMean + ((newSample - currentMean) / newSampleCount);
+}
+
+/*
+  Computes the arithmetic mean based on the current mean at n, subtracting one sample
+  NOTE: currentSampleCount includes the sample to be removed
+*/
+double SubtractFromArithmeticMean(double currentMean, long currentSampleCount, double removingSample)
+{
+    return ((currentMean * currentSampleCount) - removingSample) / (currentSampleCount - 1);
+}
+
+void TransactionGraphWidget::setTransactionsPerSecond(double nTxPerSec,
+    double nInstantaneousTxPerSec,
+    double nPeakTxPerSec)
+{
+    nTotalSamplesRuntime++;
+
+    // Add new instantaneous sample
+    vInstantaneousSamples.push_front((float)nInstantaneousTxPerSec);
+
+    // Update instantaneous peak for the total runtime
+    // NOTE: This peak may no longer be in the sample set if it was purged for being too old
+    if (nInstantaneousTxPerSec > fInstantaneousTpsPeak_Runtime)
+        fInstantaneousTpsPeak_Runtime = nInstantaneousTxPerSec;
+
+    // Adjust instantaneous mean for total runtime to include new sample
+    fInstantaneousTpsAverage_Runtime =
+        AddToArithmeticMean(fInstantaneousTpsAverage_Runtime, nTotalSamplesRuntime, nInstantaneousTxPerSec);
+
+    // Adjust instantaneous mean for total sample set to include new sample
+    fInstantaneousTpsAverage_Sampled =
+        AddToArithmeticMean(fInstantaneousTpsAverage_Sampled, vInstantaneousSamples.count(), nInstantaneousTxPerSec);
+
+    // NOTE: Instantaneous mean for displayed samples is handled in updateTransactionsPerSecondLabelValues()
+
+    // Purge instantaneous sample(s) that have moved beyond the sample set size limit
+    while (vInstantaneousSamples.size() > MAXIMUM_SAMPLES_TO_KEEP)
+    {
+        float fRemoving = vInstantaneousSamples.last();
+        // Adjust instantaneous mean for total sample set to exclude the sample being purged
+        fInstantaneousTpsAverage_Sampled =
+            SubtractFromArithmeticMean(fInstantaneousTpsAverage_Sampled, vInstantaneousSamples.size(), fRemoving);
+
+        vInstantaneousSamples.pop_back();
+    }
+
+
+    // Add new smoothed sample
+    vSmoothedSamples.push_front((float)nTxPerSec);
+
+    // Update smoothed peak for the total runtime
+    // NOTE: This peak may no longer be in the sample set if it was purged for being too old
+    if (nTxPerSec > fSmoothedTpsPeak_Runtime)
+        fSmoothedTpsPeak_Runtime = nTxPerSec;
+
+    // Adjust smoothed mean for total runtime to include new sample
+    fSmoothedTpsAverage_Runtime = AddToArithmeticMean(fSmoothedTpsAverage_Runtime, nTotalSamplesRuntime, nTxPerSec);
+
+    // Adjust smoothed mean for total sample set to include new sample
+    fSmoothedTpsAverage_Sampled = AddToArithmeticMean(fSmoothedTpsAverage_Sampled, vSmoothedSamples.count(), nTxPerSec);
+
+    // NOTE: Smoothed mean for displayed samples is handled in updateTransactionsPerSecondLabelValues()
+
+    // Purge smoothed sample(s) that have moved beyond the sample set size limit
+    while (vSmoothedSamples.size() > MAXIMUM_SAMPLES_TO_KEEP)
+    {
+        float fRemoving = vInstantaneousSamples.last();
+        // Adjust smoothed mean for total sample set to exclude the sample being purged
+        fSmoothedTpsAverage_Sampled =
+            SubtractFromArithmeticMean(fSmoothedTpsAverage_Sampled, vSmoothedSamples.size(), fRemoving);
+
+        vSmoothedSamples.pop_back();
+    }
+
+    // Update the TPS values matching the current display window
+    updateTransactionsPerSecondLabelValues();
+
+    // Limit redraw requests
+    static int64_t nLastRedrawTime = GetTimeMillis();
+    int64_t nCurrentTime = GetTimeMillis();
+    if (nCurrentTime >= nLastRedrawTime + nRedrawRateMillis)
+    {
+        update();
+        nLastRedrawTime = nCurrentTime;
+    }
+}
+
+void TransactionGraphWidget::updateTransactionsPerSecondLabelValues()
+{
+    int numSamples = getSamplesInDisplayWindow();
+
+    // Recompute the instantaneous peak for the current sample set and the average for the display window
+    // Runtime peak is computed in the add sample method because that tracks the peak even beyond the maintained sample
+    // set
+    float tSumAll = 0.0f, tSumDisplay = 0.0f;
+    int countAll = vSmoothedSamples.size();
+    int countDisplay = countAll < numSamples ? countAll : numSamples;
+    float tMaxSamples = 0.0f, tMaxDisplay = 0.0f;
+    for (int i = 0; i < vInstantaneousSamples.size(); i++)
+    {
+        float f = vInstantaneousSamples.at(i);
+        tSumAll += f;
+        if (i <= numSamples)
+            tSumDisplay += f;
+
+        if (f > tMaxSamples)
+        {
+            tMaxSamples = f;
+            if (i <= numSamples)
+                tMaxDisplay = f;
+        }
+    }
+    fInstantaneousTpsPeak_Sampled = tMaxSamples;
+    fInstantaneousTpsPeak_Displayed = tMaxDisplay;
+    fInstantaneousTpsAverage_Displayed = tSumDisplay / countDisplay;
+
+    // Adjust the y-axis scaling factor based on the highest peak currently visible
+    float tmax = fInstantaneousTpsPeak_Displayed;
+    if (tmax < MINIMUM_DISPLAY_YVALUE)
+        tmax = MINIMUM_DISPLAY_YVALUE;
+    fDisplayMax = tmax;
+
+
+    // Recompute the smoothed peak for the current sample set and the average for the display window
+    // Runtime peak is computed in the add sample method because that tracks the peak even beyond the maintained sample
+    // set
+    tSumAll = 0.0f;
+    tSumDisplay = 0.0f;
+    tMaxSamples = 0.0f;
+    tMaxDisplay = 0.0f;
+    for (int i = 0; i < vSmoothedSamples.size(); i++)
+    {
+        float f = vSmoothedSamples.at(i);
+        tSumAll += f;
+        if (i <= numSamples)
+            tSumDisplay += f;
+
+        if (f > tMaxSamples)
+        {
+            tMaxSamples = f;
+            if (i <= numSamples)
+                tMaxDisplay = f;
+        }
+    }
+    fSmoothedTpsPeak_Sampled = tMaxSamples;
+    fSmoothedTpsPeak_Displayed = tMaxDisplay;
+    fSmoothedTpsAverage_Displayed = tSumDisplay / countDisplay;
+}
+
+void TransactionGraphWidget::setTpsGraphRangeMins(int mins)
+{
+    nMinutes = mins;
+
+    if (mins < 60)
+        displayWindowLabelText = QString::number(mins) + "-Minutes";
+    else if (mins == 60)
+        displayWindowLabelText = "1-Hour";
+    else
+        displayWindowLabelText = QString::number(mins / 60.0f, 'g', 4) + "-Hours";
+
+    // Update the redraw frequency at a rate of 1 second per 30 minutes worth of sample data displayed
+    int rateMillis = nMinutes * 1000 / 30;
+
+    // Ensure we don't exceed the redraw rate limits
+    if (rateMillis < MAXIMUM_REDRAW_RATE_MILLIS)
+        rateMillis = MAXIMUM_REDRAW_RATE_MILLIS;
+    else if (rateMillis > MINIMUM_REDRAW_RATE_MILLIS)
+        rateMillis = MINIMUM_REDRAW_RATE_MILLIS;
+
+    nRedrawRateMillis = rateMillis;
+
+    // Lastly update the transaction rate statistics values as changing the display window also
+    // changes some of these values
+    updateTransactionsPerSecondLabelValues();
+}

--- a/src/qt/transactiongraphwidget.h
+++ b/src/qt/transactiongraphwidget.h
@@ -1,0 +1,78 @@
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_QT_TRANSACTIONGRAPHWIDGET_H
+#define BITCOIN_QT_TRANSACTIONGRAPHWIDGET_H
+
+#include <QQueue>
+#include <QWidget>
+
+class ClientModel;
+
+QT_BEGIN_NAMESPACE
+class QPaintEvent;
+QT_END_NAMESPACE
+
+class TransactionGraphWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit TransactionGraphWidget(QWidget *parent = 0);
+    void setClientModel(ClientModel *model);
+
+protected:
+    void paintEvent(QPaintEvent *);
+
+public Q_SLOTS:
+    void setTransactionsPerSecond(double nTxPerSec, double nInstantaneousTxPerSec, double nPeakTxPerSec);
+    void setTpsGraphRangeMins(int mins);
+
+public:
+    float getInstantaneousTpsPeak_Runtime() const { return fInstantaneousTpsPeak_Runtime; }
+    float getInstantaneousTpsPeak_Sampled() const { return fInstantaneousTpsPeak_Sampled; }
+    float getInstantaneousTpsPeak_Displayed() const { return fInstantaneousTpsPeak_Displayed; }
+    float getInstantaneousTpsAverage_Runtime() const { return fInstantaneousTpsAverage_Runtime; }
+    float getInstantaneousTpsAverage_Sampled() const { return fInstantaneousTpsAverage_Sampled; }
+    float getInstantaneousTpsAverage_Displayed() const { return fInstantaneousTpsAverage_Displayed; }
+    float getSmoothedTpsPeak_Runtime() const { return fSmoothedTpsPeak_Runtime; }
+    float getSmoothedTpsPeak_Sampled() const { return fSmoothedTpsPeak_Sampled; }
+    float getSmoothedTpsPeak_Displayed() const { return fSmoothedTpsPeak_Displayed; }
+    float getSmoothedTpsAverage_Runtime() const { return fSmoothedTpsAverage_Runtime; }
+    float getSmoothedTpsAverage_Sampled() const { return fSmoothedTpsAverage_Sampled; }
+    float getSmoothedTpsAverage_Displayed() const { return fSmoothedTpsAverage_Displayed; }
+    QString getDisplayWindowLabelText() const { return displayWindowLabelText; }
+private:
+    void paintPath(QPainterPath &avgPath, QPainterPath &peakPath);
+    long getSamplesInDisplayWindow() const;
+    void updateTransactionsPerSecondLabelValues();
+
+    int nMinutes;
+    int nRedrawRateMillis;
+    float fDisplayMax;
+
+    float fInstantaneousTpsPeak_Runtime;
+    float fInstantaneousTpsPeak_Sampled;
+    float fInstantaneousTpsPeak_Displayed;
+    float fInstantaneousTpsAverage_Runtime;
+    float fInstantaneousTpsAverage_Sampled;
+    float fInstantaneousTpsAverage_Displayed;
+
+    float fSmoothedTpsPeak_Runtime;
+    float fSmoothedTpsPeak_Sampled;
+    float fSmoothedTpsPeak_Displayed;
+    float fSmoothedTpsAverage_Runtime;
+    float fSmoothedTpsAverage_Sampled;
+    float fSmoothedTpsAverage_Displayed;
+
+    QString displayWindowLabelText;
+
+    long nTotalSamplesRuntime;
+    QQueue<float> vInstantaneousSamples;
+    QQueue<float> vSmoothedSamples;
+
+    ClientModel *clientModel;
+};
+
+#endif // BITCOIN_QT_TRANSACTIONGRAPHWIDGET_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1336,9 +1336,12 @@ UniValue mempoolInfoToJSON()
     size_t maxmempool = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
     ret.pushKV("maxmempool", (int64_t)maxmempool);
     ret.pushKV("mempoolminfee", ValueFromAmount(mempool.GetMinFee(maxmempool).GetFeePerK()));
+
+    double smoothedTps = 0.0, instantaneousTps = 0.0, peakTps = 0.0;
+    mempool.GetTransactionRateStatistics(smoothedTps, instantaneousTps, peakTps);
     try
     {
-        ret.pushKV("tps", std::stod(strprintf("%.2f", mempool.TransactionsPerSecond())));
+        ret.pushKV("tps", std::stod(strprintf("%.2f", smoothedTps)));
     }
     catch (...)
     {
@@ -1346,7 +1349,7 @@ UniValue mempoolInfoToJSON()
     }
     try
     {
-        ret.pushKV("peak_tps", std::stod(strprintf("%.2f", mempool.GetPeakRate())));
+        ret.pushKV("peak_tps", std::stod(strprintf("%.2f", peakTps)));
     }
     catch (...)
     {

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -35,6 +35,10 @@ inline bool AllowFree(double dPriority)
 
 /** Fake height value used in Coin to signify they are only in the memory pool (since 0.8) */
 static const uint32_t MEMPOOL_HEIGHT = 0x7FFFFFFF;
+/** Length of time in seconds over which to smooth the tx rate */
+static const double TX_RATE_SMOOTHING_SEC = 60;
+/** Sample resolution in milliseconds over which to compute the instantaneous transaction rate */
+static const int TX_RATE_RESOLUTION_MILLIS = 1000;
 
 /** Dump the mempool to disk. */
 bool DumpMempool();
@@ -470,6 +474,7 @@ private:
 
     std::mutex cs_txPerSec;
     double nTxPerSec GUARDED_BY(cs_txPerSec); //! txns per second accepted into the mempool
+    double nInstantaneousTxPerSec GUARDED_BY(cs_txPerSec); //! instantaneous (1-second resolution) txns per second
     double nPeakRate GUARDED_BY(cs_txPerSec); //! peak rate since startup for txns per second
 
 public:


### PR DESCRIPTION
This is a customization I added to my client that I figured I'd put a PR in for.  This is based on the existing network traffic graph and basically expands upon the existing smoothed 60-second average and runtime peak transaction rate statistics displayed on the first tab of the debug dialog in the Qt client.  The trend graph is based on taking 1-second samples of the smoothed and instantaneous rates and storing up to 24-hours worth of samples.  Samples older than 24-hours are purged from memory.  In addition to the graph of the instantaneous and smoothed samples, some high level statistics are displayed giving the runtime, sample size (24-hour), and display window (dynamic) instantaneous peak values and smoothed average values.

Unlike the network traffic graph, the transaction rate trend graph maintains up to 24 hours of samples in memory allowing changing the display time window without losing the previous samples.  The displayed window can be as short as the last 5 minutes or as long as the full 24 hours of samples.

The main changes related to this PR are as follows:
1. Expose some of the method local constants for use external to `txmempool.UpdateTransactionsPerSec()` related to smoothing window size (60 seconds) and resolution of the instantaneous rate (1 second).  These are used to set some of the display strings as well as control the sampling timer to ensure we don't attempt to gather samples at a higher frequency than the instantaneous resolution.

2. Expose most recently computed instantaneous transaction rate computed in `txmempool.UpdateTransactionsPerSec()` to use as a sample point in the trend graph.  This allows displaying the instantaneous rate which will show when there are gaps in transactions (when zoomed in to a small enough window).  The instantaneous rate is overlaid with the smoothed average on the graph.

3. Refactor `txmempool.UpdateTransactionsPerSec()` to allow updating the smoothed average without adding a new transaction.  This fixes an issue where if there are gaps between transactions the smoothed rate would not decay and would falsely appear to be at a plateau until the next transaction was added to the commit queue.  This was very obvious when looking at the samples on the graph if there were several seconds between transactions.

4. Refactor accessor methods for the individual statistics to instead return all 3 stats (smoothed average, instantaneous value, peak value) to instead all be returned atomically as a group.  This reduces the taking/releasing of the `cs_txPerSec` lock when displaying the statistics.  NOTE: The `cs_txPerSec` critical section is using `std::lock_guard` instead of the `LOCK` macro, and as such I made the helper method require the lock be passed in as there is no equivalent to `AssertLockHeld` and this avoids the need to change the lock type (though perhaps it should be changed).

5. Add the new transaction rate widget to the debug dialog.  When at larger sample window sizes, all sample points which end up mapping to the same pixel x value are aggregated.  For the instantaneous rate, the max sample is used, for the smoothed average, the average of all samples is used.

Some sample images from recent runs.  I took these screen captures at minimum size of the dialog for inclusion here, but they look much better on a wide screen monitor fully stretched horizontally across the screen.

5-minute window:
<img width="451" alt="TxnRate_5m" src="https://user-images.githubusercontent.com/6402604/65295585-d3827980-db2f-11e9-947a-9572348a518d.png">

1-hour window:
<img width="451" alt="TxnRate_1h" src="https://user-images.githubusercontent.com/6402604/65295604-de3d0e80-db2f-11e9-9e85-b2d78afe7a4c.png">

24-hour window:
<img width="451" alt="TxnRate_24h" src="https://user-images.githubusercontent.com/6402604/65295623-ea28d080-db2f-11e9-91c4-1e8dabf2d1a7.png">

Based on having used this for a couple of weeks now, I have discovered some areas that I believe could be improved upon in subsequent versions.
1. The sample window is locked to always show the most recent samples.  To see older samples requires increasing the window size which loses the finer detail.  It would be useful to have a horizontal scroll bar to allow seeing older samples at a smaller window size.

2. The sample window slider is 5 minutes per tick all the way across.  I feel that this is probably only useful for shorter windows (1 hour or less).  Make the ticks step size dynamic base on window size.

3. When there are large spikes, the y-axis is scaled to show the peak of this spike.  This can lose detail of most of the data and it would be useful to be able to set a maximum scale on the y-axis, truncating the tops of spikes.  Perhaps an option to set the maximum y-axis value based either on the peak or the 95th percentile value.

4. I don't really see any issues with resource usage with this, but maybe it would make sense to have a command line/config argument to turn this feature off

5. Related to 4 above, I have not tested this during high transaction throughput.  This could potentially run into issues in that case due to the locking of `cs_txPerSec`.  I'm interested to see what the trend graph looks like during the next GTI run.