### PR TITLE
allow multiple thintype blocks in flight

### DIFF
--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -143,6 +143,9 @@ bool ThinTypeRelay::HasBlockRelayTimerExpired(const uint256 &hash)
 
 bool ThinTypeRelay::IsBlockRelayTimerEnabled()
 {
+    if (GetArg("-preferential-timer", DEFAULT_PREFERENTIAL_TIMER) == 0)
+        return false;
+
     // Only engage the timer if one or more, but not all, thin type relays are active.
     // If all types are active, or all inactive, then we do not need the timer.
     // Generally speaking all types will be active and we can return early.

--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -185,6 +185,7 @@ bool ThinTypeRelay::AreTooManyBlocksInFlight(CNode *pfrom, const std::string thi
 bool ThinTypeRelay::IsBlockInFlight(CNode *pfrom, const std::string thinType, const uint256 &hash)
 {
     // check if this node already has this thinType of block in flight.
+    LOCK(cs_inflight);
     auto range = mapThinTypeBlocksInFlight.equal_range(pfrom->GetId());
     while (range.first != range.second)
     {

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -64,7 +64,8 @@ public:
     bool HasBlockRelayTimerExpired(const uint256 &hash);
     bool IsBlockRelayTimerEnabled();
     void ClearBlockRelayTimer(const uint256 &hash);
-    bool IsBlockInFlight(CNode *pfrom, const std::string thinType);
+    bool AreTooManyBlocksInFlight(CNode *pfrom, const std::string thinType);
+    bool IsBlockInFlight(CNode *pfrom, const std::string thinType, const uint256 &hash);
     unsigned int TotalBlocksInFlight();
     void BlockWasReceived(CNode *pfrom, const uint256 &hash);
     bool AddBlockInFlight(CNode *pfrom, const uint256 &hash, const std::string thinType);

--- a/src/blockrelay/compactblock.cpp
+++ b/src/blockrelay/compactblock.cpp
@@ -164,7 +164,7 @@ bool CompactBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
         compactBlock->GetSize());
 
     // Ban a node for sending unrequested compact blocks
-    if (!thinrelay.IsBlockInFlight(pfrom, NetMsgType::CMPCTBLOCK))
+    if (!thinrelay.IsBlockInFlight(pfrom, NetMsgType::CMPCTBLOCK, inv.hash))
     {
         dosMan.Misbehaving(pfrom, 100);
         return error("unrequested compact block from peer %s", pfrom->GetLogName());
@@ -460,7 +460,7 @@ bool CompactReReqResponse::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     LOG(CMPCT, "received compactReReqResponse for %s peer=%s\n", inv.hash.ToString(), pfrom->GetLogName());
     {
         // Do not process unrequested xblocktx unless from an expedited node.
-        if (!thinrelay.IsBlockInFlight(pfrom, NetMsgType::CMPCTBLOCK) && !connmgr->IsExpeditedUpstream(pfrom))
+        if (!thinrelay.IsBlockInFlight(pfrom, NetMsgType::CMPCTBLOCK, inv.hash) && !connmgr->IsExpeditedUpstream(pfrom))
         {
             dosMan.Misbehaving(pfrom, 10);
             return error("Received compactReReqResponse %s from peer %s but was unrequested", inv.hash.ToString(),

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -105,7 +105,8 @@ bool CGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     LOG(GRAPHENE, "Received grblocktx for %s peer=%s\n", inv.hash.ToString(), pfrom->GetLogName());
     {
         // Do not process unrequested grblocktx unless from an expedited node.
-        if (!thinrelay.IsBlockInFlight(pfrom, NetMsgType::GRAPHENEBLOCK) && !connmgr->IsExpeditedUpstream(pfrom))
+        if (!thinrelay.IsBlockInFlight(pfrom, NetMsgType::GRAPHENEBLOCK, inv.hash) &&
+            !connmgr->IsExpeditedUpstream(pfrom))
         {
             dosMan.Misbehaving(pfrom, 10);
             return error(
@@ -411,7 +412,7 @@ bool CGrapheneBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string
                 pfrom->GetLogName(), grapheneBlock->GetSize());
 
             // Do not process unrequested grapheneblocks.
-            if (!thinrelay.IsBlockInFlight(pfrom, NetMsgType::GRAPHENEBLOCK))
+            if (!thinrelay.IsBlockInFlight(pfrom, NetMsgType::GRAPHENEBLOCK, inv.hash))
             {
                 dosMan.Misbehaving(pfrom, 10);
                 return error(

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -101,7 +101,7 @@ bool CThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
 
     // Ban a node for sending unrequested thinblocks unless from an expedited node.
     {
-        if (!thinrelay.IsBlockInFlight(pfrom, NetMsgType::XTHINBLOCK) && !connmgr->IsExpeditedUpstream(pfrom))
+        if (!thinrelay.IsBlockInFlight(pfrom, NetMsgType::XTHINBLOCK, inv.hash) && !connmgr->IsExpeditedUpstream(pfrom))
         {
             dosMan.Misbehaving(pfrom, 100);
             return error("unrequested thinblock from peer %s", pfrom->GetLogName());
@@ -289,7 +289,7 @@ bool CXThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     LOG(THIN, "received xblocktx for %s peer=%s\n", inv.hash.ToString(), pfrom->GetLogName());
     {
         // Do not process unrequested xblocktx unless from an expedited node.
-        if (!thinrelay.IsBlockInFlight(pfrom, NetMsgType::XTHINBLOCK) && !connmgr->IsExpeditedUpstream(pfrom))
+        if (!thinrelay.IsBlockInFlight(pfrom, NetMsgType::XTHINBLOCK, inv.hash) && !connmgr->IsExpeditedUpstream(pfrom))
         {
             dosMan.Misbehaving(pfrom, 10);
             return error(
@@ -568,7 +568,8 @@ bool CXThinBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string st
                 pfrom->GetLogName(), thinBlock->GetSize());
 
             // Do not process unrequested xthinblocks unless from an expedited node.
-            if (!thinrelay.IsBlockInFlight(pfrom, NetMsgType::XTHINBLOCK) && !connmgr->IsExpeditedUpstream(pfrom))
+            if (!thinrelay.IsBlockInFlight(pfrom, NetMsgType::XTHINBLOCK, inv.hash) &&
+                !connmgr->IsExpeditedUpstream(pfrom))
             {
                 dosMan.Misbehaving(pfrom, 10);
                 return error(

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1388,17 +1388,17 @@ bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
         if (IsChainNearlySyncd())
         {
             // Update Thinblock stats
-            if (thinrelay.IsBlockInFlight(pnode, NetMsgType::XTHINBLOCK))
+            if (thinrelay.IsBlockInFlight(pnode, NetMsgType::XTHINBLOCK, hash))
             {
                 thindata.UpdateResponseTime(nResponseTime);
             }
             // Update Graphene stats
-            if (thinrelay.IsBlockInFlight(pnode, NetMsgType::GRAPHENEBLOCK))
+            if (thinrelay.IsBlockInFlight(pnode, NetMsgType::GRAPHENEBLOCK, hash))
             {
                 graphenedata.UpdateResponseTime(nResponseTime);
             }
             // Update CompactBlock stats
-            if (thinrelay.IsBlockInFlight(pnode, NetMsgType::CMPCTBLOCK))
+            if (thinrelay.IsBlockInFlight(pnode, NetMsgType::CMPCTBLOCK, hash))
             {
                 compactdata.UpdateResponseTime(nResponseTime);
             }

--- a/src/test/requestmanager_tests.cpp
+++ b/src/test/requestmanager_tests.cpp
@@ -27,10 +27,23 @@
 
 #include "test/test_bitcoin.h"
 
+#include <algorithm>
 #include <atomic>
 #include <boost/test/unit_test.hpp>
 #include <sstream>
-#include <string.h>
+#include <string>
+
+// Cleanup all maps
+static void CleanupAll(std::vector<CNode *> &vPeers)
+{
+    for (auto pnode : vPeers)
+    {
+        thinrelay.ClearAllBlocksToReconstruct(pnode->GetId());
+        thinrelay.ClearAllBlocksInFlight(pnode->GetId());
+        thinrelay.RemovePeers(pnode);
+    }
+    requester.MapBlocksInFlightClear();
+}
 
 // Return the netmessage string for a block/xthin/graphene request
 static std::string NetMessage(std::deque<CSerializeData> &_vSendMsg)
@@ -39,27 +52,37 @@ static std::string NetMessage(std::deque<CSerializeData> &_vSendMsg)
         return "none";
 
     CInv inv_result;
-    CSerializeData &data = _vSendMsg.front();
+    CSerializeData data = _vSendMsg.front();
     CDataStream ssCommand(SER_NETWORK, PROTOCOL_VERSION);
     ssCommand.insert(ssCommand.begin(), &data[4], &data[16]);
     _vSendMsg.pop_front();
 
+    std::string ss = ssCommand.str();
+    ss.erase(std::remove(ss.begin(), ss.end(), '\000'), ss.end());
+
     // if it's a getdata then we need to find out what type
-    if (ssCommand.str().compare("getdata"))
+    if (ss == "getdata")
     {
+        // We have to add a character/s to the end of the CSerializeData object or we will go out
+        // of bounds when we insert the data into the ssInv datastream since there are only 61
+        // characters in the string and we want to copy up to and including the very last character.
+        std::string aa("end");
+        data.insert(data.end(), aa.begin(), aa.end());
+
         CDataStream ssInv(SER_NETWORK, PROTOCOL_VERSION);
-        ssInv.insert(ssInv.begin(), &data[24], &data[60]);
+        ssInv.insert(ssInv.begin(), &data[25], &data[61]);
 
         CInv inv;
         ssInv >> inv;
 
         if (inv.type == MSG_BLOCK)
             return "getdata";
-        if (inv.type == MSG_CMPCT_BLOCK)
+        else if (inv.type == MSG_CMPCT_BLOCK)
             return "cmpctblock";
+        else
+            return "nothing";
     }
-
-    return ssCommand.str();
+    return ss;
 }
 
 static void ClearThinBlocksInFlight(CNode &node, CInv &inv) { thinrelay.ClearBlockInFlight(&node, inv.hash); }
@@ -85,20 +108,29 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     dummyNodeXthin.state_incoming = ConnectionStateIncoming::READY;
     dummyNodeXthin.state_outgoing = ConnectionStateOutgoing::READY;
     dummyNodeXthin.nServices |= NODE_XTHIN;
+    dummyNodeXthin.nServices &= ~NODE_GRAPHENE;
+    dummyNodeXthin.fSupportsCompactBlocks = false;
     dummyNodeXthin.id = 1;
     dummyNodeGraphene.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNodeGraphene.state_incoming = ConnectionStateIncoming::READY;
     dummyNodeGraphene.state_outgoing = ConnectionStateOutgoing::READY;
     dummyNodeGraphene.nServices |= NODE_GRAPHENE;
+    dummyNodeGraphene.nServices &= ~NODE_XTHIN;
+    dummyNodeGraphene.fSupportsCompactBlocks = false;
     dummyNodeGraphene.id = 2;
     dummyNodeCmpct.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNodeCmpct.state_incoming = ConnectionStateIncoming::READY;
     dummyNodeCmpct.state_outgoing = ConnectionStateOutgoing::READY;
+    dummyNodeCmpct.nServices &= ~NODE_GRAPHENE;
+    dummyNodeCmpct.nServices &= ~NODE_XTHIN;
     dummyNodeCmpct.fSupportsCompactBlocks = true;
     dummyNodeCmpct.id = 3;
     dummyNodeNone.nVersion = MIN_PEER_PROTO_VERSION;
     dummyNodeNone.state_incoming = ConnectionStateIncoming::READY;
     dummyNodeNone.state_outgoing = ConnectionStateOutgoing::READY;
+    dummyNodeNone.nServices &= ~NODE_GRAPHENE;
+    dummyNodeNone.nServices &= ~NODE_XTHIN;
+    dummyNodeNone.fSupportsCompactBlocks = false;
     dummyNodeNone.id = 4;
 
     // Add to vNodes
@@ -118,6 +150,7 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     uint256 hash = GetRandHash();
     uint256 randhash = GetRandHash();
     CInv inv(MSG_BLOCK, hash);
+    CInv inv_cmpct(MSG_CMPCT_BLOCK, hash);
 
     uint64_t nTime = GetTime();
     dosMan.ClearBanned();
@@ -133,31 +166,25 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddCompactBlockPeer(&dummyNodeCmpct);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeXthin, inv);
-    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("get_xthin") != 0);
-    requester.MapBlocksInFlightClear();
-
-    requester.RequestBlock(&dummyNodeGraphene, inv);
-    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("get_graphene") != 0);
-    requester.MapBlocksInFlightClear();
-
-    requester.RequestBlock(&dummyNodeCmpct, inv);
-    BOOST_CHECK(NetMessage(dummyNodeCmpct.vSendMsg).compare("cmpctblock") != 0);
-    requester.MapBlocksInFlightClear();
-
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
-
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeXthin, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg) == "get_xthin");
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    ClearThinBlocksInFlight(dummyNodeCmpct, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeCmpct);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
+
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeGraphene, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg) == "get_grblk");
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    CleanupAll(vNodes);
+
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeCmpct, inv_cmpct) == true);
+    BOOST_CHECK(NetMessage(dummyNodeCmpct.vSendMsg) == "cmpctblock");
+    thinrelay.ClearBlockRelayTimer(inv_cmpct.hash);
+    CleanupAll(vNodes);
+
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    CleanupAll(vNodes);
 
     // Test the General Case: Chain synced, graphene ON, Thinblocks ON, Cmpct ON
     // This should return a Graphene block.
@@ -170,31 +197,25 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddCompactBlockPeer(&dummyNodeCmpct);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeXthin, inv);
-    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("get_xthin") != 0);
-    requester.MapBlocksInFlightClear();
-
-    requester.RequestBlock(&dummyNodeGraphene, inv);
-    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("get_graphene") != 0);
-    requester.MapBlocksInFlightClear();
-
-    requester.RequestBlock(&dummyNodeCmpct, inv);
-    BOOST_CHECK(NetMessage(dummyNodeCmpct.vSendMsg).compare("cmpctblock") != 0);
-    requester.MapBlocksInFlightClear();
-
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
-
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeXthin, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg) == "get_xthin");
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    ClearThinBlocksInFlight(dummyNodeCmpct, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeCmpct);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
+
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeGraphene, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg) == "get_grblk");
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    CleanupAll(vNodes);
+
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeCmpct, inv_cmpct) == true);
+    BOOST_CHECK(NetMessage(dummyNodeCmpct.vSendMsg) == "cmpctblock");
+    thinrelay.ClearBlockRelayTimer(inv_cmpct.hash);
+    CleanupAll(vNodes);
+
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    CleanupAll(vNodes);
 
     // Thin timer disabled: Chain synced, graphene ON, Thinblocks OFF, Cmpct ON
     // Although the timer would have been on because one relay type was off, here we explicity turn off
