### PR TITLE
Reject transactions that have more than one input for long unconfirmed chains

### DIFF
--- a/qa/rpc-tests/mempool_push.py
+++ b/qa/rpc-tests/mempool_push.py
@@ -41,9 +41,11 @@ class MyTest (BitcoinTestFramework):
              "-limitdescendantsize=%d" % (BCH_UNCONF_SIZE_KB*2),
              "-limitancestorcount=%d" % (BCH_UNCONF_DEPTH*2),
              "-limitdescendantcount=%d" % (BCH_UNCONF_DEPTH*2),
-             "-net.unconfChainResendAction=2"],
+             "-net.unconfChainResendAction=2",
+             "-net.restrictInputs=0"],
             ["-blockprioritysize=2000000", "-limitdescendantcount=1000", "-limitancestorcount=1000",
-             "-limitancestorsize=1000", "-limitdescendantsize=1000", "-net.unconfChainResendAction=2"],
+             "-limitancestorsize=1000", "-limitdescendantsize=1000", "-net.unconfChainResendAction=2",
+             "-net.restrictInputs=0"],
             ["-blockprioritysize=2000000", "-limitancestorsize=150","-net.unconfChainResendAction=2"]
             ]
         self.nodes = start_nodes(4, self.options.tmpdir, mempoolConf)
@@ -63,7 +65,7 @@ class MyTest (BitcoinTestFramework):
         txhex = []
         for i in range(0,BCH_UNCONF_DEPTH*2):
           try:
-            txhex.append(self.nodes[1].sendtoaddress(addr, bal-1))  # enough so that it uses all UTXO, but has fee left over
+              txhex.append(self.nodes[1].sendtoaddress(addr, bal-1))  # enough so that it uses all UTXO, but has fee left over
           except JSONRPCException as e: # an exception you don't catch is a testing error
               print(str(e))
               raise

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -357,6 +357,9 @@ CTweak<unsigned int> unconfPushAction("net.unconfChainResendAction",
     "Action to take when this node thinks that a peer will now accept a previously unacceptable unconfirmed transaction"
     "0: do not resend, 1: send an INV, 2: send the TX",
     0);
+CTweak<bool> restrictInputs("net.restrictInputs",
+    "Do we want to restrict max inputs to 1 for unconfirmed transaction chains that are longer than 25 (default: true)",
+    true);
 
 CTweak<CAmount> maxTxFee("wallet.maxTxFee",
     "Maximum total fees to use in a single wallet transaction or raw transaction; setting this too low may abort large "

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -507,7 +507,7 @@ BOOST_FIXTURE_TEST_CASE(long_unconfirmed_chains, TestChain100Setup)
         BOOST_CHECK(coinbaseKey.SignECDSA(hash, vchSig));
         vchSig.push_back((unsigned char)sighashType);
         tx.vin[0].scriptSig << vchSig;
-        BOOST_CHECK(!ToMemPool(tx, "too-many-inputs"));
+        BOOST_CHECK(!ToMemPool(tx, "bad-txn-too-many-inputs"));
     }
 
     // Now try to add a tx with only one input. It should succeed.

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -26,11 +26,16 @@ extern void LimitMempoolSize(CTxMemPool &pool, size_t limit, unsigned long age);
 
 BOOST_AUTO_TEST_SUITE(txvalidationcache_tests) // BU harmonize suite name with filename
 
-static bool ToMemPool(CMutableTransaction &tx)
+static bool ToMemPool(CMutableTransaction &tx, std::string rejectReason = "")
 {
     CValidationState state;
     bool fMissingInputs = false;
-    return AcceptToMemoryPool(mempool, state, MakeTransactionRef(tx), false, &fMissingInputs, true, false);
+    bool ret = false;
+    ret = AcceptToMemoryPool(mempool, state, MakeTransactionRef(tx), false, &fMissingInputs, true, false);
+
+    if (rejectReason != "")
+        BOOST_CHECK_EQUAL(rejectReason, state.GetRejectReason());
+    return ret;
 }
 
 BOOST_FIXTURE_TEST_CASE(tx_mempool_block_doublespend, TestChain100Setup)
@@ -396,4 +401,156 @@ BOOST_FIXTURE_TEST_CASE(uncache_coins, TestChain100Setup)
     SetMockTime(0);
 }
 
