### PR TITLE
Set lexicographical transaction ordering on by default

### DIFF
--- a/qa/rpc-tests/rpc_getblockstats.py
+++ b/qa/rpc-tests/rpc_getblockstats.py
@@ -47,7 +47,7 @@ class GetblockstatsTest(BitcoinTestFramework):
     def set_test_params(self):
         self.num_nodes = 1
         self.setup_clean_chain = True
-        self.extra_args = [['-debug=rpc']]
+        self.extra_args = [['-debug=rpc', '-consensus.enableCanonicalTxOrder=0']]
 
     def get_stats(self):
         stats = [ ]

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -180,7 +180,7 @@ uint64_t excessiveBlockSize = DEFAULT_EXCESSIVE_BLOCK_SIZE;
 unsigned int excessiveAcceptDepth = DEFAULT_EXCESSIVE_ACCEPT_DEPTH;
 unsigned int maxMessageSizeMultiplier = DEFAULT_MAX_MESSAGE_SIZE_MULTIPLIER;
 int nMaxOutConnections = DEFAULT_MAX_OUTBOUND_CONNECTIONS;
-
+bool fCanonicalTxsOrder = true;
 uint32_t blockVersion = 0; // Overrides the mined block version if non-zero
 
 std::vector<std::string> BUComments = std::vector<std::string>();
@@ -341,10 +341,10 @@ CTweakRef<std::string> subverOverrideTweak("net.subversionOverride",
     &subverOverride,
     &SubverValidator);
 
-CTweak<bool> enableCanonicalTxOrder("consensus.enableCanonicalTxOrder",
+CTweakRef<bool> enableCanonicalTxOrder("consensus.enableCanonicalTxOrder",
     "True if canonical transaction ordering is enabled.  Reflects the actual state so may be switched on or off by"
     " fork time flags and blockchain reorganizations.",
-    false);
+    &fCanonicalTxsOrder);
 
 CTweak<unsigned int> numMsgHandlerThreads("net.msgHandlerThreads", "Max message handler threads", 0);
 CTweak<unsigned int> numTxAdmissionThreads("net.txAdmissionThreads", "Max transaction mempool admission threads", 0);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1262,10 +1262,10 @@ bool AppInit2(Config &config, thread_group &threadGroup)
         mempool.ReadFeeEstimates(est_filein);
     fFeeEstimatesInitialized = true;
 
-    // Set enableCanonicalTxOrder for the BCH early in the bootstrap phase
+    // Set fCanonicalTxsOrder for the BCH early in the bootstrap phase
     if (IsNov2018Activated(Params().GetConsensus(), chainActive.Tip()) && chainparams.NetworkIDString() != "regtest")
     {
-        enableCanonicalTxOrder = true;
+        fCanonicalTxsOrder = true;
     }
 
 

--- a/src/main.h
+++ b/src/main.h
@@ -122,7 +122,6 @@ struct BlockHasher
     size_t operator()(const uint256 &hash) const { return hash.GetCheapHash(); }
 };
 
-extern CTweak<bool> enableCanonicalTxOrder;
 extern CCriticalSection cs_main;
 extern CTxMemPool mempool;
 typedef boost::unordered_map<uint256, CBlockIndex *, BlockHasher> BlockMap;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -246,8 +246,8 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript &sc
         nLockTimeCutoff =
             (STANDARD_LOCKTIME_VERIFY_FLAGS & LOCKTIME_MEDIAN_TIME_PAST) ? nMedianTimePast : pblock->GetBlockTime();
 
-        bool canonical = enableCanonicalTxOrder.Value();
-        // On BCH always allow overwite of enableCanonicalTxOrder but not for regtest
+        bool canonical = fCanonicalTxsOrder;
+        // On BCH always allow overwite of fCanonicalTxsOrder but not for regtest
         if (IsNov2018Activated(Params().GetConsensus(), chainActive.Tip()))
         {
             if (chainparams.NetworkIDString() != "regtest")

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -96,6 +96,7 @@ void TestPackageSelection(const CChainParams &chainparams, CScript scriptPubKey,
     dMinLimiterTxFee.Set(1.0);
     dMaxLimiterTxFee.Set(1.0);
     excessiveBlockSize = maxGeneratedBlock;
+    fCanonicalTxsOrder = false;
 
     // Test that a medium fee transaction will be selected after a higher fee
     // rate package with a low fee rate parent.
@@ -219,6 +220,9 @@ void TestPackageSelection(const CChainParams &chainparams, CScript scriptPubKey,
     BOOST_CHECK(pblocktemplate->block.vtx[5]->GetHash() == hashHighFeeTx2);
     BOOST_CHECK(pblocktemplate->block.vtx[6]->GetHash() == hashFreeTx3);
     BOOST_CHECK(pblocktemplate->block.vtx[9]->GetHash() == hashLowFeeTx2);
+
+    // reset back to ctor
+    fCanonicalTxsOrder = true;
 }
 
 void GenerateBlocks(const CChainParams &chainparams,

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -76,6 +76,7 @@ extern uint64_t maxGeneratedBlock;
 extern uint64_t excessiveBlockSize;
 extern unsigned int excessiveAcceptDepth;
 extern unsigned int maxMessageSizeMultiplier;
+extern bool fCanonicalTxsOrder;
 
 /** This function searches the mempool for transactions that are recently acceptable into the mempools of other
 nodes and forwards any found to those nodes.

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -2579,8 +2579,8 @@ bool ConnectBlock(const CBlock &block,
     vPos.reserve(block.vtx.size());
 
     // Discover how to handle this block
-    bool canonical = enableCanonicalTxOrder.Value();
-    // Always allow overwite of enableCanonicalTxOrder but for regtest on BCH
+    bool canonical = fCanonicalTxsOrder;
+    // Always allow overwite of fCanonicalTxsOrder but for regtest on BCH
     if (IsNov2018Activated(chainparams.GetConsensus(), chainActive.Tip()))
     {
         if (!(chainparams.NetworkIDString() == "regtest"))
@@ -2911,12 +2911,12 @@ void UpdateTip(CBlockIndex *pindexNew)
     }
 
     // Set the global variables based on the fork state of the NEXT block
-    // Always allow overwite of enableCanonicalTxOrder but for regtest)
+    // Always allow overwite of fCanonicalTxsOrder but for regtest)
     if (IsNov2018Activated(chainParams.GetConsensus(), chainActive.Tip()))
     {
         if (chainParams.NetworkIDString() != "regtest")
         {
-            enableCanonicalTxOrder = true;
+            fCanonicalTxsOrder = true;
         }
     }
 }


### PR DESCRIPTION
This is mainly a PR that has to do with QA/unit tests. In fact even thou on main net this change does not have any effect since the activation code took care of setting ctor on during the init step, this was not the case for regtest. 

Once we turned on ctor also on regtest we have only one failure for the unit tests in `miner.cpp` (see e77e102 for more details), and one for the QA tests (see  f1edbfd). 

In the former case there's no easy other way to test the txns selection method by fee rate than setting ctor to false. 

For the latter (`rpc_getblockstats`) I think we can change the json data the test use to adapt it to the new default rather than turn ctor off, wonder what @gandrewstone have to say about that.