@@ -211,31 +232,27 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
 
     // This test would generally cause a request for a "get_xthin", however xthins is not on and
     // the timer is off which results in a full block request.
-    requester.RequestBlock(&dummyNodeXthin, inv);
-    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("getdata") != 0);
-    requester.MapBlocksInFlightClear();
-
-    requester.RequestBlock(&dummyNodeGraphene, inv);
-    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("get_graphene") != 0);
-    requester.MapBlocksInFlightClear();
-
-    requester.RequestBlock(&dummyNodeCmpct, inv);
-    BOOST_CHECK(NetMessage(dummyNodeCmpct.vSendMsg).compare("cmpctblock") != 0);
-    requester.MapBlocksInFlightClear();
-
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
-
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeXthin, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg) == "getdata");
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    ClearThinBlocksInFlight(dummyNodeCmpct, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeCmpct);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
+
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeGraphene, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg) == "get_grblk");
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    CleanupAll(vNodes);
+
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeCmpct, inv_cmpct) == true);
+    BOOST_CHECK(NetMessage(dummyNodeCmpct.vSendMsg) == "cmpctblock");
+    thinrelay.ClearBlockRelayTimer(inv_cmpct.hash);
+    CleanupAll(vNodes);
+
+    inv.type = MSG_BLOCK;
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
+    thinrelay.ClearBlockRelayTimer(inv.hash);
+    CleanupAll(vNodes);
+    SetArg("-preferential-timer", "10000"); // reset from 0
 
     // Chain NOT synced with any nodes, graphene ON, Thinblocks ON, Cmpct ON
     IsChainNearlySyncdSet(false);
