### PR TITLE
[QA only] Isolate QA features from PR #2022

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,33 @@ env:
 
 matrix:
   include:
+    #x86_64 Linux + deps as via system lib
+    - compiler: gcc
+      env:
+        - A="ia64 linux  full tests  system deps, enable debug, debug boost"
+        - CXX=g++ CC=gcc
+        - HOST=x86_64-unknown-linux-gnu
+        - PACKAGES="python python3-zmq libzmq3-dev qttools5-dev-tools qttools5-dev libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-program-options-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev"
+        - NODEPENDS=true
+        - RUN_FORMATTING_CHECK=true
+        - RUN_TESTS=true
+        - GOAL="install"
+        - BITCOIN_CONFIG="--enable-debug --with-incompatible-bdb --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports"
+    #bitcoind
+    - compiler: gcc
+      env:
+        - A="ia64 linux  gcc   full test"
+        - CXX=g++ CC=gcc
+        - HOST=x86_64-unknown-linux-gnu
+        - PACKAGES="libedit2 python3-zmq"
+        - DEP_OPTS="NO_UPNP=1 DEBUG=1"
+        - RUN_TESTS=true
+        - GOAL="install"
+        - BITCOIN_CONFIG="--enable-shared --enable-zmq --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER" #need to test also libdb 4.8
     #bitcoind clang (no depend, only system lib installed via apt)
     - compiler: clang
       env:
+        - A="ia64 linux clang  no test"
         - CXX=clang++-5.0 CC=clang-5.0
         - CXXFLAGS="-std=c++14"
         - HOST=x86_64-unknown-linux-gnu
@@ -44,20 +68,10 @@ matrix:
         - GOAL="install"
         - BITCOIN_CONFIG="--enable-zmq --with-gui=qt5 CC=clang-5.0 --with-incompatible-bdb CXX=clang++-5.0 CPPFLAGS=-DDEBUG_LOCKORDER CXXFLAGS=\"-std=c++14\""
         - NODEPENDS=true
-    #bitcoind
-    - compiler: gcc
-      env:
-        - CXX=g++ CC=gcc
-        - HOST=x86_64-unknown-linux-gnu
-        - PACKAGES="libedit2 python python3-zmq"
-        - DEP_OPTS="NO_UPNP=1 DEBUG=1"
-        - RUN_TESTS=true
-        - RUN_FORMATTING_CHECK=true
-        - GOAL="install"
-        - BITCOIN_CONFIG="--enable-shared --enable-zmq --enable-glibc-back-compat --enable-reduce-exports CPPFLAGS=-DDEBUG_LOCKORDER" #need to test also libdb 4.8
     #ARM64
     - compiler: gcc
       env:
+        - A="ARM64 linux  no test"
         - CXX=g++ CC=gcc
         - HOST=aarch64-linux-gnu
         - PACKAGES="g++-aarch64-linux-gnu"
@@ -66,6 +80,7 @@ matrix:
     #ARM32
     - compiler: gcc
       env:
+        - A="ARM32 linux  no test"
         - CXX=g++ CC=gcc
         - HOST=arm-linux-gnueabihf
         - PACKAGES="g++-arm-linux-gnueabihf"
@@ -74,6 +89,7 @@ matrix:
     #Win32
     - compiler: gcc
       env:
+        - A="ia32 win32  no test"
         - CXX=g++ CC=gcc
         - HOST=i686-w64-mingw32
         - DPKG_ADD_ARCH="i386"
@@ -84,6 +100,7 @@ matrix:
     #Win64
     - compiler: gcc
       env:
+        - A="ia64 win64  no test"
         - CXX=g++ CC=gcc
         - HOST=x86_64-w64-mingw32
         - DEP_OPTS="NO_QT=1"
@@ -93,23 +110,17 @@ matrix:
     #Linux32-bit + dash
     - compiler: gcc
       env:
+        - A="ia32 linux gcc  full test" 
         - CXX=g++ CC=gcc
         - HOST=i686-pc-linux-gnu
         - PACKAGES="g++-multilib bc python3-zmq"
         - DEP_OPTS="NO_QT=1" RUN_TESTS=true GOAL="install"
         - BITCOIN_CONFIG="--enable-zmq --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++"
         - USE_SHELL="/bin/dash"
-    #x86_64 Linux + deps as via system lib
-    - compiler: gcc
-      env:
-        - CXX=g++ CC=gcc
-        - HOST=x86_64-unknown-linux-gnu
-        - PACKAGES="python3-zmq libzmq3-dev qttools5-dev-tools qttools5-dev libssl1.0-dev libevent-dev bsdmainutils libboost-system-dev libboost-program-options-dev libboost-filesystem-dev libboost-chrono-dev libboost-test-dev libboost-thread-dev libdb5.3++-dev libminiupnpc-dev libzmq3-dev libprotobuf-dev protobuf-compiler libqrencode-dev"
-        - NODEPENDS=true
-        - RUN_TESTS=true GOAL="install" BITCOIN_CONFIG="--enable-debug --with-incompatible-bdb --with-gui=qt5 --enable-glibc-back-compat --enable-reduce-exports"
     #Cross-Mac
     - compiler: gcc
       env:
+        - A="ia64 apple gcc  no test"
         - HOST=x86_64-apple-darwin11
         - PACKAGES="cmake imagemagick libcap-dev librsvg2-bin libz-dev libbz2-dev libtiff-tools python-dev python3-setuptools-git"
         - BITCOIN_CONFIG="--enable-reduce-exports"
@@ -117,6 +128,7 @@ matrix:
 
     - compiler: gcc
       env:
+        - A="ia64 centos  no test"
         - CXX=g++ CC=gcc
         - HOST=x86_64-unknown-linux-gnu
         - DOCKER_NAME_TAG=centos:7.6.1810

--- a/.travis/after_failure.sh
+++ b/.travis/after_failure.sh
@@ -8,6 +8,7 @@ if [ $DIST != "RPM" ]; then
   export LC_ALL=C.UTF-8
 fi
 
+# TODO the following have to be made aware of DOCKER
 for i in `find /home/travis/ -name debug.log`; do echo $i; echo "-----"; tail -100 $i; done
 for i in `find /tmp/ -name debug.log`; do echo $i; echo "-----"; tail -100 $i; done
 for i in `find /home/travis/ -name bitcoin.conf`; do echo $i; echo "-----"; cat $i; done

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -10,11 +10,11 @@ if [ $DIST != "RPM" ]; then
 fi
 
 travis_retry docker pull "$DOCKER_NAME_TAG"
-env | grep -E '^(CCACHE_|WINEDEBUG|LC_ALL|BOOST_TEST_RANDOM|CONFIG_SHELL)' | tee /tmp/env
+env | grep -E '^(CCACHE_|WINEDEBUG|LC_ALL|BOOST_TEST_RANDOM|CONFIG_SHELL|TRAVIS)' | tee /tmp/env
 if [[ $HOST = *-mingw32 ]]; then
   DOCKER_ADMIN="--cap-add SYS_ADMIN";
 fi
-DOCKER_ID=$(docker run $DOCKER_ADMIN -idt --mount type=bind,src=$TRAVIS_BUILD_DIR,dst=$TRAVIS_BUILD_DIR --mount type=bind,src=$CCACHE_DIR,dst=$CCACHE_DIR -w $TRAVIS_BUILD_DIR --env-file /tmp/env $DOCKER_NAME_TAG)
+DOCKER_ID=$(docker run --ulimit core=99999999999:99999999999 $DOCKER_ADMIN -idt --mount type=bind,src=$TRAVIS_BUILD_DIR,dst=$TRAVIS_BUILD_DIR --mount type=bind,src=$CCACHE_DIR,dst=$CCACHE_DIR -w $TRAVIS_BUILD_DIR --env-file /tmp/env $DOCKER_NAME_TAG)
 DOCKER_EXEC () {
   docker exec $DOCKER_ID bash -c "cd $PWD && $*";
 }
@@ -24,6 +24,7 @@ fi
 if [ $DIST = "DEB" ]; then
   travis_retry DOCKER_EXEC apt-get update
   travis_retry DOCKER_EXEC apt-get install --no-install-recommends --no-upgrade -qq $PACKAGES $DOCKER_PACKAGES
+  travis_retry DOCKER_EXEC apt-get install -y gdb
 fi
 if [ $DIST = "RPM" ]; then
   travis_retry DOCKER_EXEC yum update -y

--- a/.travis/script_b.sh
+++ b/.travis/script_b.sh
@@ -11,6 +11,8 @@ fi
 
 cd "build" || (echo "could not enter distdir build"; exit 1)
 
+# Create location to place core files, and change the kernel setting to direct
+# cores into the newly created directory
 mkdir /tmp/cores
 DOCKER_EXEC mkdir /tmp/cores
 echo '/tmp/cores/core.%e.%p.%h.%t' | sudo tee /proc/sys/kernel/core_pattern

--- a/.travis/script_b.sh
+++ b/.travis/script_b.sh
@@ -11,18 +11,24 @@ fi
 
 cd "build" || (echo "could not enter distdir build"; exit 1)
 
+mkdir /tmp/cores
+DOCKER_EXEC mkdir /tmp/cores
+echo '/tmp/cores/core.%e.%p.%h.%t' | sudo tee /proc/sys/kernel/core_pattern
+
 if [ "$RUN_TESTS" = "true" ]; then
-  BEGIN_FOLD unit-tests
-  if [ $HOST != "x86_64-w64-mingw32" ]; then
-    DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1;
-  fi
-  END_FOLD
+    BEGIN_FOLD unit-tests
+    echo "Unit tests"
+    if [ $HOST != "x86_64-w64-mingw32" ]; then
+        DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1;
+    fi
+    END_FOLD
 fi
 
 if [ "$RUN_TESTS" = "true" ]; then
