### PR TITLE
Another pass to use c++11 nullptr across the codebase when appropriate

### DIFF
--- a/src/cashlib/cashlib.cpp
+++ b/src/cashlib/cashlib.cpp
@@ -587,7 +587,7 @@ public:
     ByteArrayAccessor(JNIEnv *e, jbyteArray &arg) : env(e), obj(arg)
     {
         size = env->GetArrayLength(obj);
-        data = (uint8_t *)env->GetByteArrayElements(obj, NULL);
+        data = (uint8_t *)env->GetByteArrayElements(obj, nullptr);
     }
 
     ~ByteArrayAccessor()
@@ -609,7 +609,7 @@ std::string toString(JNIEnv *env, jstring jStr)
     const jbyteArray stringJbytes = (jbyteArray)env->CallObjectMethod(jStr, getBytes, env->NewStringUTF("UTF-8"));
 
     size_t length = (size_t)env->GetArrayLength(stringJbytes);
-    jbyte *pBytes = env->GetByteArrayElements(stringJbytes, NULL);
+    jbyte *pBytes = env->GetByteArrayElements(stringJbytes, nullptr);
 
     std::string ret = std::string((char *)pBytes, length);
     env->ReleaseByteArrayElements(stringJbytes, pBytes, JNI_ABORT);