@@ -247,25 +264,17 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddCompactBlockPeer(&dummyNodeCmpct);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeXthin, inv);
-    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeXthin, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg) == "getdata");
 
-    requester.RequestBlock(&dummyNodeGraphene, inv);
-    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeGraphene, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg) == "getdata");
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    ClearThinBlocksInFlight(dummyNodeCmpct, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeCmpct);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd: No graphene nodes, No Thinblock nodes, No Cmpct nodes, Thinblocks OFF, Graphene OFF, CMPCT OFF
     IsChainNearlySyncdSet(true);
@@ -274,8 +283,8 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     SetBoolArg("-use-compactblocks", false);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
     ClearThinBlocksInFlight(dummyNodeNone, inv);
@@ -291,15 +300,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddPeers(&dummyNodeGraphene);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd,  NO graphene nodes, NO Thinblock nodes, No Cmpt nodes, Graphene OFF, Thinblocks ON, Cmpctblocks
     // OFF
@@ -309,13 +314,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     SetBoolArg("-use-compactblocks", false);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd,  NO graphene nodes, NO Thinblock nodes, No Cmpt nodes, Graphene OFF, Thinblocks OFF,
     // Cmpctblocks ON
@@ -325,13 +328,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     SetBoolArg("-use-compactblocks", true);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd, HAVE graphene nodes, NO Thinblock nodes, No Cmpct nodes, Graphene OFF, Thinblocks ON,
     // Cmpctblocks OFF