-  BEGIN_FOLD functional-tests
-  DOCKER_EXEC qa/pull-tester/rpc-tests.py --coverage --no-ipv6-rpc-listen;
-  END_FOLD
+    BEGIN_FOLD functional-tests
+    echo "QA python functional tests"
+    DOCKER_EXEC qa/pull-tester/rpc-tests.py --coverage --no-ipv6-rpc-listen;
+    END_FOLD
 fi
 
 cd ${TRAVIS_BUILD_DIR} || (echo "could not enter travis build dir $TRAVIS_BUILD_DIR"; exit 1)

--- a/contrib/devtools/coreanalysis.gdb
+++ b/contrib/devtools/coreanalysis.gdb
@@ -1,0 +1,17 @@
+echo info threads:\n
+info threads
+echo \nthread backtrace:\n
+thread apply all backtrace
+echo \ncs_main:\n
+print ((CCriticalSection) cs_main)
+echo \npwalletMain->cs_wallet:\n
+print pwalletMain->cs_wallet
+echo \nchainActive->cs_chainLock:\n
+print ((CChain)chainActive).cs_chainLock
+echo \ncs_vNodes:\n
+print ((CCriticalSection) cs_vNodes)
+echo \ncsTxInQ:\n
+print ((CCriticalSection) csTxInQ)
+
+echo \nchainActive tip:\n
+print /x *(chainActive.tip._M_b._M_p)

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -556,12 +556,12 @@ class RPCTestHandler:
                         try:
                             comms(0.1)
                         except subprocess.TimeoutExpired as e:
-                            # print("%s: communicate timed out, but process should have been killed already!" % proc.args[0])
+                            # communicate timed out, but process should have been killed already!
                             proc.terminate()
                             try:
                                 comms(1)
                             except subprocess.TimeoutExpired as e:
-                                # print("%s: terminate didn't work" % proc.args[0])
+                                # terminate didn't work as expected
                                 proc.kill()
                                 try:
                                     comms(5)
@@ -573,7 +573,6 @@ class RPCTestHandler:
                     try:
                         coreDir = "/tmp/cores"
                         cores = os.listdir(coreDir)
-                        # print("\nfiles in %s: %s" % (coreDir, cores))
                         for core in cores:
                             fullCoreFile = os.path.join(coreDir, core)
                             bitcoindBin = os.environ["BITCOIND"]
@@ -582,7 +581,6 @@ class RPCTestHandler:
                                 popenList = ["gdb", "-core", fullCoreFile, bitcoindBin, "-x", CORE_ANALYSIS_SCRIPT, "-batch"]
                             else:
                                 popenList = ["gdb", "-core", fullCoreFile, bitcoindBin, "-ex", "thread apply all bt", "-ex", "set pagination 0", "-batch"]