+BOOST_FIXTURE_TEST_CASE(long_unconfirmed_chains, TestChain100Setup)
+{
+    CScript scriptPubKey = CScript() << ToByteVector(coinbaseKey.GetPubKey()) << OP_CHECKSIG;
+
+    unsigned int sighashType = SIGHASH_ALL;
+    if (IsUAHFforkActiveOnNextBlock(chainActive.Tip()->nHeight))
+        sighashType |= SIGHASH_FORKID;
+
+    uint256 prevout = coinbaseTxns[0].GetHash();
+    uint256 hash;
+
+    // Create a chain of 25 unconfirmed transactions
+    for (int i = 1; i <= 25; i++)
+    {
+        CMutableTransaction tx;
+        tx.vin.resize(1);
+        tx.vin[0].prevout.hash = prevout;
+        tx.vin[0].prevout.n = 0;
+        tx.vout.resize(1);
+        tx.vout[0].nValue = 11 * CENT;
+        tx.vout[0].scriptPubKey = scriptPubKey;
+
+        // Sign:
+        std::vector<unsigned char> vchSig;
+        if (i == 1)
+        {
+            hash = SignatureHash(scriptPubKey, tx, 0, sighashType, coinbaseTxns[0].vout[0].nValue, 0);
+        }
+        else
+        {
+            hash = SignatureHash(scriptPubKey, tx, 0, sighashType, 11 * CENT, 0);
+        }
+        BOOST_CHECK(hash != SIGNATURE_HASH_ERROR);
+        BOOST_CHECK(coinbaseKey.SignECDSA(hash, vchSig));
+        vchSig.push_back((unsigned char)sighashType);
+        tx.vin[0].scriptSig << vchSig;
+        BOOST_CHECK(ToMemPool(tx));
+
+        prevout = tx.GetHash();
+    }
+
+
+    // Add one more which should fail because it's over the 25 limit.
+    {
+        CMutableTransaction tx;
+        tx.vin.resize(1);
+        tx.vin[0].prevout.hash = prevout;
+        tx.vin[0].prevout.n = 0;
+        tx.vout.resize(1);
+        tx.vout[0].nValue = 11 * CENT;
+        tx.vout[0].scriptPubKey = scriptPubKey;
+
+        // Sign:
+        std::vector<unsigned char> vchSig;
+        hash = SignatureHash(scriptPubKey, tx, 0, sighashType, 11 * CENT, 0);
+        BOOST_CHECK(hash != SIGNATURE_HASH_ERROR);
+        BOOST_CHECK(coinbaseKey.SignECDSA(hash, vchSig));
+        vchSig.push_back((unsigned char)sighashType);
+        tx.vin[0].scriptSig << vchSig;
+        BOOST_CHECK(!ToMemPool(tx, "too-long-mempool-chain"));
+    }
+
+    SetArg("-limitancestorcount", std::to_string(27));
+    SetArg("-limitdescendantcount", std::to_string(27));
+
+    // Add one more which should should work because the limit is now 27
+    {
+        CMutableTransaction tx;
+        tx.vin.resize(1);
+        tx.vin[0].prevout.hash = prevout;
+        tx.vin[0].prevout.n = 0;
+        tx.vout.resize(1);
+        tx.vout[0].nValue = 11 * CENT;
+        tx.vout[0].scriptPubKey = scriptPubKey;
+
+        // Sign:
+        std::vector<unsigned char> vchSig;
+        hash = SignatureHash(scriptPubKey, tx, 0, sighashType, 11 * CENT, 0);
+        BOOST_CHECK(hash != SIGNATURE_HASH_ERROR);
+        BOOST_CHECK(coinbaseKey.SignECDSA(hash, vchSig));
+        vchSig.push_back((unsigned char)sighashType);
+        tx.vin[0].scriptSig << vchSig;
+        BOOST_CHECK(ToMemPool(tx));
+
+        prevout = tx.GetHash();
+    }
+
+    // Now try to add a tx with multiple inputs.  It should fail
+    {
+        CMutableTransaction tx;
+        tx.vin.resize(2);
+        tx.vin[1].prevout.hash = prevout;
+        tx.vin[1].prevout.n = 0;
+        tx.vin[0].prevout.hash = coinbaseTxns[0].GetHash();
+        tx.vin[0].prevout.n = 0;
+        tx.vout.resize(1);
+        tx.vout[0].nValue = 11 * CENT;
+        tx.vout[0].scriptPubKey = scriptPubKey;
+
+        // Sign:
+        std::vector<unsigned char> vchSig;
+        hash = SignatureHash(scriptPubKey, tx, 0, sighashType, 11 * CENT, 0);
+        BOOST_CHECK(hash != SIGNATURE_HASH_ERROR);
+        BOOST_CHECK(coinbaseKey.SignECDSA(hash, vchSig));
+        vchSig.push_back((unsigned char)sighashType);
+        tx.vin[0].scriptSig << vchSig;
+        BOOST_CHECK(!ToMemPool(tx, "too-many-inputs"));
+    }
+
+    // Now try to add a tx with only one input. It should succeed.
+    {
+        CMutableTransaction tx;
+        tx.vin.resize(1);
+        tx.vin[0].prevout.hash = prevout;
+        tx.vin[0].prevout.n = 0;
+        tx.vout.resize(1);
+        tx.vout[0].nValue = 11 * CENT;
+        tx.vout[0].scriptPubKey = scriptPubKey;
+
+        // Sign:
+        std::vector<unsigned char> vchSig;
+        hash = SignatureHash(scriptPubKey, tx, 0, sighashType, 11 * CENT, 0);
+        BOOST_CHECK(hash != SIGNATURE_HASH_ERROR);
+        BOOST_CHECK(coinbaseKey.SignECDSA(hash, vchSig));
+        vchSig.push_back((unsigned char)sighashType);
+        tx.vin[0].scriptSig << vchSig;
+        BOOST_CHECK(ToMemPool(tx));
+
+        prevout = tx.GetHash();
+    }
+
+    // Now try to add one more tx with only one input. It should fail because
+    // we are over the limit of 27.
+    {
+        CMutableTransaction tx;
+        tx.vin.resize(1);
+        tx.vin[0].prevout.hash = prevout;
+        tx.vin[0].prevout.n = 0;
+        tx.vout.resize(1);
+        tx.vout[0].nValue = 11 * CENT;
+        tx.vout[0].scriptPubKey = scriptPubKey;
+
+        // Sign:
+        std::vector<unsigned char> vchSig;
+        hash = SignatureHash(scriptPubKey, tx, 0, sighashType, 11 * CENT, 0);
+        BOOST_CHECK(hash != SIGNATURE_HASH_ERROR);
+        BOOST_CHECK(coinbaseKey.SignECDSA(hash, vchSig));
+        vchSig.push_back((unsigned char)sighashType);
+        tx.vin[0].scriptSig << vchSig;
+        BOOST_CHECK(!ToMemPool(tx, "too-long-mempool-chain"));
+    }
+}
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -201,7 +201,7 @@ BOOST_FIXTURE_TEST_CASE(uncache_coins, TestChain100Setup)
     BOOST_CHECK(fSpent == false);
 
     // Try to add the same tx to the memory pool. The coins should still be present.
