### PR TITLE
Improve IBD when pruning

### DIFF
--- a/src/blockstorage/blockstorage.cpp
+++ b/src/blockstorage/blockstorage.cpp
@@ -605,9 +605,9 @@ bool FlushStateToDiskInternal(CValidationState &state,
     bool fPeriodicFlush =
         mode == FLUSH_STATE_PERIODIC && nNow > nLastFlush + (int64_t)DATABASE_FLUSH_INTERVAL * 1000000;
     // Combine all conditions that result in a full cache flush.
-    bool fDoFullFlush = (mode == FLUSH_STATE_ALWAYS) || fCacheCritical || fPeriodicFlush || fFlushForPrune;
+    bool fDoFullFlush = (mode == FLUSH_STATE_ALWAYS) || fCacheCritical || fPeriodicFlush;
     // Write blocks and block index to disk.
-    if (fDoFullFlush || fPeriodicWrite)
+    if (fDoFullFlush || fPeriodicWrite || fFlushForPrune)
     {
         // Depend on nMinDiskSpace to ensure we can write block index
         if (!CheckDiskSpace(0))
@@ -711,8 +711,8 @@ bool FlushStateToDiskInternal(CValidationState &state,
 
         nSizeAfterLastFlush = pcoinsTip->DynamicMemoryUsage();
     }
-    if (fDoFullFlush || ((mode == FLUSH_STATE_ALWAYS || mode == FLUSH_STATE_PERIODIC) &&
-                            nNow > nLastSetChain + (int64_t)DATABASE_WRITE_INTERVAL * 1000000))
+    if (fDoFullFlush || fFlushForPrune || ((mode == FLUSH_STATE_ALWAYS || mode == FLUSH_STATE_PERIODIC) &&
+                                              nNow > nLastSetChain + (int64_t)DATABASE_WRITE_INTERVAL * 1000000))
     {
         // Update best block in wallet (so we can detect restored wallets).
         GetMainSignals().SetBestChain(chainActive.GetLocator());


### PR DESCRIPTION
There was too much constant flushing of the dbcache which was slowing
down IBD performance when pruning. When we remove this flushing and
let flushing happen normally (when the cache is full), then IBD
perfomance is the same whether the node is a pruning node or a network
node.