### PR TITLE
Improve block post processing from O(n^2) to O(n)

### DIFF
--- a/src/test/mempool_tests.cpp
+++ b/src/test/mempool_tests.cpp
@@ -12,7 +12,1402 @@
 #include <list>
 #include <vector>
 
+extern CCoinsViewCache *pcoinsTip;
+
+struct MempoolData
+{
+    uint256 hash;
+
+    // Ancestor counters
+    uint64_t nCountWithAncestors = 0;
+    uint64_t nSizeWithAncestors = 0;
+    uint64_t nSigopsWithAncestors = 0;
+    uint64_t nFeesWithAncestors = 0;
+
+    // Descendant counters
+    uint64_t nCountWithDescendants = 0;
+    uint64_t nSizeWithDescendants = 0;
+    uint64_t nFeesWithDescendants = 0;
+};
+
+void CheckAncestors(CTxMemPool::txiter iter, MempoolData &expected_result, CTxMemPool &pool)
+{
+    if (iter == pool.mapTx.end())
+    {
+        printf("ERROR: tx %s not found in mempool\n", expected_result.hash.ToString().c_str());
+        throw;
+    }
+
+    BOOST_CHECK_EQUAL(iter->GetCountWithAncestors(), expected_result.nCountWithAncestors);
+    BOOST_CHECK_EQUAL(iter->GetSizeWithAncestors(), expected_result.nSizeWithAncestors);
+    BOOST_CHECK_EQUAL(iter->GetSigOpCountWithAncestors(), expected_result.nSigopsWithAncestors);
+    BOOST_CHECK_EQUAL(iter->GetModFeesWithAncestors(), expected_result.nFeesWithAncestors);
+    BOOST_CHECK_EQUAL(iter->GetCountWithDescendants(), expected_result.nCountWithDescendants);
+    BOOST_CHECK_EQUAL(iter->GetSizeWithDescendants(), expected_result.nSizeWithDescendants);
+    BOOST_CHECK_EQUAL(iter->GetModFeesWithDescendants(), expected_result.nFeesWithDescendants);
+}
+
 BOOST_FIXTURE_TEST_SUITE(mempool_tests, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(MempoolUpdateChainStateTest)
+{
+    TestMemPoolEntryHelper entry;
+    CTxMemPool pool(CFeeRate(0));
+    pool.clear();
+
+    /* Create a complex set of chained transactions and then update their state after removing some from the mempool.
+       (The numbers indicate the tx number, ie. 1 == tx1)
+
+    Chain1:
+
+    1      2   3      4
+    |      |   |      |
+    5      6   7      8
+     \    /     \    /
+      \  /       \  /
+       9          10      20
+       | \        |       /
+       |  \______ 11 ____/
+       |          |\
+       12         | \
+      /|\        13 14      19
+     / | \        | /       /
+    15 16 17      18 ______/
+
+    */
+
+    // Chain:1 Transactions
+
+    // tx1
+    CMutableTransaction tx1 = CMutableTransaction();
+    tx1.vout.resize(1);
+    tx1.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx1.vout[0].nValue = 1 * COIN;
+    pool.addUnchecked(tx1.GetHash(), entry.Fee(1000LL).Priority(10.0).SigOps(1).FromTx(tx1));
+
+    // tx2
+    CMutableTransaction tx2 = CMutableTransaction();
+    tx2.vout.resize(1);
+    tx2.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx2.vout[0].nValue = 2 * COIN;
+    pool.addUnchecked(tx2.GetHash(), entry.Fee(2000LL).Priority(10.0).SigOps(1).FromTx(tx2));
+
+    // tx3
+    CMutableTransaction tx3 = CMutableTransaction();
+    tx3.vout.resize(1);
+    tx3.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx3.vout[0].nValue = 3 * COIN;
+    pool.addUnchecked(tx3.GetHash(), entry.Fee(3000LL).Priority(10.0).SigOps(1).FromTx(tx3));
+
+    // tx4
+    CMutableTransaction tx4 = CMutableTransaction();
+    tx4.vout.resize(1);
+    tx4.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx4.vout[0].nValue = 4 * COIN;
+    pool.addUnchecked(tx4.GetHash(), entry.Fee(4000LL).Priority(10.0).SigOps(1).FromTx(tx4));
+
+
+    // tx5 - child of tx1
+    CMutableTransaction tx5 = CMutableTransaction();
+    tx5.vin.resize(1);
+    tx5.vin[0].scriptSig = CScript() << OP_11;
+    tx5.vin[0].prevout.hash = tx1.GetHash();
+    tx5.vin[0].prevout.n = 0;
+    tx5.vout.resize(1);
+    tx5.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx5.vout[0].nValue = 1 * COIN;
+    pool.addUnchecked(tx5.GetHash(), entry.Fee(1000LL).Priority(10.0).SigOps(1).FromTx(tx5));
+
+
+    // tx6 - child of tx2
+    CMutableTransaction tx6 = CMutableTransaction();
+    tx6.vin.resize(1);
+    tx6.vin[0].scriptSig = CScript() << OP_11;
+    tx6.vin[0].prevout.hash = tx2.GetHash();
+    tx6.vin[0].prevout.n = 0;
+    tx6.vout.resize(1);
+    tx6.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx6.vout[0].nValue = 2 * COIN;
+    pool.addUnchecked(tx6.GetHash(), entry.Fee(2000LL).Priority(10.0).SigOps(1).FromTx(tx6));
+
+    // tx7 - child of tx3
+    CMutableTransaction tx7 = CMutableTransaction();
+    tx7.vin.resize(1);
+    tx7.vin[0].scriptSig = CScript() << OP_11;
+    tx7.vin[0].prevout.hash = tx3.GetHash();
+    tx7.vin[0].prevout.n = 0;
+    tx7.vout.resize(1);
+    tx7.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx7.vout[0].nValue = 3 * COIN;
+    pool.addUnchecked(tx7.GetHash(), entry.Fee(3000LL).Priority(10.0).SigOps(1).FromTx(tx7));
+
+
+    // tx8 - child of tx4
+    CMutableTransaction tx8 = CMutableTransaction();
+    tx8.vin.resize(1);
+    tx8.vin[0].scriptSig = CScript() << OP_11;
+    tx8.vin[0].prevout.hash = tx4.GetHash();
+    tx8.vin[0].prevout.n = 0;
+    tx8.vout.resize(1);
+    tx8.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx8.vout[0].nValue = 4 * COIN;
+    pool.addUnchecked(tx8.GetHash(), entry.Fee(4000LL).Priority(10.0).SigOps(1).FromTx(tx8));
+
+    // tx9 - child of tx5 and tx6 and has two outputs
+    CMutableTransaction tx9 = CMutableTransaction();
+    tx9.vin.resize(2);
+    tx9.vin[0].scriptSig = CScript() << OP_11;
+    tx9.vin[0].prevout.hash = tx5.GetHash();
+    tx9.vin[0].prevout.n = 0;
+    tx9.vin[1].scriptSig = CScript() << OP_11;
+    tx9.vin[1].prevout.hash = tx6.GetHash();
+    tx9.vin[1].prevout.n = 0;
+    tx9.vout.resize(2);
+    tx9.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx9.vout[0].nValue = 1 * COIN;
+    tx9.vout[1].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx9.vout[1].nValue = 2 * COIN;
+    pool.addUnchecked(tx9.GetHash(), entry.Fee(3000LL).Priority(10.0).SigOps(1).FromTx(tx9));
+
+    // tx10 - child of tx7 and tx8 and has one output
+    CMutableTransaction tx10 = CMutableTransaction();
+    tx10.vin.resize(2);
+    tx10.vin[0].scriptSig = CScript() << OP_11;
+    tx10.vin[0].prevout.hash = tx7.GetHash();
+    tx10.vin[0].prevout.n = 0;
+    tx10.vin[1].scriptSig = CScript() << OP_11;
+    tx10.vin[1].prevout.hash = tx8.GetHash();
+    tx10.vin[1].prevout.n = 0;
+    tx10.vout.resize(1);
+    tx10.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx10.vout[0].nValue = 7 * COIN;
+    pool.addUnchecked(tx10.GetHash(), entry.Fee(7000LL).SigOps(1).FromTx(tx10));
+
+    // tx20
+    CMutableTransaction tx20 = CMutableTransaction();
+    tx20.vout.resize(1);
+    tx20.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx20.vout[0].nValue = 5 * COIN;
+    pool.addUnchecked(tx20.GetHash(), entry.Fee(5000LL).Priority(10.0).SigOps(1).FromTx(tx20));
+
+    // tx11 - child of tx9, tx10 and tx20, and has two outputs
+    CMutableTransaction tx11 = CMutableTransaction();
+    tx11.vin.resize(3);
+    tx11.vin[0].scriptSig = CScript() << OP_11;
+    tx11.vin[0].prevout.hash = tx9.GetHash();
+    tx11.vin[0].prevout.n = 1;
+    tx11.vin[1].scriptSig = CScript() << OP_11;
+    tx11.vin[1].prevout.hash = tx10.GetHash();
+    tx11.vin[1].prevout.n = 0;
+    tx11.vin[2].scriptSig = CScript() << OP_11;
+    tx11.vin[2].prevout.hash = tx20.GetHash();
+    tx11.vin[2].prevout.n = 0;
+    tx11.vout.resize(2);
+    tx11.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx11.vout[0].nValue = 1 * COIN;
+    tx11.vout[1].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx11.vout[1].nValue = 2 * COIN;
+    pool.addUnchecked(tx11.GetHash(), entry.Fee(10000LL).SigOps(1).FromTx(tx11));
+
+    // tx12 - child of tx9 and has three outputs
+    CMutableTransaction tx12 = CMutableTransaction();
+    tx12.vin.resize(1);
+    tx12.vin[0].scriptSig = CScript() << OP_11;
+    tx12.vin[0].prevout.hash = tx9.GetHash();
+    tx12.vin[0].prevout.n = 0;
+    tx12.vout.resize(3);
+    tx12.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx12.vout[0].nValue = .5 * COIN;
+    tx12.vout[1].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx12.vout[1].nValue = .2 * COIN;
+    tx12.vout[2].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx12.vout[2].nValue = .3 * COIN;
+    pool.addUnchecked(tx12.GetHash(), entry.Fee(1000LL).Priority(10.0).SigOps(1).FromTx(tx12));
+
+    // tx13 - child of tx11 and has one output
+    CMutableTransaction tx13 = CMutableTransaction();
+    tx13.vin.resize(1);
+    tx13.vin[0].scriptSig = CScript() << OP_11;
+    tx13.vin[0].prevout.hash = tx11.GetHash();
+    tx13.vin[0].prevout.n = 0;
+    tx13.vout.resize(1);
+    tx13.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx13.vout[0].nValue = 1 * COIN;
+    pool.addUnchecked(tx13.GetHash(), entry.Fee(1000LL).SigOps(1).FromTx(tx13));
+
+
+    // tx14 - child of tx11 and has one output
+    CMutableTransaction tx14 = CMutableTransaction();
+    tx14.vin.resize(1);
+    tx14.vin[0].scriptSig = CScript() << OP_11;
+    tx14.vin[0].prevout.hash = tx11.GetHash();
+    tx14.vin[0].prevout.n = 1;
+    tx14.vout.resize(1);
+    tx14.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx14.vout[0].nValue = 1 * COIN;
+    pool.addUnchecked(tx14.GetHash(), entry.Fee(1000LL).SigOps(1).FromTx(tx14));
+
+    // tx15 - child of tx12
+    CMutableTransaction tx15 = CMutableTransaction();
+    tx15.vin.resize(1);
+    tx15.vin[0].scriptSig = CScript() << OP_11;
+    tx15.vin[0].prevout.hash = tx12.GetHash();
+    tx15.vin[0].prevout.n = 0;
+    tx15.vout.resize(1);
+    tx15.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx15.vout[0].nValue = 1 * COIN;
+    pool.addUnchecked(tx15.GetHash(), entry.Fee(500LL).SigOps(1).FromTx(tx15));
+
+    // tx16 - child of tx12
+    CMutableTransaction tx16 = CMutableTransaction();
+    tx16.vin.resize(1);
+    tx16.vin[0].scriptSig = CScript() << OP_11;
+    tx16.vin[0].prevout.hash = tx12.GetHash();
+    tx16.vin[0].prevout.n = 1;
+    tx16.vout.resize(1);
+    tx16.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx16.vout[0].nValue = 1 * COIN;
+    pool.addUnchecked(tx16.GetHash(), entry.Fee(200LL).SigOps(1).FromTx(tx16));
+
+    // tx17 - child of tx12
+    CMutableTransaction tx17 = CMutableTransaction();
+    tx17.vin.resize(1);
+    tx17.vin[0].scriptSig = CScript() << OP_11;
+    tx17.vin[0].prevout.hash = tx12.GetHash();
+    tx17.vin[0].prevout.n = 2;
+    tx17.vout.resize(1);
+    tx17.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx17.vout[0].nValue = 1 * COIN;
+    pool.addUnchecked(tx17.GetHash(), entry.Fee(300LL).SigOps(1).FromTx(tx17));
+
+    // tx19
+    CMutableTransaction tx19 = CMutableTransaction();
+    tx19.vout.resize(1);
+    tx19.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx19.vout[0].nValue = 6 * COIN;
+    pool.addUnchecked(tx19.GetHash(), entry.Fee(6000LL).Priority(10.0).SigOps(1).FromTx(tx19));
+
+
+    // tx18 - child of tx13, tx14 and 19, and has two outputs
+    CMutableTransaction tx18 = CMutableTransaction();
+    tx18.vin.resize(3);
+    tx18.vin[0].scriptSig = CScript() << OP_11;
+    tx18.vin[0].prevout.hash = tx13.GetHash();
+    tx18.vin[0].prevout.n = 0;
+    tx18.vin[1].scriptSig = CScript() << OP_11;
+    tx18.vin[1].prevout.hash = tx14.GetHash();
+    tx18.vin[1].prevout.n = 0;
+    tx18.vin[2].scriptSig = CScript() << OP_11;
+    tx18.vin[2].prevout.hash = tx19.GetHash();
+    tx18.vin[2].prevout.n = 0;
+    tx18.vout.resize(2);
+    tx18.vout[0].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx18.vout[0].nValue = 1 * COIN;
+    tx18.vout[1].scriptPubKey = CScript() << OP_11 << OP_EQUAL;
+    tx18.vout[1].nValue = 2 * COIN;
+    pool.addUnchecked(tx18.GetHash(), entry.Fee(2000LL).SigOps(1).FromTx(tx18));
+
+
+    // Chain:2 Transactions
+    /*
+
+                            21                     27
+                            |                      /
+            ________________22_______________     /
+           /         /      |      \         \   28
+          /         /       23      \         \  /
+         /         /       / \       \         \/
+        31        32      24 25      33        29
+         \         \       \ /       /         /\
+          \         \       26      /         /  \
+           \         \      |      /         /    \
+           34_________\_____35____/_________/     30
+                           / \
+                          36 37
+                           \ /
+                            38
+    */
+
+    // tx21
+    CMutableTransaction tx21 = CMutableTransaction();
+    tx21.vout.resize(1);
+    tx21.vout[0].scriptPubKey = CScript();
+    tx21.vout[0].nValue = 100 * COIN;
+    pool.addUnchecked(tx21.GetHash(), entry.Fee(100000LL).Priority(10.0).SigOps(1).FromTx(tx21));
+
+
+    // tx22 - child of tx21 and has 5 outputs
+    CMutableTransaction tx22 = CMutableTransaction();
+    tx22.vin.resize(1);
+    tx22.vin[0].scriptSig = CScript();
+    tx22.vin[0].prevout.hash = tx21.GetHash();
+    tx22.vin[0].prevout.n = 0;
+    tx22.vout.resize(5);
+    tx22.vout[0].scriptPubKey = CScript();
+    tx22.vout[0].nValue = 20 * COIN;
+    tx22.vout[1].scriptPubKey = CScript();
+    tx22.vout[1].nValue = 20 * COIN;
+    tx22.vout[2].scriptPubKey = CScript();
+    tx22.vout[2].nValue = 20 * COIN;
+    tx22.vout[3].scriptPubKey = CScript();
+    tx22.vout[3].nValue = 20 * COIN;
+    tx22.vout[4].scriptPubKey = CScript();
+    tx22.vout[4].nValue = 20 * COIN;
+    pool.addUnchecked(tx22.GetHash(), entry.Fee(100000LL).Priority(10.0).SigOps(1).FromTx(tx22));
+
+
+    // tx23 - child of tx22 and has two outputs
+    CMutableTransaction tx23 = CMutableTransaction();
+    tx23.vin.resize(1);
+    tx23.vin[0].scriptSig = CScript();
+    tx23.vin[0].prevout.hash = tx22.GetHash();
+    tx23.vin[0].prevout.n = 2;
+    tx23.vout.resize(2);
+    tx23.vout[0].scriptPubKey = CScript();
+    tx23.vout[0].nValue = 10 * COIN;
+    tx23.vout[1].scriptPubKey = CScript();
+    tx23.vout[1].nValue = 10 * COIN;
+    pool.addUnchecked(tx23.GetHash(), entry.Fee(20000LL).Priority(10.0).SigOps(1).FromTx(tx23));
+
+    // tx24 - child of tx23 and has one output
+    CMutableTransaction tx24 = CMutableTransaction();
+    tx24.vin.resize(1);
+    tx24.vin[0].scriptSig = CScript();
+    tx24.vin[0].prevout.hash = tx23.GetHash();
+    tx24.vin[0].prevout.n = 0;
+    tx24.vout.resize(1);
+    tx24.vout[0].scriptPubKey = CScript();
+    tx24.vout[0].nValue = 10 * COIN;
+    pool.addUnchecked(tx24.GetHash(), entry.Fee(10000LL).SigOps(1).FromTx(tx24));
+
+    // tx25 - child of tx23 and has one output
+    CMutableTransaction tx25 = CMutableTransaction();
+    tx25.vin.resize(1);
+    tx25.vin[0].scriptSig = CScript();
+    tx25.vin[0].prevout.hash = tx23.GetHash();
+    tx25.vin[0].prevout.n = 1;
+    tx25.vout.resize(1);
+    tx25.vout[0].scriptPubKey = CScript();
+    tx25.vout[0].nValue = 10 * COIN;
+    pool.addUnchecked(tx25.GetHash(), entry.Fee(10000LL).SigOps(1).FromTx(tx25));
+
+    // tx26 - child of tx24 and tx25 and has one output
+    CMutableTransaction tx26 = CMutableTransaction();
+    tx26.vin.resize(2);
+    tx26.vin[0].scriptSig = CScript();
+    tx26.vin[0].prevout.hash = tx24.GetHash();
+    tx26.vin[0].prevout.n = 0;
+    tx26.vin[1].scriptSig = CScript();
+    tx26.vin[1].prevout.hash = tx25.GetHash();
+    tx26.vin[1].prevout.n = 0;
+    tx26.vout.resize(1);
+    tx26.vout[0].scriptPubKey = CScript();
+    tx26.vout[0].nValue = 20 * COIN;
+    pool.addUnchecked(tx26.GetHash(), entry.Fee(20000LL).SigOps(1).FromTx(tx26));
+
+    // tx27
+    CMutableTransaction tx27 = CMutableTransaction();
+    tx27.vout.resize(1);
+    tx27.vout[0].scriptPubKey = CScript();
+    tx27.vout[0].nValue = 101 * COIN;
+    pool.addUnchecked(tx27.GetHash(), entry.Fee(101000LL).Priority(10.0).SigOps(1).FromTx(tx27));
+
+    // tx28 - child of tx27 and has one output
+    CMutableTransaction tx28 = CMutableTransaction();
+    tx28.vin.resize(1);
+    tx28.vin[0].scriptSig = CScript();
+    tx28.vin[0].prevout.hash = tx27.GetHash();
+    tx28.vin[0].prevout.n = 0;
+    tx28.vout.resize(1);
+    tx28.vout[0].scriptPubKey = CScript();
+    tx28.vout[0].nValue = 101 * COIN;
+    pool.addUnchecked(tx28.GetHash(), entry.Fee(101000LL).SigOps(1).FromTx(tx28));
+
+    // tx29 - child of tx22 and tx28 and has two outputs
+    CMutableTransaction tx29 = CMutableTransaction();
+    tx29.vin.resize(2);
+    tx29.vin[0].scriptSig = CScript();
+    tx29.vin[0].prevout.hash = tx22.GetHash();
+    tx29.vin[0].prevout.n = 4;
+    tx29.vin[1].scriptSig = CScript();
+    tx29.vin[1].prevout.hash = tx28.GetHash();
+    tx29.vin[1].prevout.n = 0;
+    tx29.vout.resize(2);
+    tx29.vout[0].scriptPubKey = CScript();
+    tx29.vout[0].nValue = 100 * COIN;
+    tx29.vout[1].scriptPubKey = CScript();
+    tx29.vout[1].nValue = 101 * COIN;
+    pool.addUnchecked(tx29.GetHash(), entry.Fee(201000LL).Priority(10.0).SigOps(1).FromTx(tx29));
+
+    // tx30 - child of tx29 and has one output
+    CMutableTransaction tx30 = CMutableTransaction();
+    tx30.vin.resize(1);
+    tx30.vin[0].scriptSig = CScript();
+    tx30.vin[0].prevout.hash = tx29.GetHash();
+    tx30.vin[0].prevout.n = 1;
+    tx30.vout.resize(1);
+    tx30.vout[0].scriptPubKey = CScript();
+    tx30.vout[0].nValue = 101 * COIN;
+    pool.addUnchecked(tx30.GetHash(), entry.Fee(101000LL).SigOps(1).FromTx(tx30));
+
+    // tx31 - child of tx22 and has one output
+    CMutableTransaction tx31 = CMutableTransaction();
+    tx31.vin.resize(1);
+    tx31.vin[0].scriptSig = CScript();
+    tx31.vin[0].prevout.hash = tx22.GetHash();
+    tx31.vin[0].prevout.n = 0;
+    tx31.vout.resize(1);
+    tx31.vout[0].scriptPubKey = CScript();
+    tx31.vout[0].nValue = 20 * COIN;
+    pool.addUnchecked(tx31.GetHash(), entry.Fee(20000LL).SigOps(1).FromTx(tx31));
+
+    // tx32 - child of tx22 and has one output
+    CMutableTransaction tx32 = CMutableTransaction();
+    tx32.vin.resize(1);
+    tx32.vin[0].scriptSig = CScript();
+    tx32.vin[0].prevout.hash = tx22.GetHash();
+    tx32.vin[0].prevout.n = 1;
+    tx32.vout.resize(1);
+    tx32.vout[0].scriptPubKey = CScript();
+    tx32.vout[0].nValue = 20 * COIN;
+    pool.addUnchecked(tx32.GetHash(), entry.Fee(20000LL).SigOps(1).FromTx(tx32));
+
+    // tx33 - child of tx22 and has one output
+    CMutableTransaction tx33 = CMutableTransaction();
+    tx33.vin.resize(1);
+    tx33.vin[0].scriptSig = CScript();
+    tx33.vin[0].prevout.hash = tx22.GetHash();
+    tx33.vin[0].prevout.n = 3;
+    tx33.vout.resize(1);
+    tx33.vout[0].scriptPubKey = CScript();
+    tx33.vout[0].nValue = 20 * COIN;
+    pool.addUnchecked(tx33.GetHash(), entry.Fee(20000LL).SigOps(1).FromTx(tx33));
+
+    // tx34 - child of tx31 and has one output
+    CMutableTransaction tx34 = CMutableTransaction();
+    tx34.vin.resize(1);
+    tx34.vin[0].scriptSig = CScript();
+    tx34.vin[0].prevout.hash = tx31.GetHash();
+    tx34.vin[0].prevout.n = 0;
+    tx34.vout.resize(1);
+    tx34.vout[0].scriptPubKey = CScript();
+    tx34.vout[0].nValue = 20 * COIN;
+    pool.addUnchecked(tx34.GetHash(), entry.Fee(20000LL).SigOps(1).FromTx(tx34));
+
+    // tx35 - child of tx26, tx29, tx32, tx33, tx34 and has two outputs
+    CMutableTransaction tx35 = CMutableTransaction();
+    tx35.vin.resize(5);
+    tx35.vin[0].scriptSig = CScript();
+    tx35.vin[0].prevout.hash = tx26.GetHash();
+    tx35.vin[0].prevout.n = 0;
+    tx35.vin[1].scriptSig = CScript();
+    tx35.vin[1].prevout.hash = tx29.GetHash();
+    tx35.vin[1].prevout.n = 0;
+    tx35.vin[2].scriptSig = CScript();
+    tx35.vin[2].prevout.hash = tx32.GetHash();
+    tx35.vin[2].prevout.n = 0;
+    tx35.vin[3].scriptSig = CScript();
+    tx35.vin[3].prevout.hash = tx33.GetHash();
+    tx35.vin[3].prevout.n = 0;
+    tx35.vin[4].scriptSig = CScript();
+    tx35.vin[4].prevout.hash = tx34.GetHash();
+    tx35.vin[4].prevout.n = 0;
+    tx35.vout.resize(2);
+    tx35.vout[0].scriptPubKey = CScript();
+    tx35.vout[0].nValue = 200 * COIN;
+    tx35.vout[1].scriptPubKey = CScript();
+    tx35.vout[1].nValue = 81 * COIN;
+    pool.addUnchecked(tx35.GetHash(), entry.Fee(281000LL).Priority(10.0).SigOps(1).FromTx(tx35));
+
+    // tx36 - child of tx35 and has one output
+    CMutableTransaction tx36 = CMutableTransaction();
+    tx36.vin.resize(1);
+    tx36.vin[0].scriptSig = CScript();
+    tx36.vin[0].prevout.hash = tx35.GetHash();
+    tx36.vin[0].prevout.n = 0;
+    tx36.vout.resize(1);
+    tx36.vout[0].scriptPubKey = CScript();
+    tx36.vout[0].nValue = 200 * COIN;
+    pool.addUnchecked(tx36.GetHash(), entry.Fee(200000LL).SigOps(1).FromTx(tx36));
+
+    // tx37 - child of tx35 and has one output
+    CMutableTransaction tx37 = CMutableTransaction();
+    tx37.vin.resize(1);
+    tx37.vin[0].scriptSig = CScript();
+    tx37.vin[0].prevout.hash = tx35.GetHash();
+    tx37.vin[0].prevout.n = 1;
+    tx37.vout.resize(1);
+    tx37.vout[0].scriptPubKey = CScript();
+    tx37.vout[0].nValue = 81 * COIN;
+    pool.addUnchecked(tx37.GetHash(), entry.Fee(81000LL).SigOps(1).FromTx(tx37));
+
+    // tx38 - child of tx36 and tx37 and has one output
+    CMutableTransaction tx38 = CMutableTransaction();
+    tx38.vin.resize(2);
+    tx38.vin[0].scriptSig = CScript();
+    tx38.vin[0].prevout.hash = tx36.GetHash();
+    tx38.vin[0].prevout.n = 0;
+    tx38.vin[1].scriptSig = CScript();
+    tx38.vin[1].prevout.hash = tx37.GetHash();
+    tx38.vin[1].prevout.n = 0;
+    tx38.vout.resize(1);
+    tx38.vout[0].scriptPubKey = CScript();
+    tx38.vout[0].nValue = 281 * COIN;
+    pool.addUnchecked(tx38.GetHash(), entry.Fee(2810000LL).SigOps(1).FromTx(tx38));
+
+    /*  Simple chain with the purpose to test and edge condition where txchaintips become decendants of other
+        txchaintips. We will mine tx39, tx44, and tx47 which means that there will be
+        three txchaintips, one at tx41, one at tx42, and one at 45, with both 42 and 45 in the same chain as 41,
+        thus being an edge condition we have to account for.
+
+    Chain3:  we will mine txn 39, 44 and 47
+
+           44
+           /
+    39 40 41
+     \ | / \
+      \|/   \   47
+       42   46  /
+       |     \ /
+       43    45
+       |       \
+       48      49
+
+    */
+
+    // tx39
+    CMutableTransaction tx39 = CMutableTransaction();
+    tx39.vout.resize(1);
+    tx39.vout[0].scriptPubKey = CScript() << OP_11;
+    tx39.vout[0].nValue = 1 * COIN;
+    pool.addUnchecked(tx39.GetHash(), entry.Fee(1000LL).Priority(10.0).SigOps(1).FromTx(tx39));
+
+    // tx40
+    CMutableTransaction tx40 = CMutableTransaction();
+    tx40.vout.resize(1);
+    tx40.vout[0].scriptPubKey = CScript() << OP_11;
+    tx40.vout[0].nValue = 2 * COIN;
+    pool.addUnchecked(tx40.GetHash(), entry.Fee(2000LL).Priority(10.0).SigOps(1).FromTx(tx40));
+
+    // tx44
+    CMutableTransaction tx44 = CMutableTransaction();
+    tx44.vout.resize(1);
+    tx44.vout[0].scriptPubKey = CScript() << OP_11;
+    tx44.vout[0].nValue = 4 * COIN;
+    pool.addUnchecked(tx44.GetHash(), entry.Fee(4000LL).Priority(10.0).SigOps(1).FromTx(tx44));
+
+    // tx41
+    CMutableTransaction tx41 = CMutableTransaction();
+    tx41.vin.resize(1);
+    tx41.vin[0].scriptSig = CScript();
+    tx41.vin[0].prevout.hash = tx44.GetHash();
+    tx41.vin[0].prevout.n = 0;
+    tx41.vout.resize(2);
+    tx41.vout[0].scriptPubKey = CScript() << OP_11;
+    tx41.vout[0].nValue = 3 * COIN;
+    tx41.vout[1].scriptPubKey = CScript() << OP_11;
+    tx41.vout[1].nValue = 3 * COIN;
+    pool.addUnchecked(tx41.GetHash(), entry.Fee(6000LL).Priority(10.0).SigOps(1).FromTx(tx41));
+
+    // tx42 - child of tx39, tx40 and tx41 and has one output
+    CMutableTransaction tx42 = CMutableTransaction();
+    tx42.vin.resize(3);
+    tx42.vin[0].scriptSig = CScript();
+    tx42.vin[0].prevout.hash = tx39.GetHash();
+    tx42.vin[0].prevout.n = 0;
+    tx42.vin[1].scriptSig = CScript();
+    tx42.vin[1].prevout.hash = tx40.GetHash();
+    tx42.vin[1].prevout.n = 0;
+    tx42.vin[2].scriptSig = CScript();
+    tx42.vin[2].prevout.hash = tx41.GetHash();
+    tx42.vin[2].prevout.n = 0;
+    tx42.vout.resize(1);
+    tx42.vout[0].scriptPubKey = CScript();
+    tx42.vout[0].nValue = 6 * COIN;
+    pool.addUnchecked(tx42.GetHash(), entry.Fee(6000LL).SigOps(1).FromTx(tx42));
+
+    // tx43 - child of tx42 and has one output
+    CMutableTransaction tx43 = CMutableTransaction();
+    tx43.vin.resize(1);
+    tx43.vin[0].scriptSig = CScript();
+    tx43.vin[0].prevout.hash = tx42.GetHash();
+    tx43.vin[0].prevout.n = 0;
+    tx43.vout.resize(1);
+    tx43.vout[0].scriptPubKey = CScript();
+    tx43.vout[0].nValue = 12 * COIN;
+    pool.addUnchecked(tx43.GetHash(), entry.Fee(12000LL).SigOps(1).FromTx(tx43));
+
+    // tx48 child of tx43
+    CMutableTransaction tx48 = CMutableTransaction();
+    tx48.vin.resize(1);
+    tx48.vin[0].scriptSig = CScript();
+    tx48.vin[0].prevout.hash = tx43.GetHash();
+    tx48.vin[0].prevout.n = 0;
+    tx48.vout.resize(1);
+    tx48.vout[0].scriptPubKey = CScript();
+    tx48.vout[0].nValue = 15 * COIN;
+    pool.addUnchecked(tx48.GetHash(), entry.Fee(15000LL).Priority(10.0).SigOps(1).FromTx(tx48));
+
+    // tx47
+    CMutableTransaction tx47 = CMutableTransaction();
+    tx47.vout.resize(1);
+    tx47.vout[0].scriptPubKey = CScript();
+    tx47.vout[0].nValue = 10 * COIN;
+    pool.addUnchecked(tx47.GetHash(), entry.Fee(10000LL).Priority(10.0).SigOps(1).FromTx(tx47));
+
+    // tx46 child of tx41
+    CMutableTransaction tx46 = CMutableTransaction();
+    tx46.vin.resize(1);
+    tx46.vin[0].scriptSig = CScript();
+    tx46.vin[0].prevout.hash = tx41.GetHash();
+    tx46.vin[0].prevout.n = 1;
+    tx46.vout.resize(1);
+    tx46.vout[0].scriptPubKey = CScript();
+    tx46.vout[0].nValue = 3 * COIN;
+    pool.addUnchecked(tx46.GetHash(), entry.Fee(3000LL).Priority(10.0).SigOps(1).FromTx(tx46));
+
+
+    // tx45 - child of tx46 and tx47 and has one output
+    CMutableTransaction tx45 = CMutableTransaction();
+    tx45.vin.resize(2);
+    tx45.vin[0].scriptSig = CScript();
+    tx45.vin[0].prevout.hash = tx46.GetHash();
+    tx45.vin[0].prevout.n = 0;
+    tx45.vin[1].scriptSig = CScript();
+    tx45.vin[1].prevout.hash = tx47.GetHash();
+    tx45.vin[1].prevout.n = 0;
+    tx45.vout.resize(1);
+    tx45.vout[0].scriptPubKey = CScript();
+    tx45.vout[0].nValue = 12 * COIN;
+    pool.addUnchecked(tx45.GetHash(), entry.Fee(12000LL).SigOps(1).FromTx(tx45));
+
+    // tx49 child of tx45
+    CMutableTransaction tx49 = CMutableTransaction();
+    tx49.vin.resize(1);
+    tx49.vin[0].scriptSig = CScript();
+    tx49.vin[0].prevout.hash = tx45.GetHash();
+    tx49.vin[0].prevout.n = 0;
+    tx49.vout.resize(1);
+    tx49.vout[0].scriptPubKey = CScript();
+    tx49.vout[0].nValue = 14 * COIN;
+    pool.addUnchecked(tx49.GetHash(), entry.Fee(14000LL).Priority(10.0).SigOps(1).FromTx(tx49));
+
+    // Validate the current state is correct
+    /* clang-format off */
+    BOOST_CHECK_EQUAL(pool.size(), 49);
+    std::vector<MempoolData> txns_expected =
+    {
+        // Chain1:
+        {tx1.GetHash(), 1, 21, 1, 1000, 11, 916, 21000},
+        {tx2.GetHash(), 1, 21, 1, 2000, 11, 916, 23000},
+        {tx3.GetHash(), 1, 21, 1, 3000, 7, 631, 27000},
+        {tx4.GetHash(), 1, 21, 1, 4000, 7, 631, 29000},
+        {tx5.GetHash(), 2, 84, 2, 2000, 10, 895, 20000},
+        {tx6.GetHash(), 2, 84, 2, 4000, 10, 895, 21000},
+        {tx7.GetHash(), 2, 84, 2, 6000, 6, 610, 24000},
+        {tx8.GetHash(), 2, 84, 2, 8000, 6, 610, 25000},
+        {tx9.GetHash(), 5, 284, 5, 9000, 9, 832, 19000},
+        {tx10.GetHash(), 5, 273, 5, 21000, 5, 547, 21000},
+        {tx11.GetHash(), 12, 736, 12, 45000, 4, 442, 14000},
+        {tx12.GetHash(), 6, 369, 6, 10000, 4, 274, 2000},
+        {tx13.GetHash(), 13, 799, 13, 46000, 2, 221, 3000},
+        {tx14.GetHash(), 13, 799, 13, 46000, 2, 221, 3000},
+        {tx15.GetHash(), 7, 432, 7, 10500, 1, 63, 500},
+        {tx16.GetHash(), 7, 432, 7, 10200, 1, 63, 200},
+        {tx17.GetHash(), 7, 432, 7, 10300, 1, 63, 300},
+        {tx18.GetHash(), 16, 1041, 16, 55000, 1, 158, 2000},
+        {tx19.GetHash(), 1, 21, 1, 6000, 2, 179, 8000},
+        {tx20.GetHash(), 1, 21, 1, 5000, 5, 463, 19000},
+
+        // Chain2:
+        {tx21.GetHash(), 1, 19, 1, 100000, 16, 1269, 4014000},
+        {tx22.GetHash(), 2, 115, 2, 200000, 15, 1250, 3914000},
+        {tx23.GetHash(), 3, 184, 3, 220000, 8, 744, 3432000},
+        {tx24.GetHash(), 4, 244, 4, 230000, 6, 615, 3402000},
+        {tx25.GetHash(), 4, 244, 4, 230000, 6, 615, 3402000},
+        {tx26.GetHash(), 6, 405, 6, 260000, 5, 555, 3392000},
+        {tx27.GetHash(), 1, 19, 1, 101000, 8, 703, 3876000},
+        {tx28.GetHash(), 2, 79, 2, 202000, 7, 684, 3775000},
+        {tx29.GetHash(), 5, 304, 5, 603000, 6, 624, 3674000},
+        {tx30.GetHash(), 6, 364, 6, 704000, 1, 60, 101000},
+        {tx31.GetHash(), 3, 175, 3, 220000, 6, 574, 3412000},
+        {tx32.GetHash(), 3, 175, 3, 220000, 5, 514, 3392000},
+        {tx33.GetHash(), 3, 175, 3, 220000, 5, 514, 3392000},
+        {tx34.GetHash(), 4, 235, 4, 240000, 5, 514, 3392000},
+        {tx35.GetHash(), 14, 1067, 14, 1024000, 4, 454, 3372000},
+        {tx36.GetHash(), 15, 1127, 15, 1224000, 2, 161, 3010000},
+        {tx37.GetHash(), 15, 1127, 15, 1105000, 2, 161, 2891000},
+        {tx38.GetHash(), 17, 1288, 17, 4115000, 1, 101, 2810000},
+
+        // Chain3:
+        {tx39.GetHash(), 1, 20, 1, 1000, 4, 282, 34000},
+        {tx40.GetHash(), 1, 20, 1, 2000, 4, 282, 35000},
+        {tx41.GetHash(), 2, 91, 2, 10000, 7, 554, 68000},
+        {tx42.GetHash(), 5, 273, 5, 19000, 3, 262, 33000},
+        {tx43.GetHash(), 6, 333, 6, 31000, 2, 120, 27000},
+        {tx44.GetHash(), 1, 20, 1, 4000, 8, 574, 72000},
+        {tx45.GetHash(), 5, 271, 5, 35000, 2, 161, 26000},
+        {tx46.GetHash(), 3, 151, 3, 13000, 3, 221, 29000},
+        {tx47.GetHash(), 1, 19, 1, 10000, 3, 180, 36000},
+        {tx48.GetHash(), 7, 393, 7, 46000, 1, 60, 15000},
+        {tx49.GetHash(), 6, 331, 6, 49000, 1, 60, 14000}
+    };
+    /* clang-format on */
+    for (size_t i = 0; i < txns_expected.size(); i++)
+    {
+        CTxMemPool::txiter iter = pool.mapTx.find(txns_expected[i].hash);
+        if (iter == pool.mapTx.end())
+        {
+            printf("ERROR: tx %s not found in mempool\n", txns_expected[i].hash.ToString().c_str());
+            throw;
+        }
+
+        /*
+        printf(
+            "tx%ld countwanc %ld sizewanc %ld sigopswanc %u feeswanc %ld countwdesc %ld sizewdesc %ld feeswdesc %ld\n",
+            i + 1, iter->GetCountWithAncestors(), iter->GetSizeWithAncestors(), iter->GetSigOpCountWithAncestors(),
+            iter->GetModFeesWithAncestors(), iter->GetCountWithDescendants(), iter->GetSizeWithDescendants(),
+            iter->GetModFeesWithDescendants());
+        printf("tx%d: hash %s\n", (int)(i + 1), iter->GetTx().GetHash().ToString().c_str());
+        */
+
+        CheckAncestors(iter, txns_expected[i], pool);
+    }
+
+
+    /* Do a removeforblock using tx1,tx2,tx3 and tx4 as having been mined and are in the block
+
+    The Resulting in mempool chain should appear as shown below:
+
+    Chain1:
+
+    5      6   7      8
+     \    /     \    /
+      \  /       \  /
+       9          10      20 (unmined chain so it has no entry in txnchaintips)
+       | \        |       /
+       |  \______ 11 ____/
+       |          |\
+       12         | \
+      /|\        13 14     19 (unmined chain so it has no entry in txnchaintips)
+     / | \        | /       /
+    15 16 17      18 ______/
+
+
+    Chain2:
+                                                   27 (unmined chain so it has no entry in txnchaintips)
+                                                   /
+            ________________22_______________     /
+           /         /      |      \         \   28
+          /         /       23      \         \  /
+         /         /       / \       \         \/
+        31        32      24 25      33        29
+         \         \       \ /       /         /\
+          \         \       26      /         /  \
+           \         \      |      /         /    \
+           34_________\_____35____/_________/     30
+                           / \
+                          36 37
+                           \ /
+                            38
+
+
+    Chain3:
+
+
+       40 41   (39,44 and 47 were mined with 40 remaining an unmined chain, and 42,41,and 45 become txnchaintips)
+       | / \
+       |/   \
+       42   46
+       |     \
+       43    45
+       |       \
+       48      49
+
+    */
+
+    // Add txns that will be mined
+    std::vector<CTransactionRef> vtx;
+    // Chain1:
+    vtx.push_back(MakeTransactionRef(tx1));
+    vtx.push_back(MakeTransactionRef(tx2));
+    vtx.push_back(MakeTransactionRef(tx3));
+    vtx.push_back(MakeTransactionRef(tx4));
+    // Chain2:
+    vtx.push_back(MakeTransactionRef(tx21));
+    // Chain3:
+    vtx.push_back(MakeTransactionRef(tx39));
+    vtx.push_back(MakeTransactionRef(tx44));
+    vtx.push_back(MakeTransactionRef(tx47));
+
+    // Now assume they were mined and do a removeForBlock()
+    std::list<CTransactionRef> dummy;
+    pool.removeForBlock(vtx, 1, dummy, false);
+    BOOST_CHECK_EQUAL(pool.size(), 41);
+
+    // Validate the new state is correct
+    /* clang-format off */
+    std::vector<MempoolData> txns_result =
+    {
+        // Chain1:
+        {tx1.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx2.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx3.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx4.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+
+        {tx5.GetHash(), 1, 63, 1, 1000, 10, 895, 20000},
+        {tx6.GetHash(), 1, 63, 1, 2000, 10, 895, 21000},
+        {tx7.GetHash(), 1, 63, 1, 3000, 6, 610, 24000},
+        {tx8.GetHash(), 1, 63, 1, 4000, 6, 610, 25000},
+        {tx9.GetHash(), 3, 242, 3, 6000, 9, 832, 19000},
+        {tx10.GetHash(), 3, 231, 3, 14000, 5, 547, 21000},
+        {tx11.GetHash(), 8, 652, 8, 35000, 4, 442, 14000},
+        {tx12.GetHash(), 4, 327, 4, 7000, 4, 274, 2000},
+        {tx13.GetHash(), 9, 715, 9, 36000, 2, 221, 3000},
+        {tx14.GetHash(), 9, 715, 9, 36000, 2, 221, 3000},
+        {tx15.GetHash(), 5, 390, 5, 7500, 1, 63, 500},
+        {tx16.GetHash(), 5, 390, 5, 7200, 1, 63, 200},
+        {tx17.GetHash(), 5, 390, 5, 7300, 1, 63, 300},
+        {tx18.GetHash(), 12, 957, 12, 45000, 1, 158, 2000},
+        {tx19.GetHash(), 1, 21, 1, 6000, 2, 179, 8000},
+        {tx20.GetHash(), 1, 21, 1, 5000, 5, 463, 19000},
+
+        // Chain2:
+        {tx21.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+
+        {tx22.GetHash(), 1, 96, 1, 100000, 15, 1250, 3914000},
+        {tx23.GetHash(), 2, 165, 2, 120000, 8, 744, 3432000},
+        {tx24.GetHash(), 3, 225, 3, 130000, 6, 615, 3402000},
+        {tx25.GetHash(), 3, 225, 3, 130000, 6, 615, 3402000},
+        {tx26.GetHash(), 5, 386, 5, 160000, 5, 555, 3392000},
+        {tx27.GetHash(), 1, 19, 1, 101000, 8, 703, 3876000},
+        {tx28.GetHash(), 2, 79, 2, 202000, 7, 684, 3775000},
+        {tx29.GetHash(), 4, 285, 4, 503000, 6, 624, 3674000},
+        {tx30.GetHash(), 5, 345, 5, 604000, 1, 60, 101000},
+        {tx31.GetHash(), 2, 156, 2, 120000, 6, 574, 3412000},
+        {tx32.GetHash(), 2, 156, 2, 120000, 5, 514, 3392000},
+        {tx33.GetHash(), 2, 156, 2, 120000, 5, 514, 3392000},
+        {tx34.GetHash(), 3, 216, 3, 140000, 5, 514, 3392000},
+        {tx35.GetHash(), 13, 1048, 13, 924000, 4, 454, 3372000},
+        {tx36.GetHash(), 14, 1108, 14, 1124000, 2, 161, 3010000},
+        {tx37.GetHash(), 14, 1108, 14, 1005000, 2, 161, 2891000},
+        {tx38.GetHash(), 16, 1269, 16, 4015000, 1, 101, 2810000},
+
+        // Chain3:
+        {tx39.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx40.GetHash(), 1, 20, 1, 2000, 4, 282, 35000},
+        {tx41.GetHash(), 1, 71, 1, 6000, 7, 554, 68000},
+        {tx42.GetHash(), 3, 233, 3, 14000, 3, 262, 33000},
+        {tx43.GetHash(), 4, 293, 4, 26000, 2, 120, 27000},
+        {tx44.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx45.GetHash(), 3, 232, 3, 21000, 2, 161, 26000},
+        {tx46.GetHash(), 2, 131, 2, 9000, 3, 221, 29000},
+        {tx47.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx48.GetHash(), 5, 353, 5, 41000, 1, 60, 15000},
+        {tx49.GetHash(), 4, 292, 4, 35000, 1, 60, 14000}
+    };
+    /* clang-format on */
+
+    for (size_t i = 0; i < txns_result.size(); i++)
+    {
+        CTxMemPool::txiter iter = pool.mapTx.find(txns_result[i].hash);
+        if (i < 4 || i == 20 || i == 38 || i == 43 || i == 46)
+        {
+            if (iter != pool.mapTx.end())
+            {
+                printf("ERROR: tx %s was found in mempool when it should not be\n",
+                    txns_result[i].hash.ToString().c_str());
+                throw;
+            }
+            continue;
+        }
+
+        /*
+        printf(
+            "tx%ld countwanc %ld sizewanc %ld sigopswanc %u feeswanc %ld countwdesc %ld sizewdesc %ld feeswdesc %ld\n",
+            i + 1, iter->GetCountWithAncestors(), iter->GetSizeWithAncestors(), iter->GetSigOpCountWithAncestors(),
+            iter->GetModFeesWithAncestors(), iter->GetCountWithDescendants(), iter->GetSizeWithDescendants(),
+            iter->GetModFeesWithDescendants());
+        printf("tx%d: hash %s\n", (int)(i + 1), iter->GetTx().GetHash().ToString().c_str());
+        */
+
+        CheckAncestors(iter, txns_result[i], pool);
+    }
+
+    // Mine two transactions which end up giving us the same txnchaintip.
+    vtx.push_back(MakeTransactionRef(tx40));
+    vtx.push_back(MakeTransactionRef(tx41));
+    pool.removeForBlock(vtx, 1, dummy, false);
+    BOOST_CHECK_EQUAL(pool.size(), 39);
+
+
+    /* clang-format off */
+    std::vector<MempoolData> txns_result2 =
+    {
+        // Chain3:
+        {tx39.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx40.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx41.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx42.GetHash(), 1, 142, 1, 6000, 3, 262, 33000},
+        {tx43.GetHash(), 2, 202, 2, 18000, 2, 120, 27000},
+        {tx44.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx45.GetHash(), 2, 161, 2, 15000, 2, 161, 26000},
+        {tx46.GetHash(), 1, 60, 1, 3000, 3, 221, 29000},
+        {tx47.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx48.GetHash(), 3, 262, 3, 33000, 1, 60, 15000},
+        {tx49.GetHash(), 3, 221, 3, 29000, 1, 60, 14000}
+    };
+    /* clang-format on */
+
+    for (size_t i = 0; i < txns_result2.size(); i++)
+    {
+        CTxMemPool::txiter iter = pool.mapTx.find(txns_result2[i].hash);
+        if (i <= 2 || i == 5 || i == 8)
+        {
+            if (iter != pool.mapTx.end())
+            {
+                printf("ERROR: tx %s was found in mempool when it should not be\n",
+                    txns_result2[i].hash.ToString().c_str());
+                throw;
+            }
+            continue;
+        }
+
+        CheckAncestors(iter, txns_result2[i], pool);
+    }
+
+    // Starting to simulate mining all the rest of the transactions in the chains defined in the
+    // above tests and following that with a mempool consistency
+    vtx.push_back(MakeTransactionRef(tx5));
+    vtx.push_back(MakeTransactionRef(tx6));
+    vtx.push_back(MakeTransactionRef(tx7));
+    pool.removeForBlock(vtx, 1, dummy, false);
+    BOOST_CHECK_EQUAL(pool.size(), 36);
+
+    /* clang-format off */
+    std::vector<MempoolData> txns_result3 =
+    {
+        // Chain1:
+        {tx1.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx2.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx3.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx4.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx5.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx6.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx7.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+
+        {tx8.GetHash(), 1,63, 1, 4000, 6, 610, 25000},
+        {tx9.GetHash(), 1,116 , 1, 3000, 9, 832, 19000},
+        {tx10.GetHash(), 2, 168, 2, 11000, 5, 547, 21000},
+        {tx11.GetHash(), 5, 463, 5, 29000, 4, 442, 14000},
+        {tx12.GetHash(), 2, 201, 2, 4000, 4, 274, 2000},
+        {tx13.GetHash(), 6, 526, 6, 30000, 2, 221, 3000},
+        {tx14.GetHash(), 6, 526, 6, 30000, 2, 221, 3000},
+        {tx15.GetHash(), 3, 264, 3, 4500, 1, 63, 500},
+        {tx16.GetHash(), 3, 264, 3, 4200, 1, 63, 200},
+        {tx17.GetHash(), 3, 264, 3, 4300, 1, 63, 300},
+        {tx18.GetHash(), 9, 768, 9, 39000, 1, 158, 2000},
+        {tx19.GetHash(), 1, 21, 1, 6000, 2, 179, 8000},
+        {tx20.GetHash(), 1, 21, 1, 5000, 5, 463, 19000},
+    };
+    /* clang-format on */
+
+    for (size_t i = 0; i < txns_result3.size(); i++)
+    {
+        CTxMemPool::txiter iter = pool.mapTx.find(txns_result3[i].hash);
+        if (i < 7)
+        {
+            if (iter != pool.mapTx.end())
+            {
+                printf("ERROR: tx %s was found in mempool when it should not be\n",
+                    txns_result3[i].hash.ToString().c_str());
+                throw;
+            }
+            continue;
+        }
+
+        CheckAncestors(iter, txns_result3[i], pool);
+    }
+
+
+    vtx.push_back(MakeTransactionRef(tx8));
+    vtx.push_back(MakeTransactionRef(tx9));
+    vtx.push_back(MakeTransactionRef(tx10));
+    pool.removeForBlock(vtx, 1, dummy, false);
+    BOOST_CHECK_EQUAL(pool.size(), 33);
+
+    /* clang-format off */
+    std::vector<MempoolData> txns_result4 =
+    {
+        // Chain1:
+        {tx1.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx2.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx3.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx4.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx5.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx6.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx7.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx8.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx9.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx10.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+
+        {tx11.GetHash(), 2, 179, 2, 15000, 4, 442, 14000},
+        {tx12.GetHash(), 1, 85, 1, 1000, 4, 274, 2000},
+        {tx13.GetHash(), 3, 242, 3, 16000, 2, 221, 3000},
+        {tx14.GetHash(), 3, 242, 3, 16000, 2, 221, 3000},
+        {tx15.GetHash(), 2, 148, 2, 1500, 1, 63, 500},
+        {tx16.GetHash(), 2, 148, 2, 1200, 1, 63, 200},
+        {tx17.GetHash(), 2, 148, 2, 1300, 1, 63, 300},
+        {tx18.GetHash(), 6, 484, 6, 25000, 1, 158, 2000},
+        {tx19.GetHash(), 1, 21, 1, 6000, 2, 179, 8000},
+        {tx20.GetHash(), 1, 21, 1, 5000, 5, 463, 19000},
+    };
+    /* clang-format on */
+
+    for (size_t i = 0; i < txns_result4.size(); i++)
+    {
+        CTxMemPool::txiter iter = pool.mapTx.find(txns_result4[i].hash);
+        if (i < 10)
+        {
+            if (iter != pool.mapTx.end())
+            {
+                printf("ERROR: tx %s was found in mempool when it should not be\n",
+                    txns_result4[i].hash.ToString().c_str());
+                throw;
+            }
+            continue;
+        }
+
+        CheckAncestors(iter, txns_result4[i], pool);
+    }
+
+
+    vtx.push_back(MakeTransactionRef(tx11));
+    vtx.push_back(MakeTransactionRef(tx14));
+    vtx.push_back(MakeTransactionRef(tx20));
+    pool.removeForBlock(vtx, 1, dummy, false);
+    BOOST_CHECK_EQUAL(pool.size(), 30);
+
+    /* clang-format off */
+    std::vector<MempoolData> txns_result5 =
+    {
+        // Chain1:
+        {tx1.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx2.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx3.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx4.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx5.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx6.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx7.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx8.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx9.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx10.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx11.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx12.GetHash(), 1, 85, 1, 1000, 4, 274, 2000},
+        {tx13.GetHash(), 1, 63, 1, 1000, 2, 221, 3000},
+        {tx14.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx15.GetHash(), 2, 148, 2, 1500, 1, 63, 500},
+        {tx16.GetHash(), 2, 148, 2, 1200, 1, 63, 200},
+        {tx17.GetHash(), 2, 148, 2, 1300, 1, 63, 300},
+        {tx18.GetHash(), 3, 242, 3, 9000, 1, 158, 2000},
+        {tx19.GetHash(), 1, 21, 1, 6000, 2, 179, 8000},
+        {tx20.GetHash(), 0, 0, 0, 0, 0, 0, 0}
+    };
+    /* clang-format on */
+
+    for (size_t i = 0; i < txns_result5.size(); i++)
+    {
+        CTxMemPool::txiter iter = pool.mapTx.find(txns_result5[i].hash);
+        if (i < 11 || i == 13 || i == 19)
+        {
+            if (iter != pool.mapTx.end())
+            {
+                printf("ERROR: tx %s was found in mempool when it should not be\n",
+                    txns_result5[i].hash.ToString().c_str());
+                throw;
+            }
+            continue;
+        }
+
+        CheckAncestors(iter, txns_result5[i], pool);
+    }
+
+    vtx.push_back(MakeTransactionRef(tx12));
+    vtx.push_back(MakeTransactionRef(tx13));
+    vtx.push_back(MakeTransactionRef(tx15));
+    pool.removeForBlock(vtx, 1, dummy, false);
+    BOOST_CHECK_EQUAL(pool.size(), 27);
+
+    /* clang-format off */
+    std::vector<MempoolData> txns_result6 =
+    {
+        // Chain1:
+        {tx1.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx2.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx3.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx4.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx5.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx6.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx7.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx8.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx9.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx10.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx11.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx12.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx13.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx14.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx15.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx16.GetHash(), 1, 63, 1, 200, 1, 63, 200},
+        {tx17.GetHash(), 1, 63, 1, 300, 1, 63, 300},
+        {tx18.GetHash(), 2, 179, 2, 8000, 1, 158, 2000},
+        {tx19.GetHash(), 1, 21, 1, 6000, 2, 179, 8000},
+        {tx20.GetHash(), 0, 0, 0, 0, 0, 0, 0}
+    };
+    /* clang-format on */
+
+    for (size_t i = 0; i < txns_result6.size(); i++)
+    {
+        CTxMemPool::txiter iter = pool.mapTx.find(txns_result6[i].hash);
+        if (i < 15 || i == 19)
+        {
+            if (iter != pool.mapTx.end())
+            {
+                printf("ERROR: tx %s was found in mempool when it should not be\n",
+                    txns_result6[i].hash.ToString().c_str());
+                throw;
+            }
+            continue;
+        }
+
+        CheckAncestors(iter, txns_result6[i], pool);
+    }
+
+    // The following is one of the most important edge conditions. Where we remove the first transaction
+    // in a graph that has an enclosure. An enclosure being where a transaction has many outputs
+    // and eventually results in other transactions that are inputs to a single transactions.
+    /*
+       for example:
+                            22
+                            |
+                            23
+                           / \
+                          24 25
+                           \ /
+                            26
+
+       after mining 22 and 23 becomes:
+
+
+                          24 25
+                           \ /
+                            26
+    */
+
+    vtx.push_back(MakeTransactionRef(tx22));
+    vtx.push_back(MakeTransactionRef(tx23));
+    pool.removeForBlock(vtx, 1, dummy, false);
+    BOOST_CHECK_EQUAL(pool.size(), 25);
+
+    /* clang-format off */
+    std::vector<MempoolData> txns_result7 =
+    {
+        // Chain2:
+        {tx21.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx22.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx23.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+
+        {tx24.GetHash(), 1, 60, 1, 10000, 6, 615, 3402000},
+        {tx25.GetHash(), 1, 60, 1, 10000, 6, 615, 3402000},
+        {tx26.GetHash(), 3, 221, 3, 40000, 5, 555, 3392000},
+        {tx27.GetHash(), 1, 19, 1, 101000, 8, 703, 3876000},
+        {tx28.GetHash(), 2, 79, 2, 202000, 7, 684, 3775000},
+        {tx29.GetHash(), 3, 189, 3, 403000, 6, 624, 3674000},
+        {tx30.GetHash(), 4, 249, 4, 504000, 1, 60, 101000},
+        {tx31.GetHash(), 1, 60, 1, 20000, 6, 574, 3412000},
+        {tx32.GetHash(), 1, 60, 1, 20000, 5, 514, 3392000},
+        {tx33.GetHash(), 1, 60, 1, 20000, 5, 514, 3392000},
+        {tx34.GetHash(), 2, 120, 2, 40000, 5, 514, 3392000},
+        {tx35.GetHash(), 11, 883, 11, 804000, 4, 454, 3372000},
+        {tx36.GetHash(), 12, 943, 12, 1004000, 2, 161, 3010000},
+        {tx37.GetHash(), 12, 943, 12, 885000, 2, 161, 2891000},
+        {tx38.GetHash(), 14, 1104, 14, 3895000, 1, 101, 2810000},
+    };
+    /* clang-format on */
+
+    for (size_t i = 0; i < txns_result7.size(); i++)
+    {
+        CTxMemPool::txiter iter = pool.mapTx.find(txns_result7[i].hash);
+        if (i <= 2)
+        {
+            if (iter != pool.mapTx.end())
+            {
+                printf("ERROR: tx %s was found in mempool when it should not be\n",
+                    txns_result7[i].hash.ToString().c_str());
+                throw;
+            }
+            continue;
+        }
+
+        CheckAncestors(iter, txns_result7[i], pool);
+    }
+
+
+    vtx.push_back(MakeTransactionRef(tx31));
+    vtx.push_back(MakeTransactionRef(tx33));
+    vtx.push_back(MakeTransactionRef(tx34));
+    pool.removeForBlock(vtx, 1, dummy, false);
+    BOOST_CHECK_EQUAL(pool.size(), 22);
+
+    /* clang-format off */
+    std::vector<MempoolData> txns_result8 =
+    {
+        // Chain2:
+        {tx21.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx22.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx23.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx24.GetHash(), 1, 60, 1, 10000, 6, 615, 3402000},
+        {tx25.GetHash(), 1, 60, 1, 10000, 6, 615, 3402000},
+        {tx26.GetHash(), 3, 221, 3, 40000, 5, 555, 3392000},
+        {tx27.GetHash(), 1, 19, 1, 101000, 8, 703, 3876000},
+        {tx28.GetHash(), 2, 79, 2, 202000, 7, 684, 3775000},
+        {tx29.GetHash(), 3, 189, 3, 403000, 6, 624, 3674000},
+        {tx30.GetHash(), 4, 249, 4, 504000, 1, 60, 101000},
+        {tx31.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx32.GetHash(), 1, 60, 1, 20000, 5, 514, 3392000},
+        {tx33.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx34.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx35.GetHash(), 8, 703, 8, 744000, 4, 454, 3372000},
+        {tx36.GetHash(), 9, 763, 9, 944000, 2, 161, 3010000},
+        {tx37.GetHash(), 9, 763, 9, 825000, 2, 161, 2891000},
+        {tx38.GetHash(), 11, 924, 11, 3835000, 1, 101, 2810000},
+    };
+    /* clang-format on */
+
+    for (size_t i = 0; i < txns_result8.size(); i++)
+    {
+        CTxMemPool::txiter iter = pool.mapTx.find(txns_result8[i].hash);
+        if (i <= 2 || i == 10 || i == 12 || i == 13)
+        {
+            if (iter != pool.mapTx.end())
+            {
+                printf("ERROR: tx %s was found in mempool when it should not be\n",
+                    txns_result8[i].hash.ToString().c_str());
+                throw;
+            }
+            continue;
+        }
+
+        CheckAncestors(iter, txns_result8[i], pool);
+    }
+
+    vtx.push_back(MakeTransactionRef(tx24));
+    vtx.push_back(MakeTransactionRef(tx25));
+    vtx.push_back(MakeTransactionRef(tx27));
+    vtx.push_back(MakeTransactionRef(tx28));
+    pool.removeForBlock(vtx, 1, dummy, false);
+    BOOST_CHECK_EQUAL(pool.size(), 18);
+
+    /* clang-format off */
+    std::vector<MempoolData> txns_result9 =
+    {
+        // Chain2:
+        {tx21.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx22.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx23.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx24.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx25.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx26.GetHash(), 1, 101, 1, 20000, 5, 555, 3392000},
+        {tx27.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx28.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx29.GetHash(), 1, 110, 1, 201000, 6, 624, 3674000},
+        {tx30.GetHash(), 2, 170, 2, 302000, 1, 60, 101000},
+        {tx31.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx32.GetHash(), 1, 60, 1, 20000, 5, 514, 3392000},
+        {tx33.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx34.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx35.GetHash(), 4, 504, 4, 522000, 4, 454, 3372000},
+        {tx36.GetHash(), 5, 564, 5, 722000, 2, 161, 3010000},
+        {tx37.GetHash(), 5, 564, 5, 603000, 2, 161, 2891000},
+        {tx38.GetHash(), 7, 725, 7, 3613000, 1, 101, 2810000},
+    };
+    /* clang-format on */
+
+    for (size_t i = 0; i < txns_result9.size(); i++)
+    {
+        CTxMemPool::txiter iter = pool.mapTx.find(txns_result9[i].hash);
+        if (i <= 4 || i == 6 || i == 7 || i == 10 || i == 12 || i == 13)
+        {
+            if (iter != pool.mapTx.end())
+            {
+                printf("ERROR: tx %s was found in mempool when it should not be\n",
+                    txns_result9[i].hash.ToString().c_str());
+                throw;
+            }
+            continue;
+        }
+
+        CheckAncestors(iter, txns_result9[i], pool);
+    }
+
+    vtx.push_back(MakeTransactionRef(tx26));
+    vtx.push_back(MakeTransactionRef(tx29));
+    vtx.push_back(MakeTransactionRef(tx32));
+    vtx.push_back(MakeTransactionRef(tx35));
+    pool.removeForBlock(vtx, 1, dummy, false);
+    BOOST_CHECK_EQUAL(pool.size(), 14);
+
+    /* clang-format off */
+    std::vector<MempoolData> txns_result10 =
+    {
+        // Chain2:
+        {tx21.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx22.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx23.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx24.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx25.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx26.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx27.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx28.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx29.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx30.GetHash(), 1, 60, 1, 101000, 1, 60, 101000},
+        {tx31.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx32.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx33.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx34.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx35.GetHash(), 0, 0, 0, 0, 0, 0, 0},
+        {tx36.GetHash(), 1, 60, 1, 200000, 2, 161, 3010000},
+        {tx37.GetHash(), 1, 60, 1, 81000, 2, 161, 2891000},
+        {tx38.GetHash(), 3, 221, 3, 3091000, 1, 101, 2810000},
+    };
+    /* clang-format on */
+
+    for (size_t i = 0; i < txns_result10.size(); i++)
+    {
+        CTxMemPool::txiter iter = pool.mapTx.find(txns_result10[i].hash);
+        if (i <= 8 || (i >= 10 && i <= 14))
+        {
+            if (iter != pool.mapTx.end())
+            {
+                printf("ERROR: tx %s was found in mempool when it should not be\n",
+                    txns_result9[i].hash.ToString().c_str());
+                throw;
+            }
+            continue;
+        }
+
+        /*
+        printf(
+            "tx%ld countwanc %ld sizewanc %ld sigopswanc %u feeswanc %ld countwdesc %ld sizewdesc %ld feeswdesc %ld\n",
+            i + 1, iter->GetCountWithAncestors(), iter->GetSizeWithAncestors(), iter->GetSigOpCountWithAncestors(),
+            iter->GetModFeesWithAncestors(), iter->GetCountWithDescendants(), iter->GetSizeWithDescendants(),
+            iter->GetModFeesWithDescendants());
+        printf("tx%d: hash %s\n", (int)(i + 1), iter->GetTx().GetHash().ToString().c_str());
+        */
+
+        CheckAncestors(iter, txns_result10[i], pool);
+    }
+}
+
 
 BOOST_AUTO_TEST_CASE(MempoolRemoveTest)
 {

--- a/src/test/policyestimator_tests.cpp
+++ b/src/test/policyestimator_tests.cpp
@@ -12,7 +12,7 @@
 
 #include <boost/test/unit_test.hpp>
 
-BOOST_FIXTURE_TEST_SUITE(policyestimator_tests, BasicTestingSetup)
+BOOST_FIXTURE_TEST_SUITE(policyestimator_tests, TestingSetup)
 
 // used in all tests in this file, declare once here so editing is easier
 static const int32_t txHashesSize = 45;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -464,8 +464,28 @@ void CTxMemPool::UpdateTxnChainState(mapEntryHistory &mapTxnChainTips)
 {
     AssertWriteLockHeld(cs_txmempool);
 
-    // As a starting point, re-calculate all chaintips ancestor state. Although at least one chaintip
+    // As a starting point, re-calculate all chaintip ancestor states. Although at least one chaintip
     // parent will have been mined there could still be other chaintip parents that were not mined.
+    //
+    /*
+       Chain prior to being mined:
+
+       tx1        tx2      tx3
+         \        |       /
+          \______ tx4____/
+
+
+       Chain after being mined:
+       Only tx1 and tx2 are mined leaving tx4 as the chaintip, and tx3 becomes an unmined
+       chaintip parent and is not considered a chaintip in the program logic even though clearly
+       it is in fact the new chaintip.
+
+                         tx3 (unmined chain so it has no entry in mapTxnChainTips)
+                          /
+                  tx4____/   (tx4 becomes the chaintip in mapTxnChainTips)
+
+    */
+
     for (auto iter_tip : mapTxnChainTips)
     {
         uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1043,7 +1043,7 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef> &vtx,
         // issue if it did.
         if (!setAncestorsFromBlock.empty())
         {
-            DbgAssert("Ancestors in the mempool when they should not be", );
+            DbgAssert(!"Ancestors in the mempool when they should not be", );
             for (txiter it : setAncestorsFromBlock)
             {
                 removeUnchecked(it);

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1041,10 +1041,13 @@ void CTxMemPool::removeForBlock(const std::vector<CTransactionRef> &vtx,
         // This is a safeguard in the case where ancestors of transactions in this block have re-entered
         // the mempool, possibly from a re-org. This should never happen and would likely indicate a locking
         // issue if it did.
-        for (txiter it : setAncestorsFromBlock)
+        if (!setAncestorsFromBlock.empty())
         {
             DbgAssert("Ancestors in the mempool when they should not be", );
-            removeUnchecked(it);
+            for (txiter it : setAncestorsFromBlock)
+            {
+                removeUnchecked(it);
+            }
         }
     }
 

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -16,6 +16,7 @@
 #include "streams.h"
 #include "timedata.h"
 #include "txadmission.h"
+#include "txorphanpool.h"
 #include "unlimited.h"
 #include "util.h"
 #include "utilmoneystr.h"
@@ -459,6 +460,62 @@ void CTxMemPool::UpdateChildrenForRemoval(txiter it)
     }
 }
 
+void CTxMemPool::UpdateTxnChainState(mapEntryHistory &mapTxnChainTips)
+{
+    AssertWriteLockHeld(cs_txmempool);
+
+    // As a starting point, re-calculate all chaintips ancestor state. Although at least one chaintip
+    // parent will have been mined there could still be other chaintip parents that were not mined.
+    for (auto iter_tip : mapTxnChainTips)
+    {
+        uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
+        std::string dummy;
+        int64_t nAncestorCount = 0;
+        int64_t nAncestorSize = 0;
+        int nAncestorSigOps = 0;
+        CAmount nAncestorModifiedFee(0);
+
+        setEntries setAncestors;
+        setAncestors.insert(iter_tip.first);
+        _CalculateMemPoolAncestors(*(iter_tip.first), setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy);
+        for (auto it : setAncestors)
+        {
+            nAncestorCount += 1;
+            nAncestorSize += it->GetTxSize();
+            nAncestorSigOps += it->GetSigOpCount();
+            nAncestorModifiedFee += it->GetModifiedFee();
+        }
+        mapTx.modify(iter_tip.first,
+            replace_ancestor_state(nAncestorSize, nAncestorModifiedFee, nAncestorCount, nAncestorSigOps));
+    }
+
+    // For each txnChainTip find the difference between the old chain tip ancestor state
+    // values and the new ancestor state values and apply them to all of the descendants.
+    for (auto iter_tip : mapTxnChainTips)
+    {
+        // Find difference
+        int64_t nAncestorCountDiff = iter_tip.first->GetCountWithAncestors() - iter_tip.second.modifyCount;
+        int64_t nAncestorSizeDiff = iter_tip.first->GetSizeWithAncestors() - iter_tip.second.modifySize;
+        int nAncestorSigOpsDiff = iter_tip.first->GetSigOpCountWithAncestors() - iter_tip.second.modifySigOps;
+        CAmount nAncestorModifiedFeeDiff = iter_tip.first->GetModFeesWithAncestors() - iter_tip.second.modifyFee;
+
+        // Get descendants but stop looking if/when we find another txnchaintip in the descendant tree.
+        setEntries setDescendants;
+        _CalculateDescendants(iter_tip.first, setDescendants, &mapTxnChainTips);
+
+        // Remove the txnChainTip since it has already been updated
+        setDescendants.erase(iter_tip.first);
+
+        // Apply the difference in sorted order
+        for (txiter it : setDescendants)
+        {
+            assert(!mapTxnChainTips.count(it));
+            mapTx.modify(it, update_ancestor_state(
+                                 nAncestorSizeDiff, nAncestorModifiedFeeDiff, nAncestorCountDiff, nAncestorSigOpsDiff));
+        }
+    }
+}
+
 void CTxMemPool::_UpdateForRemoveFromMempool(const setEntries &entriesToRemove,
     bool updateDescendants,
     CTxMemPool::TxMempoolOriginalStateMap *changeSet)
@@ -564,6 +621,17 @@ void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, CAmount modifyFee,
     nCountWithAncestors += modifyCount;
     assert(int64_t(nCountWithAncestors) > 0);
     nSigOpCountWithAncestors += modifySigOps;
+    assert(int(nSigOpCountWithAncestors) >= 0);
+}
+
+void CTxMemPoolEntry::ReplaceAncestorState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount, int modifySigOps)
+{
+    nSizeWithAncestors = modifySize;
+    assert(int64_t(nSizeWithAncestors) > 0);
+    nModFeesWithAncestors = modifyFee;
+    nCountWithAncestors = modifyCount;
+    assert(int64_t(nCountWithAncestors) > 0);
+    nSigOpCountWithAncestors = modifySigOps;
     assert(int(nSigOpCountWithAncestors) >= 0);
 }
 
@@ -698,7 +766,7 @@ void CTxMemPool::removeUnchecked(txiter it)
 // Also assumes that if an entry is in setDescendants already, then all
 // in-mempool descendants of it are already in setDescendants as well, so that we
 // can save time by not iterating over those entries.
-void CTxMemPool::_CalculateDescendants(txiter entryit, setEntries &setDescendants)
+void CTxMemPool::_CalculateDescendants(txiter entryit, setEntries &setDescendants, mapEntryHistory *mapTxnChainTips)
 {
     AssertWriteLockHeld(cs_txmempool);
     setEntries stage;
@@ -720,6 +788,9 @@ void CTxMemPool::_CalculateDescendants(txiter entryit, setEntries &setDescendant
         {
             if (!setDescendants.count(childiter))
             {
+                if (mapTxnChainTips && mapTxnChainTips->count(childiter))
+                    continue;
+
                 stage.insert(childiter);
             }
         }
@@ -886,6 +957,140 @@ void CTxMemPool::_removeConflicts(const CTransaction &tx, std::list<CTransaction
 // queue of tx that are removable.
 void CTxMemPool::removeForBlock(const std::vector<CTransactionRef> &vtx,
     uint64_t nBlockHeight,
+    std::list<CTransactionRef> &conflicts,
+    bool fCurrentEstimate,
+    std::vector<CTxChange> *txChanges)
+{
+    WRITELOCK(cs_txmempool);
+
+    // Process the block for transasction removal and ancestor state updates.
+    // As a first step remove all the txns that are in the block from the mempool by
+    // first updating the children for removal of the parent, and also saving the entries
+    // for policy estimate updates.  Then in the final loop simply remove all the txns.
+    //
+    // While we're updating the child transactions prior to removal we can also gather the
+    // mapTxnChaiTips.
+    mapEntryHistory mapTxnChainTips;
+    std::vector<CTxMemPoolEntry> entries;
+    setEntries setAncestorsFromBlock;
+    {
+        setEntries setTxnsInBlock;
+        for (const auto &tx : vtx)
+        {
+            uint256 hash = tx->GetHash();
+            txiter it = mapTx.find(hash);
+            if (it == mapTx.end())
+            {
+                continue;
+            }
+
+            // Get all ancestors from related to txns in the block. Stop looking if we've already looked up
+            // this set of ancestors before; we don't want to be traversing the same part of the ancestor
+            // tree more than once.
+            setEntries setAncestors;
+            uint64_t nNoLimit = std::numeric_limits<uint64_t>::max();
+            std::string dummy;
+            _CalculateMemPoolAncestors(
+                *it, setAncestors, nNoLimit, nNoLimit, nNoLimit, nNoLimit, dummy, &setAncestorsFromBlock, false);
+            setAncestorsFromBlock.insert(setAncestors.begin(), setAncestors.end());
+
+            setTxnsInBlock.insert(it);
+            entries.push_back(*it); // TODO: seems inefficient to do a full copy here?
+
+            const setEntries &setMemPoolChildren = GetMemPoolChildren(it);
+            for (txiter updateIt : setMemPoolChildren)
+            {
+                // Get the current ancestor state values and save them for later comparison
+                ancestor_state ancestorState(updateIt->GetSizeWithAncestors(), updateIt->GetModFeesWithAncestors(),
+                    updateIt->GetCountWithAncestors(), updateIt->GetSigOpCountWithAncestors());
+                mapTxnChainTips.emplace(updateIt, ancestorState);
+
+                // Remove each block entry from the parent map in mapLinks
+                _UpdateParent(updateIt, it, false);
+            }
+        }
+        for (txiter it : setTxnsInBlock)
+        {
+            setAncestorsFromBlock.erase(it);
+            mapTxnChainTips.erase(it);
+            removeUnchecked(it);
+        }
+
+        // This is a safeguard in the case where ancestors of transactions in this block have re-entered
+        // the mempool, possibly from a re-org. This should never happen and would likely indicate a locking
+        // issue if it did.
+        for (txiter it : setAncestorsFromBlock)
+        {
+            DbgAssert("Ancestors in the mempool when they should not be", );
+            removeUnchecked(it);
+        }
+    }
+
+    // For every chain tip walk through their decendants finding any transaction that have more than one parent.
+    // These will then need to be considered as chain tips.
+    CTxMemPool::TxMempoolOriginalStateMap changeSet;
+    mapEntryHistory mapAdditionalChainTips;
+    for (auto iter : mapTxnChainTips)
+    {
+        // Get descendants but stop looking if/when we find another txnchaintip in the descendant tree.
+        setEntries setDescendants;
+        _CalculateDescendants(iter.first, setDescendants, &mapTxnChainTips);
+        for (txiter dit : setDescendants)
+        {
+            // If long chain transaction forwarding is turned on, get the original descendant state
+            // and save it for later comparison.
+            if (txChanges && changeSet.count(dit) == 0)
+                changeSet.insert({dit, TxMempoolOriginalState(dit)});
+
+            // Add a new chaintip if there is more than 1 parent.
+            if (GetMemPoolParents(dit).size() > 1)
+            {
+                ancestor_state ancestorState(dit->GetSizeWithAncestors(), dit->GetModFeesWithAncestors(),
+                    dit->GetCountWithAncestors(), dit->GetSigOpCountWithAncestors());
+                mapAdditionalChainTips.emplace(dit, ancestorState);
+            }
+        }
+    }
+    mapTxnChainTips.insert(mapAdditionalChainTips.begin(), mapAdditionalChainTips.end());
+
+    // Update ancestor state for remaining chains
+    UpdateTxnChainState(mapTxnChainTips);
+
+    // After the updates are complete then process changeSet into a list of tx and mempool changes
+    // and sort into dependency order.
+    if (!changeSet.empty())
+    {
+        txChanges->reserve(changeSet.size());
+        for (auto &mc : changeSet)
+        {
+            txChanges->push_back(CTxChange(mc.second));
+        }
+        sort(txChanges->begin(), txChanges->end(), [](const CTxChange &a, const CTxChange &b) {
+            return a.now.countWithDescendants > b.now.countWithDescendants;
+        });
+    }
+
+    // Remove conflicting tx
+    for (const auto &tx : vtx)
+    {
+        _removeConflicts(*tx, conflicts);
+        _ClearPrioritisation(tx->GetHash());
+    }
+
+    // After the txs in the new block have been removed from the mempool, update policy estimates
+    minerPolicyEstimator->processBlock(nBlockHeight, entries, fCurrentEstimate);
+    lastRollingFeeUpdate = GetTime();
+    blockSinceLastRollingFeeBump = true;
+
+    // With the cs_txmepool lock on, resubmit the txCommitQ so we don't allow txns back into
+    // the mempool that may be ancestors of txns that were in the block we just processed.  If we allowed
+    // this then the txns would essentialy be orphans within the mempool.
+    ResubmitCommitQ();
+}
+
+// This is the old version of remove for block which is still kept for testing purposes.
+void CTxMemPool::removeForBlock_Legacy(const std::vector<CTransactionRef> &vtx,
+    unsigned int nBlockHeight,
     std::list<CTransactionRef> &conflicts,
     bool fCurrentEstimate,
     std::vector<CTxChange> *txChanges)

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -275,7 +275,14 @@ bool CTxMemPool::_CalculateMemPoolAncestors(const CTxMemPoolEntry &entry,
         if (inBlock)
         {
             if (!inBlock->count(stageit))
+            {
                 setAncestors.insert(stageit);
+            }
+            else
+            {
+                parentHashes.erase(stageit);
+                continue;
+            }
         }
         else
         {
@@ -309,15 +316,7 @@ bool CTxMemPool::_CalculateMemPoolAncestors(const CTxMemPoolEntry &entry,
             // If this is a new ancestor, add it.
             if (setAncestors.count(phash) == 0)
             {
-                if (inBlock)
-                {
-                    if (!inBlock->count(phash))
-                        parentHashes.insert(phash);
-                }
-                else
-                {
-                    parentHashes.insert(phash);
-                }
+                parentHashes.insert(phash);
             }
 
             // removed +1 from test below as per BU: Fix use after free bug

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -266,6 +266,7 @@ bool CTxMemPool::_CalculateMemPoolAncestors(const CTxMemPoolEntry &entry,
 
     while (!parentHashes.empty())
     {
+        auto parentElemIter = parentHashes.begin();
         txiter stageit = *parentHashes.begin();
 
         // If inBlock then we only return a set of ancestors that have not yet been added to a block.
@@ -328,7 +329,7 @@ bool CTxMemPool::_CalculateMemPoolAncestors(const CTxMemPoolEntry &entry,
             }
         }
 
-        parentHashes.erase(stageit); // BU: Fix use after free bug by removing this last
+        parentHashes.erase(parentElemIter); // BU: Fix use after free bug by removing this last
     }
 
     return true;

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -635,13 +635,15 @@ void CTxMemPoolEntry::UpdateDescendantState(int64_t modifySize, CAmount modifyFe
 
 void CTxMemPoolEntry::UpdateAncestorState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount, int modifySigOps)
 {
+    // Ancestor state can be modified by subtraction so we use a DbgAssert here to make sure
+    // we don't accitdentally trigger these asserts on mainnet.
     nSizeWithAncestors += modifySize;
-    assert(int64_t(nSizeWithAncestors) > 0);
+    DbgAssert(int64_t(nSizeWithAncestors) > 0, );
     nModFeesWithAncestors += modifyFee;
     nCountWithAncestors += modifyCount;
-    assert(int64_t(nCountWithAncestors) > 0);
+    DbgAssert(int64_t(nCountWithAncestors) > 0, );
     nSigOpCountWithAncestors += modifySigOps;
-    assert(int(nSigOpCountWithAncestors) >= 0);
+    DbgAssert(int(nSigOpCountWithAncestors) >= 0, );
 }
 
 void CTxMemPoolEntry::ReplaceAncestorState(int64_t modifySize, CAmount modifyFee, int64_t modifyCount, int modifySigOps)


### PR DESCRIPTION
Still needs a little testing but works...

1) For the general case where all txns are mined from the mempool there will be no post processing required as is currently the case.

2) All other scenarios will be O(n)