### PR TITLE
Fix warning related to the wrong use of static_assert in interp…

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1474,7 +1474,8 @@ bool ScriptMachine::Step()
                     if ((flags & SCRIPT_ENABLE_SCHNORR_MULTISIG) && stacktop(-idxDummy).size() != 0)
                     {
                         // SCHNORR MULTISIG
-                        static_assert(MAX_PUBKEYS_PER_MULTISIG < 32);
+                        static_assert(MAX_PUBKEYS_PER_MULTISIG < 32,
+                            "Multisig dummy element decoded as bitfield can't represent more than 32 keys");
                         uint32_t checkBits = 0;
 
                         // Dummy element is to be interpreted as a bitfield


### PR DESCRIPTION
```
../src/script/interpreter.cpp:1477:68: warning: static_assert with no message is a C++1z extension [-Wc++1z-extensions]
                        static_assert(MAX_PUBKEYS_PER_MULTISIG < 32);
```