@@ -632,10 +632,10 @@ jbyteArray encodeUint256(JNIEnv *env, arith_uint256 value)
 {
     const size_t size = 256 / 8;
     jbyteArray result = env->NewByteArray(size);
-    if (result != NULL)
+    if (result != nullptr)
     {
-        jbyte *data = env->GetByteArrayElements(result, NULL);
-        if (data != NULL)
+        jbyte *data = env->GetByteArrayElements(result, nullptr);
+        if (data != nullptr)
         {
             int i;
             for (i = (int)(size - 1); i >= 0; i--)
@@ -830,7 +830,7 @@ extern "C" JNIEXPORT jbyteArray JNICALL Java_bitcoinunlimited_libbitcoincash_Pay
     jbyteArray arg)
 {
     size_t len = env->GetArrayLength(arg);
-    jbyte *data = env->GetByteArrayElements(arg, NULL);
+    jbyte *data = env->GetByteArrayElements(arg, nullptr);
 
     if (len != 32)
     {

--- a/src/httprpc.cpp
+++ b/src/httprpc.cpp
@@ -60,7 +60,7 @@ private:
 /* Pre-base64-encoded authentication token */
 static std::string strRPCUserColonPass;
 /* Stored RPC timer interface (for unregistration) */
-static HTTPRPCTimerInterface *httpRPCTimerInterface = 0;
+static HTTPRPCTimerInterface *httpRPCTimerInterface = nullptr;
 
 static void JSONErrorReply(HTTPRequest *req, const UniValue &objError, const UniValue &id)
 {
@@ -270,6 +270,6 @@ void StopHTTPRPC()
     {
         RPCUnsetTimerInterface(httpRPCTimerInterface);
         delete httpRPCTimerInterface;
-        httpRPCTimerInterface = 0;
+        httpRPCTimerInterface = nullptr;
     }
 }

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -150,13 +150,13 @@ struct HTTPPathHandler
 /** HTTP module state */
 
 //! libevent event loop
-static struct event_base *eventBase = 0;
+static struct event_base *eventBase = nullptr;
 //! HTTP server
-struct evhttp *eventHTTP = 0;
+struct evhttp *eventHTTP = nullptr;
 //! List of subnets to allow RPC connections from
 static std::vector<CSubNet> rpc_allow_subnets;
 //! Work queue for handling longer requests off the event loop thread
-static WorkQueue<HTTPClosure> *workQueue = 0;
+static WorkQueue<HTTPClosure> *workQueue = nullptr;
 //! Handlers for (sub)paths
 std::vector<HTTPPathHandler> pathHandlers;
 //! Bound listening sockets
@@ -549,12 +549,12 @@ void StopHTTPServer()
     if (eventHTTP)
     {
         evhttp_free(eventHTTP);
-        eventHTTP = 0;
+        eventHTTP = nullptr;
     }
     if (eventBase)
     {
         event_base_free(eventBase);
-        eventBase = 0;
+        eventBase = nullptr;
     }
     LOG(HTTP, "Stopped HTTP server\n");
 }
@@ -665,7 +665,7 @@ void HTTPRequest::WriteReply(int nStatus, const std::string &strReply)
     });
     ev->trigger(nullptr);
     replySent = true;
-    req = 0; // transferred back to main thread
+    req = nullptr; // transferred back to main thread
 }
 
 CService HTTPRequest::GetPeer()

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -1460,9 +1460,9 @@ static bool fShutdownUPnP = false;
 void ThreadMapPort()
 {
     std::string port = strprintf("%u", GetListenPort());
-    const char *multicastif = 0;
-    const char *minissdpdpath = 0;
-    struct UPNPDev *devlist = 0;
+    const char *multicastif = nullptr;
+    const char *minissdpdpath = nullptr;
+    struct UPNPDev *devlist = nullptr;
     char lanaddr[64];
 
 #ifndef UPNPDISCOVER_SUCCESS

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -117,7 +117,7 @@ void static ProcessGetData(CNode *pfrom, const Consensus::Params &consensusParam
                             // best equivalent proof of work) than the best header chain we know about.
                             {
                                 READLOCK(cs_mapBlockIndex);
-                                fSend = mi->IsValid(BLOCK_VALID_SCRIPTS) && (pindexBestHeader != NULL) &&
+                                fSend = mi->IsValid(BLOCK_VALID_SCRIPTS) && (pindexBestHeader != nullptr) &&
                                         (pindexBestHeader.load()->GetBlockTime() - mi->GetBlockTime() < nOneMonth) &&
                                         (GetBlockProofEquivalentTime(
                                              *pindexBestHeader, *mi, *pindexBestHeader, consensusParams) < nOneMonth);

--- a/src/netbase.h
+++ b/src/netbase.h
@@ -85,13 +85,13 @@ bool Lookup(const char *pszName,
  */
 bool LookupNumeric(const char *pszName, CService &addr, int portDefault = 0);
 
-bool ConnectSocket(const CService &addr, SOCKET &hSocketRet, int nTimeout, bool *outProxyConnectionFailed = 0);
+bool ConnectSocket(const CService &addr, SOCKET &hSocketRet, int nTimeout, bool *outProxyConnectionFailed = nullptr);
 bool ConnectSocketByName(CService &addr,
     SOCKET &hSocketRet,
     const char *pszDest,
     int portDefault,
     int nTimeout,
-    bool *outProxyConnectionFailed = 0);
+    bool *outProxyConnectionFailed = nullptr);
 /** Return readable error string for a network error code */
 std::string NetworkErrorString(int err);
 /** Close socket and set hSocket to INVALID_SOCKET */

--- a/src/pubkey.cpp
+++ b/src/pubkey.cpp
@@ -13,7 +13,7 @@
 namespace
 {
 /* Global secp256k1_context object used for verification. */
-secp256k1_context *secp256k1_context_verify = NULL;
+secp256k1_context *secp256k1_context_verify = nullptr;
 }
 
 /** This function is taken from the libsecp256k1 distribution and implements
@@ -370,7 +370,7 @@ bool CExtPubKey::Derive(CExtPubKey &out, unsigned int _nChild) const
     {
         return false;
     }
-    return (!secp256k1_ecdsa_signature_normalize(secp256k1_context_verify, NULL, &sig));
+    return (!secp256k1_ecdsa_signature_normalize(secp256k1_context_verify, nullptr, &sig));
 }
 
 /* static */ int ECCVerifyHandle::refcount = 0;
@@ -379,9 +379,9 @@ ECCVerifyHandle::ECCVerifyHandle()
 {
     if (refcount == 0)
     {
-        assert(secp256k1_context_verify == NULL);
+        assert(secp256k1_context_verify == nullptr);
         secp256k1_context_verify = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY);
-        assert(secp256k1_context_verify != NULL);
+        assert(secp256k1_context_verify != nullptr);
     }
     refcount++;
 }
@@ -391,8 +391,8 @@ ECCVerifyHandle::~ECCVerifyHandle()
     refcount--;
     if (refcount == 0)
     {
-        assert(secp256k1_context_verify != NULL);
+        assert(secp256k1_context_verify != nullptr);
         secp256k1_context_destroy(secp256k1_context_verify);
-        secp256k1_context_verify = NULL;
+        secp256k1_context_verify = nullptr;
     }
 }

--- a/src/torcontrol.cpp
+++ b/src/torcontrol.cpp
@@ -119,7 +119,7 @@ private:
     static void eventcb(struct bufferevent *bev, short what, void *ctx);
 };
 
