### PR TITLE
Update OpenBSD build instructions

### DIFF
--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -17,12 +17,12 @@ pkg_add autoconf # (select highest version, e.g. 2.69)
 pkg_add automake # (select highest version, e.g. 1.16)
 pkg_add python # (select highest version, e.g. 3.7)
 ```
-To install openSSL, find download link here [[https://www.openssl.org/source/]].
+To install openSSL, find download link here https://www.openssl.org/source/.
 
 Still as root (while modifying the version as apropriate) run
 
 ```bash
-curl https://www.openssl.org/source/openssl-1.1.0l.tar.gz -o openssl-1.1.0l.tar.gz
+curl 'https://www.openssl.org/source/openssl-1.1.0l.tar.gz' -o openssl-1.1.0l.tar.gz
 echo '74a2f756c64fd7386a29184dc0344f4831192d61dc2481a93a4c5dd727f41148 openssl-1.1.0l.tar.gz' | sha256 -c
 # MUST output: (SHA256) openssl-1.1.0l.tar.gz: OK
 tar xvzf openssl-1.1.0l.tar.gz
@@ -37,7 +37,7 @@ See [dependencies.md](dependencies.md) for a complete overview.
 
 ## Building Bitcoin Unlimited
 
-As your normal, non root go through the relevant steps below
+As your normal (non root) user, go through the steps below
 
 ### Fetch the code
 
@@ -89,7 +89,7 @@ BDB_PREFIX=$(pwd)/db4
 mkdir -p $BDB_PREFIX
 
 # Fetch the source and verify that it is not tampered with
-curl https://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz -o db-4.8.30.NC.tar.gz
+curl 'https://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz' -o db-4.8.30.NC.tar.gz
 echo '12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz' | sha256 -c
 # MUST output: (SHA256) db-4.8.30.NC.tar.gz: OK
 tar -xzf db-4.8.30.NC.tar.gz
@@ -114,6 +114,7 @@ You should now have the required files in `db4/lib/` and `db4/include/`.
 
 Make sure `BDB_PREFIX` is set to the appropriate path from building BDB. See above.
 
+While in the `BitcoinUnlimited` directory.
 
 ```bash
 ./autogen.sh

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -1,158 +1,123 @@
 # OpenBSD build guide
-(updated for OpenBSD 5.7)
+(Tested with OpenBSD 6.6)
 
 This guide describes how to build bitcoind and command-line utilities on OpenBSD.
 
 As OpenBSD is most common as a server OS, we will not bother with the GUI.
+
+**Important**: use `gmake`, not `make`. The non-GNU `make` will exit with a horrible error.
 
 ## Preparation
 
 Run the following as root to install the base dependencies for building:
 
 ```bash
-pkg_add gmake libtool libevent
+pkg_add gmake libtool libevent git boost
 pkg_add autoconf # (select highest version, e.g. 2.69)
-pkg_add automake # (select highest version, e.g. 1.15)
-pkg_add python # (select version 2.7.x, not 3.x)
-ln -sf /usr/local/bin/python2.7 /usr/local/bin/python2
+pkg_add automake # (select highest version, e.g. 1.16)
+pkg_add python # (select highest version, e.g. 3.7)
+```
+To install openSSL, find download link here [[https://www.openssl.org/source/]].
+
+Still as root (while modifying the version as apropriate) run
+
+```bash
+curl https://www.openssl.org/source/openssl-1.1.0l.tar.gz -o openssl-1.1.0l.tar.gz
+echo '74a2f756c64fd7386a29184dc0344f4831192d61dc2481a93a4c5dd727f41148 openssl-1.1.0l.tar.gz' | sha256 -c
+# MUST output: (SHA256) openssl-1.1.0l.tar.gz: OK
+tar xvzf openssl-1.1.0l.tar.gz
+cd openssl-1.1.0l
+./config
+gmake
+gmake install
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.
 
-## GCC
 
-The default C++ compiler that comes with OpenBSD 5.9 is g++ 4.2. This version is old (from 2007), and is not able to compile the current version of Bitcoin Core, primarily as it has no C++11 support, but even before there were issues. So here we will be installing a newer compiler:
+## Building Bitcoin Unlimited
 
-```bash
-pkg_add g++ # (select newest 4.x version, e.g. 4.9.2)
-```
+As your normal, non root go through the relevant steps below
 