@@ -342,15 +343,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddPeers(&dummyNodeGraphene);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd, HAVE graphene nodes, NO Thinblock nodes, No Cmpct nodes, Graphene OFF, Thinblocks ON,
     // Cmpctblocks ON
@@ -361,15 +358,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddPeers(&dummyNodeGraphene);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd, HAVE graphene nodes, NO Thinblock nodes, No Cmpct nodes, Graphene OFF, Thinblocks OFF,
     // Cmpctblocks ON
@@ -380,15 +373,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddPeers(&dummyNodeGraphene);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd,  NO graphene nodes, HAVE Thinblock nodes, No Cmpct Nodes, Thinblocks OFF, Graphene ON, Cmpct
     // blocks OFF
@@ -399,15 +388,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddPeers(&dummyNodeXthin);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd,  NO graphene nodes, HAVE Thinblock nodes, No Cmpct Nodes, Thinblocks OFF, Graphene ON, Cmpct
     // blocks ON
@@ -418,15 +403,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddPeers(&dummyNodeXthin);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd, NO graphene nodes, HAVE Thinblock nodes, No Cmpct Nodes, Thinblocks OFF, Graphene OFF, Cmpct
     // blocks ON
@@ -437,15 +418,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddPeers(&dummyNodeXthin);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd, NO graphene nodes, HAVE Thinblock nodes, No Cmpct Nodes, Thinblocks OFF, Graphene OFF, Cmpct
     // blocks OFF
