### PR TITLE
[Travis failures] Force the log to flush before checking the log for entries

### DIFF
--- a/qa/rpc-tests/test_framework/test_node.py
+++ b/qa/rpc-tests/test_framework/test_node.py
@@ -18,6 +18,7 @@ class TestNode():
 
     @contextlib.contextmanager
     def assert_debug_log(self, *, expected_msgs, unexpected_msgs):
+        self.logline('flush log')
         debug_log = os.path.join(self.datadir, 'regtest', 'debug.log')
         with open(debug_log, encoding='utf-8') as dl:
             dl.seek(0, 2)
@@ -25,6 +26,7 @@ class TestNode():
         try:
             yield
         finally:
+            self.logline('flush log')
             with open(debug_log, encoding='utf-8') as dl:
                 dl.seek(prev_size)
                 log = dl.read()

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -141,6 +141,7 @@ UniValue logline(const UniValue &params, bool fHelp)
                             "Writes a string into the log (prefixed with 'rpc-logline: ').\n"
                             "\nResult: None\n");
     LOGA("rpc-logline: %s\n", params[0].get_str());
+    LogFlush();
     return NullUniValue;
 }
 


### PR DESCRIPTION
This should prevent some of the test failures we're seeing
on travis when we're looking for a log entry but the current
logs haven't been fully flushed to disk yet.