### PR TITLE
[electrum] Allow overriding verboseness argument

### DIFF
--- a/src/electrum/electrs.cpp
+++ b/src/electrum/electrs.cpp
@@ -33,6 +33,25 @@ static std::string rpc_port(const std::string &network)
 }
 static void remove_conflicting_arg(std::vector<std::string> &args, const std::string &override_arg)
 {
+    // special case: verboseness argument
+    const std::regex verbose("^-v+$");
+    if (std::regex_search(override_arg, verbose))
+    {
+        auto it = begin(args);
+        while (it != end(args))
+        {
+            if (!std::regex_search(*it, verbose))
+            {
+                ++it;
+                continue;
+            }
+            LOGA("Electrum: Argument '%s' overrides '%s'", override_arg, *it);
+            it = args.erase(it);
+        }
+        return;
+    }
+
+    // normal case
     auto separator = override_arg.find_first_of("=");
     if (separator == std::string::npos)
     {

--- a/src/test/electrs_tests.cpp
+++ b/src/test/electrs_tests.cpp
@@ -58,4 +58,21 @@ BOOST_AUTO_TEST_CASE(rawargs)
     mapMultiArgs.clear();
 }
 
+BOOST_AUTO_TEST_CASE(rawargs_verboseness)
+{
+    Logging::LogToggleCategory(ELECTRUM, true);
+    BOOST_CHECK(electrs_args_has("-vvvv"));
+    BOOST_CHECK(!electrs_args_has("-v"));
+
+    mapMultiArgs["-electrum.rawarg"].push_back("-v");
+    BOOST_CHECK(!electrs_args_has("-vvvv"));
+    BOOST_CHECK(electrs_args_has("-v"));
+
+    mapMultiArgs["-electrum.rawarg"].push_back("-vv");
+    BOOST_CHECK(!electrs_args_has("-vvvv"));
+    BOOST_CHECK(electrs_args_has("-vv"));
+    mapMultiArgs.clear();
+    Logging::LogToggleCategory(ELECTRUM, false);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fixes issue where "invalid format" exception is thrown when attempting to adjust logging verboseness with `electrum.rawarg`.