-TorControlConnection::TorControlConnection(struct event_base *_base) : base(_base), b_conn(0) {}
+TorControlConnection::TorControlConnection(struct event_base *_base) : base(_base), b_conn(nullptr) {}
 TorControlConnection::~TorControlConnection()
 {
     if (b_conn)
@@ -239,7 +239,7 @@ bool TorControlConnection::Disconnect()
 {
     if (b_conn)
         bufferevent_free(b_conn);
-    b_conn = 0;
+    b_conn = nullptr;
     return true;
 }
 
@@ -444,7 +444,7 @@ TorController::~TorController()
     if (reconnect_ev)
     {
         event_free(reconnect_ev);
-        reconnect_ev = 0;
+        reconnect_ev = nullptr;
     }
     if (service.IsValid())
     {
@@ -783,6 +783,6 @@ void StopTorControl()
     {
         torControlThread.join();
         event_base_free(base);
-        base = 0;
+        base = nullptr;
     }
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1700,10 +1700,10 @@ UniValue listtransactions(const UniValue &params, bool fHelp)
     for (CWallet::TxItems::const_reverse_iterator it = txOrdered.rbegin(); it != txOrdered.rend(); ++it)
     {
         CWalletTx *const pwtx = (*it).second.first;
-        if (pwtx != 0)
+        if (pwtx != nullptr)
             ListTransactions(*pwtx, strAccount, 0, true, ret, filter);
         CAccountingEntry *const pacentry = (*it).second.second;
-        if (pacentry != 0)
+        if (pacentry != nullptr)
             AcentryToJSON(*pacentry, strAccount, ret);
 
         if ((int)ret.size() >= (nCount + nFrom))

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -733,7 +733,7 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
         mapWallet[hash] = wtxIn;
         CWalletTx &wtx = mapWallet[hash];
         wtx.BindWallet(this);
-        wtxOrdered.insert(make_pair(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry *)0)));
+        wtxOrdered.insert(make_pair(wtx.nOrderPos, TxPair(&wtx, nullptr)));
         AddToSpends(hash);
         for (const CTxIn &txin : wtx.vin)
         {
@@ -758,7 +758,7 @@ bool CWallet::AddToWallet(const CWalletTx &wtxIn, bool fFromLoadWallet, CWalletD
         {
             wtx.nTimeReceived = GetAdjustedTime();
             wtx.nOrderPos = IncOrderPosNext(pwalletdb);
-            wtxOrdered.insert(make_pair(wtx.nOrderPos, TxPair(&wtx, (CAccountingEntry *)0)));
+            wtxOrdered.insert(make_pair(wtx.nOrderPos, TxPair(&wtx, nullptr)));
 
             wtx.nTimeSmart = wtx.nTimeReceived;
             if (!wtxIn.hashUnset())
@@ -1602,7 +1602,7 @@ CAmount CWalletTx::GetImmatureCredit(bool fUseCache) const
 
 CAmount CWalletTx::GetAvailableCredit(bool fUseCache) const
 {
-    if (pwallet == 0)
+    if (pwallet == nullptr)
         return 0;
 
     // Must wait until coinbase is safely deep enough in the chain before valuing it
@@ -1646,7 +1646,7 @@ CAmount CWalletTx::GetImmatureWatchOnlyCredit(const bool &fUseCache) const
 
 CAmount CWalletTx::GetAvailableWatchOnlyCredit(const bool &fUseCache) const
 {
-    if (pwallet == 0)
+    if (pwallet == nullptr)
         return 0;
 
     // Must wait until coinbase is safely deep enough in the chain before valuing it
@@ -2616,7 +2616,7 @@ bool CWallet::AddAccountingEntry(const CAccountingEntry &acentry, CWalletDB &pwa
 
     laccentries.push_back(acentry);
     CAccountingEntry &entry = laccentries.back();
-    wtxOrdered.insert(make_pair(entry.nOrderPos, TxPair((CWalletTx *)0, &entry)));
+    wtxOrdered.insert(make_pair(entry.nOrderPos, TxPair(nullptr, &entry)));
 
     return true;
 }

--- a/src/wallet/walletdb.cpp
+++ b/src/wallet/walletdb.cpp
@@ -283,13 +283,13 @@ DBErrors CWalletDB::ReorderTransactions(CWallet *pwallet)
     for (map<uint256, CWalletTx>::iterator it = pwallet->mapWallet.begin(); it != pwallet->mapWallet.end(); ++it)
     {
         CWalletTx *wtx = &((*it).second);
-        txByTime.insert(make_pair(wtx->nTimeReceived, TxPair(wtx, (CAccountingEntry *)0)));
+        txByTime.insert(make_pair(wtx->nTimeReceived, TxPair(wtx, nullptr)));
     }
     list<CAccountingEntry> acentries;
     ListAccountCreditDebit("", acentries);
     for (CAccountingEntry &entry : acentries)
     {
-        txByTime.insert(make_pair(entry.nTime, TxPair((CWalletTx *)0, &entry)));
+        txByTime.insert(make_pair(entry.nTime, TxPair(nullptr, &entry)));
     }
 
     int64_t &nOrderPosNext = pwallet->nOrderPosNext;
@@ -755,7 +755,7 @@ DBErrors CWalletDB::LoadWallet(CWallet *pwallet)
     ListAccountCreditDebit("*", pwallet->laccentries);
     for (CAccountingEntry &entry : pwallet->laccentries)
     {
-        pwallet->wtxOrdered.insert(make_pair(entry.nOrderPos, CWallet::TxPair((CWalletTx *)0, &entry)));
+        pwallet->wtxOrdered.insert(make_pair(entry.nOrderPos, CWallet::TxPair(nullptr, &entry)));
     }
 
     return result;

--- a/src/zmq/zmqabstractnotifier.h
+++ b/src/zmq/zmqabstractnotifier.h
@@ -16,7 +16,7 @@ typedef CZMQAbstractNotifier *(*CZMQNotifierFactory)();
 class CZMQAbstractNotifier
 {
 public:
-    CZMQAbstractNotifier() : psocket(0) {}
+    CZMQAbstractNotifier() : psocket(nullptr) {}
     virtual ~CZMQAbstractNotifier();
 
     template <typename T>

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -119,7 +119,7 @@ void CZMQAbstractPublishNotifier::Shutdown()
         zmq_close(psocket);
     }
 
-    psocket = 0;
+    psocket = nullptr;
 }
 
 bool CZMQPublishHashBlockNotifier::NotifyBlock(const CBlockIndex *pindex)


### PR DESCRIPTION
- nullptr rather than NULL macro
- nullptr rather than null pointer constant (0)