@@ -456,15 +433,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddPeers(&dummyNodeXthin);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
 
     // Chains IS sync'd,  NO graphene nodes, NO Thinblock nodes, No Cmpctblock nodes, Thinblocks OFF, Graphene ON, Cmpt
@@ -475,13 +448,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     SetBoolArg("-use-compactblocks", false);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd,  NO graphene nodes, NO Thinblock nodes, No Cmpctblock nodes, Thinblocks OFF, Graphene ON, Cmpt
     // blocks ON
@@ -491,13 +462,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     SetBoolArg("-use-compactblocks", true);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd,  NO graphene nodes, NO Thinblock nodes, No Cmpctblock nodes, Thinblocks ON, Graphene ON, Cmpt
     // blocks ON
@@ -507,13 +476,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     SetBoolArg("-use-compactblocks", true);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd,  NO graphene nodes, NO Thinblock nodes, No Cmpctblock nodes, Thinblocks ON, Graphene ON, Cmpt
     // blocks OFF
@@ -523,13 +490,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     SetBoolArg("-use-compactblocks", false);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd, HAVE graphene nodes, NO Thinblock nodes, No Cmpct nodes, Thinblocks ON, Graphene ON, Cmpct
     // blocks ON
@@ -540,15 +505,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddPeers(&dummyNodeGraphene);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeGraphene, inv);
-    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("get_graphene") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeGraphene, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg) == "get_grblk");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd, HAVE graphene nodes, NO Thinblock nodes, No Cmpct nodes, Thinblocks OFF, Graphene ON, Cmpct
     // blocks ON
