### PR TITLE
Add a description as to why we sort by time for ancestor transactions

### DIFF
--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -304,6 +304,11 @@ public:
 
         if (f1 == f2)
         {
+            // Sorting by time here does two things when mining CPFP packages. In the case of long
+            // packages, it finds the part of the package that fits perfectly into the block, because
+            // we won't bail out early due to package insertion failures. Secondly it also preserves some
+            // sense of fairness that, all other things begin equal, the first transation to arrive in the
+            // mempool has priority over ones that follow.
             return a.GetTime() < b.GetTime();
         }
 


### PR DESCRIPTION
When mining CPFP packages it's important to sort by time for two reasons. One
so that we end up filling a block perfectly int the case of long chains that
have the same fees for each transaction, and secondly to preserve some sense
of fairness that the first transaction to arrive in the mempool is the one
that has the higher priority.