### PR TITLE
add flag to enable build against libstdc++ debug mode

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -236,6 +236,13 @@ AC_ARG_ENABLE([debug],
     [enable_debug=$enableval],
     [enable_debug=no])
 
+# Enable std library debug
+AC_ARG_ENABLE([std-debug],
+    [AS_HELP_STRING([--enable-std-debug],
+                    [use glib std debug library with range checking on containers, etc.  This requires boost to be built with "./b2 define=_GLIBCXX_DEBUG define=GLIB_CXX_DEBUG_PEDANTIC" options.])],
+    [enable_std_debug=$enableval],
+    [enable_std_debug=no])
+
 # Turn warnings into errors
 AC_ARG_ENABLE([werror],
     [AS_HELP_STRING([--enable-werror],
@@ -261,6 +268,10 @@ if test "x$enable_debug" = xyes; then
     if test "x$GXX" = xyes; then
         CXXFLAGS="$CXXFLAGS -g3 -O0"
     fi
+fi
+
+if test "x$enable_std_debug" = xyes; then
+    CPPFLAGS="$CPPFLAGS -D_GLIBCXX_DEBUG -DGLIB_CXX_DEBUG_PEDANTIC"
 fi
 
 ERROR_CXXFLAGS=

--- a/src/univalue/configure.ac
+++ b/src/univalue/configure.ac
@@ -52,8 +52,19 @@ AC_ARG_ENABLE([debug],
     [enable_debug=$enableval],
     [enable_debug=no])
 
+# Enable std library debug
+AC_ARG_ENABLE([std-debug],
+    [AS_HELP_STRING([--enable-std-debug],
+                    [use glib std debug library with range checking on containers, etc.  This requires boost to be built with "./b2 define=_GLIBCXX_DEBUG define=GLIB_CXX_DEBUG_PEDANTIC" options.])],
+    [enable_std_debug=$enableval],
+    [enable_std_debug=no])
+
 if test "x$enable_debug" = xyes; then
     CPPFLAGS="$CPPFLAGS -DDEBUG"
+fi
+
+if test "x$enable_std_debug" = xyes; then
+    CPPFLAGS="$CPPFLAGS -D_GLIBCXX_DEBUG -DGLIB_CXX_DEBUG_PEDANTIC"
 fi
 
 case $host in


### PR DESCRIPTION
libstdc++ debug mode has bounds checking, etc, see:

https://gcc.gnu.org/onlinedocs/libstdc%2B%2B/manual/debug_mode_using.html

However, since boost uses std, you also must compile boost with the libstdc++ debug mode to use this flag.  

For example, download the boost source and compile with:
./b2 -d2 --libdir=built/lib --includedir=built/include define=_GLIBCXX_DEBUG define=GLIB_CXX_DEBUG_PEDANTIC cxxflags="-D_GLIBCXX_DEBUG -DGLIB_CXX_DEBUG_PEDANTIC" install

Then configure bitcoind with:

../configure --enable-shared --enable-debug --enable-std-debug --with-boost=**{your boost dir}**/built --with-boost-libdir=**{your boost dir}**/built/lib