@@ -559,15 +520,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddPeers(&dummyNodeGraphene);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeGraphene, inv);
-    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("get_graphene") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeGraphene, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg) == "get_grblk");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd, HAVE graphene nodes, NO Thinblock nodes, No Cmpct nodes, Thinblocks OFF, Graphene ON, Cmpct
     // blocks OFF
@@ -578,15 +535,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddPeers(&dummyNodeGraphene);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeGraphene, inv);
-    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("get_graphene") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeGraphene, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg) == "get_grblk");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd,  HAVE graphene nodes, HAVE Thinblock nodes, Thinblocks ON, Graphene ON
     IsChainNearlySyncdSet(true);
@@ -596,16 +549,10 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddPeers(&dummyNodeXthin);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeGraphene, inv);
-    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("get_graphene") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeGraphene, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg) == "get_grblk");
 
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd,  NO graphene nodes, HAVE Thinblock nodes, No Cmpct Nodes, Thinblocks ON, Graphene OFF, Cmpct
     // OFF
@@ -616,15 +563,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddPeers(&dummyNodeXthin);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeXthin, inv);
-    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("get_xthin") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeXthin, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg) == "get_xthin");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd,  NO graphene nodes, HAVE Thinblock nodes, No Cmpct Nodes, Thinblocks ON, Graphene ON, Cmpct ON
     IsChainNearlySyncdSet(true);
@@ -634,15 +577,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddPeers(&dummyNodeXthin);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeXthin, inv);
-    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("get_xthin") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeXthin, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg) == "get_xthin");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd,  NO graphene nodes, No Thinblock nodes, Have Cmpct Nodes, Thinblocks OFF, Graphene OFF, Cmpct
     // ON
@@ -653,15 +592,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddCompactBlockPeer(&dummyNodeCmpct);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeCmpct, inv);
-    BOOST_CHECK(NetMessage(dummyNodeCmpct.vSendMsg).compare("cmpctblock") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeCmpct, inv_cmpct) == true);
+    BOOST_CHECK(NetMessage(dummyNodeCmpct.vSendMsg) == "cmpctblock");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeCmpct, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeCmpct);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     // Chains IS sync'd,  NO graphene nodes, No Thinblock nodes, Have Cmpct Nodes, Thinblocks ON, Graphene ON, Cmpct ON
     IsChainNearlySyncdSet(true);