-    BOOST_CHECK(!ToMemPool(spends[0]));
+    BOOST_CHECK(!ToMemPool(spends[0], "txn-already-in-mempool"));
     BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[0].vin[0].prevout, fSpent));
     BOOST_CHECK(fSpent == false);
 
@@ -223,7 +223,7 @@ BOOST_FIXTURE_TEST_CASE(uncache_coins, TestChain100Setup)
     vchSig2.push_back((unsigned char)sighashType);
     spends[1].vin[0].scriptSig << vchSig2;
 
-    BOOST_CHECK(!ToMemPool(spends[1]));
+    BOOST_CHECK(!ToMemPool(spends[1], "bad-txns-premature-spend-of-coinbase"));
     // not uncached because from a previous txn
     BOOST_CHECK(pcoinsTip->HaveCoinInCache(spends[0].vin[0].prevout, fSpent));
     BOOST_CHECK(fSpent == false);

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -1158,7 +1158,7 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
         if (setAncestors.size() >= BCH_DEFAULT_ANCESTOR_LIMIT && restrictInputs.Value() == true)
         {
             if (tx->vin.size() > 1)
-                return state.DoS(0, false, REJECT_NONSTANDARD, "too-many-inputs");
+                return state.DoS(0, false, REJECT_NONSTANDARD, "bad-txn-too-many-inputs");
         }
 
         if (txProps) // This is inefficient since _CalculateMemPoolAncestors also calculates this

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -1130,6 +1130,51 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
         size_t nLimitDescendants = GetArg("-limitdescendantcount", BU_DEFAULT_DESCENDANT_LIMIT);
         size_t nLimitDescendantSize = GetArg("-limitdescendantsize", BU_DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000;
         std::string errString;
+        CTxMemPool::setEntries setAncestors;
+        {
+            READLOCK(pool.cs_txmempool);
+            // note we could resolve ancestors to hashes and return those if that saves time in the txc thread
+            if (!pool._CalculateMemPoolAncestors(entry, setAncestors, nLimitAncestors, nLimitAncestorSize,
+                    nLimitDescendants, nLimitDescendantSize, errString))
+            {
+                if (debugger)
+                {
+                    debugger->AddInvalidReason("too-long-mempool-chain");
+                    debugger->mineable = false;
+                }
+                else
+                {
+                    // If the chain is not sync'd entirely then we'll defer this tx until the new block is processed.
+                    if (!IsChainSyncd() && IsChainNearlySyncd())
+                        return state.DoS(0, false, REJECT_WAITING, "too-long-mempool-chain");
+                    else
+                        return state.DoS(0, false, REJECT_NONSTANDARD, "too-long-mempool-chain", false, errString);
+                }
+            }
+        }
+        // If restrict inputs is enabled and we are extending a long unconfirmed chain past the network
+        // default limit, then make sure to check that the txn only has one input. This prevents the reverse
+        // double spend attack.
+        if (setAncestors.size() >= BCH_DEFAULT_ANCESTOR_LIMIT && restrictInputs.Value() == true)
+        {
+            if (tx->vin.size() > 1)
+                return state.DoS(0, false, REJECT_NONSTANDARD, "too-many-inputs");
+        }
+
+        if (txProps) // This is inefficient since _CalculateMemPoolAncestors also calculates this
+        {
+            txProps->countWithAncestors = setAncestors.size();
+            uint64_t size = tx->GetTxSize();
+            for (auto ancestor : setAncestors)
+            {
+                size += ancestor->GetTxSize();
+            }
+            txProps->sizeWithAncestors = size;
+
+            // How can something we are just adding have any descendants?  It can't so these values are just this tx
+            txProps->countWithDescendants = 1;
+            txProps->sizeWithDescendants = tx->GetTxSize();
+        }
 
         // Check against previous transactions
         // This is done last to help prevent CPU exhaustion denial-of-service attacks.
@@ -1208,44 +1253,6 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
             else
             {
                 return state.Invalid(false, REJECT_CONFLICT, "txn-mempool-conflict");
-            }
-        }
-
-        {
-            READLOCK(pool.cs_txmempool);
-            CTxMemPool::setEntries setAncestors;
-            // note we could resolve ancestors to hashes and return those if that saves time in the txc thread
-            if (!pool._CalculateMemPoolAncestors(entry, setAncestors, nLimitAncestors, nLimitAncestorSize,
-                    nLimitDescendants, nLimitDescendantSize, errString))
-            {
-                if (debugger)
-                {
-                    debugger->AddInvalidReason("too-long-mempool-chain");
-                    debugger->mineable = false;
-                }
-                else
-                {
-                    // If the chain is not sync'd entirely then we'll defer this tx until the new block is processed.
-                    if (!IsChainSyncd() && IsChainNearlySyncd())
-                        return state.DoS(0, false, REJECT_WAITING, "too-long-mempool-chain");
-                    else
-                        return state.DoS(0, false, REJECT_NONSTANDARD, "too-long-mempool-chain", false, errString);
-                }
-            }
-
-            if (txProps) // This is inefficient since _CalculateMemPoolAncestors also calculates this
-            {
-                txProps->countWithAncestors = setAncestors.size();
-                uint64_t size = tx->GetTxSize();
-                for (auto ancestor : setAncestors)
-                {
-                    size += ancestor->GetTxSize();
-                }
-                txProps->sizeWithAncestors = size;
-
-                // How can something we are just adding have any descendants?  It can't so these values are just this tx
-                txProps->countWithDescendants = 1;
-                txProps->sizeWithDescendants = tx->GetTxSize();
             }
         }
 