-This compiler will not overwrite the system compiler, it will be installed as `egcc` and `eg++` in `/usr/local/bin`.
-
-### Building boost
-
-Do not use `pkg_add boost`! The boost version installed thus is compiled using the `g++` compiler not `eg++`, which will result in a conflict between `/usr/local/lib/libestdc++.so.XX.0` and `/usr/lib/libstdc++.so.XX.0`, resulting in a test crash:
-
-    test_bitcoin:/usr/lib/libstdc++.so.57.0: /usr/local/lib/libestdc++.so.17.0 : WARNING: symbol(_ZN11__gnu_debug17_S_debug_me ssagesE) size mismatch, relink your program
-    ...
-    Segmentation fault (core dumped)
-
-This makes it necessary to build boost, or at least the parts used by Bitcoin Unlimited, manually:
+### Fetch the code
 
 ```bash
-# Pick some path to install boost to, here we create a directory within the bitcoin directory
-BITCOIN_ROOT=$(pwd)
-BOOST_PREFIX="${BITCOIN_ROOT}/boost"
-mkdir -p $BOOST_PREFIX
-
-# Fetch the source and verify that it is not tampered with
-wget https://kent.dl.sourceforge.net/project/boost/boost/1.59.0/boost_1_59_0.tar.bz2
-echo '727a932322d94287b62abb1bd2d41723eec4356a7728909e38adb65ca25241ca  boost_1_59_0.tar.bz2' | sha256 -c
-# MUST output: (SHA256) boost_1_59_0.tar.bz2: OK
-tar -xjf boost_1_59_0.tar.bz2
-
-# Boost 1.59 needs two small patches for OpenBSD
-cd boost_1_59_0
-# Also here: https://gist.githubusercontent.com/laanwj/bf359281dc319b8ff2e1/raw/92250de8404b97bb99d72ab898f4a8cb35ae1ea3/patch-boost_test_impl_execution_monitor_ipp.patch
-patch -p0 < /usr/ports/devel/boost/patches/patch-boost_test_impl_execution_monitor_ipp
-# https://github.com/boostorg/filesystem/commit/90517e459681790a091566dce27ca3acabf9a70c
-sed 's/__OPEN_BSD__/__OpenBSD__/g' < libs/filesystem/src/path.cpp > libs/filesystem/src/path.cpp.tmp
-mv libs/filesystem/src/path.cpp.tmp libs/filesystem/src/path.cpp
-
-# Build w/ minimum configuration necessary for bitcoin
-echo 'using gcc : : eg++ : <cxxflags>"-fvisibility=hidden -fPIC" <linkflags>"" <archiver>"ar" <striper>"strip"  <ranlib>"ranlib" <rc>"" : ;' > user-config.jam
-config_opts="runtime-link=shared threadapi=pthread threading=multi link=static variant=release --layout=tagged --build-type=complete --user-config=user-config.jam -sNO_BZIP2=1"
-./bootstrap.sh --without-icu --with-libraries=chrono,filesystem,program_options,system,thread,test
-./b2 -d2 -j2 -d1 ${config_opts} --prefix=${BOOST_PREFIX} stage
-./b2 -d0 -j4 ${config_opts} --prefix=${BOOST_PREFIX} install
+git clone https://github.com/BitcoinUnlimited/BitcoinUnlimited.git
+cd BitcoinUnlimited/
 ```
 
-### Building BerkeleyDB
+### Preparation
 
-BerkeleyDB is only necessary for the wallet functionality. To skip this, pass `--disable-wallet` to `./configure`.
+```bash
+export AUTOCONF_VERSION=2.69 # replace this with the autoconf version that you installed
+export AUTOMAKE_VERSION=1.16 # replace this with the automake version that you installed
+export CC=cc
+export CXX=c++
+export MAKE=gmake
+```
 
-See "Berkeley DB" in [build_unix.md](build_unix.md) for instructions on how to build BerkeleyDB 4.8.
-You cannot use the BerkeleyDB library from ports, for the same reason as boost above (g++/libstd++ incompatibility).
+Now you need to choose to build without or with wallet functionality. If you just require a running node, you generally don't need wallet functionality
+
+### To build without wallet
+
+While in the `BitcoinUnlimited` directory
+
+```bash
+./autogen.sh
+./configure --disable-wallet --with-gui=no
+gmake # You may get an error with one of the tests.
+```
+
+You will find the `bitcoind` binary in the `src/` folder.
+
+
+### To build with wallet
+
+To stay backwards compatible with old walletfiles we specifically need BerkeleyDB 4.8.
+You cannot use the BerkeleyDB library from ports.
+
+
+#### Building BerkeleyDB
+
+BerkeleyDB is only necessary for the wallet functionality. To skip this, pass `--disable-wallet` to `./configure`. See above.
+
+To build Berkeley DB 4.8:
 
 ```bash
 # Pick some path to install BDB to, here we create a directory within the bitcoin directory
-BITCOIN_ROOT=$(pwd)
-BDB_PREFIX="${BITCOIN_ROOT}/db4"
+BDB_PREFIX=$(pwd)/db4
 mkdir -p $BDB_PREFIX
 
 # Fetch the source and verify that it is not tampered with
-wget 'https://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
+curl https://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz -o db-4.8.30.NC.tar.gz
 echo '12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz' | sha256 -c
 # MUST output: (SHA256) db-4.8.30.NC.tar.gz: OK
 tar -xzf db-4.8.30.NC.tar.gz
 
+# Fetch, verify that it is not tampered with and apply clang related patch
+cd db-4.8.30.NC/
+curl 'https://gist.githubusercontent.com/LnL7/5153b251fd525fe15de69b67e63a6075/raw/7778e9364679093a32dec2908656738e16b6bdcb/clang.patch' -o clang.patch
+echo '7a9a47b03fd5fb93a16ef42235fa9512db9b0829cfc3bdf90edd3ec1f44d637c  clang.patch' | sha256 -c
+# MUST output: (SHA256) clang.patch: OK
+patch -p2 < clang.patch
+
 # Build the library and install to specified prefix
-cd db-4.8.30.NC/build_unix/
-#  Note: Do a static build so that it can be embedded into the executable, instead of having to find a .so at runtime
-../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX CC=egcc CXX=eg++ CPP=ecpp
-make install
+cd build_unix/
+../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
+gmake install
+cd ../..
 ```
 
