### PR TITLE
[doc] Update dependencies.md

### DIFF
--- a/doc/dependencies.md
+++ b/doc/dependencies.md
@@ -21,7 +21,7 @@ These are the dependencies currently used by Bitcoin Unlimited. You can find ins
 | OpenSSL | [1.0.1k](https://www.openssl.org/source) |  | Yes |  |  |
 | PCRE |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk#L76) |
 | protobuf | [2.6.3](https://github.com/google/protobuf/releases) |  | No |  |  |
-| Python (tests) |  | [3.4](https://www.python.org/downloads) |  |  |  |
+| Python (tests) |  | [3.6](https://www.python.org/downloads) |  |  |  |
 | qrencode | [3.4.4](https://fukuchi.org/works/qrencode) |  | No |  |  |
 | Qt | [5.9.7](https://download.qt.io/official_releases/qt/) | 5.3+ | No |  |  |
 | XCB |  |  |  |  | [Yes](https://github.com/bitcoin/bitcoin/blob/master/depends/packages/qt.mk#L94) (Linux only) |


### PR DESCRIPTION
test_framework/cashlib/cashlib.py IntFlag which is imported
from the enum package, has been added in Python 3.6. Before
it wasn't available

[skip ci]