### PR TITLE
Ignore the state of the queues when disconnecting a node

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1122,8 +1122,7 @@ void CleanupDisconnectedNodes()
         vector<CNode *> vNodesCopy = vNodes;
         for (CNode *pnode : vNodesCopy)
         {
-            if (pnode->fDisconnect || (pnode->GetRefCount() <= 0 && pnode->vRecvMsg.empty() && pnode->nSendSize == 0 &&
-                                          pnode->ssSend.empty()))
+            if (pnode->fDisconnect || pnode->GetRefCount() <= 0)
             {
                 // remove from vNodes
                 vNodes.erase(remove(vNodes.begin(), vNodes.end(), pnode), vNodes.end());


### PR DESCRIPTION
It should matter whether the message queues are empty or not
when we want to disconnect a peer and it could prevent us from
disconnect from a peer that is slow to process our outgoing messages or
that we've stopped processing their receive messages for some reason.