### PR TITLE
Port wallet optimizations from old coinselection branch

### DIFF
--- a/qa/rpc-tests/fundrawtransaction.py
+++ b/qa/rpc-tests/fundrawtransaction.py
@@ -339,6 +339,7 @@ class RawTransactionsTest(BitcoinTestFramework):
 
         try:
             rawtxfund = self.nodes[2].fundrawtransaction(rawtx)
+            logging.info("Unspent: " + str(len(listunspent)) + "\n" + str(listunspent))  # if we spend more let's see what's unspent
             raise AssertionError("Spent more than available")
         except JSONRPCException as e:
             assert("Insufficient" in e.error['message'])
@@ -670,12 +671,14 @@ class RawTransactionsTest(BitcoinTestFramework):
         assert(changeaddress != nextaddr)
 
 if __name__ == '__main__':
-    RawTransactionsTest().main(None,{"keypool":1})
+    # this test sends a 0 value transaction so we need to turn off the fee percent check
+    RawTransactionsTest().main(None,{"keypool":1 })
 
 def Test():
     t = RawTransactionsTest()
+    t.drop_to_pdb = True
     bitcoinConf = {
-        "debug": ["rpc","net", "blk", "thin", "mempool", "req", "bench", "evict"],
+        "debug": ["all"], # ["rpc","net", "blk", "thin", "mempool", "req", "bench", "evict"],
         "keypool":1
     }
 

--- a/qa/rpc-tests/wallet.py
+++ b/qa/rpc-tests/wallet.py
@@ -445,7 +445,7 @@ class WalletTest (BitcoinTestFramework):
             # wait for blockchain to catch up
             waitFor(60, lambda : [block_count] * 3 == [self.nodes[i].getblockcount() for i in range(3)])
             # wait for wallet to catch up to blockchain
-            waitFor(60, lambda : balance_nodes == [self.nodes[i].getbalance() for i in range(3)], lambda: print("balances: " + [self.nodes[i].getbalance() for i in range(3)] + " expecting: " + balance_nodes))
+            waitFor(60, lambda : balance_nodes == [self.nodes[i].getbalance() for i in range(3)], lambda: print("balances: " + str([self.nodes[i].getbalance() for i in range(3)]) + " expecting: " + str(balance_nodes)))
 
         # Exercise listsinceblock with the last two blocks
         coinbase_tx_1 = self.nodes[0].listsinceblock(blocks[0])
@@ -462,7 +462,7 @@ if __name__ == '__main__':
 def Test():
     t = WalletTest()
     bitcoinConf = {
-        "debug": ["rpc","net", "blk", "thin", "mempool", "req", "bench", "evict"],
+        "debug": ["selectcoins", "rpc","net", "blk", "thin", "mempool", "req", "bench", "evict"]
     }
 
     flags = standardFlags()

--- a/src/.formatted-files
+++ b/src/.formatted-files
@@ -392,6 +392,7 @@ wallet/wallet.cpp
 wallet/walletdb.cpp
 wallet/walletdb.h
 wallet/wallet.h
+wallet/coinselection.cpp
 zmq/zmqabstractnotifier.cpp
 zmq/zmqabstractnotifier.h
 zmq/zmqconfig.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -347,6 +347,7 @@ endif
 libbitcoin_wallet_a_CPPFLAGS = $(AM_CPPFLAGS) $(BITCOIN_INCLUDES)
 libbitcoin_wallet_a_CXXFLAGS = $(AM_CXXFLAGS) $(PIE_FLAGS)
 libbitcoin_wallet_a_SOURCES = \
+  wallet/coinselection.cpp \
   wallet/crypter.cpp \
   wallet/db.cpp \
   wallet/rpcdump.cpp \

--- a/src/amount.cpp
+++ b/src/amount.cpp
@@ -5,8 +5,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "amount.h"
-
 #include "tinyformat.h"
+#include "tweak.h"
+extern CTweak<unsigned int> txWalletDust; // minimum wallet tx output size
+extern CTweak<unsigned int> nDustThreshold; // minimum "standard" tx output size (below this won't relay)
 
 CFeeRate::CFeeRate(const CAmount &nFeePaid, size_t nSize)
 {
@@ -29,4 +31,17 @@ CAmount CFeeRate::GetFee(size_t nSize) const
 std::string CFeeRate::ToString() const
 {
     return strprintf("%d.%08d %s/kB", nSatoshisPerK / COIN, nSatoshisPerK % COIN, CURRENCY_UNIT);
+}
+
+
+CAmount CFeeRate::GetDust() const
+{
+    CAmount dust = txWalletDust.Value();
+    // If dust has not been configured, then
+    // "Dust" is defined in terms of CTransaction::minRelayTxFee, which has units satoshis-per-kilobyte.
+    // If you'd pay more than 1/3 in fees to spend something, then we consider it dust.
+    // A typical spendable txout is 34 bytes big, and will need a CTxIn of at least 148 bytes to spend:
+    if (dust == 0)
+        dust = 3 * minRelayTxFee.GetFee(TYPICAL_UTXO_LIFECYCLE_SIZE);
+    return std::max(dust, (CAmount)nDustThreshold.Value());
 }

--- a/src/amount.h
+++ b/src/amount.h
@@ -19,6 +19,12 @@ static const CAmount CENT = 1000000;
 
 extern const std::string CURRENCY_UNIT;
 
+enum
+{
+    //! Minimum # of bytes to generate and spend a UTXO. 34 for the output, 148 for the input. Used in dust calculation
+    TYPICAL_UTXO_LIFECYCLE_SIZE = 148 + 34,
+};
+
 /** No amount larger than this (in satoshi) is valid.
  *
  * Note that this constant is *not* the total money supply, which in Bitcoin
@@ -44,6 +50,10 @@ public:
     CFeeRate(const CFeeRate &other) { nSatoshisPerK = other.nSatoshisPerK; }
     CAmount GetFee(size_t size) const; // unit returned is satoshis
     CAmount GetFeePerK() const { return GetFee(1000); } // satoshis-per-1000-bytes
+    /** Dust is too small to be spendable.  It is either set via the txDust tweak or proportional to the cost to
+        spend an output. */
+    CAmount GetDust() const;
+
     friend bool operator<(const CFeeRate &a, const CFeeRate &b) { return a.nSatoshisPerK < b.nSatoshisPerK; }
     friend bool operator>(const CFeeRate &a, const CFeeRate &b) { return a.nSatoshisPerK > b.nSatoshisPerK; }
     friend bool operator==(const CFeeRate &a, const CFeeRate &b) { return a.nSatoshisPerK == b.nSatoshisPerK; }
@@ -64,5 +74,8 @@ public:
         READWRITE(nSatoshisPerK);
     }
 };
