### PR TITLE
[WIP] Introduce EndPoints and use them

### DIFF
--- a/src/coins.cpp
+++ b/src/coins.cpp
@@ -440,11 +440,10 @@ void CCoinsViewCache::Trim(size_t nTrimSize) const
     }
 }
 
-void CCoinsViewCache::Uncache(const COutPoint &hash)
+void CCoinsViewCache::Uncache(const COutPoint &outpoint)
 {
     WRITELOCK(cs_utxo);
-    CCoinsMap::iterator it = cacheCoins.find(hash);
-
+    CCoinsMap::iterator it = cacheCoins.find(outpoint);
     // only uncache coins that are not dirty.
     if (it != cacheCoins.end() && it->second.flags == 0)
     {

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -50,6 +50,8 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     std::list<CTransactionRef> dummyConflicted;
     tx.vin.resize(1);
     tx.vin[0].scriptSig = garbage;
+    tx.vin[0].prevout.hash = GetRandHash();
+    tx.vin[0].prevout.n = 0;
     tx.vout.resize(1);
     tx.vout[0].nValue = 0LL;
     CFeeRate baseRate(basefee, ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION));
@@ -110,7 +112,6 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
             BOOST_CHECK(mpool.estimateSmartFee(8, &answerFound) == mpool.estimateFee(8) && answerFound == 8);
         }
     }
-
     std::vector<CAmount> origFeeEst;
     std::vector<double> origPriEst;
     // Highest feerate is 10*baseRate and gets in all blocks,
@@ -192,6 +193,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
             txHashes[j].pop_back();
         }
     }
+
     mpool.removeForBlock(block, 265, dummyConflicted);
     block.clear();
     for (int i = 1; i < 10; i++)
@@ -223,6 +225,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
         mpool.removeForBlock(block, ++blocknum, dummyConflicted);
         block.clear();
     }
+
     for (int i = 1; i < 10; i++)
     {
         BOOST_CHECK(mpool.estimateFee(i).GetFeePerK() < origFeeEst[i - 1] - deltaFee);
@@ -236,6 +239,7 @@ BOOST_AUTO_TEST_CASE(BlockPolicyEstimates)
     // evict that transaction which should set a mempool min fee of minRelayTxFee + feeV[0][5]
     mpool.TrimToSize(1);
     BOOST_CHECK(mpool.GetMinFee(1).GetFeePerK() > feeV[0][5]);
+
     for (int i = 1; i < 10; i++)
     {
         BOOST_CHECK(mpool.estimateSmartFee(i).GetFeePerK() >= mpool.estimateFee(i).GetFeePerK());

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -256,16 +256,16 @@ void ThreadCommitToMempool()
 void LimitMempoolSize(CTxMemPool &pool, size_t limit, unsigned long age)
 {
     std::vector<COutPoint> vCoinsToUncache;
-    int expired = pool.Expire(GetTime() - age, vCoinsToUncache);
+    int expired = pool.Expire(GetTime() - age, &vCoinsToUncache);
     for (const COutPoint &txin : vCoinsToUncache)
         pcoinsTip->Uncache(txin);
     if (expired != 0)
         LOG(MEMPOOL, "Expired %i transactions from the memory pool\n", expired);
 
-    std::vector<COutPoint> vNoSpendsRemaining;
-    pool.TrimToSize(limit, &vNoSpendsRemaining);
-    for (const COutPoint &removed : vNoSpendsRemaining)
-        pcoinsTip->Uncache(removed);
+    vCoinsToUncache.clear();
+    pool.TrimToSize(limit, &vCoinsToUncache);
+    for (const COutPoint &txin : vCoinsToUncache)
+        pcoinsTip->Uncache(txin);
 }
 
 void CommitTxToMempool()


### PR DESCRIPTION
An endpoint is  simply a transaction that is either at the beginning of a long
chain or at the end, it either has no parent or no child. This can be useful in
speeding up the processing of transaction chains.

Improve performance of Expire() and TrimToSize() by simply removing the entire
chain associated with any given transaction. In the case of Expire() it is
completely useless to do any proessing on ancestor/descendant state since
any ancestors will logically be older than the current transaction being expired
and therefore should be expired as well, and of course the descendants can not
be held in the mempool without its parent.  In the case of TrimToSize() removing
the entire chain is faster but may remove a few more txns than necessary, however,
this is good  since it's helpful to flush a few more txns which prevents us
from having to go through another flush cycle when the next txn arrives. This is similar
to our our dbcache flushing works and in the end prevents us from having to do and expensive round of ancestor/descendant state updates.