--- a/src/txadmission.h
+++ b/src/txadmission.h
@@ -122,6 +122,9 @@ enum
 // maximum transaction mempool admission threads
 extern CTweak<unsigned int> numTxAdmissionThreads;
 
+// restrict transaction inputs to 1 for long unconfirmed chains
+extern CTweak<bool> restrictInputs;
+
 extern CRollingFastFilter<4 * 1024 * 1024> recentRejects;
 extern CRollingFastFilter<4 * 1024 * 1024> txRecentlyInBlock;
 

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -3634,8 +3634,13 @@ bool CMerkleTx::AcceptToMemoryPool(bool fLimitFree, bool fRejectAbsurdFee)
     CValidationState state;
     // Skip mempool commit because the commit informs the wallet but with the accounts stripped.
     // By not committing inline, the caller wallet code can place this tx into the wallet first
-    return ::AcceptToMemoryPool(mempool, state, MakeTransactionRef(*this), fLimitFree, nullptr, false, fRejectAbsurdFee,
-        TransactionClass::DEFAULT);
+    bool ret = ::AcceptToMemoryPool(mempool, state, MakeTransactionRef(*this), fLimitFree, nullptr, false,
+        fRejectAbsurdFee, TransactionClass::DEFAULT);
+    if (!ret)
+    {
+        LOGA("ERROR: Transaction not sent - %s\n", state.GetRejectReason());
+    }
+    return ret;
 }
 
 


### PR DESCRIPTION
When we exceed the standard unconfirmed chain length of 25 then do not accept any more unconfirmed transactions that extend that chain unless they have a single input.