### PR TITLE
fix potential xversion segfault

### DIFF
--- a/src/xversionmessage.cpp
+++ b/src/xversionmessage.cpp
@@ -26,9 +26,9 @@ uint64_t XMapSaltedHasher::operator()(const uint64_t key) const
 
 uint64_t CXVersionMessage::as_u64c(const uint64_t k) const
 {
+    LOCK(cacheProtector);
     if (xmap.count(k) == 0)
         return 0;
-    LOCK(cacheProtector);
     if (cache_u64c.count(k) == 0)
     {
         const std::vector<uint8_t> &vec = xmap.at(k);


### PR DESCRIPTION
move lock before count to solve potential segfault issue where map can be read and written to at the same time