### PR TITLE
[qa] Add assert_debug_log

### DIFF
--- a/qa/rpc-tests/test_framework/test_node.py
+++ b/qa/rpc-tests/test_framework/test_node.py
@@ -1,0 +1,40 @@
+import contextlib
+import re
+import os
+
+class TestNode():
+    def __init__(self, rpc, datadir):
+        self.rpc = rpc
+        self.datadir = datadir
+
+    def __getattr__(self, name):
+        """
+        Assume anything not implemented here is an rpc call and pass it on
+        """
+        return getattr(self.rpc, name)
+
+    def _raise_assertion_error(self, error):
+        assert False, error
+
+    @contextlib.contextmanager
+    def assert_debug_log(self, *, expected_msgs, unexpected_msgs):
+        debug_log = os.path.join(self.datadir, 'regtest', 'debug.log')
+        with open(debug_log, encoding='utf-8') as dl:
+            dl.seek(0, 2)
+            prev_size = dl.tell()
+        try:
+            yield
+        finally:
+            with open(debug_log, encoding='utf-8') as dl:
+                dl.seek(prev_size)
+                log = dl.read()
+            print_log = " - " + "\n - ".join(log.splitlines())
+            for expected_msg in expected_msgs:
+                if re.search(re.escape(expected_msg), log, flags=re.MULTILINE) is None:
+                    self._raise_assertion_error(
+                        'Expected message "{}" does not partially match log:\n\n{}\n\n'.format(expected_msg, print_log))
+
+            for unexpected in unexpected_msgs:
+                if re.search(re.escape(unexpected), log, flags=re.MULTILINE) is not None:
+                    self._raise_assertion_error(
+                        'Unexpected message "{}" matched log:\n\n{}\n\n'.format(unexpected, print_log))

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -29,6 +29,7 @@ import urllib.parse as urlparse
 import errno
 import logging
 import traceback
+from . import test_node
 
 from . import coverage
 from .authproxy import AuthServiceProxy, JSONRPCException
@@ -604,7 +605,7 @@ def start_node(i, dirname, extra_args=None, rpchost=None, timewait=None, binary=
     if COVERAGE_DIR:
         coverage.write_all_rpc_commands(COVERAGE_DIR, proxy)
 
-    return proxy
+    return test_node.TestNode(proxy, datadir)
 
 def start_nodes(num_nodes, dirname, extra_args=None, rpchost=None, binary=None,timewait=None):
     """


### PR DESCRIPTION
This was copied from Bitcoin ABC, but appears to be originally written
by MarcoFalke in Bitcoin Core PR14024

Notable difference is the addition of unexpected_msgs, which allows you
to check for example that a peer was NOT banned.

The TestNode wrapper is for being as API compatible as possible with
other node implementations.