-                            # print("running %s" % str(popenList))
                             gdb = subprocess.Popen(popenList, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                             (out, err) = gdb.communicate(None, 60)
                             fold_start = ("\ntravis_fold:start:%s\nCore dump analysis\n" % core) if inTravis() else ""

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -48,6 +48,10 @@ if sourcePath != outOfSourceBuildPath:
 from tests_config import *
 from test_classes import RpcTest, Disabled, Skip, WhenElectrumFound
 
+def inTravis():
+  return os.environ.get("TRAVIS", None) == "true"
+
+
 BOLD = ("","")
 if os.name == 'posix':
     # primitive formatting on supported
@@ -55,6 +59,8 @@ if os.name == 'posix':
     BOLD = ('\033[0m', '\033[1m')
 
 RPC_TESTS_DIR = SRCDIR + '/qa/rpc-tests/'
+
+CORE_ANALYSIS_SCRIPT = SRCDIR + '/contrib/devtools/coreanalysis.gdb'
 
 #If imported values are not defined then set to zero (or disabled)
 if 'ENABLE_WALLET' not in vars():
@@ -181,7 +187,6 @@ if ENABLE_ZMQ:
 #Tests
 testScripts = [ RpcTest(t) for t in [
     'txindex',
-    'mempool_push',
     Disabled('schnorr-activation', 'Need to be updated to work with BU'),
     'schnorrsig',
     'segwit_recovery',
@@ -218,6 +223,7 @@ testScripts = [ RpcTest(t) for t in [
     'mempool_persist',
     'mempool_validate',
     'mempoolsync',
+    'mempool_push',
     'httpbasics',
     'multi_rpc',
     'zapwallettxes',
@@ -255,7 +261,7 @@ testScripts = [ RpcTest(t) for t in [
     'rpc_getblockstats',
     WhenElectrumFound('electrum_cashaccount'),
     'minimaldata-activation',
-    'schnorrmultisig-activation',
+    'schnorrmultisig_activation',
     WhenElectrumFound('electrum_subscriptions')
 
 ] ]
@@ -419,20 +425,31 @@ def runtests():
         all_passed = True
 
         for _ in range(len(tests_to_run)):
-            (name, stdout, stderr, stderr_filtered, passed, duration) = job_queue.get_next()
+            (name, retCode, coreOutput, stdout, stderr, stderr_filtered, passed, duration) = job_queue.get_next()
             test_passed.append(passed)
             all_passed = all_passed and passed
             time_sum += duration
-
-            print("\n"+"#"*50)
-            print(BOLD[1] + name + BOLD[0] + ":")
-            print("-"*50+'\nstdout:\n' if not stdout == '' else '', stdout)
-            print("-"*50+'\nstderr:\n' if not stderr == '' else '', stderr)
-            #print('stderr_filtered:\n' if not stderr_filtered == '' else '', repr(stderr_filtered))
-            if stderr!="" or stdout!="":
-                print("-"*50)
             results += "%s | %s | %s s\n" % (name.ljust(max_len_name), str(passed).ljust(6), duration)
-            print("Pass: %s%s%s, Duration: %s s\n" % (BOLD[1], passed, BOLD[0], duration))
+
+            print("")
+            if inTravis():
+                print("travis_fold:start:%s_%s" % (name, passed))
+            print(BOLD[1] + name + BOLD[0] + ": Pass: %s%s%s, Duration: %s s" % (BOLD[1], passed, BOLD[0], duration))
+            print("#"*50)
+            print("- " + retCode)
+            if stdout != "":
+                print('- stdout '+("-"*50)+"\n", stdout)
+            if stderr != "":
+                print('- stderr '+("-"*50)+"\n", stderr)
+            if coreOutput != "":
+                if inTravis():  # if in travis we already folded this
+                    print(coreOutput)
+                else: # so no need for another header
+                    print('- core dump '+("-"*50)+"\n", coreOutput)
+            #print('stderr_filtered:\n' if not stderr_filtered == '' else '', repr(stderr_filtered))
+            print("#"*25)
+            if inTravis():
+                print("travis_fold:end:%s_%s" % (name, passed))
 
         results += BOLD[1] + "\n%s | %s | %s s (accumulated)" % ("ALL".ljust(max_len_name), str(all_passed).ljust(6), time_sum) + BOLD[0]
         print(results)
@@ -504,6 +521,8 @@ class RPCTestHandler:
                     # providing useful output.
                     proc.send_signal(signal.SIGINT)
 
+                # print("handling " + str(proc))
+
                 def comms(timeout):
                     stdout_data, stderr_data = proc.communicate(timeout=timeout)
                     log_stdout.write(stdout_data)
@@ -531,9 +550,56 @@ class RPCTestHandler:
                 except subprocess.TimeoutExpired:
                     pass
 
-                if proc.poll() is not None:
+                retval = proc.poll()
+                if not retval is None:
                     if not got_outputs[0]:
-                        comms(50)
+                        try:
+                            comms(0.1)
+                        except subprocess.TimeoutExpired as e:
+                            # print("%s: communicate timed out, but process should have been killed already!" % proc.args[0])
+                            proc.terminate()
+                            try:
+                                comms(1)
+                            except subprocess.TimeoutExpired as e:
+                                # print("%s: terminate didn't work" % proc.args[0])
+                                proc.kill()
+                                try:
+                                    comms(5)
+                                except subprocess.TimeoutExpired as e:
+                                     print("%s: Expect a core dump" % proc.args[0])
+                                     dumpLogs = True
+
+                    coreOutput = ""
+                    try:
+                        coreDir = "/tmp/cores"
+                        cores = os.listdir(coreDir)
+                        # print("\nfiles in %s: %s" % (coreDir, cores))
+                        for core in cores:
+                            fullCoreFile = os.path.join(coreDir, core)
+                            bitcoindBin = os.environ["BITCOIND"]
+                            path, fil = os.path.split(bitcoindBin)
+                            if os.path.isfile(CORE_ANALYSIS_SCRIPT):
+                                popenList = ["gdb", "-core", fullCoreFile, bitcoindBin, "-x", CORE_ANALYSIS_SCRIPT, "-batch"]
+                            else:
+                                popenList = ["gdb", "-core", fullCoreFile, bitcoindBin, "-ex", "thread apply all bt", "-ex", "set pagination 0", "-batch"]
+                            # print("running %s" % str(popenList))
+                            gdb = subprocess.Popen(popenList, universal_newlines=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                            (out, err) = gdb.communicate(None, 60)
+                            fold_start = ("\ntravis_fold:start:%s\nCore dump analysis\n" % core) if inTravis() else ""
+                            fold_end = ("\ntravis_fold:end:%s\n" % core) if inTravis() else ""
+                            coreOutput = fold_start + out + "\n-------\n" + err + fold_end
+                            # Now delete this file so we don't dump it repeatedly.  Better would be to move it somewhere for export out of the container.
+                            coreDest = os.environ.get("CORE_SAVE_DIR", None)
+                            if coreDest is not None:
+                                shutil.move(fullCoreFile, os.path.join(coreDest, core))
+                            else:
+                                os.remove(fullCoreFile)
+                    except FileNotFoundError:
+                        print("No directory /tmp/cores")
+                    except Exception as e:
+                        print("Exception trying to show core:" + str(e))
+
+                    returnCode = "Process %s return code: %d" % (" ".join(proc.args),retval)
                     log_stdout.seek(0), log_stderr.seek(0)
                     stdout = log_stdout.read()
                     stderr = log_stderr.read()
@@ -554,7 +620,7 @@ class RPCTestHandler:
                     passed = stderr_filtered == "" and proc.returncode == 0
                     self.num_running -= 1
                     self.jobs.remove(j)
-                    return name, stdout, stderr, stderr_filtered, passed, int(time.time() - time0)
+                    return name, returnCode, coreOutput, stdout, stderr, stderr_filtered, passed, int(time.time() - time0)
             print('.', end='', flush=True)
 
 class RPCCoverage(object):

--- a/qa/rpc-tests/listtransactions.py
+++ b/qa/rpc-tests/listtransactions.py
@@ -105,7 +105,7 @@ class ListTransactionsTest(BitcoinTestFramework):
                             {"category": "receive", "account": "", "amount": Decimal("0.1"), "confirmations": 0})
         # mine a block, confirmations should change:
         self.nodes[0].generate(1)
-        self.sync_all()
+        self.sync_blocks()
         assert_array_result(self.nodes[0].listtransactions(),
                             {"txid": txid},
                             {"category": "send", "account": "", "amount": Decimal("-0.1"), "confirmations": 1})
@@ -158,7 +158,7 @@ class ListTransactionsTest(BitcoinTestFramework):
         self.nodes[0].importaddress(multisig["redeemScript"], "watchonly", False, True)
         txid = self.nodes[1].sendtoaddress(multisig["address"], 0.1)
         self.nodes[1].generate(1)
-        self.sync_all()
+        self.sync_blocks()
         assert(len(self.nodes[0].listtransactions("watchonly", 100, 0, False)) == 0)
         assert_array_result(self.nodes[0].listtransactions("watchonly", 100, 0, True),
                             {"category": "receive", "amount": Decimal("0.1")},
@@ -166,14 +166,18 @@ class ListTransactionsTest(BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    ListTransactionsTest().main()
+    ListTransactionsTest().main(None, {
+        "debug": ["all"],
+    })
 
 
 def Test():
     t = ListTransactionsTest()
+    t.drop_to_pdb = True
     bitcoinConf = {
         "debug": ["all"],
         "blockprioritysize": 2000000  # we don't want any transactions rejected due to insufficient fees...
     }
     # "--tmppfx=/ramdisk/test", "--nocleanup", "--noshutdown"
-    t.main([], bitcoinConf, None)
+    flags = standardFlags()
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/mempool_reorg.py
+++ b/qa/rpc-tests/mempool_reorg.py
@@ -24,7 +24,6 @@ class MempoolCoinbaseTest(BitcoinTestFramework):
         self.nodes.append(start_node(1, self.options.tmpdir, args))
         connect_nodes(self.nodes[1], 0)
         self.is_network_split = False
-        self.sync_all()
 
     def run_test(self):
 

--- a/qa/rpc-tests/miningtest.py
+++ b/qa/rpc-tests/miningtest.py
@@ -156,15 +156,16 @@ class MyTest (BitcoinTestFramework):
         self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
         self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
         self.sync_all()
+        # print(str(self.nodes[0].getmempoolinfo()))
         assert_equal(str(self.nodes[0].getnetworkinfo()["relayfee"]), "0.01000000")
-        self.nodes[0].generate(1);
+        self.nodes[0].generate(1)
         self.sync_all()
-        print(str(self.nodes[0].getmempoolinfo()["mempoolminfee"]))
+        # print(str(self.nodes[0].getmempoolinfo()))
         assert_equal(self.nodes[0].getmempoolinfo()["size"], 0)
 
 
 if __name__ == '__main__':
-    MyTest().main()
+    MyTest().main(None, {  "blockprioritysize": 2000000, "blockminsize":200000 })
 
 # Create a convenient function for an interactive python debugging session
 
@@ -173,7 +174,8 @@ def Test():
     t = MyTest()
     bitcoinConf = {
         "debug": ["net", "blk", "thin", "mempool", "req", "bench", "evict"],
-        "blockprioritysize": 2000000  # we don't want any transactions rejected due to insufficient fees...
+        "blockprioritysize": 2000000,  # we don't want any transactions rejected due to insufficient fees...
+        "blockminsize":200000
     }
 
     flags = standardFlags()

--- a/qa/rpc-tests/miningtest.py
+++ b/qa/rpc-tests/miningtest.py
@@ -16,7 +16,7 @@ from test_framework.nodemessages import *
 from test_framework.script import *
 
 
-class MyTest (BitcoinTestFramework):
+class MiningTest (BitcoinTestFramework):
 
     def setup_chain(self, bitcoinConfDict=None, wallets=None):
         logging.info("Initializing test directory " + self.options.tmpdir)
@@ -156,22 +156,20 @@ class MyTest (BitcoinTestFramework):
         self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
         self.nodes[0].sendtoaddress(self.nodes[1].getnewaddress(), 1)
         self.sync_all()
-        # print(str(self.nodes[0].getmempoolinfo()))
         assert_equal(str(self.nodes[0].getnetworkinfo()["relayfee"]), "0.01000000")
         self.nodes[0].generate(1)
         self.sync_all()
-        # print(str(self.nodes[0].getmempoolinfo()))
         assert_equal(self.nodes[0].getmempoolinfo()["size"], 0)
 
 
 if __name__ == '__main__':
-    MyTest().main(None, {  "blockprioritysize": 2000000, "blockminsize":200000 })
+    MiningTest().main(None, {  "blockprioritysize": 2000000, "blockminsize":200000 })
 
 # Create a convenient function for an interactive python debugging session
 
 
 def Test():
-    t = MyTest()
+    t = MiningTest()
     bitcoinConf = {
         "debug": ["net", "blk", "thin", "mempool", "req", "bench", "evict"],
         "blockprioritysize": 2000000,  # we don't want any transactions rejected due to insufficient fees...

--- a/qa/rpc-tests/parallel_rpc.py
+++ b/qa/rpc-tests/parallel_rpc.py
@@ -168,7 +168,7 @@ class MyTest (BitcoinTestFramework):
 
 
 if __name__ == '__main__':
-    MyTest ().main ()
+    MyTest ().main (None, { "blockprioritysize": 2000000, "rpcworkqueue": 1024 })
 
 # Create a convenient function for an interactive python debugging session
 def Test():

--- a/qa/rpc-tests/schnorrmultisig_activation.py
+++ b/qa/rpc-tests/schnorrmultisig_activation.py
@@ -153,7 +153,7 @@ class SchnorrTest(BitcoinTestFramework):
             [block], self.nodes[0], success=False, reject_reason=reject_reason, expect_ban=True)
 
     def run_test(self):
-        print("Initializing test directory "+self.options.tmpdir)
+        logging.info("Initializing test directory "+self.options.tmpdir)
         node = self.nodes[0]
 
         self.bootstrap_p2p()

--- a/qa/rpc-tests/schnorrmultisig_activation.py
+++ b/qa/rpc-tests/schnorrmultisig_activation.py
@@ -153,6 +153,7 @@ class SchnorrTest(BitcoinTestFramework):
             [block], self.nodes[0], success=False, reject_reason=reject_reason, expect_ban=True)
 
     def run_test(self):
+        print("Initializing test directory "+self.options.tmpdir)
         node = self.nodes[0]
 
         self.bootstrap_p2p()
@@ -380,6 +381,22 @@ class SchnorrTest(BitcoinTestFramework):
         assert set(tx.rehash() for tx in tip.vtx).issuperset(
             {ecdsa0tx_2.hash, schnorr1tx.hash})
 
-
 if __name__ == '__main__':
     SchnorrTest().main()
+
+    # Create a convenient function for an interactive python debugging session
+def Test():
+    from test_framework.util import standardFlags 
+    t = SchnorrTest()
+    t.drop_to_pdb = True
+    bitcoinConf = {
+        "debug": ["dbase", "selectcoins"], # ["net", "blk", "thin", "mempool", "req", "bench", "evict"],
+        "blockprioritysize": 2000000,  # we don't want any transactions rejected due to insufficient fees...
+        "logtimemicros":1,
+        "checkmempool":0,
+        # "par":1  # Reduce the # of threads in bitcoind for easier debugging
+    }
+
+
+    flags = standardFlags()
+    t.main(flags, bitcoinConf, None)

--- a/qa/rpc-tests/segwit_recovery.py
+++ b/qa/rpc-tests/segwit_recovery.py
@@ -291,6 +291,7 @@ if __name__ == '__main__':
 def Test():
     from test_framework.util import standardFlags
     t = SegwitRecoveryTest()
+    t.drop_to_pdb = True
     bitcoinConf = {
         "debug": ["net", "blk", "thin", "mempool", "req", "bench", "evict"],
         "blockprioritysize": 2000000  # we don't want any transactions rejected due to insufficient fees...

--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -49,7 +49,7 @@ except ImportError:
 
 USER_AGENT = "AuthServiceProxy/0.1"
 
-HTTP_TIMEOUT = 60
+HTTP_TIMEOUT = 120
 
 log = logging.getLogger("BitcoinRPC")
 
@@ -137,7 +137,7 @@ class AuthServiceProxy(object):
             self.__conn.request(method, path, postdata, headers)
             return self._get_response()
           except httplib.CannotSendRequest as e:
-            print("Cannot send request:", str(e))
+            log.error("%s:%s Cannot send request: %s" % (self.__service_url, self.__url.port ,str(e)))
             self.reconnect()
           except httplib.BadStatusLine as e:
             if e.line == "''": # if connection was closed, try again

--- a/qa/rpc-tests/test_framework/mininode.py
+++ b/qa/rpc-tests/test_framework/mininode.py
@@ -514,7 +514,7 @@ class P2PDataStore(SingleNodeConnCB):
             elif inv.type == CInv.MSG_BLOCK and inv.hash in self.block_store.keys():
                 self.send_message(msg_block(self.block_store[inv.hash]))
             else:
-                logger.debug(
+                logging.debug(
                     'getdata message type {} received.'.format(hex(inv.type)))
 
     def on_getheaders(self, conn, message):
@@ -540,7 +540,7 @@ class P2PDataStore(SingleNodeConnCB):
                     # if this is the hashstop header, stop here
                     break
             else:
-                logger.debug('block hash {} not found in block store'.format(
+                logging.debug('block hash {} not found in block store'.format(
                     hex(prev_block_hash)))
                 break
 

--- a/qa/rpc-tests/test_framework/test_framework.py
+++ b/qa/rpc-tests/test_framework/test_framework.py
@@ -222,6 +222,8 @@ class BitcoinTestFramework(object):
 
         os.environ['PATH'] = self.options.srcdir + ":" + os.path.join(self.options.srcdir, "qt") + ":" + os.environ['PATH']
 
+        self.bitcoindBin = os.path.join(self.options.srcdir, "bitcoind")
+
         check_json_precision()
 
         # By setting the environment variable BITCOIN_CONF_OVERRIDE to "key=value,key2=value2,..." you can inject bitcoin configuration into every test

--- a/qa/rpc-tests/wallet_bench.py
+++ b/qa/rpc-tests/wallet_bench.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2018 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+import test_framework.loginit
+
+# Wallet performance benchmarks
+
+import time
+import sys
+import random
+if sys.version_info[0] < 3:
+    raise "Use Python 3"
+import logging
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.nodemessages import *
+from test_framework.util import *
+
+SATPERBCH = Decimal(100000000)
+
+class MyTest (BitcoinTestFramework):
+
+    def setup_chain(self,bitcoinConfDict=None, wallets=None):
+        print("Initializing test directory "+self.options.tmpdir)
+        # pick this one to start from the cached 4 node 100 blocks mined configuration
+        initialize_chain(self.options.tmpdir, bitcoinConfDict, wallets)
+        # pick this one to start at 0 mined blocks
+        # initialize_chain_clean(self.options.tmpdir, 2, bitcoinConfDict, wallets)
+        # Number of nodes to initialize ----------> ^
+
+    def setup_network(self, split=False):
+        self.nodes = start_nodes(2, self.options.tmpdir)
+        # Nodes to start --------^
+        # Note for this template I readied 4 nodes but only started 2
+
+        # Now interconnect the nodes
+        connect_nodes_full(self.nodes)
+        # Let the framework know if the network is fully connected.
+        # If not, the framework assumes this partition: (0,1) and (2,3)
+        # For more complex partitions, you can't use the self.sync* member functions
+        self.is_network_split=False
+        self.sync_blocks()
+
+    def run_test (self):
+        # generate enough blocks so that nodes[0] has a balance
+        self.sync_blocks()
+        self.nodes[1].generate(50)
+        self.sync_blocks()
+
+        start = time.time()
+        NUM_ADDRS = 500
+        addrs1=[]
+        for i in range(0,NUM_ADDRS):
+            addrs1.append(self.nodes[1].getnewaddress())
+        getAddr1Done = time.time()
+        print("sequential getnewaddress/sec: %4.2f" % (float(NUM_ADDRS)/float(getAddr1Done-start)))
+
+        start = time.time()
+        addrs0=[]
+        for i in range(0,NUM_ADDRS):
+            addrs0.append(self.nodes[0].getnewaddress())
+        getAddr0Done = time.time()
+        print("sequential getnewaddress/sec: %4.2f" % (float(NUM_ADDRS)/float(getAddr0Done-start)))
+
+        # Doesn't matter: self.nodes[0].set("wallet.coinSelSearchTime=1")
+
+        # Split so we can spend
+        logging.info("split")
+        for i in range(0,NUM_ADDRS-20,2):
+          try:
+            dests = {}
+            for j in range(i,i+20):
+                dests[addrs0[j]] = "0.01"
+            txid = self.nodes[1].sendmany('', dests, 0, "", [])
+          except JSONRPCException as e:  # Expecting to run out of UTXOs
+            self.nodes[1].generate(1)
+
+        self.nodes[1].generate(1)
+        time.sleep(1)
+
+        logging.info("Begin small wallet sendtoaddress test")
+        unspentSize = len(self.nodes[0].listunspent())
+        start = time.time()
+        for i in range(0,NUM_ADDRS):
+            self.nodes[0].sendtoaddress(addrs1[i], round(0.001 + (i*0.0001),8))
+        sendtoaddressDone = time.time()
+
+        print("sequential sendtoaddress/sec at %d utxos: %4.2f" % (unspentSize, float(NUM_ADDRS)/float(sendtoaddressDone - start)))
+
+        if 1:
+          logging.info("split into large wallet")
+        # Split so we can spend
+          for i in range(0,int(NUM_ADDRS/2-30)):
+            try:
+              dests = {}
+              for j in range(i,i+30):
+                dests[addrs0[j]] = "0.01"
+              txid = self.nodes[1].sendmany('', dests, 0, "", [])
+            except JSONRPCException as e:  # Expecting to run out of UTXOs
+              print(i, ": Generate block, utxos: ", len(self.nodes[0].listunspent()))
+              self.nodes[1].generate(1)
+
+        self.nodes[1].generate(1)
+        time.sleep(1)
+
+        LOOP = 200 # int(NUM_ADDRS/4)
+        logging.info("Begin sequential sendtoaddress test")
+        unspentSize = len(self.nodes[0].listunspent())
+        start = time.time()
+        for i in range(0,LOOP):
+            self.nodes[0].sendtoaddress(addrs1[i], round(0.001 + (i*0.0001),8))
+        sendtoaddressDone = time.time()
+        print("sequential sendtoaddress/sec at %d utxos: %4.2f" % (unspentSize, float(LOOP)/float(sendtoaddressDone - start)))
+
+        self.nodes[0].generate(1)
+        time.sleep(0.25)
+
+        # Gather statistics on the transactions
+        fees = Decimal("0")
+        nInputs = 0
+        nOutputs = 0
+        txsize = 0
+        print("sendtoaddress tx analysis")
+        random.seed(1)
+        for i in range(0,LOOP):
+            # txid = self.nodes[0].sendtoaddress(addrs1[i], round(0.01 + (i*0.001),8))
+            txid = self.nodes[0].sendtoaddress(addrs1[i], round(random.random()/10.0,8))
+            try:
+                txhex = self.nodes[0].getrawtransaction(txid)
+            except JSONRPCException as e:
+                time.sleep(0.25)
+                txhex = self.nodes[0].getrawtransaction(txid)
+            txinfo = self.nodes[0].gettransaction(txid)
+            txinfo2 = self.nodes[0].decoderawtransaction(txhex)
+            tx = CTransaction().deserialize(txhex)
+            txsize += len(txhex)/2
+            fees += txinfo["fee"]
+            nInputs += len(tx.vin)
+            nOutputs += len(tx.vout)
+
+        print("%d tx, size %d.  Total Fees: %s. Fees SAT/byte: %s  Inputs spent: %d.  Outputs sent: %d." % (LOOP, txsize, str(fees), str(fees*SATPERBCH/Decimal(txsize)), nInputs, nOutputs))
+        
+        self.nodes[0].generate(1)
+        time.sleep(0.25)
+
+        self.nodes[0].set("wallet.coinSelSearchTime=1")
+        unspentSize = len(self.nodes[0].listunspent())
+        logging.info("Begin sendfrom test")
+        start = time.time()
+        for i in range(0,LOOP):
+            self.nodes[0].sendfrom("",addrs1[i], round(0.001 + (i*0.0001),8))
+        sendfromDone = time.time()
+        print("sequential sendfrom/sec at %d utxos: %4.2f" % (unspentSize, float(LOOP)/float(sendfromDone - start)))
+
+        self.nodes[0].generate(1)
+        time.sleep(0.25)
+
+        unspentSize = len(self.nodes[0].listunspent())
+        logging.info("Begin sequential sendmany test with 1ms search time")
+        start = time.time()
+        for i in range(0,LOOP-1):
+            self.nodes[0].sendmany("", { addrs0[i]: str(round(0.001 + (i*0.0001),8)), addrs0[i+1]: str(round(0.001 + (i*0.0001),8)) }, 0, "", [])
+        sendtoaddressDone = time.time()
+
+        print("sequential sendmany/sec at %d utxos: %4.2f" % (unspentSize, float(LOOP-1)/float(sendtoaddressDone - start)))
+
+
+if __name__ == '__main__':
+    MyTest ().main ()
+
+# Create a convenient function for an interactive python debugging session
+def Test():
+    t = MyTest()
+    t.drop_to_pdb = True
+    bitcoinConf = {
+        "debug": ["selectcoins"], # ["net", "blk", "thin", "mempool", "req", "bench", "evict"],
+        "blockprioritysize": 2000000,  # we don't want any transactions rejected due to insufficient fees...
+        "logtimemicros":1,
+        "checkmempool":0,
+        # "par":1  # Reduce the # of threads in bitcoind for easier debugging
+    }
+
+
+    flags = standardFlags()
+    t.main(flags, bitcoinConf, None)


### PR DESCRIPTION
Allow parallel_rpc to run from command line, speed up mempool_push.py
Add useful output on a timeout.
Simultaneously spawn bitcoinds
Fix race condition in tests between bitcoind writing to the log, and the test checking it by looping and waiting if the desired log messages were not found.
Fix logging object in mininode
add core file detection and display
add TRAVIS variable to container so scripts know we are under the travis ci build environment
add core analysis file, clean up printouts