### PR TITLE
fix an undefined behavior in uint::SetHex

### DIFF
--- a/src/uint256.cpp
+++ b/src/uint256.cpp
@@ -47,18 +47,18 @@ void base_blob<BITS>::SetHex(const char *psz)
         psz += 2;
 
     // hex string to uint
-    const char *pbegin = psz;
-    while (::HexDigit(*psz) != -1)
-        psz++;
-    psz--;
+    size_t digits = 0;
+    while (::HexDigit(psz[digits]) != -1)
+        digits++;
+
     unsigned char *p1 = (unsigned char *)data;
     unsigned char *pend = p1 + WIDTH;
-    while (psz >= pbegin && p1 < pend)
+    while (digits > 0 && p1 < pend)
     {
-        *p1 = ::HexDigit(*psz--);
-        if (psz >= pbegin)
+        *p1 = ::HexDigit(psz[--digits]);
+        if (digits > 0)
         {
-            *p1 |= ((unsigned char)::HexDigit(*psz--) << 4);
+            *p1 |= ((unsigned char)::HexDigit(psz[--digits]) << 4);
             p1++;
         }
     }


### PR DESCRIPTION
Decrementing psz beyond the beginning of the string is UB, even though
the out-of-bounds pointer is never dereferenced.

This is port of core #14734