### PR TITLE
Temporarily disable live dld and tests

### DIFF
--- a/src/deadlock-detection/threaddeadlock.cpp
+++ b/src/deadlock-detection/threaddeadlock.cpp
@@ -547,12 +547,14 @@ void push_lock(void *c, const CLockLocation &locklocation, LockType locktype, Ow
         return;
     }
     AddNewWaitingLock(c, tid, ownership);
+    /*
     std::vector<LockStackEntry> deadlocks;
     std::set<uint64_t> threads;
     if (RecursiveCheck(tid, c, tid, c, true, deadlocks, threads))
     {
         deadlock_detected(now, deadlocks, threads);
     }
+    */
 }
 
 // removes all instances of the critical section

--- a/src/test/deadlock_tests/test5.cpp
+++ b/src/test/deadlock_tests/test5.cpp
@@ -43,6 +43,7 @@ void TestThread(CSharedCriticalSection *mutexA, CSharedCriticalSection *mutexB)
 
 BOOST_AUTO_TEST_CASE(TEST_5)
 {
+    /*
     CSharedCriticalSection mutexA;
     CSharedCriticalSection mutexB;
 
@@ -54,6 +55,7 @@ BOOST_AUTO_TEST_CASE(TEST_5)
     thread2.join();
     BOOST_CHECK(lock_exceptions == 1);
     lockdata.ordertracker.clear();
+    */
 }
 
 #else

--- a/src/test/deadlock_tests/test6.cpp
+++ b/src/test/deadlock_tests/test6.cpp
@@ -62,6 +62,7 @@ void Thread2()
 
 BOOST_AUTO_TEST_CASE(TEST_6)
 {
+    /*
     std::thread thread1(Thread1);
     std::thread thread2(Thread2);
     while(!lock_exceptions) ;
@@ -70,6 +71,7 @@ BOOST_AUTO_TEST_CASE(TEST_6)
     thread2.join();
     BOOST_CHECK(lock_exceptions == 1);
     lockdata.ordertracker.clear();
+    */
 }
 
 #else

--- a/src/test/deadlock_tests/test7.cpp
+++ b/src/test/deadlock_tests/test7.cpp
@@ -84,6 +84,7 @@ void Thread3()
 
 BOOST_AUTO_TEST_CASE(TEST_7)
 {
+    /*
     std::thread thread1(Thread1);
     std::thread thread2(Thread2);
     std::thread thread3(Thread3);
@@ -94,6 +95,7 @@ BOOST_AUTO_TEST_CASE(TEST_7)
     thread3.join();
     BOOST_CHECK(lock_exceptions == 1);
     lockdata.ordertracker.clear();
+    */
 }
 
 #else

--- a/src/test/deadlock_tests/test8.cpp
+++ b/src/test/deadlock_tests/test8.cpp
@@ -83,6 +83,7 @@ void Thread3()
 
 BOOST_AUTO_TEST_CASE(TEST_8)
 {
+    /*
     std::thread thread1(Thread1);
     std::thread thread2(Thread2);
     std::thread thread3(Thread3);
@@ -93,6 +94,7 @@ BOOST_AUTO_TEST_CASE(TEST_8)
     thread3.join();
     BOOST_CHECK(lock_exceptions == 1);
     lockdata.ordertracker.clear();
+    */
 }
 
 #else


### PR DESCRIPTION
There is an unknown issue with the live part of the deadlock detector where it seems to not be releasing held locks properly causing a lot of false positives for deadlocks especially during initialization and shutdown. This PR temporarily disables the live dld functionality. The lock order issue detector code is still functional