-### Building Bitcoin Unlimited
+You should now have the required files in `db4/lib/` and `db4/include/`.
 
-**Important**: use `gmake`, not `make`. The non-GNU `make` will exit with a horrible error.
+### To build with wallet
 
-Preparation:
+Make sure `BDB_PREFIX` is set to the appropriate path from building BDB. See above.
+
+
 ```bash
-export AUTOCONF_VERSION=2.69 # replace this with the autoconf version that you installed
-export AUTOMAKE_VERSION=1.15 # replace this with the automake version that you installed
 ./autogen.sh
-```
-Make sure `BDB_PREFIX` and `BOOST_PREFIX` are set to the appropriate paths from the above steps.
-
-To configure with wallet:
-```bash
-./configure --with-gui=no --with-boost=$BOOST_PREFIX \
-    CC=egcc CXX=eg++ CPP=ecpp \
-    LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/"
-```
-
-To configure without wallet:
-```bash
-./configure --disable-wallet --with-gui=no --with-boost=$BOOST_PREFIX \
-    CC=egcc CXX=eg++ CPP=ecpp
-```
-
-Build and run the tests:
-```bash
-gmake
-gmake check
-```
-
-## Clang (not currently working)
-
-Using a newer g++ results in linking the new code to a new libstdc++.
-Libraries built with the old g++, will still import the old library.
-This produces conflicts, necessitating rebuild of all C++ dependencies of the application.
-
-With clang this can - at least theoretically - be avoided because it uses the
-base system's libstdc++.
-
-```bash
-pkg_add llvm boost
-```
-
-```bash
-./configure --disable-wallet --with-gui=no CC=clang CXX=clang++
+./configure LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/" --with-gui=no
 gmake
 ```
 
-However, this does not appear to work. Compilation succeeds, but link fails
-with many 'local symbol discarded' errors:
-
-    local symbol 150: discarded in section `.text._ZN10tinyformat6detail14FormatIterator6finishEv' from libbitcoin_util.a(libbitcoin_util_a-random.o)
-    local symbol 151: discarded in section `.text._ZN10tinyformat6detail14FormatIterator21streamStateFromFormatERSoRjPKcii' from libbitcoin_util.a(libbitcoin_util_a-random.o)
-    local symbol 152: discarded in section `.text._ZN10tinyformat6detail12convertToIntIA13_cLb0EE6invokeERA13_Kc' from libbitcoin_util.a(libbitcoin_util_a-random.o)
-
-According to similar reported errors this is a binutils (ld) issue in 2.15, the
-version installed by OpenBSD 5.7:
-
-- http://openbsd-archive.7691.n7.nabble.com/UPDATE-cppcheck-1-65-td248900.html
-- https://llvm.org/bugs/show_bug.cgi?id=9758
-
-There is no known workaround for this.

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -28,7 +28,6 @@ echo '74a2f756c64fd7386a29184dc0344f4831192d61dc2481a93a4c5dd727f41148 openssl-1
 tar xvzf openssl-1.1.0l.tar.gz
 cd openssl-1.1.0l
 ./config
-gmake
 gmake install
 ```
 


### PR DESCRIPTION
- boost from the package archive works, so no need to build that from source.
- instructions to install openSSL
- Added this patch to the BDB4.8 build instructions. (It can't build without)
https://gist.githubusercontent.com/LnL7/5153b251fd525fe15de69b67e63a6075/raw/7778e9364679093a32dec2908656738e16b6bdcb/
