### PR TITLE
Fix mempool sync bug

### DIFF
--- a/qa/rpc-tests/mempoolsync.py
+++ b/qa/rpc-tests/mempoolsync.py
@@ -49,19 +49,8 @@ class MempoolSyncTest(BitcoinTestFramework):
         for i in range(10):
             self.nodes[0].sendtoaddress(addr, Decimal("10"))
 
-        logging.info("Send 10 transactions from node1 (to its own address)")
-        addr = self.nodes[1].getnewaddress()
-        for i in range(10):
-            self.nodes[1].sendtoaddress(addr, Decimal("10"))
-
-        logging.info("Send 10 transactions from node2 (to its own address)")
-        addr = self.nodes[2].getnewaddress()
-        for i in range(10):
-            self.nodes[2].sendtoaddress(addr, Decimal("10"))
-
-        waitFor(180, lambda: len(self.nodes[0].getrawmempool()) == 30)
-        waitFor(180, lambda: len(self.nodes[1].getrawmempool()) == 30)
-        waitFor(180, lambda: len(self.nodes[2].getrawmempool()) == 30)
+        waitFor(180, lambda: len(self.nodes[1].getrawmempool()) == 10)
+        waitFor(180, lambda: len(self.nodes[2].getrawmempool()) == 10)
 
 if __name__ == '__main__':
     MempoolSyncTest().main()

--- a/src/blockrelay/mempool_sync.cpp
+++ b/src/blockrelay/mempool_sync.cpp
@@ -132,8 +132,7 @@ bool HandleMempoolSyncRequest(CDataStream &vRecv, CNode *pfrom)
         }
 
         // Assemble mempool sync object
-        uint64_t nBothMempools = mempoolTxHashes.size() + mempoolinfo.nTxInMempool;
-        CMempoolSync mempoolSync(mempoolTxHashes, mempoolinfo.nTxInMempool, nBothMempools, mempoolinfo.shorttxidk0,
+        CMempoolSync mempoolSync(mempoolTxHashes, mempoolinfo.nTxInMempool, mempoolTxHashes.size(), mempoolinfo.shorttxidk0,
             mempoolinfo.shorttxidk1, NegotiateMempoolSyncVersion(pfrom));
 
         pfrom->PushMessage(NetMsgType::MEMPOOLSYNC, mempoolSync);

--- a/src/blockrelay/mempool_sync.cpp
+++ b/src/blockrelay/mempool_sync.cpp
@@ -219,6 +219,8 @@ bool CMempoolSync::process(CNode *pfrom)
     {
         LOG(MPOOLSYNC, "Mempool sync failed for peer %s. Graphene set could not be reconciled: %s\n",
             pfrom->GetLogName(), e.what());
+
+        return false;
     }
 
     LOG(MPOOLSYNC, "Mempool sync received: %d total responder txns, requester waiting for %d txs from peer %s\n",

--- a/src/blockrelay/mempool_sync.cpp
+++ b/src/blockrelay/mempool_sync.cpp
@@ -132,8 +132,8 @@ bool HandleMempoolSyncRequest(CDataStream &vRecv, CNode *pfrom)
         }
 
         // Assemble mempool sync object
-        CMempoolSync mempoolSync(mempoolTxHashes, mempoolinfo.nTxInMempool, mempoolTxHashes.size(), mempoolinfo.shorttxidk0,
-            mempoolinfo.shorttxidk1, NegotiateMempoolSyncVersion(pfrom));
+        CMempoolSync mempoolSync(mempoolTxHashes, mempoolinfo.nTxInMempool, mempoolTxHashes.size(),
+            mempoolinfo.shorttxidk0, mempoolinfo.shorttxidk1, NegotiateMempoolSyncVersion(pfrom));
 
         pfrom->PushMessage(NetMsgType::MEMPOOLSYNC, mempoolSync);
         LOG(MPOOLSYNC, "Sent mempool sync to peer %s using version %d\n", pfrom->GetLogName(), mempoolSync.version);
@@ -221,8 +221,8 @@ bool CMempoolSync::process(CNode *pfrom)
             pfrom->GetLogName(), e.what());
     }
 
-    LOG(MPOOLSYNC, "Mempool sync received: %d total txns, waiting for: %d from peer %s\n", nSenderMempoolTxs,
-        setHashesToRequest.size(), pfrom->GetLogName());
+    LOG(MPOOLSYNC, "Mempool sync received: %d total responder txns, requester waiting for %d txs from peer %s\n",
+        nSenderMempoolTxs, setHashesToRequest.size(), pfrom->GetLogName());
 
     // If there are any missing transactions then we request them here.
     if (!setHashesToRequest.empty())
@@ -501,7 +501,7 @@ CNode *SelectMempoolSyncPeer(std::vector<CNode *> vNodesCopy)
         return nullptr;
 }
 
-void ClearDisconnectedFromMempoolSyncMaps(NodeId nodeid)    
+void ClearDisconnectedFromMempoolSyncMaps(NodeId nodeid)
 {
     LOCK(cs_mempoolsync);
     mempoolSyncRequested.erase(nodeid);


### PR DESCRIPTION
In the version of mempool sync committed to dev and release branches, the size of the IBLT sent by the responder grows linearly with the size of the responder's mempool (crucially even after sync is successful) until a block is mined, at which point IBLTs become small again, only to grow as before.

It turns out that the problem can be traced back to a single line where the total size of the responder's mempool was previously calculated to be equal to the size of his mempool plus the size of the requester's mempool. After fixing this error, IBLTs are made just large enough to accommodate the missing transactions (as desired).

However, making this change revealed another issue that was previously overlooked due to the extremely large sizes of IBLTs. In particular, the QA test mempoolsync.py fails consistently with the change in place. In the test, three nodes each generate 10 distinct transactions and attempt to pass them to the others by means of mempool sync alone. This is a pathological case for Graphene because the protocol attempts to estimate the number of missing transactions based on the sizes of requester and responder mempools. However, in this scenario, mempools have the same size and totally distinct transactions. I regard this scenario to be highly unlikely in real deployments unless the syncing peer is intentionally trying to trick Graphene. In any case, the consequence of a sync failure is not dire, the peer simply attempts to sync with a different peer when it's time for the next update. For this reason, it is my opinion that the QA test case be reasonably updated so that only a single peer generates transactions, which are subsequently propagated to other peers using mempool sync.

I have successfully run more than 50 mempool sync QA tests (with the change made above) without failure. I have also been running the updated version of mempool sync on mainnet for the last day or so without issue.