### PR TITLE
Fix lock guard definition in lockorder.h

### DIFF
--- a/src/deadlock-detection/lockorder.h
+++ b/src/deadlock-detection/lockorder.h
@@ -4,7 +4,7 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #ifndef BITCOIN_LOCK_ORDER_H
-#define BITCOIN_LOCK_RODER_H
+#define BITCOIN_LOCK_ORDER_H
 
 #include <inttypes.h>
 #include <map>


### PR DESCRIPTION
There was a type BITCOIN_LOCK_RODER --> should be BITCOIN_LOCK_ORDER