### PR TITLE
Remove giving DOS points for unknown inv types

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -944,15 +944,19 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         for (unsigned int nInv = 0; nInv < vInv.size(); nInv++)
         {
             if (shutdown_threads.load() == true)
-            {
                 return false;
-            }
 
             const CInv &inv = vInv[nInv];
-            if (!((inv.type == MSG_TX) || (inv.type == MSG_BLOCK)) || inv.hash.IsNull())
+            if (!((inv.type == MSG_TX) || (inv.type == MSG_BLOCK)))
+            {
+                LOG(NET, "message inv invalid type = %u hash %s", inv.type, inv.hash.ToString());
+                return false;
+            }
+            else if (inv.hash.IsNull())
             {
                 dosMan.Misbehaving(pfrom, 20);
-                return error("message inv invalid type = %u or is null hash %s", inv.type, inv.hash.ToString());
+                LOG(NET, "message inv has null hash %s", inv.type, inv.hash.ToString());
+                return false;
             }
 
             if (inv.type == MSG_BLOCK)

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -441,8 +441,8 @@ BOOST_AUTO_TEST_CASE(inv_tests)
 
     vRecv1 << vInv;
     ProcessMessage(&dummyNode3, NetMsgType::INV, vRecv1, GetStopwatchMicros());
-    SendMessages(&dummyNode3); // send a fifth message should cause ban
-    BOOST_CHECK(dosMan.IsBanned(addr3));
+    SendMessages(&dummyNode3); // send a fifth message and should not cause ban
+    BOOST_CHECK(!dosMan.IsBanned(addr3));
 
 
     // INV with null hash


### PR DESCRIPTION
  We should be more permissive of unknown types in case other implementions
  decide to do something new. This way we don't penalize permissionless
  innovation.

Reduce potential log spam in some error messages.