### PR TITLE
Add some range protections to tx rate graph widget

### DIFF
--- a/src/qt/transactiongraphwidget.h
+++ b/src/qt/transactiongraphwidget.h
@@ -45,11 +45,11 @@ public:
     QString getDisplayWindowLabelText() const { return displayWindowLabelText; }
 private:
     void paintPath(QPainterPath &avgPath, QPainterPath &peakPath);
-    long getSamplesInDisplayWindow() const;
+    size_t getSamplesInDisplayWindow() const;
     void updateTransactionsPerSecondLabelValues();
 
-    int nMinutes;
-    int nRedrawRateMillis;
+    size_t nMinutes;
+    size_t nRedrawRateMillis;
     float fDisplayMax;
 
     float fInstantaneousTpsPeak_Runtime;
@@ -68,7 +68,7 @@ private:
 
     QString displayWindowLabelText;
 
-    long nTotalSamplesRuntime;
+    size_t nTotalSamplesRuntime;
     QQueue<float> vInstantaneousSamples;
     QQueue<float> vSmoothedSamples;
 


### PR DESCRIPTION
Corrects some potential divide by 0 cases pointed out in the prior review of PR #1935 by @gandrewstone as well as adding some additional range protections.
1. Changes several variables from int/long to size_t to ensure no negatives and align with vector size()/count() return type.
2. Add asserts to protect against developer misuse of certain methods/variables which have required ranges.  Range violations aren't possible with the current implementation, these asserts are to protect against future changes introducing a violation of the expected ranges.
3. Explicitly protect against divide by zero in several locations