@@ -671,15 +606,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddCompactBlockPeer(&dummyNodeCmpct);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeCmpct, inv);
-    BOOST_CHECK(NetMessage(dummyNodeCmpct.vSendMsg).compare("cmpctblock") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeCmpct, inv_cmpct) == true);
+    BOOST_CHECK(NetMessage(dummyNodeCmpct.vSendMsg) == "cmpctblock");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeCmpct, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeCmpct);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
 
     /******************************
@@ -698,18 +629,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.AddCompactBlockPeer(&dummyNodeCmpct);
     thinrelay.AddPeers(&dummyNodeNone);
 
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeNone);
-    thinrelay.RemovePeers(&dummyNodeCmpct);
+    CleanupAll(vNodes);
 
 
     /******************************
@@ -737,19 +661,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     // Now move the clock ahead so that the timer is exceeded and we should now
     // download a full block
     SetMockTime(nTime + 20);
-    requester.RequestBlock(&dummyNodeNone, inv);
-    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeNone, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeNone.vSendMsg) == "getdata");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    ClearThinBlocksInFlight(dummyNodeCmpct, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeCmpct);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
 
     /******************************
@@ -778,18 +694,10 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     SetMockTime(nTime + 20);
     randhash = GetRandHash();
     thinrelay.AddBlockInFlight(&dummyNodeGraphene, randhash, NetMsgType::GRAPHENEBLOCK);
-    requester.RequestBlock(&dummyNodeGraphene, inv);
-    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg).compare("getdata") != 0);
-    thinrelay.ClearBlockInFlight(&dummyNodeGraphene, randhash);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeGraphene, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeGraphene.vSendMsg) == "getdata");
 
-    thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     /******************************
      * Check another graphene block is downloaded when Graphene timer is exceeded and then we get an announcement
@@ -848,14 +756,7 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     BOOST_CHECK(dummyNodeGraphene.vSendMsg.size() == 5);
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeNone);
-
+    CleanupAll(vNodes);
 
     /******************************
      * Check a Xthin is is downloaded when thinblock timer is exceeded but then we get an announcement
@@ -880,17 +781,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     // Now move the clock ahead so that the timer is exceeded and we should now
     // download a full block
     SetMockTime(nTime + 20);
-    requester.RequestBlock(&dummyNodeXthin, inv);
-    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("get_xthin") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeXthin, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg) == "get_xthin");
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     /******************************
      * Check a Xthin is is downloaded when thinblock timer is exceeded but then we get an announcement
@@ -918,18 +813,12 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     SetMockTime(nTime + 20);
     randhash = GetRandHash();
     thinrelay.AddBlockInFlight(&dummyNodeXthin, randhash, NetMsgType::XTHINBLOCK);
-    requester.RequestBlock(&dummyNodeXthin, inv);
-    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeXthin, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeXthin.vSendMsg) == "getdata");
 
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    requester.MapBlocksInFlightClear();
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
     /******************************
      * Check a full block is is downloaded when thinblock timer is exceeded but then we get an announcement
@@ -960,19 +849,12 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     SetMockTime(nTime + 20);
     randhash = GetRandHash();
     thinrelay.AddBlockInFlight(&dummyNodeCmpct, randhash, NetMsgType::CMPCTBLOCK);
-    requester.RequestBlock(&dummyNodeCmpct, inv);
-    BOOST_CHECK(NetMessage(dummyNodeCmpct.vSendMsg).compare("getdata") != 0);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeCmpct, inv) == true);
+    BOOST_CHECK(NetMessage(dummyNodeCmpct.vSendMsg) == "getdata");
 
 
     thinrelay.ClearBlockRelayTimer(inv.hash);
-    ClearThinBlocksInFlight(dummyNodeGraphene, inv);
-    ClearThinBlocksInFlight(dummyNodeNone, inv);
-    ClearThinBlocksInFlight(dummyNodeCmpct, inv);
-    ClearThinBlocksInFlight(dummyNodeXthin, inv);
-    thinrelay.RemovePeers(&dummyNodeGraphene);
-    thinrelay.RemovePeers(&dummyNodeCmpct);
-    thinrelay.RemovePeers(&dummyNodeXthin);
-    thinrelay.RemovePeers(&dummyNodeNone);
+    CleanupAll(vNodes);
 
 
     // Final cleanup: Unset mocktime

--- a/src/test/requestmanager_tests.cpp
+++ b/src/test/requestmanager_tests.cpp
@@ -793,10 +793,11 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     thinrelay.RemovePeers(&dummyNodeNone);
 
     /******************************
-     * Check an Xthin is downloaded when Graphene timer is exceeded but then we get an announcement
+     * Check another graphene block is downloaded when Graphene timer is exceeded and then we get an announcement
      * from a graphene peer (thinblocks is ON), and then request from that graphene peer before we
      * request from any others.
-     * However this time we already have a grapheneblock in flight for this peer so we end up downloading a thinblock.
+     * However this time we already have a grapheneblock in flight but we end up downloading another graphene block
+     * because we haven't exceeded the limit on number of thintype blocks in flight.
      */
 
     // Chains IS sync'd,  HAVE graphene nodes, HAVE Thinblock nodes, Thinblocks ON, Graphene ON, Cmpct OFF
@@ -815,7 +816,7 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     // The first request should fail but the timers should be triggered for both xthin and graphene
     randhash = GetRandHash();
     thinrelay.AddBlockInFlight(&dummyNodeGraphene, randhash, NetMsgType::GRAPHENEBLOCK);
-    BOOST_CHECK(requester.RequestBlock(&dummyNodeGraphene, inv) == false);
+    BOOST_CHECK(requester.RequestBlock(&dummyNodeGraphene, inv) == true);
 
     // Now move the clock ahead so that the timers are exceeded and we should now
     // download an xthin


### PR DESCRIPTION
This allows us to download more that one thintype block simultaneously which gives us faster propagation during block races and also better propagation for blocks mined in close succession whether they arrive in order or not.