### PR TITLE
Init and qa fixes

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -184,7 +184,7 @@ testScripts = [ RpcTest(t) for t in [
     'mempool_push',
     Disabled('schnorr-activation', 'Need to be updated to work with BU'),
     'schnorrsig',
-    'segwit-recovery',
+    'segwit_recovery',
     'bip135basic',
     'ctor',
     'mining_ctor',

--- a/qa/rpc-tests/segwit_recovery.py
+++ b/qa/rpc-tests/segwit_recovery.py
@@ -9,8 +9,6 @@ accepted with -acceptnonstdtxn=1, and that segwit recovery transactions don't re
 """
 
 import time
-from test_framework.util import *
-
 
 from test_framework.blocktools import (
     create_block,

--- a/qa/rpc-tests/segwit_recovery.py
+++ b/qa/rpc-tests/segwit_recovery.py
@@ -9,6 +9,8 @@ accepted with -acceptnonstdtxn=1, and that segwit recovery transactions don't re
 """
 
 import time
+from test_framework.util import *
+
 
 from test_framework.blocktools import (
     create_block,
@@ -287,3 +289,12 @@ class SegwitRecoveryTest(BitcoinTestFramework):
 
 if __name__ == '__main__':
     SegwitRecoveryTest().main()
+
+def Test():
+    t = SegwitRecoveryTest()
+    bitcoinConf = {
+        "debug": ["net", "blk", "thin", "mempool", "req", "bench", "evict"],
+        "blockprioritysize": 2000000  # we don't want any transactions rejected due to insufficient fees...
+    }
+    flags = standardFlags()
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/segwit_recovery.py
+++ b/qa/rpc-tests/segwit_recovery.py
@@ -289,6 +289,7 @@ if __name__ == '__main__':
     SegwitRecoveryTest().main()
 
 def Test():
+    from test_framework.util import standardFlags
     t = SegwitRecoveryTest()
     bitcoinConf = {
         "debug": ["net", "blk", "thin", "mempool", "req", "bench", "evict"],

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -206,7 +206,7 @@ class BitcoinTestFramework(object):
         logging.info("Random seed: %s" % self.randomseed)
 
         if self.options.tmpdir is None:
-            self.options.tmpdir = self.options.tmppfx
+            self.options.tmpdir = os.path.join(self.options.tmppfx, str(self.options.port_seed))
 
         if self.options.trace_rpc:
             logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -206,7 +206,11 @@ class BitcoinTestFramework(object):
         logging.info("Random seed: %s" % self.randomseed)
 
         if self.options.tmppfx is not None:
-            self.options.tmpdir = tempfile.mkdtemp(dir=self.options.tmppfx, prefix="test_"+testname+"_")
+            i = self.options.port_seed
+            # find a short path that's easy to remember compared to mkdtemp
+            while os.path.exists(self.options.tmppfx + os.sep + testname[0:-2] + str(i)):
+                i+=1
+            self.options.tmpdir = self.options.tmppfx + os.sep + testname[0:-2] + str(i)
 
         if self.options.trace_rpc:
             logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -175,10 +175,10 @@ class BitcoinTestFramework(object):
 
         default_tempdir = tempfile.mkdtemp(prefix="test_"+testname+"_")
 
-        parser.add_option("--tmppfx", dest="tmppfx", default=default_tempdir,
-                          help="Directory prefix for data directories")
-        parser.add_option("--tmpdir", dest="tmpdir", default=None,
-                          help="Root directory for data directories. If specified, overrides tmppfx.")
+        parser.add_option("--tmppfx", dest="tmppfx", default=None,
+                          help="Directory custom prefix for data directories, if specified, overrides tmpdir")
+        parser.add_option("--tmpdir", dest="tmpdir", default=default_tempdir,
+                          help="Root directory for data directories.")
         parser.add_option("--tracerpc", dest="trace_rpc", default=False, action="store_true",
                           help="Print out all RPC calls as they are made")
         parser.add_option("--portseed", dest="port_seed", default=os.getpid(), type='int',
@@ -205,8 +205,8 @@ class BitcoinTestFramework(object):
         random.seed(self.randomseed)
         logging.info("Random seed: %s" % self.randomseed)
 
-        if self.options.tmpdir is None:
-            self.options.tmpdir = os.path.join(self.options.tmppfx, str(self.options.port_seed))
+        if self.options.tmppfx is not None:
+            self.options.tmpdir = tempfile.mkdtemp(dir=self.options.tmppfx, prefix="test_"+testname+"_")
 
         if self.options.trace_rpc:
             logging.basicConfig(level=logging.DEBUG, stream=sys.stdout)

--- a/qa/rpc-tests/wallet-hd.py
+++ b/qa/rpc-tests/wallet-hd.py
@@ -90,6 +90,9 @@ class WalletHDTest(BitcoinTestFramework):
         self.nodes[1] = start_node(1, self.options.tmpdir, self.node_args[1] + ['-rescan'])
         assert_equal(self.nodes[1].getbalance(), num_hd_adds + 1)
 
+        # cleanup backup file
+        os.remove(tmpdir + "hd.bak")
+
 
 if __name__ == '__main__':
     WalletHDTest().main ()

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1106,6 +1106,13 @@ bool AppInit2(Config &config, thread_group &threadGroup)
 
     bool fLoaded = false;
     StartTxAdmission(threadGroup);
+
+    if (fTxIndex)
+    {
+        auto txindex_db = new TxIndexDB(cacheConfig.nTxIndexCache, false, fReindex);
+        g_txindex = std::make_unique<TxIndex>(txindex_db);
+    }
+
     while (!fLoaded)
     {
         bool fReset = fReindex;
@@ -1304,10 +1311,8 @@ bool AppInit2(Config &config, thread_group &threadGroup)
 #endif // !ENABLE_WALLET
 
     // ********************************************************* Step 8: data directory maintenance
-    if (GetBoolArg("-txindex", DEFAULT_TXINDEX))
+    if (g_txindex)
     {
-        auto txindex_db = new TxIndexDB(cacheConfig.nTxIndexCache, false, fReindex);
-        g_txindex = std::make_unique<TxIndex>(txindex_db);
         g_txindex->Start();
     }
 


### PR DESCRIPTION
fix initialization ordering problem when txindex=1 and checklevel>=4
restore qa --tmppfx behavior  
Add quick-run capability to setwit_recovery test"