+
+/** A fee rate smaller than this is considered zero fee (for relaying, mining and transaction creation) */
+extern CFeeRate minRelayTxFee;
 
 #endif //  BITCOIN_AMOUNT_H

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -63,6 +63,8 @@ using namespace std;
 LockData lockdata;
 #endif
 
+//! Maximum fee as a percentage of the value input into the transaction
+extern int MAX_FEE_PERCENT_OF_VALUE;
 
 // this flag is set to true when a wallet rescan has been invoked.
 std::atomic<bool> fRescan{false};
@@ -374,6 +376,33 @@ CTweak<unsigned int> maxBlocksInTransitPerPeer("net.maxBlocksInTransitPerPeer",
 CTweak<unsigned int> blockDownloadWindow("net.blockDownloadWindow",
     "How far ahead of our current height do we fetch? 0 means use algorithm.",
     0);
+
+/** If transactions overpay by less than this amount in Satoshis, the extra will be put in the fee rather than a
+    change address.  Zero means calculate this dynamically as a fraction of the current transaction fee
+    (recommended). */
+CTweak<unsigned int> txWalletDust("wallet.txFeeOverpay",
+    "If transactions overpay by less than this amount in Satoshis, the extra will be put in the fee rather than a "
+    "change address.  Zero means calculate this dynamically as a fraction of the current transaction fee "
+    "(recommended).",
+    0);
+
+/** When sending, how long should this wallet search for a more efficient or no-change payment solution in
+    milliseconds.  A no-change solution reduces transaction fees, but is extremely unlikely unless your wallet
+    is very large and well distributed because transaction fees add a small quantity of dust to the normal round
+    numbers that humans use.
+*/
+CTweak<unsigned int> maxCoinSelSearchTime("wallet.coinSelSearchTime",
+    "When sending, how long should this wallet search for a no-change payment solution in milliseconds.  A no-change "
+    "solution reduces transaction fees.",
+    25);
+
+/** How many UTXOs should be maintained in this wallet (on average).  If the number of UTXOs exceeds this value,
+    transactions will be found that tend to have more inputs.  This will consolidate UTXOs.
+ */
+CTweak<unsigned int> preferredNumUTXO("wallet.preferredNumUTXO",
+    "How many UTXOs should be maintained in this wallet (on average).  If the number of UTXOs exceeds this value, "
+    "transactions will be found that tend to have more inputs.  This will consolidate UTXOs.",
+    5000);
 
 /** This setting specifies the minimum supported Graphene version (inclusive).
  *  The actual version used will be negotiated between sender and receiver.

--- a/src/keystore.h
+++ b/src/keystore.h
@@ -19,10 +19,13 @@
 /** A virtual base class for key stores */
 class CKeyStore
 {
-protected:
+public:
+    /** This lock only needs to be explicitly taken by the caller if lock-free functions are called.  All lock-free
+        functions are preceded by an _.  In general, use the locking functions.  Only use the lock-free functions
+        for optimization of loops by factoring the lock out of the loop and calling the lock-free function in the loop.
+    */
     mutable CCriticalSection cs_KeyStore;
 
-public:
     virtual ~CKeyStore() {}
     //! Add a key to the store.
     virtual bool AddKeyPubKey(const CKey &key, const CPubKey &pubkey) = 0;
@@ -30,6 +33,9 @@ public:
 
     //! Check whether a key corresponding to a given address is present in the store.
     virtual bool HaveKey(const CKeyID &address) const = 0;
+    //! Check whether a key corresponding to a given address is present in the store, caller must hold cs_KeyStore
+    virtual bool _HaveKey(const CKeyID &address) const = 0;
+
     virtual bool GetKey(const CKeyID &address, CKey &keyOut) const = 0;
     virtual void GetKeys(std::set<CKeyID> &setAddress) const = 0;
     virtual bool GetPubKey(const CKeyID &address, CPubKey &vchPubKeyOut) const = 0;
@@ -72,6 +78,7 @@ public:
         }
         return result;
     }
