### PR TITLE
Make sure to lock cs_blockvalidationthread during the time

### DIFF
--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -379,7 +379,7 @@ void CParallelValidation::SetLocks(const bool fParallel)
     }
 }
 
-void CParallelValidation::IsReorgInProgress(const boost::thread::id this_id, const bool fReorg, const bool fParallel)
+void CParallelValidation::MarkReorgInProgress(const boost::thread::id this_id, const bool fReorg, const bool fParallel)
 {
     if (fParallel)
     {

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -110,6 +110,9 @@ public:
 
 class CParallelValidation
 {
+public:
+    CCriticalSection cs_blockvalidationthread;
+
 private:
     /** txn hashes that are in the previous block */
     CCriticalSection cs_previousblock;
@@ -138,9 +141,7 @@ private:
         bool fIsValidating; // is the block currently in connectblock() and validating inputs
         bool fIsReorgInProgress; // has a re-org to another chain been triggered.
     };
-    CCriticalSection cs_blockvalidationthread;
     std::map<boost::thread::id, CHandleBlockMsgThreads> mapBlockValidationThreads GUARDED_BY(cs_blockvalidationthread);
-
 
 public:
     /**
@@ -201,7 +202,7 @@ public:
     void SetLocks(const bool fParallel);
 
     /** Is there a re-org in progress */
-    void IsReorgInProgress(const boost::thread::id this_id, const bool fReorg, const bool fParallel);
+    void MarkReorgInProgress(const boost::thread::id this_id, const bool fReorg, const bool fParallel);
     bool IsReorgInProgress();
 
     /** Update the nMostWorkOurFork when a new header arrives */

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1517,6 +1517,10 @@ UniValue rollbackchain(const UniValue &params, bool fHelp)
                             " blocks. Set "
                             "the override to true if you want rollback more than the default");
 
+    // Lock block validation threads to make sure no new inbound block announcements
+    // cause any block validation state to change while we're unwinding the chain.
+    LOCK(PV->cs_blockvalidationthread);
+
     while (chainActive.Height() > nRollBackHeight)
     {
         // save the current tip


### PR DESCRIPTION
we are disconnecting a block. This ensures no other block validation
threads can start of interfere while the next  chain tip is being unwound.

Also, be more precise about tracking whether a re-org is in process.