### PR TITLE
Fix computation for smoothed runtime TPS statistic

### DIFF
--- a/src/qt/transactiongraphwidget.cpp
+++ b/src/qt/transactiongraphwidget.cpp
@@ -281,7 +281,7 @@ void TransactionGraphWidget::setTransactionsPerSecond(double nTxPerSec,
     // Purge smoothed sample(s) that have moved beyond the sample set size limit
     while (vSmoothedSamples.size() > MAXIMUM_SAMPLES_TO_KEEP)
     {
-        float fRemoving = vInstantaneousSamples.last();
+        float fRemoving = vSmoothedSamples.last();
         // Adjust smoothed mean for total sample set to exclude the sample being purged
         fSmoothedTpsAverage_Sampled =
             SubtractFromArithmeticMean(fSmoothedTpsAverage_Sampled, vSmoothedSamples.size(), fRemoving);


### PR DESCRIPTION
The total runtime statistic for average smoothed TPS rate was incorrectly computed once samples started being evicted after 24-hours worth of samples were collected.  This was a typo where the instantaneous sample was subtracted from the smoothed average instead of the smoothed sample.
