### PR TITLE
Makes getLabelPublic() to work with string longer than 16 chars

### DIFF
--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -45,7 +45,13 @@ std::string getLabelPublic(const CScript &scriptPubKey)
         if (whichType == TX_LABELPUBLIC)
         {
             CScript labelPublic(vSolutions[1]);
-            return std::string(labelPublic.begin() + 1, labelPublic.end());
+
+            valtype data;
+            opcodetype opcode;
+            CScript::const_iterator s = labelPublic.begin();
+            labelPublic.GetOp(s, opcode, data);
+
+            return std::string(data.begin(), data.end());
         }
     }
 

--- a/src/test/multisig_tests.cpp
+++ b/src/test/multisig_tests.cpp
@@ -409,18 +409,39 @@ BOOST_AUTO_TEST_CASE(opreturn_send)
 
     CBasicKeyStore keystore;
 
-    // Create and unpack a CLTV script
+    // Create and unpack a LABELPUBLIC script
     vector<valtype> solutions;
     txnouttype whichType;
     vector<CTxDestination> addresses;
 
     string inMsg = "hello world", outMsg = "";
     CScript s = GetScriptLabelPublic(inMsg);
-
     outMsg = getLabelPublic(s);
     BOOST_CHECK(inMsg == outMsg);
     BOOST_CHECK(Solver(s, whichType, solutions));
     BOOST_CHECK(whichType == TX_LABELPUBLIC);
+    BOOST_CHECK(solutions.size() == 2);
+
+    inMsg = "hello world hello world hello world hello world hello world"
+            "hello world hello world";
+    s.clear();
+    s = GetScriptLabelPublic(inMsg);
+    outMsg = getLabelPublic(s);
+    BOOST_CHECK(inMsg == outMsg);
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK(whichType == TX_LABELPUBLIC);
+
+    inMsg = "hello world hello world hello world hello world hello world"
+            "hello world hello world hello world hello world hello world"
+            "hello world hello world hello world hello world hello world"
+            "hello world hello world";
+    s.clear();
+    s = GetScriptLabelPublic(inMsg);
+    outMsg = getLabelPublic(s);
+    BOOST_CHECK(inMsg == outMsg);
+    BOOST_CHECK(Solver(s, whichType, solutions));
+    BOOST_CHECK(whichType == TX_LABELPUBLIC);
+    BOOST_CHECK(solutions.size() == 2);
 }
 #endif
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
In GetScriptiLabelPublic use "<<" to add the user string to the
LABELPUBLIC string. Since #1890 got merged we make sure that appending
vector to CScript generates MINIMAL_DATA compliant script binary.

Hence to extract from the script the user string we should use GetOp().

Added a test a for a longer string so that we check that we could deal
with different kind of pushing. With a string len < 17, the second
element of vSolutions has as first byte the len of the user string.

With a longer string the first two bytes are OP_PUSHDATA1 and len(str).