+    bool _HaveKey(const CKeyID &address) const { return (mapKeys.count(address) > 0); }
     void GetKeys(std::set<CKeyID> &setAddress) const
     {
         setAddress.clear();

--- a/src/main.h
+++ b/src/main.h
@@ -140,8 +140,6 @@ extern bool fIsBareMultisigStd;
 extern unsigned int nBytesPerSigOp;
 extern bool fCheckBlockIndex;
 extern bool fCheckpointsEnabled;
-/** A fee rate smaller than this is considered zero fee (for relaying, mining and transaction creation) */
-extern CFeeRate minRelayTxFee;
 /** Absolute maximum transaction fee (in satoshis) used by wallet and mempool (rejects high fee in sendrawtransaction)
  */
 extern CTweak<CAmount> maxTxFee;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -282,8 +282,8 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript &sc
 
         nLastBlockTx = nBlockTx;
         nLastBlockSize = nBlockSize;
-        LOGA("CreateNewBlock(): total size %llu txs: %llu fees: %lld sigops %u\n", nBlockSize, nBlockTx, nFees,
-            nBlockSigOps);
+        LOGA("CreateNewBlock: total size %llu txs: %llu of %llu fees: %lld sigops %u\n", nBlockSize, nBlockTx,
+            mempool._size(), nFees, nBlockSigOps);
 
 
         // sort tx if there are any and the feature is enabled

--- a/src/qt/sendcoinsdialog.cpp
+++ b/src/qt/sendcoinsdialog.cpp
@@ -262,7 +262,24 @@ void SendCoinsDialog::on_sendButton_clicked()
     WalletModelTransaction currentTransaction(recipients);
     WalletModel::SendCoinsReturn prepareStatus;
     if (model->getOptionsModel()->getCoinControlFeatures()) // coin control enabled
+    {
+        // The way the GUI works is that removing all checked coins automatically switches to allowing other inputs.
+        // We need to make the coinControl structure consistent with this GUI behavior.  We could do it in many places
+        // as coins are selected and unselected in various UI ways, or we can have a single catch-all rule here.
+        if (CoinControlDialog::coinControl)
+        {
+            if (!CoinControlDialog::coinControl->HasSelected())
+            {
+                CoinControlDialog::coinControl->fAllowOtherInputs = true;
+            }
+            else // The GUI has no way to use some coins and supplement with additional -- instead it errors
+            {
+                CoinControlDialog::coinControl->fAllowOtherInputs = false;
+            }
+        }
+
         prepareStatus = model->prepareTransaction(currentTransaction, CoinControlDialog::coinControl);
+    }
     else
         prepareStatus = model->prepareTransaction(currentTransaction);
 

--- a/src/script/ismine.cpp
+++ b/src/script/ismine.cpp
@@ -83,13 +83,11 @@ bool isFreezeCLTV(const CKeyStore &keystore, const CScript &scriptPubKey, CScrip
     return false;
 }
 
-isminetype IsMine(const CKeyStore &keystore, const CTxDestination &dest, CBlockIndex *bestBlock)
-{
-    CScript script = GetScriptForDestination(dest);
-    return IsMine(keystore, script, bestBlock);
-}
 
-isminetype IsMine(const CKeyStore &keystore, const CScript &scriptPubKey, CBlockIndex *bestBlock)
+static isminetype IsMine(const CKeyStore &keystore,
+    const CScript &scriptPubKey,
+    CBlockIndex *bestBlock,
+    bool alreadyLocked)
 {
     vector<valtype> vSolutions;
     txnouttype whichType;
@@ -108,15 +106,21 @@ isminetype IsMine(const CKeyStore &keystore, const CScript &scriptPubKey, CBlock
     case TX_LABELPUBLIC:
         break;
     case TX_PUBKEY:
+    {
         keyID = CPubKey(vSolutions[0]).GetID();
-        if (keystore.HaveKey(keyID))
+        bool haveKey = alreadyLocked ? keystore._HaveKey(keyID) : keystore.HaveKey(keyID);
+        if (haveKey)
             return ISMINE_SPENDABLE;
-        break;
+    }
+    break;
     case TX_PUBKEYHASH:
+    {
         keyID = CKeyID(uint160(vSolutions[0]));
-        if (keystore.HaveKey(keyID))
+        bool haveKey = alreadyLocked ? keystore._HaveKey(keyID) : keystore.HaveKey(keyID);
+        if (haveKey)
             return ISMINE_SPENDABLE;
-        break;
+    }
+    break;
     case TX_SCRIPTHASH:
     {
         CScriptID scriptID = CScriptID(uint160(vSolutions[0]));
@@ -146,7 +150,8 @@ isminetype IsMine(const CKeyStore &keystore, const CScript &scriptPubKey, CBlock
     case TX_CLTV:
     {
         keyID = CPubKey(vSolutions[1]).GetID();
-        if (keystore.HaveKey(keyID))
+        bool haveKey = alreadyLocked ? keystore._HaveKey(keyID) : keystore.HaveKey(keyID);
+        if (haveKey)
         {
             CScriptNum nFreezeLockTime(vSolutions[0], true, 5);
 
@@ -185,4 +190,22 @@ isminetype IsMine(const CKeyStore &keystore, const CScript &scriptPubKey, CBlock
                                                                                              ISMINE_WATCH_UNSOLVABLE;
     }
     return ISMINE_NO;
+}
+
+
+isminetype IsMine(const CKeyStore &keystore, const CTxDestination &dest, CBlockIndex *bestBlock)
+{
+    CScript script = GetScriptForDestination(dest);
+    return IsMine(keystore, script, bestBlock);
+}
+
+isminetype IsMine(const CKeyStore &keystore, const CScript &scriptPubKey, CBlockIndex *bestBlock)
+{
+    return IsMine(keystore, scriptPubKey, bestBlock, false);
+}
+
+isminetype _IsMine(const CKeyStore &keystore, const CScript &scriptPubKey, CBlockIndex *bestBlock)
+{
+    AssertLockHeld(keystore.cs_KeyStore);
+    return IsMine(keystore, scriptPubKey, bestBlock, true);
 }

--- a/src/script/ismine.h
+++ b/src/script/ismine.h
@@ -35,7 +35,18 @@ typedef uint8_t isminefilter;
 std::string getLabelPublic(const CScript &scriptPubKey);
 bool isFreezeCLTV(const CKeyStore &keystore, const CScript &scriptPubKey, CScriptNum &nFreezeLockTime); // Freeze
 // bestBlock - Freeze CLTV
+
+/** Determines if an output is spendable by this wallet
+ */
 isminetype IsMine(const CKeyStore &keystore, const CScript &scriptPubKey, CBlockIndex *bestBlock);
+
+/** Determines if an output is spendable by this wallet
+ */
 isminetype IsMine(const CKeyStore &keystore, const CTxDestination &dest, CBlockIndex *bestBlock);
+
+/** Determines if an output is spendable by this wallet -- lockless version (you must take cs_KeyStore)
+ */
+isminetype _IsMine(const CKeyStore &keystore, const CScript &scriptPubKey, CBlockIndex *bestBlock);
+
 
 #endif // BITCOIN_SCRIPT_ISMINE_H

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -796,6 +796,7 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
         CAmount nValueIn = 0;
         LockPoints lp;
         {
+            READLOCK(ss.cs_snapshot);
             READLOCK(pool.cs_txmempool);
             CCoinsViewMemPool &viewMemPool(*ss.cvMempool);
             view.SetBackend(viewMemPool);
@@ -1371,7 +1372,7 @@ void ProcessOrphans(std::vector<uint256> &vWorkQueue)
 
 void Snapshot::Load(void)
 {
-    LOCK(cs_snapshot);
+    WRITELOCK(cs_snapshot);
     tipHeight = chainActive.Height();
     tip = chainActive.Tip();
     if (tip)

--- a/src/txadmission.h
+++ b/src/txadmission.h
@@ -57,7 +57,7 @@ static const bool DEFAULT_RELAYPRIORITY = false;
 class Snapshot
 {
 public:
-    CCriticalSection cs_snapshot;
+    CSharedCriticalSection cs_snapshot;
     uint64_t tipHeight;
     uint64_t tipMedianTimePast;
     int64_t adjustedTime;

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1969,7 +1969,23 @@ uint256 CalculateMerkleRoot(uint256 &coinbase_hash, const std::vector<uint256> &
     return merkle_root;
 }
 
-/** Mining-Candidate end */
+#ifdef DEBUG
+// This RPC is very useful for checking that the test system works, but we don't want it to be part of the
+// normal release
+UniValue crash(const UniValue &params, bool fHelp)
+{
+    if (fHelp || params.size() >= 1)
+        throw runtime_error("crash \n"
+                            "\nCrashes this program, generating a core dump.\n"
+                            "\nArguments\n"
+                            "none\n"
+                            "\nResult:\n" +
+                            HelpExampleCli("crash", "") + HelpExampleRpc("crash", ""));
+
+
+    abort();
+}
+#endif
 
 /* clang-format off */
 static const CRPCCommand commands[] =
@@ -2001,7 +2017,8 @@ static const CRPCCommand commands[] =
     { "util",               "set",                    &settweak,               true  },
     { "util",               "validatechainhistory",   &validatechainhistory,   true  },
 #ifdef DEBUG
-    { "util",               "getstructuresizes",      &getstructuresizes,      true  },  // BU
+    { "util",               "getstructuresizes",      &getstructuresizes,      true  },
+    { "util",               "crash",                  &crash,                  true  },
 #endif
     { "util",               "getaddressforms",        &getaddressforms,        true  },
     { "util",               "log",                    &setlog,                 true  },
@@ -2373,6 +2390,7 @@ UniValue getaddressforms(const UniValue &params, bool fHelp)
     node.pushKV("bitpay", bitpayAddr);
     return node;
 }
+
 
 std::string CStatusString::GetPrintable() const
 {

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -1,0 +1,349 @@
+#include "../tweak.h"
+#include "random.h"
+#include "wallet.h"
+
+// needed for tx validation
+#include "../main.h"
+#include "../script/sign.h"
+#include "../txmempool.h"
+const int MAX_SOLUTIONS = 2000; // The approximate maximum number of solutions we will find before giving up.
+// What's the maximum number of TXOs we should use as inputs to a transaction (if we have a choice).
+const int MAX_ELECTIVE_TXOS = 5;
+const int MAX_TXOS = 100; // What's the maximum number of TXOs to put in a transaction
+// how many satoshi's the coin selection is willing to be off by per iteration through the loop.  Makes it progressively
+// easier to find a solution
+// (now its a simple exponential) const long int LOOP_COST = 500;
+const int P2PKH_INPUT_SIZE = 72; // <Sig> <PubKey> OP_DUP OP_HASH160 <PubkeyHash> OP_EQUALVERIFY OP_CHECKSIG
+
+extern CTweak<unsigned int> maxCoinSelSearchTime;
+extern CTweak<unsigned int> preferredNumUTXO;
+
+// This holds a sorted map of coin amounts and the set of Txos required to get to that amount
+typedef std::multimap<CAmount, TxoGroup> TxoGroupMap;
+
+// How close do we want to get to targetValue (at first).  The longer it takes the more we add to this value.
+CAmount reasonableExcess(CAmount targetValue) { return targetValue / 1024; }
+// Create a group of Txos from a Txo index and another group.
+TxoGroup makeGroup(SpendableTxos::iterator i, const TxoGroup *prev = nullptr)
+{
+    TxoGroup ret;
+    if (prev != nullptr)
+        ret = *prev;
+    else
+        ret.first = 0;
+    // Don't add an element that already exists  -- allow this, bad solutions eliminated later
+    // assert(ret.second.find(i) == ret.second.end());
+    ret.first += i->first; // update the amount
+    COutput outp = i->second;
+    // verify that the output value is consistent -- TODO: Check pcoin and make sure it doesn't get deleted -- located
+    // in mapWallet
+    assert(outp.tx->vout[outp.i].nValue == i->first);
+    ret.second.insert(i); // add this txo to the set
+    return ret;
+}
+
+// Take a group that is not a solution and find a bunch of solutions by appending additional TXOs onto it.
+// This is a recursive function that is limited by MAX_TXOs and MAX_ELECTIVE_TXOS
+bool extendCoinSelectionSolution(const CAmount targetValue,
+    /*const*/ SpendableTxos &available,
+    TxoGroup grp,
+    TxoGroupMap &solutions,
+    int depth)
+{
+    if (depth >= MAX_TXOS)
+        return false; // unambiguously break the recursion
+    SpendableTxos::iterator aEnd = available.end(); // For speed, get these once
+    SpendableTxos::iterator aBeg = available.begin();
+    bool ret = false;
+    SpendableTxos::iterator small;
+    small = available.lower_bound(targetValue - grp.first); // Find a value at or above what we need
+
+    {
+        SpendableTxos::iterator i = small;
+        // while not at the end and there's too little value or we already used this output then keep going.
+        // while((i != aEnd) && ((i->first + grp.first < targetValue) || (grp.second.find(i) != grp.second.end()))  )
+        // allow dups and eliminate later for performance
+        while ((i != aEnd) && (i->first + grp.first < targetValue)) // iterate to make sure it is actually big enough.
+        {
+            ++i;
+        }
+
+        if (i != aEnd) // Ok we have a solution so add it.
+        {
+            TxoGroup g = makeGroup(i, &grp);
+            solutions.insert(TxoGroupMap::value_type(g.first, g));
+            ret = true;
+        }
+    }
+
+    if (small == aEnd)
+        --small;
+    for (int count = 0; count < 5; count++) // check 5 more close values
+    {
+        // lower_bound returns an element >= the passed value, so get one that is smaller
+        while ((small != aBeg) && (small->first + grp.first > targetValue))
+            --small;
+        // keep looking if there are no solutions or if the depth is low
+        if ((solutions.empty() || (depth < MAX_ELECTIVE_TXOS)))
+        {
+            // Its better performance to accidentally add a double than to check every time
+            // go to the prev if this one is already in the group.
+            // while ((small != aBeg) && (grp.second.find(small) != grp.second.end())) --small;
+            // if (small != aBeg)
+            {
+                TxoGroup newGrp = makeGroup(small, &grp);
+                ret |= extendCoinSelectionSolution(targetValue, available, newGrp, solutions, depth + 1);
+            }
+        }
+
+        if (small == aBeg)
+            break;
+    }
+    return ret;
+}
+
+// Make sure that the group sums to >= the target value.
+// Since the TxoGroup is a set, identical Txos are eliminated meaning that this may not sum, and that the
+// TxoGroup->first may be inaccurate.
+// There may be identical Txos because the search algorithm does not eliminate used txos from the search set for
+// efficiency.
+// Also check various other aspects that would block the transaction from being accepted into the mempool.
+bool validate(const TxoGroup &grp, const CAmount targetValue)
+{
+    CAmount acc = 0;
+    int nTx = grp.second.size();
+    for (TxoItVec::iterator i = grp.second.begin(); i != grp.second.end(); ++i)
+    {
+        acc += (*i)->first;
+    }
+    if (acc < targetValue)
+        return false;
+
+    std::vector<CTxIn> txIn(nTx);
+    int count = 0;
+    for (TxoItVec::iterator i = grp.second.begin(); i != grp.second.end(); ++i, ++count)
+    {
+        COutput &tmp = (*i)->second;
+        txIn[count] = CTxIn(tmp.tx->GetHash(), tmp.i);
+    }
+
+    size_t limitAncestorCount = GetArg("-limitancestorcount", BU_DEFAULT_ANCESTOR_LIMIT);
+    size_t limitAncestorSize = GetArg("-limitancestorsize", BU_DEFAULT_ANCESTOR_SIZE_LIMIT) * 1000;
+    size_t limitDescendantsCount = GetArg("-limitdescendantcount", BU_DEFAULT_DESCENDANT_LIMIT);
+    size_t limitDescendantSize = GetArg("-limitdescendantsize", BU_DEFAULT_DESCENDANT_SIZE_LIMIT) * 1000;
+    std::string errString;
+
+    READLOCK(mempool.cs_txmempool);
+    bool ret = mempool.ValidateMemPoolAncestors(
+        txIn, limitAncestorCount, limitAncestorSize, limitDescendantsCount, limitDescendantSize, errString);
+    if (!ret)
+    {
+        LOG(SELECTCOINS, "CoinSelection eliminated a solution, error: %s\n", errString.c_str());
+    }
+    return ret;
+}
+
+// Select coins.
+TxoGroup CoinSelection(/*const*/ SpendableTxos &available,
+    const CAmount targetValue,
+    const CAmount &dust,
+    CFeeRate feeRate,
+    unsigned int changeLen)
+{
+    FastRandomContext insecureRand;
+    uint64_t utxosInWallet = available.size();
+    SpendableTxos::iterator aEnd = available.end();
+    SpendableTxos::iterator aBegin = available.begin();
+    TxoGroupMap solutions;
+    TxoGroupMap candidates;
+
+    LOG(SELECTCOINS, "CoinSelection: Target: %d, num available txos: %d\n", targetValue, available.size());
+
+    // Find the smallest output > TargetValue & add it to solutions (if it exists).
+    SpendableTxos::iterator large;
+    large = available.lower_bound(targetValue); // Find the elem nearest the target but greater or =
+    // The amount is bigger than our biggest output.  We'll create a simple solution from a set of our biggest outputs.
+    if (large == aEnd)
+    {
+        if (large == aBegin) // beginning == ending, there is nothing
+        {
+            return TxoGroup(0, TxoItVec());
+        }
+        --large;
+        SpendableTxos::iterator i = large;
+        CAmount total = large->first;
+        TxoGroup group = makeGroup(i);
+        while ((total < targetValue) && (i != aBegin))
+        {
+            --i;
+            total += i->first;
+            group = makeGroup(i, &group);
+        }
+        if (total >= targetValue)
+        {
+            solutions.insert(TxoGroupMap::value_type(total, group));
+        }
+        else // We added every transaction and it did not sum to totalValue, so no solution.
+        {
+            LOG(SELECTCOINS, "Every available UTXO sums to %llu which is lower than the target %llu\n", total,
+                targetValue);
+            return TxoGroup(0, TxoItVec());
+        }
+    }
+    else // otherwise, the next one could be a solution
+    {
+        SpendableTxos::iterator i = large;
+        if (i != aEnd)
+        {
+            assert(i->first >= targetValue);
+            if (i->first == targetValue) // If its equal then done
+            {
+                return makeGroup(i);
+            }
+            // If its greater then add it to the solutions list.
+            solutions.insert(TxoGroupMap::value_type(i->first, makeGroup(i)));
+        }
+    }
+
+    // Now iterate looking for better solutions.
+    while ((large->first > targetValue) && (large != available.begin()))
+        --large; // get something <= our target value
+    bool done = (large == available.begin());
+    long int loop = 0;
+    long int excessModifier = 0;
+    long int loopCost = 1;
+    uint64_t startTime = GetTimeMillis();
+    while (!done)
+    {
+        loopCost++; // for every loop, make it exponentially easier to find an acceptable solutions
+        excessModifier += loopCost;
+
+        // Calculate the size of this new input
+        large->second.i;
+        const CScript &scriptPubKey = large->second.tx->vout[large->second.i].scriptPubKey;
+        CScript scriptSigRes; // = txNew.vin[nIn].scriptSig;
+        CWallet dummyWallet;
+        bool signSuccess = ProduceSignature(DummySignatureCreator(&dummyWallet), scriptPubKey, scriptSigRes);
+        int inputLen = signSuccess ? scriptSigRes.size() : P2PKH_INPUT_SIZE;
+        CAmount fee = feeRate.GetFee(inputLen);
+        // We will take the "large" txo and decrement it each time through this loop.
+        // If large ever hits the beginning, we have checked everything and can quit.
+        TxoGroup grp = makeGroup(large); // Make a group out of our current txo
+        // And attempt to extend it into solutions (automatically added to the "solutions" object)
+        extendCoinSelectionSolution(targetValue + fee, available, grp, solutions, 0);
+
+        TxoGroupMap::iterator i = solutions.begin();
+
+        uint64_t nSolutions = solutions.size();
+
+        // Have we looked for a long time?
+        if ((GetTimeMillis() - startTime > maxCoinSelSearchTime.Value()) && (nSolutions >= 1))
+        {
+            LOG(SELECTCOINS, "CoinSelection searched for the alloted time and found %d solutions\n", nSolutions);
+            done = true; // If yes then quit.
+        }
+        else if (i->first - targetValue <= dust / 2) // Did we find any good solutions?
+        {
+            LOG(SELECTCOINS, "CoinSelection found a close solution\n");
+            done = true; // If yes then quit.
+        }
+        else if (solutions.size() > MAX_SOLUTIONS) // Did we find lots of solutions?
+        {
+            LOG(SELECTCOINS, "CoinSelection found many solutions\n");
+            done = true; // If yes then quit.
+        }
+        else // No good solutions, so decrement large
+        {
+            CAmount a = large->first;
+            // Skip all Txos whose value is the exact same as the Txo I just looked at.
+            do
+            {
+                --large;
+            } while ((large != available.begin()) && (large->first != a));
+
+            done = (large == available.begin()); // We are done if we get to the beginning.
+        }
+
+        if (!done) // Now grab a random Txo and search for a solution near it
+        {
+            // Looking for a Txo > 1/4 of the needed value
+            CAmount r = insecureRand.rand32() % (3 * targetValue / 4) + (targetValue / 4);
+            SpendableTxos::iterator rit = available.lower_bound(r);
+            if (rit != aEnd)
+            {
+                TxoGroup grp2 = makeGroup(rit); // Make a group out of it
+                // And attempt to extend it for solutions.
+                extendCoinSelectionSolution(targetValue, available, grp2, solutions, 0);
+                // Did we find any good solutions?
+                if (i->first - targetValue < reasonableExcess(targetValue) + excessModifier)
+                {
+                    done = true; // If yes then quit.
+                }
+            }
+        }
+
+        loop++;
+    }
+
+    // Let's see what solutions we found.
+    TxoGroupMap::iterator i = solutions.begin();
+    done = false;
+    TxoGroupMap::iterator end = solutions.end();
+    TxoGroupMap::iterator singleIn = end;
+    TxoGroupMap::iterator noChange = end;
+    int noChangeCount = 0;
+    TxoGroupMap::iterator multiIn = end;
+    int multiInCount = 0;
+    for (i = solutions.begin(); (i != end) && !done; ++i)
+    {
+        // some bad solutions can occur (repeated elements), it is more efficient to eliminate them here than inside the
+        // loops
+        if (!validate(i->second, targetValue))
+            continue;
+        int ntxo = i->second.second.size();
+        if (ntxo == 1)
+            singleIn = i; // ok this solution works but does not reduce the utxo set
+        // look for a solution that won't need to pay change.
+        if ((i->first - targetValue <= dust) && (ntxo > noChangeCount))
+        {
+            noChange = i;
+            noChangeCount = ntxo;
+            LOG(SELECTCOINS, "CoinSelection found a nochange solution\n");
+        }
+        if ((ntxo > 1) && (ntxo > multiInCount))
+        {
+            multiIn = i;
+            multiInCount = ntxo;
+        }
+    }
+
+    if (noChange != end)
+        i = noChange; // prefer the best no change solution
+    else
+    {
+        if (utxosInWallet <= preferredNumUTXO.Value()) // Find the cheapest (shortest) solution
+        {
+            if (singleIn != end)
+                i = singleIn;
+            else
+                i = multiIn;
+        }
+        else // Reduce UTXO
+        {
+            if (multiIn != end)
+                i = multiIn; // or pick one the reduces the UTXO
+            else
+                i = singleIn; // ok take whatever I can get
+        }
+    }
+
+    if (i == solutions.end())
+    {
+        LOG(SELECTCOINS, "%d solutions found, but none chosen\n", solutions.size());
+        return TxoGroup(0, TxoItVec());
+    }
+    LOG(SELECTCOINS, "CoinSelection returns %d choices. Dust: %d, Target: %d, found: %d, txos: %d\n", solutions.size(),
+        dust, targetValue, i->first, i->second.second.size());
+    TxoGroup ret = i->second;
+    return ret;
+}

--- a/src/wallet/crypter.h
+++ b/src/wallet/crypter.h
@@ -171,16 +171,20 @@ public:
 
     virtual bool AddCryptedKey(const CPubKey &vchPubKey, const std::vector<unsigned char> &vchCryptedSecret);
     bool AddKeyPubKey(const CKey &key, const CPubKey &pubkey);
+
     bool HaveKey(const CKeyID &address) const
     {
-        {
-            LOCK(cs_KeyStore);
-            if (!IsCrypted())
-                return CBasicKeyStore::HaveKey(address);
-            return mapCryptedKeys.count(address) > 0;
-        }
-        return false;
+        LOCK(cs_KeyStore);
+        return _HaveKey(address);
     }
+
+    bool _HaveKey(const CKeyID &address) const
+    {
+        if (!IsCrypted())
+            return CBasicKeyStore::_HaveKey(address);
+        return mapCryptedKeys.count(address) > 0;
+    }
+
     bool GetKey(const CKeyID &address, CKey &keyOut) const;
     bool GetPubKey(const CKeyID &address, CPubKey &vchPubKeyOut) const;
     void GetKeys(std::set<CKeyID> &setAddress) const

--- a/src/wallet/wallet.h
+++ b/src/wallet/wallet.h
@@ -48,7 +48,7 @@ static const unsigned int DEFAULT_KEYPOOL_SIZE = 100;
 //! -paytxfee default
 static const CAmount DEFAULT_TRANSACTION_FEE = 0;
 //! -fallbackfee default
-static const CAmount DEFAULT_FALLBACK_FEE = 20000;
+static const CAmount DEFAULT_FALLBACK_FEE = 1000;
 //! -mintxfee default
 static const CAmount DEFAULT_TRANSACTION_MINFEE = 1000;
 //! minimum change amount
@@ -403,8 +403,12 @@ public:
 class COutput
 {
 public:
-    const CWalletTx *tx;
-    int i;
+    const CWalletTx *tx; //*< transaction
+    int i; //*< index of this output in transaction's vout
+
+    /** output of GetDepthInMainChain().  That is, how many blocks from the tip did this output get created in.  0 means
+     * not in blockchain (unconfirmed)
+     */
     int nDepth;
     bool fSpendable;
 
@@ -417,7 +421,55 @@ public:
     }
 
     std::string ToString() const;
+
+    inline int cmp(const COutput &rhs) const
+    {
+        if (tx->GetHash() == rhs.tx->GetHash())
+        {
+            if (i < rhs.i)
+                return -1;
+            if (i > rhs.i)
+                return 1;
+            return 0;
+        }
+        if (tx->GetHash() < rhs.tx->GetHash())
+            return -1;
+        return 1;
+    }
 };
+
+inline bool operator==(const COutput &lhs, const COutput &rhs) { return lhs.cmp(rhs) == 0; }
+inline bool operator!=(const COutput &lhs, const COutput &rhs) { return lhs.cmp(rhs) != 0; }
+inline bool operator<(const COutput &lhs, const COutput &rhs) { return lhs.cmp(rhs) < 0; }
+inline bool operator>(const COutput &lhs, const COutput &rhs) { return lhs.cmp(rhs) > 0; }
+inline bool operator<=(const COutput &lhs, const COutput &rhs) { return lhs.cmp(rhs) <= 0; }
+inline bool operator>=(const COutput &lhs, const COutput &rhs) { return lhs.cmp(rhs) >= 0; }
+typedef std::multimap<CAmount, COutput> SpendableTxos;
+
+struct TxoIterLess // : binary_function <T,T,bool>
+{
+    typedef SpendableTxos::iterator T;
+    bool operator()(const T &x, const T &y) const
+    {
+        if (x->first == y->first)
+        {
+            return x->second < y->second;
+        }
+        return x->first < y->first;
+    }
+};
+
+typedef std::set<SpendableTxos::iterator, TxoIterLess> TxoItVec;
+typedef std::pair<CAmount, TxoItVec> TxoGroup; // A set of coins and how much they sum to.
+
+// Select a group of UTXOs that sum up to above targetvalue.  The best choice is to be within dust of targetValue
+// because
+// that will mean that I do not create any change.
+extern TxoGroup CoinSelection(/* const */ SpendableTxos &available,
+    const CAmount targetValue,
+    const CAmount &dust,
+    CFeeRate fee,
+    unsigned int changeLen);
 
 
 /** Private key that includes an expiration date in case it never gets used. */
@@ -542,9 +594,11 @@ private:
      * if they are not ours
      */
     bool SelectCoins(const CAmount &nTargetValue,
+        CFeeRate fee,
+        unsigned int changeLen,
         std::set<std::pair<const CWalletTx *, unsigned int> > &setCoinsRet,
         CAmount &nValueRet,
-        const CCoinControl *coinControl = nullptr) const;
+        const CCoinControl *coinControl = nullptr);
 
     CWalletDB *pwalletdbEncryption;
 
@@ -586,6 +640,9 @@ public:
      *      strWalletFile (immutable after instantiation)
      */
     mutable CCriticalSection cs_wallet;
+
+    SpendableTxos available;
+    bool fOnlyConfirmed; // Only allow spending of confirmed coins
 
     bool fFileBacked;
     std::string strWalletFile;
@@ -645,6 +702,9 @@ public:
     int64_t nTimeFirstKey;
 
     const CWalletTx *GetWalletTx(const uint256 &hash) const;
+
+    bool IsTxSpendable(const CWalletTx *) const;
+    void FillAvailableCoins(const CCoinControl *coinControl); // populate available COutputs.
 
     //! check whether we are allowed to upgrade (or already support) to the named feature
     bool CanSupportFeature(enum WalletFeature wf)

--- a/src/zmq/zmqpublishnotifier.cpp
+++ b/src/zmq/zmqpublishnotifier.cpp
@@ -94,32 +94,34 @@ bool CZMQAbstractPublishNotifier::Initialize(void *pcontext)
 
 void CZMQAbstractPublishNotifier::Shutdown()
 {
-    assert(psocket);
-
-    int count = mapPublishNotifiers.count(address);
-
-    // remove this notifier from the list of publishers using this address
-    typedef std::multimap<std::string, CZMQAbstractPublishNotifier *>::iterator iterator;
-    std::pair<iterator, iterator> iterpair = mapPublishNotifiers.equal_range(address);
-
-    for (iterator it = iterpair.first; it != iterpair.second; ++it)
+    // If Initialize did not succeed, or was never called, then shutdown may be called with psocket == nullptr
+    if (psocket != nullptr)
     {
-        if (it->second == this)
+        int count = mapPublishNotifiers.count(address);
+
+        // remove this notifier from the list of publishers using this address
+        typedef std::multimap<std::string, CZMQAbstractPublishNotifier *>::iterator iterator;
+        std::pair<iterator, iterator> iterpair = mapPublishNotifiers.equal_range(address);
+
+        for (iterator it = iterpair.first; it != iterpair.second; ++it)
         {
-            mapPublishNotifiers.erase(it);
-            break;
+            if (it->second == this)
+            {
+                mapPublishNotifiers.erase(it);
+                break;
+            }
         }
-    }
 
-    if (count == 1)
-    {
-        LOG(ZMQ, "Close socket at address %s\n", address);
-        int linger = 0;
-        zmq_setsockopt(psocket, ZMQ_LINGER, &linger, sizeof(linger));
-        zmq_close(psocket);
-    }
+        if (count <= 1)
+        {
+            LOG(ZMQ, "Close socket at address %s\n", address);
+            int linger = 0;
+            zmq_setsockopt(psocket, ZMQ_LINGER, &linger, sizeof(linger));
+            zmq_close(psocket);
+        }
 
-    psocket = nullptr;
+        psocket = nullptr;
+    }
 }
 
 bool CZMQPublishHashBlockNotifier::NotifyBlock(const CBlockIndex *pindex)


### PR DESCRIPTION
Add a wallet benchmark test.  Also change the default fee (when no fee can be calculated from prior data) to 1 sat/byte rather than 20 sat/byte to be more in line with BCH low fee.

These optimizations make the send-money RPC calls run between 17 and 60 times faster (from approx 5 tx/sec to 200 tx/sec) for wallets that have a nontrivial number of UTXOs -- wallets containing between 5000 and 10000 UTXOs were tested.  More importantly, wallet send performance is no longer proportional to the number of UTXOs, so very large wallets should perform well.

Interestingly, the new algorithm **ALSO outperforms** the old algorithm in finding solutions (at least for the wallet configuration tested).  In a test of 200 multi-input transactions, it managed to use 1.1% fewer inputs, saving a small amount in fees.  But this is less important than speed, given how inexpensive txes are, and a lot more testing would need to be done with a large variety of wallet configurations to come to any firm conclusions about average wallet solution-finding performance -- different algorithms may excel based on different wallet input distributions.

This is code was written before the gigaperf work, and was used extensively in gigaperf testing.

The following data was run on wallets backed by a RAM disk so that disk latency is mostly removed from the test.  However, this means that real-world performance may have a significant (but equal) constant time added to each transaction.  This means that these results should not be used for capacity planning, instead run the test on your chosen hardware.

**Benchmark run on dev branch, backed by a ram disk**:

sequential sendtoaddress/sec at 4790 utxos: 4.43
sequential sendtoaddress/sec at 9826 utxos: 3.45

sendtoaddress tx analysis
200 tx, size 183774.  Total Fees: -0.03683660. Fees SAT/byte: -20.04451119309586775060672348  Inputs spent: 1141.  Outputs sent: 399.

sequential sendfrom/sec at 8774 utxos: 3.22


**Benchmark run on this branch, backed by a ram disk**:

sequential sendtoaddress/sec at 4690 utxos: 76.19
sequential sendtoaddress/sec at 10260 utxos: 106.94

sendtoaddress tx analysis
200 tx, size 174054.  Total Fees: -0.00174731. Fees SAT/byte: -1.003889597481241453801693727  Inputs spent: 1075.  Outputs sent: 399.

sequential sendfrom/sec at 9264 utxos: 189.39


