### PR TITLE
[port] Remove template matching and pseudo opcodes

### DIFF
--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -36,10 +36,10 @@ public:
     /**
      * secp256k1:
      */
-    static const unsigned int PUBLIC_KEY_SIZE = 65;
-    static const unsigned int COMPRESSED_PUBLIC_KEY_SIZE = 33;
-    static const unsigned int SIGNATURE_SIZE = 72;
-    static const unsigned int COMPACT_SIGNATURE_SIZE = 65;
+    static constexpr unsigned int PUBLIC_KEY_SIZE = 65;
+    static constexpr unsigned int COMPRESSED_PUBLIC_KEY_SIZE = 33;
+    static constexpr unsigned int SIGNATURE_SIZE = 72;
+    static constexpr unsigned int COMPACT_SIGNATURE_SIZE = 65;
     /**
      * see www.keylength.com
      * script supports up to 75 for single byte push

--- a/src/pubkey.h
+++ b/src/pubkey.h
@@ -40,6 +40,7 @@ public:
     static constexpr unsigned int COMPRESSED_PUBLIC_KEY_SIZE = 33;
     static constexpr unsigned int SIGNATURE_SIZE = 72;
     static constexpr unsigned int COMPACT_SIGNATURE_SIZE = 65;
+    static constexpr unsigned int PUBLIC_KEY_HASH160_SIZE = 20;
     /**
      * see www.keylength.com
      * script supports up to 75 for single byte push

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -128,6 +128,7 @@ static isminetype IsMine(const CKeyStore &keystore,
         if (keystore.GetCScript(scriptID, subscript))
         {
             isminetype ret = IsMine(keystore, subscript, bestBlock);
+            // FIXME do not always log, use a  specific debug category or create one if no others fit
             LOGA("Freeze SUBSCRIPT = %s! **** MINE=%d  *****  \n", ::ScriptToAsmStr(subscript), ret);
             // if (ret == ISMINE_SPENDABLE) TODO Don't understand why this line was required. Had to comment it so all
             // minetypes in subscripts (eg CLTV) are recognizable
@@ -155,6 +156,7 @@ static isminetype IsMine(const CKeyStore &keystore,
         {
             CScriptNum nFreezeLockTime(vSolutions[0], true, 5);
 
+            // FIXME do not always log, use a  specific debug category or create one if no others fit
             LOGA("Found Freeze Have Key. nFreezeLockTime=%d. BestBlockHeight=%d \n", nFreezeLockTime.getint64(),
                 bestBlock->nHeight);
             if (nFreezeLockTime < LOCKTIME_THRESHOLD)

--- a/src/script/script.cpp
+++ b/src/script/script.cpp
@@ -264,11 +264,6 @@ const char *GetOpName(opcodetype opcode)
     case OP_INVALIDOPCODE:
         return "OP_INVALIDOPCODE";
 
-    // Note:
-    //  The template matching params OP_SMALLINTEGER/etc are defined in opcodetype enum
-    //  as kind of implementation hack, they are *NOT* real opcodes.  If found in real
-    //  Script, just let the default: case deal with them.
-
     default:
         return "OP_UNKNOWN";
     }

--- a/src/script/script.h
+++ b/src/script/script.h
@@ -189,14 +189,6 @@ enum opcodetype
     // The first op_code value after all defined opcodes
     FIRST_UNDEFINED_OP_VALUE,
 
-    // template matching params
-    OP_BIGINTEGER = 0xf0,
-    OP_DATA = 0xf1,
-    OP_SMALLINTEGER = 0xfa,
-    OP_PUBKEYS = 0xfb,
-    OP_PUBKEYHASH = 0xfd,
-    OP_PUBKEY = 0xfe,
-
     OP_INVALIDOPCODE = 0xff,
 };
 

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -70,10 +70,10 @@ static bool MatchPayToPubkeyHash(const CScript &script, valtype &pubkeyhash)
     // Bitcoin address tx, sender provides hash of pubkey, receiver provides signature and pubkey
     // Template: "OP_DUP << OP_HASH160 << OP_PUBKEYHASH << OP_EQUALVERIFY << OP_CHECKSIG"
 
-    if (script.size() == 25 && script[0] == OP_DUP && script[1] == OP_HASH160 && script[2] == 20 &&
-        script[23] == OP_EQUALVERIFY && script[24] == OP_CHECKSIG)
+    if (script.size() == 25 && script[0] == OP_DUP && script[1] == OP_HASH160 &&
+        script[2] == CPubKey::PUBLIC_KEY_HASH160_SIZE && script[23] == OP_EQUALVERIFY && script[24] == OP_CHECKSIG)
     {
-        pubkeyhash = valtype(script.begin() + 3, script.begin() + 23);
+        pubkeyhash = valtype(script.begin() + 3, script.begin() + CPubKey::PUBLIC_KEY_HASH160_SIZE + 3);
         return true;
     }
     return false;

--- a/src/script/standard.cpp
+++ b/src/script/standard.cpp
@@ -169,7 +169,7 @@ static bool MatchFreezeCLTV(const CScript &script, std::vector<valtype> &pubkeys
         return false;
     }
     pubkeys.emplace_back(std::move(data));
-    // after key extraction we should still have on byte which represent OP_CHECKSIG
+    // after key extraction we should still have one byte which represent OP_CHECKSIG
     return (it + 1 == script.end());
 }
 

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -380,7 +380,6 @@ BOOST_AUTO_TEST_CASE(cltv_freeze)
         BOOST_CHECK(EncodeDestination(newAddr1) == EncodeDestination(addr));
     BOOST_CHECK(nRequiredReturn == 1);
 
-
     // check cltv solve for datetime
     CPubKey newKey2 = ToByteVector(key[0].GetPubKey());
     CTxDestination newAddr2 = CTxDestination(newKey2.GetID());


### PR DESCRIPTION
The current code contains a rather complex script template matching engine, which is only used for 3 particular script types (P2PK, P2PKH, multisig).

The first two of these are trivial to match for otherwise, and a specialized matcher for multisig is both more compact and more efficient than a generic one.

The goal is being more flexible, so that for example larger standard multisigs inside SegWit outputs are more easy to implement.

As a side-effect, it also gets rid of the pseudo opcodes hack.

Committer's note:

This is a port of bitcoin/bitcoin/pull/13194 tha has been adapted to
work with BU. The main differencies are related to the fact that we
expose to the user two other kind of transaction use cases: TX_LABELPUBLIC, TX_CLTV.

edit: based on top of #1988 