### PR TITLE
[port] Improvements to ECDSA key-handling code

### DIFF
--- a/src/key.cpp
+++ b/src/key.cpp
@@ -181,6 +181,9 @@ static int ec_privkey_export_der(const secp256k1_context *ctx,
     int compressed)
 {
     assert(*privkeylen >= PRIVATE_KEY_SIZE);
+    static_assert(
+        PRIVATE_KEY_SIZE >= COMPRESSED_PRIVATE_KEY_SIZE, "COMPRESSED_PRIVATE_KEY_SIZE is larger than PRIVATE_KEY_SIZE");
+
     secp256k1_pubkey pubkey;
     size_t pubkeylen = 0;
     if (!secp256k1_ec_pubkey_create(ctx, &pubkey, key32))

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -121,7 +121,7 @@ static int ec_privkey_import_der(const secp256k1_context *ctx,
     {
         return 0;
     }
-    size_t lenb = *privkey & ~0x80u;
+    ptrdiff_t lenb = *privkey & ~0x80u;
     privkey++;
     if (lenb < 1 || lenb > 2)
     {
@@ -132,7 +132,7 @@ static int ec_privkey_import_der(const secp256k1_context *ctx,
         return 0;
     }
     /* sequence length */
-    size_t len = privkey[lenb - 1] | (lenb > 1 ? privkey[lenb - 2] << 8 : 0u);
+    ptrdiff_t len = privkey[lenb - 1] | (lenb > 1 ? privkey[lenb - 2] << 8 : 0u);
     privkey += lenb;
     if (end - privkey < len)
     {
@@ -149,7 +149,7 @@ static int ec_privkey_import_der(const secp256k1_context *ctx,
     {
         return 0;
     }
-    size_t oslen = privkey[1];
+    ptrdiff_t oslen = privkey[1];
     privkey += 2;
     if (oslen > 32 || end - privkey < oslen)
     {

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -109,8 +109,6 @@ static int ec_privkey_import_der(const secp256k1_context *ctx,
     size_t privkeylen)
 {
     const unsigned char *end = privkey + privkeylen;
-    size_t lenb = 0;
-    size_t len = 0;
     memset(out32, 0, 32);
     /* sequence header */
     if (end - privkey < 1 || *privkey != 0x30u)
@@ -123,7 +121,7 @@ static int ec_privkey_import_der(const secp256k1_context *ctx,
     {
         return 0;
     }
-    lenb = *privkey & ~0x80u;
+    size_t lenb = *privkey & ~0x80u;
     privkey++;
     if (lenb < 1 || lenb > 2)
     {
@@ -134,7 +132,7 @@ static int ec_privkey_import_der(const secp256k1_context *ctx,
         return 0;
     }
     /* sequence length */
-    len = privkey[lenb - 1] | (lenb > 1 ? privkey[lenb - 2] << 8 : 0u);
+    size_t len = privkey[lenb - 1] | (lenb > 1 ? privkey[lenb - 2] << 8 : 0u);
     privkey += lenb;
     if (end - privkey < len)
     {

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -87,6 +87,22 @@ int Hd44DeriveChildKey(CKey key,
 
 
 /** These functions are taken from the libsecp256k1 distribution and are very ugly. */
+
+/**
+ * This parses a format loosely based on a DER encoding of the ECPrivateKey type from
+ * section C.4 of SEC 1 <http://www.secg.org/sec1-v2.pdf>, with the following caveats:
+ *
+ * * The octet-length of the SEQUENCE must be encoded as 1 or 2 octets. It is not
+ *   required to be encoded as one octet if it is less than 256, as DER would require.
+ * * The octet-length of the SEQUENCE must not be greater than the remaining
+ *   length of the key encoding, but need not match it (i.e. the encoding may contain
+ *   junk after the encoded SEQUENCE).
+ * * The privateKey OCTET STRING is zero-filled on the left to 32 octets.
+ * * Anything after the encoding of the privateKey OCTET STRING is ignored, whether
+ *   or not it is validly encoded DER.
+ *
+ * out32 must point to an output buffer of length at least 32 bytes.
+ */
 static int ec_privkey_import_der(const secp256k1_context *ctx,
     unsigned char *out32,
     const unsigned char *privkey,
@@ -150,6 +166,13 @@ static int ec_privkey_import_der(const secp256k1_context *ctx,
     return 1;
 }
 
+/**
+ * This serializes to a DER encoding of the ECPrivateKey type from section C.4 of SEC 1
+ * <http://www.secg.org/sec1-v2.pdf>. The optional parameters and publicKey fields are
+ * included.
+ *
+ * key32 must point to a 32-byte raw private key.
+ */
 static int ec_privkey_export_der(const secp256k1_context *ctx,
     unsigned char *privkey,
     size_t *privkeylen,

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 // Copyright (c) 2015-2019 The Bitcoin Unlimited developers
+// Copyright (c) 2017 The Zcash developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -92,49 +93,55 @@ static int ec_privkey_import_der(const secp256k1_context *ctx,
     size_t privkeylen)
 {
     const unsigned char *end = privkey + privkeylen;
-    int lenb = 0;
-    int len = 0;
+    size_t lenb = 0;
+    size_t len = 0;
     memset(out32, 0, 32);
     /* sequence header */
-    if (end < privkey + 1 || *privkey != 0x30)
+    if (end - privkey < 1 || *privkey != 0x30u)
     {
         return 0;
     }
     privkey++;
     /* sequence length constructor */
-    if (end < privkey + 1 || !(*privkey & 0x80))
+    if (end - privkey < 1 || !(*privkey & 0x80u))
     {
         return 0;
     }
-    lenb = *privkey & ~0x80;
+    lenb = *privkey & ~0x80u;
     privkey++;
     if (lenb < 1 || lenb > 2)
     {
         return 0;
     }
-    if (end < privkey + lenb)
+    if (end - privkey < lenb)
     {
         return 0;
     }
     /* sequence length */
-    len = privkey[lenb - 1] | (lenb > 1 ? privkey[lenb - 2] << 8 : 0);
+    len = privkey[lenb - 1] | (lenb > 1 ? privkey[lenb - 2] << 8 : 0u);
     privkey += lenb;
-    if (end < privkey + len)
+    if (end - privkey < len)
     {
         return 0;
     }
     /* sequence element 0: version number (=1) */
-    if (end < privkey + 3 || privkey[0] != 0x02 || privkey[1] != 0x01 || privkey[2] != 0x01)
+    if (end - privkey < 3 || privkey[0] != 0x02u || privkey[1] != 0x01u || privkey[2] != 0x01u)
     {
         return 0;
     }
     privkey += 3;
     /* sequence element 1: octet string, up to 32 bytes */
-    if (end < privkey + 2 || privkey[0] != 0x04 || privkey[1] > 0x20 || end < privkey + 2 + privkey[1])
+    if (end - privkey < 2 || privkey[0] != 0x04u)
     {
         return 0;
     }
-    memcpy(out32 + 32 - privkey[1], privkey + 2, privkey[1]);
+    size_t oslen = privkey[1];
+    privkey += 2;
+    if (oslen > 32 || end - privkey < oslen)
+    {
+        return 0;
+    }
+    memcpy(out32 + (32 - oslen), privkey, oslen);
     if (!secp256k1_ec_seckey_verify(ctx, out32))
     {
         memset(out32, 0, 32);
@@ -348,12 +355,12 @@ bool CKey::Derive(CKey &keyChild, ChainCode &ccChild, unsigned int nChild, const
     if ((nChild >> 31) == 0)
     {
         CPubKey pubkey = GetPubKey();
-        assert(pubkey.begin() + 33 == pubkey.end());
+        assert(pubkey.size() == 33);
         BIP32Hash(cc, nChild, *pubkey.begin(), pubkey.begin() + 1, out);
     }
     else
     {
-        assert(begin() + 32 == end());
+        assert(size() == 32);
         BIP32Hash(cc, nChild, 0, begin(), out);
     }
     memcpy(ccChild.begin(), out + 32, 32);

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -169,7 +169,7 @@ static int ec_privkey_import_der(const secp256k1_context *ctx,
  * <http://www.secg.org/sec1-v2.pdf>. The optional parameters and publicKey fields are
  * included.
  *
- * privkey must point to an output buffer of length at least PRIVATE_KEY_SIZE bytes.
+ * privkey must point to an output buffer of length at least CKey::PRIVATE_KEY_SIZE bytes.
  * privkeylen must initially be set to the size of the privkey buffer. Upon return it
  * will be set to the number of bytes used in the buffer.
  * key32 must point to a 32-byte raw private key.
@@ -180,9 +180,7 @@ static int ec_privkey_export_der(const secp256k1_context *ctx,
     const unsigned char *key32,
     int compressed)
 {
-    assert(*privkeylen >= PRIVATE_KEY_SIZE);
-    static_assert(
-        PRIVATE_KEY_SIZE >= COMPRESSED_PRIVATE_KEY_SIZE, "COMPRESSED_PRIVATE_KEY_SIZE is larger than PRIVATE_KEY_SIZE");
+    assert(*privkeylen >= CKey::PRIVATE_KEY_SIZE);
 
     secp256k1_pubkey pubkey;
     size_t pubkeylen = 0;
@@ -210,11 +208,11 @@ static int ec_privkey_export_der(const secp256k1_context *ctx,
         ptr += 32;
         memcpy(ptr, middle, sizeof(middle));
         ptr += sizeof(middle);
-        pubkeylen = COMPRESSED_PUBLIC_KEY_SIZE;
+        pubkeylen = CPubKey::COMPRESSED_PUBLIC_KEY_SIZE;
         secp256k1_ec_pubkey_serialize(ctx, ptr, &pubkeylen, &pubkey, SECP256K1_EC_COMPRESSED);
         ptr += pubkeylen;
         *privkeylen = ptr - privkey;
-        assert(*privkeylen == COMPRESSED_PRIVATE_KEY_SIZE);
+        assert(*privkeylen == CKey::COMPRESSED_PRIVATE_KEY_SIZE);
     }
     else
     {
@@ -236,11 +234,11 @@ static int ec_privkey_export_der(const secp256k1_context *ctx,
         ptr += 32;
         memcpy(ptr, middle, sizeof(middle));
         ptr += sizeof(middle);
-        pubkeylen = PUBLIC_KEY_SIZE;
+        pubkeylen = CPubKey::PUBLIC_KEY_SIZE;
         secp256k1_ec_pubkey_serialize(ctx, ptr, &pubkeylen, &pubkey, SECP256K1_EC_UNCOMPRESSED);
         ptr += pubkeylen;
         *privkeylen = ptr - privkey;
-        assert(*privkeylen == PRIVATE_KEY_SIZE);
+        assert(*privkeylen == CKey::PRIVATE_KEY_SIZE);
     }
     return 1;
 }
@@ -285,7 +283,7 @@ CPubKey CKey::GetPubKey() const
 {
     assert(fValid);
     secp256k1_pubkey pubkey;
-    size_t clen = PUBLIC_KEY_SIZE;
+    size_t clen = CPubKey::PUBLIC_KEY_SIZE;
     CPubKey result;
     int ret = secp256k1_ec_pubkey_create(secp256k1_context_sign, &pubkey, begin());
     assert(ret);
@@ -300,8 +298,8 @@ bool CKey::SignECDSA(const uint256 &hash, std::vector<uint8_t> &vchSig, uint32_t
 {
     if (!fValid)
         return false;
-    vchSig.resize(SIGNATURE_SIZE);
-    size_t nSigLen = SIGNATURE_SIZE;
+    vchSig.resize(CPubKey::SIGNATURE_SIZE);
+    size_t nSigLen = CPubKey::SIGNATURE_SIZE;
     unsigned char extra_entropy[32] = {0};
     WriteLE32(extra_entropy, test_case);
     secp256k1_ecdsa_signature sig;
@@ -349,7 +347,7 @@ bool CKey::SignCompact(const uint256 &hash, std::vector<uint8_t> &vchSig) const
 {
     if (!fValid)
         return false;
-    vchSig.resize(COMPACT_SIGNATURE_SIZE);
+    vchSig.resize(CPubKey::COMPACT_SIGNATURE_SIZE);
     int rec = -1;
     secp256k1_ecdsa_recoverable_signature sig;
     int ret = secp256k1_ecdsa_sign_recoverable(
@@ -385,7 +383,7 @@ bool CKey::Derive(CKey &keyChild, ChainCode &ccChild, unsigned int nChild, const
     if ((nChild >> 31) == 0)
     {
         CPubKey pubkey = GetPubKey();
-        assert(pubkey.size() == COMPRESSED_PUBLIC_KEY_SIZE);
+        assert(pubkey.size() == CPubKey::COMPRESSED_PUBLIC_KEY_SIZE);
         BIP32Hash(cc, nChild, *pubkey.begin(), pubkey.begin() + 1, out);
     }
     else

--- a/src/key.h
+++ b/src/key.h
@@ -20,16 +20,6 @@ extern const uint32_t BIP32_HARDENED_KEY_LIMIT;
 
 
 /**
- * secp256k1:
- */
-const unsigned int PRIVATE_KEY_SIZE = 279;
-const unsigned int COMPRESSED_PRIVATE_KEY_SIZE = 214;
-/**
- * see www.keylength.com
- * script supports up to 75 for single byte push
- */
-
-/**
  * secure_allocator is defined in allocators.h
  * CPrivKey is a serialized private key, with all parameters included (PRIVATE_KEY_SIZE bytes)
  */
@@ -38,6 +28,20 @@ typedef std::vector<unsigned char, secure_allocator<unsigned char> > CPrivKey;
 /** An encapsulated secp256k1 private key. */
 class CKey
 {
+public:
+    /**
+     * secp256k1:
+     */
+    static const unsigned int PRIVATE_KEY_SIZE = 279;
+    static const unsigned int COMPRESSED_PRIVATE_KEY_SIZE = 214;
+    /**
+     * see www.keylength.com
+     * script supports up to 75 for single byte push
+     */
+    static_assert(PRIVATE_KEY_SIZE >= COMPRESSED_PRIVATE_KEY_SIZE,
+        "COMPRESSED_PRIVATE_KEY_SIZE is larger than PRIVATE_KEY_SIZE");
+
+
 private:
     //! Whether this private key is valid. We check for correctness when modifying the key
     //! data, so fValid should always correspond to the actual state.

--- a/src/key.h
+++ b/src/key.h
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 // Copyright (c) 2015-2019 The Bitcoin Unlimited developers
+// Copyright (c) 2017 The Zcash developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -20,17 +21,17 @@ extern const uint32_t BIP32_HARDENED_KEY_LIMIT;
 
 /**
  * secp256k1:
- * const unsigned int PRIVATE_KEY_SIZE = 279;
- * const unsigned int PUBLIC_KEY_SIZE  = 65;
- * const unsigned int SIGNATURE_SIZE   = 72;
- *
+ */
+const unsigned int PRIVATE_KEY_SIZE = 279;
+const unsigned int COMPRESSED_PRIVATE_KEY_SIZE = 214;
+/**
  * see www.keylength.com
  * script supports up to 75 for single byte push
  */
 
 /**
  * secure_allocator is defined in allocators.h
- * CPrivKey is a serialized private key, with all parameters included (279 bytes)
+ * CPrivKey is a serialized private key, with all parameters included (PRIVATE_KEY_SIZE bytes)
  */
 typedef std::vector<unsigned char, secure_allocator<unsigned char> > CPrivKey;
 

--- a/src/keystore.cpp
+++ b/src/keystore.cpp
@@ -69,7 +69,7 @@ static bool ExtractPubKey(const CScript &dest, CPubKey &pubKeyOut)
     CScript::const_iterator pc = dest.begin();
     opcodetype opcode;
     std::vector<unsigned char> vch;
-    if (!dest.GetOp(pc, opcode, vch) || vch.size() < 33 || vch.size() > 65)
+    if (!dest.GetOp(pc, opcode, vch) || !CPubKey::ValidSize(vch))
         return false;
     pubKeyOut = CPubKey(vch);
     if (!pubKeyOut.IsFullyValid())

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -341,8 +341,8 @@ void CExtPubKey::Encode(unsigned char code[BIP32_EXTKEY_SIZE]) const
     code[7] = (nChild >> 8) & 0xFF;
     code[8] = (nChild >> 0) & 0xFF;
     memcpy(code + 9, chaincode.begin(), 32);
-    assert(pubkey.size() == COMPRESSED_PUBLIC_KEY_SIZE);
-    memcpy(code + 41, pubkey.begin(), COMPRESSED_PUBLIC_KEY_SIZE);
+    assert(pubkey.size() == CPubKey::COMPRESSED_PUBLIC_KEY_SIZE);
+    memcpy(code + 41, pubkey.begin(), CPubKey::COMPRESSED_PUBLIC_KEY_SIZE);
 }
 
 void CExtPubKey::Decode(const unsigned char code[BIP32_EXTKEY_SIZE])

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 // Copyright (c) 2015-2019 The Bitcoin Unlimited developers
+// Copyright (c) 2017 The Zcash developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -55,7 +56,7 @@ static int ecdsa_signature_parse_der_lax(const secp256k1_context *ctx,
     if (lenbyte & 0x80)
     {
         lenbyte -= 0x80;
-        if (pos + lenbyte > inputlen)
+        if (lenbyte > inputlen - pos)
         {
             return 0;
         }
@@ -78,7 +79,7 @@ static int ecdsa_signature_parse_der_lax(const secp256k1_context *ctx,
     if (lenbyte & 0x80)
     {
         lenbyte -= 0x80;
-        if (pos + lenbyte > inputlen)
+        if (lenbyte > inputlen - pos)
         {
             return 0;
         }
@@ -87,7 +88,8 @@ static int ecdsa_signature_parse_der_lax(const secp256k1_context *ctx,
             pos++;
             lenbyte--;
         }
-        if (lenbyte >= sizeof(size_t))
+        static_assert(sizeof(size_t) >= 4, "size_t too small");
+        if (lenbyte >= 4)
         {
             return 0;
         }
@@ -126,7 +128,7 @@ static int ecdsa_signature_parse_der_lax(const secp256k1_context *ctx,
     if (lenbyte & 0x80)
     {
         lenbyte -= 0x80;
-        if (pos + lenbyte > inputlen)
+        if (lenbyte > inputlen - pos)
         {
             return 0;
         }
@@ -135,7 +137,8 @@ static int ecdsa_signature_parse_der_lax(const secp256k1_context *ctx,
             pos++;
             lenbyte--;
         }
-        if (lenbyte >= sizeof(size_t))
+        static_assert(sizeof(size_t) >= 4, "size_t too small");
+        if (lenbyte >= 4)
         {
             return 0;
         }
@@ -309,7 +312,7 @@ bool CPubKey::Derive(CPubKey &pubkeyChild, ChainCode &ccChild, unsigned int _nCh
 {
     assert(IsValid());
     assert((_nChild >> 31) == 0);
-    assert(begin() + 33 == end());
+    assert(size() == 33);
     unsigned char out[64];
     BIP32Hash(cc, _nChild, *begin(), begin() + 1, out);
     memcpy(ccChild.begin(), out + 32, 32);

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -262,7 +262,7 @@ bool CPubKey::VerifySchnorr(const uint256 &hash, const std::vector<uint8_t> &vch
 
 bool CPubKey::RecoverCompact(const uint256 &hash, const std::vector<uint8_t> &vchSig)
 {
-    if (vchSig.size() != 65)
+    if (vchSig.size() != COMPACT_SIGNATURE_SIZE)
         return false;
     int recid = (vchSig[0] - 27) & 3;
     bool fComp = ((vchSig[0] - 27) & 4) != 0;
@@ -276,8 +276,8 @@ bool CPubKey::RecoverCompact(const uint256 &hash, const std::vector<uint8_t> &vc
     {
         return false;
     }
-    unsigned char pub[65];
-    size_t publen = 65;
+    unsigned char pub[PUBLIC_KEY_SIZE];
+    size_t publen = PUBLIC_KEY_SIZE;
     secp256k1_ec_pubkey_serialize(
         secp256k1_context_verify, pub, &publen, &pubkey, fComp ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED);
     Set(pub, pub + publen);
@@ -301,8 +301,8 @@ bool CPubKey::Decompress()
     {
         return false;
     }
-    unsigned char pub[65];
-    size_t publen = 65;
+    unsigned char pub[PUBLIC_KEY_SIZE];
+    size_t publen = PUBLIC_KEY_SIZE;
     secp256k1_ec_pubkey_serialize(secp256k1_context_verify, pub, &publen, &pubkey, SECP256K1_EC_UNCOMPRESSED);
     Set(pub, pub + publen);
     return true;
@@ -312,7 +312,7 @@ bool CPubKey::Derive(CPubKey &pubkeyChild, ChainCode &ccChild, unsigned int _nCh
 {
     assert(IsValid());
     assert((_nChild >> 31) == 0);
-    assert(size() == 33);
+    assert(size() == COMPRESSED_PUBLIC_KEY_SIZE);
     unsigned char out[64];
     BIP32Hash(cc, _nChild, *begin(), begin() + 1, out);
     memcpy(ccChild.begin(), out + 32, 32);
@@ -325,8 +325,8 @@ bool CPubKey::Derive(CPubKey &pubkeyChild, ChainCode &ccChild, unsigned int _nCh
     {
         return false;
     }
-    unsigned char pub[33];
-    size_t publen = 33;
+    unsigned char pub[COMPRESSED_PUBLIC_KEY_SIZE];
+    size_t publen = COMPRESSED_PUBLIC_KEY_SIZE;
     secp256k1_ec_pubkey_serialize(secp256k1_context_verify, pub, &publen, &pubkey, SECP256K1_EC_COMPRESSED);
     pubkeyChild.Set(pub, pub + publen);
     return true;
@@ -341,8 +341,8 @@ void CExtPubKey::Encode(unsigned char code[BIP32_EXTKEY_SIZE]) const
     code[7] = (nChild >> 8) & 0xFF;
     code[8] = (nChild >> 0) & 0xFF;
     memcpy(code + 9, chaincode.begin(), 32);
-    assert(pubkey.size() == 33);
-    memcpy(code + 41, pubkey.begin(), 33);
+    assert(pubkey.size() == COMPRESSED_PUBLIC_KEY_SIZE);
+    memcpy(code + 41, pubkey.begin(), COMPRESSED_PUBLIC_KEY_SIZE);
 }
 
 void CExtPubKey::Decode(const unsigned char code[BIP32_EXTKEY_SIZE])

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -68,6 +68,7 @@ private:
     //! Set this key data to be invalid
     void Invalidate() { vch[0] = 0xFF; }
 public:
+    bool static ValidSize(const std::vector<uint8_t> &vch) { return vch.size() > 0 && GetLen(vch[0]) == vch.size(); }
     //! Construct an invalid public key.
     CPubKey() { Invalidate(); }
     //! Initialize a public key using begin/end iterators to byte data.

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -16,10 +16,12 @@
 
 /**
  * secp256k1:
- * const unsigned int PRIVATE_KEY_SIZE = 279;
- * const unsigned int PUBLIC_KEY_SIZE  = 65;
- * const unsigned int SIGNATURE_SIZE   = 72;
- *
+ */
+const unsigned int PUBLIC_KEY_SIZE = 65;
+const unsigned int COMPRESSED_PUBLIC_KEY_SIZE = 33;
+const unsigned int SIGNATURE_SIZE = 72;
+const unsigned int COMPACT_SIGNATURE_SIZE = 65;
+/**
  * see www.keylength.com
  * script supports up to 75 for single byte push
  */
@@ -47,15 +49,15 @@ private:
      * Just store the serialized data.
      * Its length can very cheaply be computed from the first byte.
      */
-    unsigned char vch[65];
+    unsigned char vch[PUBLIC_KEY_SIZE];
 
     //! Compute the length of a pubkey with a given first byte.
     unsigned int static GetLen(unsigned char chHeader)
     {
         if (chHeader == 2 || chHeader == 3)
-            return 33;
+            return COMPRESSED_PUBLIC_KEY_SIZE;
         if (chHeader == 4 || chHeader == 6 || chHeader == 7)
-            return 65;
+            return PUBLIC_KEY_SIZE;
         return 0;
     }
 
@@ -112,7 +114,7 @@ public:
     void Unserialize(Stream &s)
     {
         unsigned int len = ::ReadCompactSize(s);
-        if (len <= 65)
+        if (len <= PUBLIC_KEY_SIZE)
         {
             s.read((char *)vch, len);
         }
@@ -140,7 +142,7 @@ public:
     bool IsFullyValid() const;
 
     //! Check whether this is a compressed public key.
-    bool IsCompressed() const { return size() == 33; }
+    bool IsCompressed() const { return size() == COMPRESSED_PUBLIC_KEY_SIZE; }
     /**
      * Verify a DER-serialized ECDSA signature (~72 bytes).
      * If this public key is not fully valid, the return value will be false.

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -50,6 +50,9 @@ private:
      * Its length can very cheaply be computed from the first byte.
      */
     unsigned char vch[PUBLIC_KEY_SIZE];
+    static_assert(PUBLIC_KEY_SIZE >= COMPRESSED_PUBLIC_KEY_SIZE,
+        "COMPRESSED_PUBLIC_KEY_SIZE is larger than PUBLIC_KEY_SIZE");
+
 
     //! Compute the length of a pubkey with a given first byte.
     unsigned int static GetLen(unsigned char chHeader)

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -14,18 +14,6 @@
 #include <stdexcept>
 #include <vector>
 
-/**
- * secp256k1:
- */
-const unsigned int PUBLIC_KEY_SIZE = 65;
-const unsigned int COMPRESSED_PUBLIC_KEY_SIZE = 33;
-const unsigned int SIGNATURE_SIZE = 72;
-const unsigned int COMPACT_SIGNATURE_SIZE = 65;
-/**
- * see www.keylength.com
- * script supports up to 75 for single byte push
- */
-
 enum
 {
     BIP32_EXTKEY_SIZE = 74
@@ -44,14 +32,27 @@ typedef uint256 ChainCode;
 /** An encapsulated secp256k1 public key. */
 class CPubKey
 {
+public:
+    /**
+     * secp256k1:
+     */
+    static const unsigned int PUBLIC_KEY_SIZE = 65;
+    static const unsigned int COMPRESSED_PUBLIC_KEY_SIZE = 33;
+    static const unsigned int SIGNATURE_SIZE = 72;
+    static const unsigned int COMPACT_SIGNATURE_SIZE = 65;
+    /**
+     * see www.keylength.com
+     * script supports up to 75 for single byte push
+     */
+    static_assert(PUBLIC_KEY_SIZE >= COMPRESSED_PUBLIC_KEY_SIZE,
+        "COMPRESSED_PUBLIC_KEY_SIZE is larger than PUBLIC_KEY_SIZE");
+
 private:
     /**
      * Just store the serialized data.
      * Its length can very cheaply be computed from the first byte.
      */
     unsigned char vch[PUBLIC_KEY_SIZE];
-    static_assert(PUBLIC_KEY_SIZE >= COMPRESSED_PUBLIC_KEY_SIZE,
-        "COMPRESSED_PUBLIC_KEY_SIZE is larger than PUBLIC_KEY_SIZE");
 
 
     //! Compute the length of a pubkey with a given first byte.

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -80,14 +80,14 @@ static void CleanupScriptCode(CScript &scriptCode, const std::vector<uint8_t> &v
 
 bool static IsCompressedOrUncompressedPubKey(const valtype &vchPubKey)
 {
-    if (vchPubKey.size() < 33)
+    if (vchPubKey.size() < CPubKey::COMPRESSED_PUBLIC_KEY_SIZE)
     {
         //  Non-canonical public key: too short
         return false;
     }
     if (vchPubKey[0] == 0x04)
     {
-        if (vchPubKey.size() != 65)
+        if (vchPubKey.size() != CPubKey::PUBLIC_KEY_SIZE)
         {
             //  Non-canonical public key: invalid length for uncompressed key
             return false;
@@ -111,7 +111,7 @@ bool static IsCompressedOrUncompressedPubKey(const valtype &vchPubKey)
 
 static bool IsCompressedPubKey(const valtype &vchPubKey)
 {
-    if (vchPubKey.size() != 33)
+    if (vchPubKey.size() != CPubKey::COMPRESSED_PUBLIC_KEY_SIZE)
     {
         //  Non-canonical public key: invalid length for compressed key
         return false;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -384,7 +384,13 @@ bool static IsLowDERSignature(const valtype &vchSig, ScriptError *serror, const 
         if (!IsValidSignatureEncodingWithoutSigHash(vchSig))
             return set_error(serror, SCRIPT_ERR_SIG_DER);
     }
+    // https://bitcoin.stackexchange.com/a/12556:
+    //     Also note that inside transaction signatures, an extra hashtype byte
+    //     follows the actual signature data.
     std::vector<unsigned char> vchSigCopy(vchSig.begin(), vchSig.begin() + vchSig.size() - (check_sighash ? 1 : 0));
+    // If the S value is above the order of the curve divided by two, its
+    // complement modulo the order could have been used instead, which is
+    // one byte shorter when encoded correctly.
     if (!CPubKey::CheckLowS(vchSigCopy))
     {
         return set_error(serror, SCRIPT_ERR_SIG_HIGH_S);

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -120,7 +120,7 @@ bool Solver(const CScript &scriptPubKey, txnouttype &typeRet, vector<vector<unsi
             // Template matching opcodes:
             if (opcode2 == OP_PUBKEYS)
             {
-                while (vch1.size() >= 33 && vch1.size() <= 65)
+                while (CPubKey::ValidSize(vch1))
                 {
                     vSolutionsRet.push_back(vch1);
                     if (!script1.GetOp(pc1, opcode1, vch1))
@@ -134,7 +134,7 @@ bool Solver(const CScript &scriptPubKey, txnouttype &typeRet, vector<vector<unsi
 
             if (opcode2 == OP_PUBKEY)
             {
-                if (vch1.size() < 33 || vch1.size() > 65)
+                if (!CPubKey::ValidSize(vch1))
                     break;
                 vSolutionsRet.push_back(vch1);
             }


### PR DESCRIPTION
This is a port https://github.com/bitcoin/bitcoin/pull/10657. In the process I ported also for convenience Core's [#12351](https://github.com/bitcoin/bitcoin/pull/12351) and [#12460](https://github.com/bitcoin/bitcoin/pull/12460).

--------
Original 10657 PR description:

Mostly trivial, but includes fixes to potential overflows in the ECDSA DER parsers. Cherry-picked from Zcash PR https://github.com/zcash/zcash/pull/2335
