### PR TITLE
Set the default behaviour of -limitfreerelay to zero

### DIFF
--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -377,7 +377,7 @@ def initialize_datadir(dirname, n, bitcoinConfDict=None, wallet=None, bins=None)
     rpc_u, rpc_p = rpc_auth_pair(n)
     defaults = {"server":1, "discover":0, "regtest":1,"rpcuser":"rt","rpcpassword":"rt",
                 "port":p2p_port(n),"rpcport":str(rpc_port(n)),"listenonion":0,"maxlimitertxfee":0,"usecashaddr":1,
-                "rpcuser":rpc_u, "rpcpassword":rpc_p, "bindallorfail" : 1}
+                "rpcuser":rpc_u, "rpcpassword":rpc_p, "bindallorfail" : 1, "minlimitertxfee":0, "limitfreerelay":15}
 
     # switch off default IPv6 listening port (for travis)
     if UtilOptions.no_ipv6_rpc_listen:

--- a/src/txadmission.h
+++ b/src/txadmission.h
@@ -23,9 +23,11 @@ static const unsigned int MAX_BLOCK_SIZE_MULTIPLIER = 3;
 /** The maximum number of free transactions (in KB) that can enter the mempool per minute.
  *  For a 1MB block we allow 15KB of free transactions per 1 minute.
  */
-static const uint32_t DEFAULT_LIMITFREERELAY = DEFAULT_BLOCK_MAX_SIZE * 0.000015;
+// static const uint32_t DEFAULT_LIMITFREERELAY = DEFAULT_BLOCK_MAX_SIZE * 0.000015;
+static const uint32_t DEFAULT_LIMITFREERELAY = 0;
 /** The minimum value possible for -limitfreerelay when rate limiting */
-static const unsigned int DEFAULT_MIN_LIMITFREERELAY = 1;
+// static const unsigned int DEFAULT_MIN_LIMITFREERELAY = 1;
+static const unsigned int DEFAULT_MIN_LIMITFREERELAY = 0;
 
 /** Subject free transactions to priority checking when entering the mempool */
 static const bool DEFAULT_RELAYPRIORITY = false;


### PR DESCRIPTION
This aligns us with ABC's policy and should stay in place until we
have double spend proofs in place.