### PR TITLE
Failure recovery for Graphene

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -253,6 +253,7 @@ testScripts = [ RpcTest(t) for t in [
     'compactblocks_2',
     'graphene_optimized',
     'graphene_versions',
+    'graphene_stage2',
     'thinblocks',
     Disabled('checkdatasig_activation', "CDSV has been already succesfully activated, keep test around as a template for other OP activation"),
     'xversion',

--- a/qa/rpc-tests/graphene_stage2.py
+++ b/qa/rpc-tests/graphene_stage2.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# Copyright (c) 2018 The Bitcoin Unlimited developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+
+class GrapheneStage2Test(BitcoinTestFramework):
+    expected_stats = {'enabled', 
+                      'filter', 
+                      'graphene_additional_tx_size', 
+                      'graphene_block_size', 
+                      'iblt', 
+                      'inbound_percent', 
+                      'outbound_percent', 
+                      'rank', 
+                      'rerequested', 
+                      'response_time', 
+                      'summary', 
+                      'validation_time'}
+    def __init__(self, test_assertion='success'):
+        self.rep = False
+        BitcoinTestFramework.__init__(self)
+
+        if test_assertion == 'success':
+            self.test_assertion = self.assert_success
+        else:
+            self.test_assertion = self.assert_failure
+
+    def setup_chain(self):
+        print ("Initializing test directory " + self.options.tmpdir)
+        initialize_chain_clean(self.options.tmpdir, 2)
+
+    def setup_network(self, split=False):
+        node_opts = [
+            "-rpcservertimeout=0",
+            "-debug=graphene",
+            "-use-grapheneblocks=1",
+            "-use-thinblocks=0",
+            "-net.grapheneIbltSizeOverride=1",
+            "-net.grapheneBloomFprOverride=0.0",
+            "-net.randomlyDontInv=100",
+            "-excessiveblocksize=6000000",
+            "-blockprioritysize=6000000",
+            "-blockmaxsize=6000000"]
+
+        self.nodes = [
+            start_node(0, self.options.tmpdir, node_opts),
+            start_node(1, self.options.tmpdir, node_opts)
+        ]
+
+        self.is_network_split = False
+        interconnect_nodes(self.nodes)
+        self.sync_all()
+
+    def extract_stats_fields(self, node):
+        gni = node.getnetworkinfo()
+        assert "grapheneblockstats" in gni
+        tbs = gni["grapheneblockstats"]
+        assert "enabled" in tbs and tbs["enabled"]
+        assert set(tbs) == self.expected_stats
+
+        return tbs
+
+    def assert_success(self):
+        # Nodes 1 should have received one block from node 0 and have experienced on decode failure.
+        assert '1 inbound and 0 outbound graphene blocks' in self.extract_stats_fields(self.nodes[1])['summary']
+        assert 'bandwidth with 1 local decode failure' in self.extract_stats_fields(self.nodes[1])['summary']
+
+        # Node 1 should have experienced only one decode failure
+        assert 'bandwidth with 2 local decode failure' not in self.extract_stats_fields(self.nodes[1])['summary']
+
+    def run_test(self):
+        # Generate blocks so we can send a few transactions.  We need some transactions in a block
+        # before a graphene block can be sent and created, otherwise we'll just end up sending a regular
+        # block.
+        self.nodes[0].generate(105)
+        self.sync_blocks()
+
+        logging.info("Send 5 transactions from node0 (to its own address)")
+        addr = self.nodes[0].getnewaddress()
+        for i in range(5):
+            self.nodes[0].sendtoaddress(addr, Decimal("10"))
+
+        self.nodes[0].generate(1)
+
+        self.sync_blocks()
+
+        self.assert_success()
+
+if __name__ == '__main__':
+    GrapheneStage2Test().main()

--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -78,6 +78,11 @@ void ThinTypeRelay::RemovePeers(CNode *pfrom)
     nThinBlockPeers = setThinBlockPeers.size();
     nGraphenePeers = setGraphenePeers.size();
     nCompactBlockPeers = setCompactBlockPeers.size();
+
+    {
+        LOCK(cs_graphene_sender);
+        mapGrapheneSentBlocks.erase(pfrom->GetId());
+    }
 }
 
 // Preferential Block Relay Timer:

--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -260,6 +260,23 @@ void ThinTypeRelay::ClearAllBlocksInFlight(NodeId id)
     mapThinTypeBlocksInFlight.erase(range.first, range.second);
 }
 
+void ThinTypeRelay::SetSentGrapheneBlocks(NodeId id, CGrapheneBlock &grapheneBlock)
+{
+    LOCK(cs_graphene_sender);
+    mapGrapheneSentBlocks[id] = std::make_shared<CGrapheneBlock>(grapheneBlock);
+}
+
+std::shared_ptr<CGrapheneBlock> ThinTypeRelay::GetSentGrapheneBlocks(NodeId id)
+{
+    LOCK(cs_graphene_sender);
+
+    auto it = mapGrapheneSentBlocks.find(id);
+    if (it != mapGrapheneSentBlocks.end())
+        return it->second;
+    else
+        return std::shared_ptr<CGrapheneBlock>();
+}
+
 void ThinTypeRelay::ClearSentGrapheneBlocks(NodeId id)
 {
     LOCK(cs_graphene_sender);

--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -78,11 +78,6 @@ void ThinTypeRelay::RemovePeers(CNode *pfrom)
     nThinBlockPeers = setThinBlockPeers.size();
     nGraphenePeers = setGraphenePeers.size();
     nCompactBlockPeers = setCompactBlockPeers.size();
-
-    {
-        LOCK(cs_graphene_sender);
-        mapGrapheneSentBlocks.erase(pfrom->GetId());
-    }
 }
 
 // Preferential Block Relay Timer:
@@ -263,6 +258,12 @@ void ThinTypeRelay::ClearAllBlocksInFlight(NodeId id)
     LOCK(cs_inflight);
     auto range = mapThinTypeBlocksInFlight.equal_range(id);
     mapThinTypeBlocksInFlight.erase(range.first, range.second);
+}
+
+void ThinTypeRelay::ClearSentGrapheneBlocks(NodeId id)
+{
+    LOCK(cs_graphene_sender);
+    mapGrapheneSentBlocks.erase(id);
 }
 
 void ThinTypeRelay::CheckForDownloadTimeout(CNode *pfrom)

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -27,6 +27,7 @@ class ThinTypeRelay
 public:
     CCriticalSection cs_inflight;
     CCriticalSection cs_reconstruct;
+    CCriticalSection cs_graphene_sender;
 
 private:
     // block relay timer
@@ -53,6 +54,10 @@ private:
     std::atomic<int32_t> nThinBlockPeers{0};
     std::atomic<int32_t> nGraphenePeers{0};
     std::atomic<int32_t> nCompactBlockPeers{0};
+
+public:
+    // blocks still in flight sent by the sender.
+    std::map<NodeId, std::shared_ptr<CGrapheneBlock> > mapGrapheneSentBlocks GUARDED_BY(cs_graphene_sender);
 
 public:
     void AddPeers(CNode *pfrom);

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -76,6 +76,7 @@ public:
     bool AddBlockInFlight(CNode *pfrom, const uint256 &hash, const std::string thinType);
     void ClearBlockInFlight(NodeId id, const uint256 &hash);
     void ClearAllBlocksInFlight(NodeId id);
+    void ClearSentGrapheneBlocks(NodeId id);
     void CheckForDownloadTimeout(CNode *pfrom);
     void RequestBlock(CNode *pfrom, const uint256 &hash);
 

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -55,7 +55,6 @@ private:
     std::atomic<int32_t> nGraphenePeers{0};
     std::atomic<int32_t> nCompactBlockPeers{0};
 
-public:
     // blocks still in flight sent by the sender.
     std::map<NodeId, std::shared_ptr<CGrapheneBlock> > mapGrapheneSentBlocks GUARDED_BY(cs_graphene_sender);
 
@@ -76,6 +75,8 @@ public:
     bool AddBlockInFlight(CNode *pfrom, const uint256 &hash, const std::string thinType);
     void ClearBlockInFlight(NodeId id, const uint256 &hash);
     void ClearAllBlocksInFlight(NodeId id);
+    void SetSentGrapheneBlocks(NodeId id, CGrapheneBlock &grapheneBlock);
+    std::shared_ptr<CGrapheneBlock> GetSentGrapheneBlocks(NodeId id);
     void ClearSentGrapheneBlocks(NodeId id);
     void CheckForDownloadTimeout(CNode *pfrom);
     void RequestBlock(CNode *pfrom, const uint256 &hash);

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1544,8 +1544,6 @@ bool HandleGrapheneBlockRecoveryResponse(CDataStream &vRecv, CNode *pfrom, const
             pfrom->GetLogName());
     }
 
-    int blockSize = pblock->GetBlockSize();
-
     return true;
 }
 

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1560,6 +1560,10 @@ bool HandleGrapheneBlockRecoveryResponse(CDataStream &vRecv, CNode *pfrom, const
             pfrom->GetLogName());
     }
 
+    int blockSize = pblock->GetBlockSize();
+    graphenedata.UpdateInBound(pblock->grapheneblock->GetSize(), blockSize);
+    LOG(GRAPHENE, "Graphene block stats: %s\n", graphenedata.ToString().c_str());
+
     return true;
 }
 
@@ -1576,6 +1580,8 @@ CRequestGrapheneReceiverRecover::CRequestGrapheneReceiverRecover(std::vector<uin
     pReceiverFilter = std::make_shared<CVariableFastFilter>(
         grapheneBlock.pGrapheneSet->FailureRecoveryFilter(relevantHashes, nItems, nSenderFilterPositives,
             nReceiverUniverseItems, FAILURE_RECOVERY_SUCCESS_RATE, grapheneBlock.fpr, grapheneSetVersion));
+
+    graphenedata.UpdateFilter(::GetSerializeSize(*pReceiverFilter, SER_NETWORK, PROTOCOL_VERSION));
 }
 
 CGrapheneReceiverRecover::CGrapheneReceiverRecover(CVariableFastFilter &receiverFilter,
@@ -1606,6 +1612,8 @@ CGrapheneReceiverRecover::CGrapheneReceiverRecover(CVariableFastFilter &receiver
         grapheneSetVersion, (uint32_t)grapheneBlock.shorttxidk0));
     std::vector<CTransaction> vTx = TransactionsFromBlockByCheapHash(vMissingCheapHashes, blockhash, pfrom);
     std::copy(vTx.begin(), vTx.end(), back_inserter(vMissingTxs));
+
+    graphenedata.UpdateIblt(::GetSerializeSize(*pRevisedIblt, SER_NETWORK, PROTOCOL_VERSION));
 }
 
 CMemPoolInfo GetGrapheneMempoolInfo()

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -172,7 +172,7 @@ bool CGrapheneBlock::ValidateAndRecontructBlock(int &missingCount,
     uint256 merkleroot = ComputeMerkleRoot(vTxHashes256, &mutated);
     if (pblock->hashMerkleRoot != merkleroot || mutated)
     {
-        thinrelay.ClearAllBlockData(pfrom, pblock);
+        thinrelay.ClearAllBlockData(pfrom, pblock->GetHash());
         return error("Merkle root for block %s does not match computed merkle root, peer=%s", blockhash.ToString(),
             pfrom->GetLogName());
     }
@@ -386,7 +386,7 @@ bool CGrapheneBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string
     if (!LookupBlockIndex(grapheneBlock->header.hashPrevBlock))
     {
         dosMan.Misbehaving(pfrom, 10);
-        thinrelay.ClearAllBlockData(pfrom, pblock);
+        thinrelay.ClearAllBlockData(pfrom, pblock->GetHash());
         return error(GRAPHENE, "Graphene block from peer %s will not connect, unknown previous block %s",
             pfrom->GetLogName(), grapheneBlock->header.hashPrevBlock.ToString());
     }

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1473,7 +1473,7 @@ bool HandleGrapheneBlockRecoveryResponse(CDataStream &vRecv, CNode *pfrom, const
     // Insert latest transactions just sent over
     for (auto &tx : recoveryResponse.vMissingTxs)
     {
-        uint256 hash = tx.GetHash();
+        const uint256 &hash = tx.GetHash();
         uint64_t cheapHash = pblock->grapheneblock->pGrapheneSet->GetShortID(hash);
 
         mapTxFromPools[cheapHash] = hash;

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1561,8 +1561,6 @@ bool HandleGrapheneBlockRecoveryResponse(CDataStream &vRecv, CNode *pfrom, const
     }
 
     int blockSize = pblock->GetBlockSize();
-    graphenedata.UpdateInBound(pblock->grapheneblock->GetSize(), blockSize);
-    LOG(GRAPHENE, "Graphene block stats: %s\n", graphenedata.ToString().c_str());
 
     return true;
 }

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -381,6 +381,8 @@ bool CGrapheneBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string
     // Is there a previous block or header to connect with?
     if (!LookupBlockIndex(grapheneBlock->header.hashPrevBlock))
     {
+        dosMan.Misbehaving(pfrom, 10);
+        thinrelay.ClearAllBlockData(pfrom, pblock);
         return error(GRAPHENE, "Graphene block from peer %s will not connect, unknown previous block %s",
             pfrom->GetLogName(), grapheneBlock->header.hashPrevBlock.ToString());
     }

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -31,8 +31,6 @@ static bool ReconstructBlock(CNode *pfrom,
 extern CTweak<uint64_t> grapheneMinVersionSupported;
 extern CTweak<uint64_t> grapheneMaxVersionSupported;
 extern CTweak<uint64_t> grapheneFastFilterCompatibility;
-extern CCriticalSection cs_graphenerecovery;
-extern std::map<NodeId, CGrapheneBlock> grapheneRecoveryBlock;
 
 CMemPoolInfo::CMemPoolInfo(uint64_t _nTx) : nTx(_nTx) {}
 CMemPoolInfo::CMemPoolInfo() { this->nTx = 0; }
@@ -1308,11 +1306,6 @@ void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CM
 
             CGrapheneBlock grapheneBlock(pblock, mempoolinfo.nTx, nSenderMempoolPlusBlock,
                 NegotiateGrapheneVersion(pfrom), NegotiateFastFilterSupport(pfrom));
-
-            {
-                LOCK(cs_graphenerecovery);
-                grapheneRecoveryBlock[pfrom->GetId()] = grapheneBlock;
-            }
 
             LOG(GRAPHENE, "Block %s to peer %s using Graphene version %d\n", grapheneBlock.header.GetHash().ToString(),
                 pfrom->GetLogName(), grapheneBlock.version);

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -31,6 +31,8 @@ static bool ReconstructBlock(CNode *pfrom,
 extern CTweak<uint64_t> grapheneMinVersionSupported;
 extern CTweak<uint64_t> grapheneMaxVersionSupported;
 extern CTweak<uint64_t> grapheneFastFilterCompatibility;
+extern CCriticalSection cs_graphenerecovery;
+extern std::map<NodeId, CGrapheneBlock> grapheneRecoveryBlock;
 
 CMemPoolInfo::CMemPoolInfo(uint64_t _nTx) : nTx(_nTx) {}
 CMemPoolInfo::CMemPoolInfo() { this->nTx = 0; }
@@ -82,6 +84,126 @@ void CGrapheneBlock::FillShortTxIDSelector()
     shorttxidk1 = shorttxidhash.GetUint64(1);
 }
 
+void CGrapheneBlock::AddNewTransactions(std::vector<CTransaction> vMissingTx, CNode *pfrom)
+{
+    if (vMissingTx.size() == 0)
+        return;
+
+    // If canonical ordering is activated, locate empty indexes in vTxHashes256 to be used in sorting
+    std::vector<size_t> missingTxIdxs;
+    if (fCanonicalTxsOrder && NegotiateGrapheneVersion(pfrom) >= 1)
+    {
+        uint256 nullhash;
+        for (size_t idx = 0; idx < vTxHashes256.size(); idx++)
+        {
+            if (vTxHashes256[idx] == nullhash)
+                missingTxIdxs.push_back(idx);
+        }
+    }
+
+    size_t idx = 0;
+    for (const CTransaction &tx : vMissingTx)
+    {
+        mapMissingTx[GetShortID(pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, tx.GetHash(),
+            NegotiateGrapheneVersion(pfrom))] = MakeTransactionRef(tx);
+
+        uint256 hash = tx.GetHash();
+        uint64_t cheapHash =
+            GetShortID(pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, hash, NegotiateGrapheneVersion(pfrom));
+
+        // Insert in arbitrary order if canonical ordering is enabled and xversion is recent enough
+        if (fCanonicalTxsOrder && NegotiateGrapheneVersion(pfrom) >= 1)
+            vTxHashes256[missingTxIdxs[idx++]] = hash;
+        // Otherwise, use ordering information
+        else
+            vTxHashes256[mapHashOrderIndex[cheapHash]] = hash;
+    }
+}
+
+void CGrapheneBlock::OrderTxHashes(CNode *pfrom)
+{
+    if (vTxHashes256.size() != nBlockTxs)
+        throw std::runtime_error("Cannot OrderTxHashes if size of vTxHashes256 unequal to nBlockTxs");
+
+    // Sort order transactions if canonical order is enabled and graphene version is late enough
+    if (fCanonicalTxsOrder && NegotiateGrapheneVersion(pfrom) >= 1)
+    {
+        // coinbase is always first
+        std::sort(vTxHashes256.begin() + 1, vTxHashes256.end());
+        LOG(GRAPHENE, "Using canonical order for block from peer=%s\n", pfrom->GetLogName());
+    }
+    else
+    {
+        uint256 nullhash;
+        std::vector<uint256> orderedTxHashes256(nBlockTxs, nullhash);
+        for (auto &hash : vTxHashes256)
+        {
+            uint64_t cheapHash =
+                GetShortID(pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, hash, NegotiateGrapheneVersion(pfrom));
+            orderedTxHashes256[mapHashOrderIndex[cheapHash]] = hash;
+        }
+        std::copy(orderedTxHashes256.begin(), orderedTxHashes256.end(), vTxHashes256.begin());
+    }
+}
+
+bool CGrapheneBlock::ValidateAndRecontructBlock(int &missingCount,
+    int &unnecessaryCount,
+    uint256 blockhash,
+    std::shared_ptr<CBlockThinRelay> pblock,
+    std::string command,
+    CNode *pfrom,
+    CDataStream &vRecv)
+{
+    size_t msgSize = vRecv.size();
+    OrderTxHashes(pfrom);
+
+    // At this point we should have all the full hashes in the block. Check that the merkle
+    // root in the block header matches the merkel root calculated from the hashes provided.
+    bool mutated;
+    uint256 merkleroot = ComputeMerkleRoot(vTxHashes256, &mutated);
+    if (pblock->hashMerkleRoot != merkleroot || mutated)
+    {
+        thinrelay.ClearAllBlockData(pfrom, pblock);
+        return error("Merkle root for block %s does not match computed merkle root, peer=%s", blockhash.ToString(),
+            pfrom->GetLogName());
+    }
+    LOG(GRAPHENE, "Merkle Root check passed for block %s peer=%s\n", blockhash.ToString(), pfrom->GetLogName());
+
+    // Look for each transaction in our various pools and buffers.
+    // With grapheneBlocks recovered txs contains only the first 8 bytes of the tx hash.
+    {
+        if (!ReconstructBlock(pfrom, missingCount, unnecessaryCount, pblock))
+            return false;
+    }
+
+    if (missingCount <= 0)
+    {
+        // We have all the transactions now that are in this block: try to reassemble and process.
+        CInv inv2(MSG_BLOCK, blockhash);
+
+        // for compression statistics, we have to add up the size of grapheneblock and the re-requested grapheneBlockTx.
+        uint64_t nSizeGrapheneBlockTx = msgSize;
+        uint64_t blockSize = pblock->GetBlockSize();
+        float nCompressionRatio = 0.0;
+        if (GetSize() + nSizeGrapheneBlockTx > 0)
+            nCompressionRatio = (float)blockSize / ((float)GetSize() + (float)nSizeGrapheneBlockTx);
+        LOG(GRAPHENE, "Reassembled grblktx for %s (%d bytes). Message was %d bytes (graphene block) and %d bytes "
+                      "(re-requested tx), compression ratio %3.2f, peer=%s\n",
+            pblock->GetHash().ToString(), blockSize, GetSize(), nSizeGrapheneBlockTx, nCompressionRatio,
+            pfrom->GetLogName());
+
+        // Update run-time statistics of graphene block bandwidth savings.
+        // We add the original graphene block size with the size of transactions that were re-requested.
+        // This is NOT double counting since we never accounted for the original graphene block due to the re-request.
+        graphenedata.UpdateInBound(nSizeGrapheneBlockTx + GetSize(), blockSize);
+        LOG(GRAPHENE, "Graphene block stats: %s\n", graphenedata.ToString());
+
+        PV->HandleBlockMessage(pfrom, command, pblock, inv2);
+    }
+
+    return true;
+}
+
 CGrapheneBlockTx::CGrapheneBlockTx(uint256 blockHash, std::vector<CTransaction> &vTx)
 {
     blockhash = blockHash;
@@ -91,7 +213,6 @@ CGrapheneBlockTx::CGrapheneBlockTx(uint256 blockHash, std::vector<CTransaction> 
 bool CGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
 {
     std::string strCommand = NetMsgType::GRAPHENETX;
-    size_t msgSize = vRecv.size();
     CGrapheneBlockTx grapheneBlockTx;
     vRecv >> grapheneBlockTx;
 
@@ -148,65 +269,14 @@ bool CGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
             pfrom->GetLogName());
     }
 
-    // If canonical ordering is activated, locate empty indexes in vTxHashes256 to be used in sorting
-    std::vector<size_t> missingTxIdxs;
-    if (fCanonicalTxsOrder && NegotiateGrapheneVersion(pfrom) >= 1)
-    {
-        uint256 nullhash;
-        for (size_t idx = 0; idx < grapheneBlock->vTxHashes256.size(); idx++)
-        {
-            if (grapheneBlock->vTxHashes256[idx] == nullhash)
-                missingTxIdxs.push_back(idx);
-        }
-    }
-
-    size_t idx = 0;
-    for (const CTransaction &tx : grapheneBlockTx.vMissingTx)
-    {
-        grapheneBlock->mapMissingTx[GetShortID(pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, tx.GetHash(),
-            NegotiateGrapheneVersion(pfrom))] = MakeTransactionRef(tx);
-
-        uint256 hash = tx.GetHash();
-        uint64_t cheapHash =
-            GetShortID(pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, hash, NegotiateGrapheneVersion(pfrom));
-
-        // Insert in arbitrary order if canonical ordering is enabled and xversion is recent enough
-        if (fCanonicalTxsOrder && NegotiateGrapheneVersion(pfrom) >= 1)
-            grapheneBlock->vTxHashes256[missingTxIdxs[idx++]] = hash;
-        // Otherwise, use ordering information
-        else
-            grapheneBlock->vTxHashes256[grapheneBlock->mapHashOrderIndex[cheapHash]] = hash;
-    }
-    // Sort order transactions if canonical ordering is enabled and xversion is recent enough
-    if (fCanonicalTxsOrder && NegotiateGrapheneVersion(pfrom) >= 1)
-    {
-        // coinbase is always first
-        std::sort(grapheneBlock->vTxHashes256.begin() + 1, grapheneBlock->vTxHashes256.end());
-        LOG(GRAPHENE, "Using canonical order for block from peer=%s\n", pfrom->GetLogName());
-    }
+    grapheneBlock->AddNewTransactions(grapheneBlockTx.vMissingTx, pfrom);
 
     LOG(GRAPHENE, "Got %d Re-requested txs from peer=%s\n", grapheneBlockTx.vMissingTx.size(), pfrom->GetLogName());
 
-    // At this point we should have all the full hashes in the block. Check that the merkle
-    // root in the block header matches the merkel root calculated from the hashes provided.
-    bool mutated;
-    uint256 merkleroot = ComputeMerkleRoot(grapheneBlock->vTxHashes256, &mutated);
-    if (pblock->hashMerkleRoot != merkleroot || mutated)
-    {
-        thinrelay.ClearAllBlockData(pfrom, pblock->GetHash());
-        return error("Merkle root for %s does not match computed merkle root, peer=%s", inv.hash.ToString(),
-            pfrom->GetLogName());
-    }
-    LOG(GRAPHENE, "Merkle Root check passed for %s peer=%s\n", inv.hash.ToString(), pfrom->GetLogName());
-
     int missingCount = 0;
     int unnecessaryCount = 0;
-    // Look for each transaction in our various pools and buffers.
-    // With grapheneBlocks recovered txs contains only the first 8 bytes of the tx hash.
-    {
-        if (!ReconstructBlock(pfrom, missingCount, unnecessaryCount, pblock))
-            return false;
-    }
+    grapheneBlock->ValidateAndRecontructBlock(
+        missingCount, unnecessaryCount, grapheneBlockTx.blockhash, pblock, strCommand, pfrom, vRecv);
 
     // If we're still missing transactions then bail out and request the failover block. This should never
     // happen unless we're under some kind of attack or somehow we lost transactions out of our memory pool
@@ -216,30 +286,6 @@ bool CGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
         RequestFailoverBlock(pfrom, pblock);
         return error("Still missing transactions after reconstructing block, peer=%s: re-requesting failover block",
             pfrom->GetLogName());
-    }
-    else
-    {
-        // We have all the transactions now that are in this block: try to reassemble and process.
-        CInv inv2(MSG_BLOCK, grapheneBlockTx.blockhash);
-
-        // for compression statistics, we have to add up the size of grapheneblock and the re-requested grapheneBlockTx.
-        uint64_t nSizeGrapheneBlockTx = msgSize;
-        uint64_t blockSize = pblock->GetBlockSize();
-        float nCompressionRatio = 0.0;
-        if (grapheneBlock->GetSize() + nSizeGrapheneBlockTx > 0)
-            nCompressionRatio = (float)blockSize / ((float)grapheneBlock->GetSize() + (float)nSizeGrapheneBlockTx);
-        LOG(GRAPHENE, "Reassembled grblktx for %s (%d bytes). Message was %d bytes (graphene block) and %d bytes "
-                      "(re-requested tx), compression ratio %3.2f, peer=%s\n",
-            pblock->GetHash().ToString(), blockSize, grapheneBlock->GetSize(), nSizeGrapheneBlockTx, nCompressionRatio,
-            pfrom->GetLogName());
-
-        // Update run-time statistics of graphene block bandwidth savings.
-        // We add the original graphene block size with the size of transactions that were re-requested.
-        // This is NOT double counting since we never accounted for the original graphene block due to the re-request.
-        graphenedata.UpdateInBound(nSizeGrapheneBlockTx + grapheneBlock->GetSize(), blockSize);
-        LOG(GRAPHENE, "Graphene block stats: %s\n", graphenedata.ToString());
-
-        PV->HandleBlockMessage(pfrom, strCommand, pblock, inv2);
     }
 
     return true;
@@ -268,42 +314,18 @@ bool CRequestGrapheneBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     CInv inv(MSG_TX, grapheneRequestBlockTx.blockhash);
     LOG(GRAPHENE, "Received get_grblocktx for %s peer=%s\n", inv.hash.ToString(), pfrom->GetLogName());
 
-    std::vector<CTransaction> vTx;
-    CBlockIndex *hdr = LookupBlockIndex(inv.hash);
-    if (!hdr)
+    try
     {
-        dosMan.Misbehaving(pfrom, 20);
-        return error("Requested block is not available");
+        std::vector<CTransaction> vTx =
+            TransactionsFromBlockByCheapHash(grapheneRequestBlockTx.setCheapHashesToRequest, inv.hash, pfrom);
+        CGrapheneBlockTx grapheneBlockTx(grapheneRequestBlockTx.blockhash, vTx);
+        pfrom->PushMessage(NetMsgType::GRAPHENETX, grapheneBlockTx);
+        pfrom->txsSent += vTx.size();
     }
-    else
+    catch (const std::exception &e)
     {
-        if (hdr->nHeight < (chainActive.Tip()->nHeight - DEFAULT_BLOCKS_FROM_TIP))
-            return error(GRAPHENE, "get_grblocktx request too far from the tip");
-
-        CBlock block;
-        const Consensus::Params &consensusParams = Params().GetConsensus();
-        if (!ReadBlockFromDisk(block, hdr, consensusParams))
-        {
-            // We do not assign misbehavior for not being able to read a block from disk because we already
-            // know that the block is in the block index from the step above. Secondly, a failure to read may
-            // be our own issue or the remote peer's issue in requesting too early.  We can't know at this point.
-            return error("Cannot load block from disk -- Block txn request possibly received before assembled");
-        }
-        else
-        {
-            for (auto &tx : block.vtx)
-            {
-                uint64_t cheapHash = GetShortID(
-                    pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, tx->GetHash(), NegotiateGrapheneVersion(pfrom));
-
-                if (grapheneRequestBlockTx.setCheapHashesToRequest.count(cheapHash))
-                    vTx.push_back(*tx);
-            }
-        }
+        return error(GRAPHENE, e.what());
     }
-    CGrapheneBlockTx grapheneBlockTx(grapheneRequestBlockTx.blockhash, vTx);
-    pfrom->PushMessage(NetMsgType::GRAPHENETX, grapheneBlockTx);
-    pfrom->txsSent += vTx.size();
 
     return true;
 }
@@ -426,6 +448,91 @@ bool CGrapheneBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom, std::string
     return result;
 }
 
+void CGrapheneBlock::FillTxMapFromPools(std::map<uint64_t, uint256> &mapTxFromPools)
+{
+    {
+        READLOCK(orphanpool.cs_orphanpool);
+        for (auto &kv : orphanpool.mapOrphanTransactions)
+        {
+            uint64_t cheapHash = GetShortID(shorttxidk0, shorttxidk1, kv.first, version);
+            mapTxFromPools.insert(std::make_pair(cheapHash, kv.first));
+        }
+    }
+
+    // We don't have to keep the lock on mempool.cs here to do mempool.queryHashes
+    // but we take the lock anyway so we don't have to re-lock again later.
+    std::vector<uint256> memPoolHashes;
+    mempool.queryHashes(memPoolHashes);
+
+    for (const uint256 &hash : memPoolHashes)
+    {
+        uint64_t cheapHash = GetShortID(shorttxidk0, shorttxidk1, hash, version);
+        mapTxFromPools.insert(std::make_pair(cheapHash, hash));
+    }
+}
+
+void CGrapheneBlock::SituateCoinbase(std::vector<uint64_t> blockCheapHashes,
+    CTransactionRef coinbase,
+    uint64_t grapheneVersion)
+{
+    // Ensure coinbase is first
+    if (blockCheapHashes[0] != GetShortID(shorttxidk0, shorttxidk1, coinbase->GetHash(), version))
+    {
+        auto it = std::find(blockCheapHashes.begin(), blockCheapHashes.end(),
+            GetShortID(shorttxidk0, shorttxidk1, coinbase->GetHash(), version));
+
+        if (it == blockCheapHashes.end())
+            throw std::runtime_error("No coinbase transaction found in graphene block");
+
+        auto idx = std::distance(blockCheapHashes.begin(), it);
+
+        blockCheapHashes[idx] = blockCheapHashes[0];
+        blockCheapHashes[0] = GetShortID(shorttxidk0, shorttxidk1, coinbase->GetHash(), version);
+    }
+}
+
+void CGrapheneBlock::SituateCoinbase(CTransactionRef coinbase)
+{
+    std::vector<uint256>::iterator it = std::find(vTxHashes256.begin(), vTxHashes256.end(), coinbase->GetHash());
+
+    if (it == vTxHashes256.end())
+        return;
+
+    std::swap(vTxHashes256[0], vTxHashes256[std::distance(vTxHashes256.begin(), it)]);
+}
+
+std::set<uint64_t> CGrapheneBlock::UpdateResolvedTxsAndIdentifyMissing(std::map<uint64_t, uint256> mapPartialTxHash,
+    std::vector<uint64_t> blockCheapHashes,
+    uint64_t grapheneVersion)
+{
+    std::set<uint64_t> setHashesToRequest;
+    uint256 nullhash;
+
+    // Sort out what hashes we have from the complete set of cheapHashes
+    for (size_t i = 0; i < blockCheapHashes.size(); i++)
+    {
+        uint64_t cheapHash = blockCheapHashes[i];
+
+        // If canonical order is not enabled or xversion is less than 1, update mapHashOrderIndex so
+        // it is available if we later receive missing txs
+        if (!fCanonicalTxsOrder || grapheneVersion < 1)
+            mapHashOrderIndex[cheapHash] = i;
+
+        const auto &elem = mapPartialTxHash.find(cheapHash);
+        if (elem != mapPartialTxHash.end())
+        {
+            vTxHashes256.push_back(elem->second);
+        }
+        else
+        {
+            vTxHashes256.push_back(nullhash);
+            setHashesToRequest.insert(cheapHash);
+        }
+    }
+
+    return setHashesToRequest;
+}
+
 bool CGrapheneBlock::process(CNode *pfrom, std::string strCommand, std::shared_ptr<CBlockThinRelay> pblock)
 {
     // In PV we must prevent two graphene blocks from simulaneously processing from that were recieved from the
@@ -438,7 +545,6 @@ bool CGrapheneBlock::process(CNode *pfrom, std::string strCommand, std::shared_p
     DbgAssert(pblock->grapheneblock.get() == this, return false);
     std::shared_ptr<CGrapheneBlock> grapheneBlock = pblock->grapheneblock;
 
-    uint256 nullhash;
     pblock->nVersion = header.nVersion;
     pblock->nBits = header.nBits;
     pblock->nNonce = header.nNonce;
@@ -451,32 +557,15 @@ bool CGrapheneBlock::process(CNode *pfrom, std::string strCommand, std::shared_p
     // Create a map of all 8 bytes tx hashes pointing to their full tx hash counterpart
     int missingCount = 0;
     int unnecessaryCount = 0;
-    bool fRequestFailover = false;
+    bool fRequestFailureRecovery = false;
     std::set<uint256> passingTxHashes;
     std::map<uint64_t, uint256> mapPartialTxHash;
-    std::vector<uint256> memPoolHashes;
     std::set<uint64_t> setHashesToRequest;
+    std::vector<uint256> vSenderFilterPositiveHahses;
 
     bool fMerkleRootCorrect = true;
     {
-        {
-            READLOCK(orphanpool.cs_orphanpool);
-            for (auto &kv : orphanpool.mapOrphanTransactions)
-            {
-                uint64_t cheapHash = GetShortID(shorttxidk0, shorttxidk1, kv.first, version);
-                mapPartialTxHash.insert(std::make_pair(cheapHash, kv.first));
-            }
-        }
-
-        // We don't have to keep the lock on mempool.cs here to do mempool.queryHashes
-        // but we take the lock anyway so we don't have to re-lock again later.
-        mempool.queryHashes(memPoolHashes);
-
-        for (const uint256 &hash : memPoolHashes)
-        {
-            uint64_t cheapHash = GetShortID(shorttxidk0, shorttxidk1, hash, version);
-            mapPartialTxHash.insert(std::make_pair(cheapHash, hash));
-        }
+        FillTxMapFromPools(mapPartialTxHash);
 
         // Add full transactions included in the block
         CTransactionRef coinbase = nullptr;
@@ -498,50 +587,26 @@ bool CGrapheneBlock::process(CNode *pfrom, std::string strCommand, std::shared_p
 
         try
         {
-            std::vector<uint64_t> blockCheapHashes = pGrapheneSet->Reconcile(mapPartialTxHash);
+            std::set<uint64_t> setSenderFilterPositiveCheapHashes;
 
-            // Ensure coinbase is first
-            if (blockCheapHashes[0] != GetShortID(shorttxidk0, shorttxidk1, coinbase->GetHash(), version))
+            // Populate tx hash array and cheap hash set for use by Graphene.
+            // Do it outside of CGrapheneSet so that we can reuse the tx hashes
+            // if failure recovery is necessary.
+            bool grSetComputeOpt = pGrapheneSet->GetComputeOptimized();
+            for (const auto &entry : mapPartialTxHash)
             {
-                auto it = std::find(blockCheapHashes.begin(), blockCheapHashes.end(),
-                    GetShortID(shorttxidk0, shorttxidk1, coinbase->GetHash(), version));
-
-                if (it == blockCheapHashes.end())
+                if ((grSetComputeOpt && pGrapheneSet->GetFastFilter()->contains(entry.second)) ||
+                    (!grSetComputeOpt && pGrapheneSet->GetRegularFilter()->contains(entry.second)))
                 {
-                    LOG(GRAPHENE, "Error: No coinbase transaction found in graphene block, peer=%s",
-                        pfrom->GetLogName());
-                    return false;
+                    setSenderFilterPositiveCheapHashes.insert(entry.first);
+                    vSenderFilterPositiveHahses.push_back(entry.second);
                 }
-
-                auto idx = std::distance(blockCheapHashes.begin(), it);
-
-                blockCheapHashes[idx] = blockCheapHashes[0];
-                blockCheapHashes[0] = GetShortID(shorttxidk0, shorttxidk1, coinbase->GetHash(), version);
             }
 
-            // Sort out what hashes we have from the complete set of cheapHashes
-            uint64_t nGrapheneTxsPossessed = 0;
-            for (size_t i = 0; i < blockCheapHashes.size(); i++)
-            {
-                uint64_t cheapHash = blockCheapHashes[i];
-
-                // If canonical order is not enabled or xversion is less than 1, update mapHashOrderIndex so
-                // it is available if we later receive missing txs
-                if (!fCanonicalTxsOrder || NegotiateGrapheneVersion(pfrom) < 1)
-                    grapheneBlock->mapHashOrderIndex[cheapHash] = i;
-
-                const auto &elem = mapPartialTxHash.find(cheapHash);
-                if (elem != mapPartialTxHash.end())
-                {
-                    grapheneBlock->vTxHashes256.push_back(elem->second);
-                    nGrapheneTxsPossessed++;
-                }
-                else
-                {
-                    grapheneBlock->vTxHashes256.push_back(nullhash);
-                    setHashesToRequest.insert(cheapHash);
-                }
-            }
+            std::vector<uint64_t> blockCheapHashes = pGrapheneSet->Reconcile(setSenderFilterPositiveCheapHashes);
+            setHashesToRequest = grapheneBlock->UpdateResolvedTxsAndIdentifyMissing(
+                mapPartialTxHash, blockCheapHashes, NegotiateGrapheneVersion(pfrom));
+            grapheneBlock->SituateCoinbase(coinbase);
 
             // Sort order transactions if canonical order is enabled and graphene version is late enough
             if (fCanonicalTxsOrder && NegotiateGrapheneVersion(pfrom) >= 1)
@@ -553,14 +618,22 @@ bool CGrapheneBlock::process(CNode *pfrom, std::string strCommand, std::shared_p
         }
         catch (const std::runtime_error &e)
         {
-            fRequestFailover = true;
+            fRequestFailureRecovery = true;
             graphenedata.IncrementDecodeFailures();
-            LOG(GRAPHENE, "Graphene set could not be reconciled; requesting failover for peer %s: %s\n",
-                pfrom->GetLogName(), e.what());
+            if (version >= 6)
+            {
+                LOG(GRAPHENE, "Graphene set could not be reconciled; requesting recovery from peer %s: %s\n",
+                    pfrom->GetLogName(), e.what());
+            }
+            else
+            {
+                LOG(GRAPHENE, "Graphene set could not be reconciled; requesting failover for peer %s: %s\n",
+                    pfrom->GetLogName(), e.what());
+            }
         }
 
         // Reconstruct the block if there are no hashes to re-request
-        if (setHashesToRequest.empty() && !fRequestFailover)
+        if (setHashesToRequest.empty() && !fRequestFailureRecovery)
         {
             bool mutated;
             uint256 merkleroot = ComputeMerkleRoot(grapheneBlock->vTxHashes256, &mutated);
@@ -577,9 +650,9 @@ bool CGrapheneBlock::process(CNode *pfrom, std::string strCommand, std::shared_p
     LOG(GRAPHENE, "Current in-memory graphene bytes size is %ld bytes\n", pblock->nCurrentBlockSize);
 
     // This must be checked outside of the above section or deadlock may occur.
-    if (fRequestFailover)
+    if (fRequestFailureRecovery)
     {
-        RequestFailoverBlock(pfrom, pblock);
+        RequestFailureRecovery(pfrom, grapheneBlock, vSenderFilterPositiveHahses);
         return true;
     }
 
@@ -616,7 +689,7 @@ bool CGrapheneBlock::process(CNode *pfrom, std::string strCommand, std::shared_p
     // and re-request failover block (This should never happen because we just checked the various pools).
     if (missingCount > 0)
     {
-        RequestFailoverBlock(pfrom, pblock);
+        RequestFailureRecovery(pfrom, grapheneBlock, vSenderFilterPositiveHahses);
         return error("Still missing transactions for graphene block: re-requesting failover block");
     }
 
@@ -1236,6 +1309,11 @@ void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CM
             CGrapheneBlock grapheneBlock(pblock, mempoolinfo.nTx, nSenderMempoolPlusBlock,
                 NegotiateGrapheneVersion(pfrom), NegotiateFastFilterSupport(pfrom));
 
+            {
+                LOCK(cs_graphenerecovery);
+                grapheneRecoveryBlock[pfrom->GetId()] = grapheneBlock;
+            }
+
             LOG(GRAPHENE, "Block %s to peer %s using Graphene version %d\n", grapheneBlock.header.GetHash().ToString(),
                 pfrom->GetLogName(), grapheneBlock.version);
 
@@ -1253,8 +1331,17 @@ void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CM
             }
             else
             {
+                LOCK(thinrelay.cs_graphene_sender);
                 graphenedata.UpdateOutBound(nSizeGrapheneBlock, nSizeBlock);
                 pfrom->PushMessage(NetMsgType::GRAPHENEBLOCK, grapheneBlock);
+
+                // First add transaction hashes to local graphene block
+                for (auto &tx : pblock->vtx)
+                {
+                    grapheneBlock.vTxHashes256.push_back(tx->GetHash());
+                }
+                // Next store graphene block in case receiver attempts failure recovery
+                thinrelay.mapGrapheneSentBlocks[pfrom->GetId()] = std::make_shared<CGrapheneBlock>(grapheneBlock);
                 LOG(GRAPHENE, "Sent graphene block - size: %d vs block size: %d => peer: %s\n", nSizeGrapheneBlock,
                     nSizeBlock, pfrom->GetLogName());
 
@@ -1334,6 +1421,193 @@ bool HandleGrapheneBlockRequest(CDataStream &vRecv, CNode *pfrom, const CChainPa
     return true;
 }
 
+bool HandleGrapheneBlockRecoveryRequest(CDataStream &vRecv, CNode *pfrom, const CChainParams &chainparams)
+{
+    CRequestGrapheneReceiverRecover recoveryRequest;
+    vRecv >> recoveryRequest;
+
+    std::shared_ptr<CGrapheneBlock> grapheneBlock;
+    {
+        LOCK(thinrelay.cs_graphene_sender);
+        auto it = thinrelay.mapGrapheneSentBlocks.find(pfrom->GetId());
+        if (it != thinrelay.mapGrapheneSentBlocks.end())
+            grapheneBlock = it->second;
+        else
+        {
+            return error("No block available to reconstruct for graphenetx");
+        }
+    }
+
+    // We had a block stored but it was the wrong one
+    if (grapheneBlock->header.GetHash() != recoveryRequest.blockhash)
+        return error("Sender does not have block for requested hash");
+
+    CGrapheneReceiverRecover recoveryResponse = CGrapheneReceiverRecover(
+        *recoveryRequest.pReceiverFilter, *grapheneBlock, recoveryRequest.nSenderFilterPositives, pfrom);
+    pfrom->PushMessage(NetMsgType::GRAPHENE_RECOVERY, recoveryResponse);
+
+    return true;
+}
+
+bool HandleGrapheneBlockRecoveryResponse(CDataStream &vRecv, CNode *pfrom, const CChainParams &chainparams)
+{
+    CGrapheneReceiverRecover recoveryResponse;
+    vRecv >> recoveryResponse;
+
+    auto pblock = thinrelay.GetBlockToReconstruct(pfrom, recoveryResponse.blockhash);
+    if (pblock == nullptr)
+        return error("No block available to reconstruct for graphenetx");
+    DbgAssert(pblock->grapheneblock != nullptr, return false);
+    CGrapheneBlock grapheneBlock = *(pblock->grapheneblock);
+
+    CIblt localIblt((*recoveryResponse.pRevisedIblt));
+    localIblt.reset();
+
+    // Initialize map with txs from various pools
+    std::map<uint64_t, uint256> mapTxFromPools;
+    pblock->grapheneblock->FillTxMapFromPools(mapTxFromPools);
+
+    // Insert additional txs and identify coinbase
+    CTransactionRef coinbase = nullptr;
+    for (auto &tx : pblock->grapheneblock->vAdditionalTxs)
+    {
+        const uint256 &hash = tx->GetHash();
+        uint64_t cheapHash = pblock->grapheneblock->pGrapheneSet->GetShortID(hash);
+
+        mapTxFromPools.insert(std::make_pair(cheapHash, hash));
+
+        if (tx->IsCoinBase())
+            coinbase = tx;
+    }
+
+    if (coinbase == nullptr)
+    {
+        LOG(GRAPHENE, "Error: No coinbase transaction found in graphene block, peer=%s", pfrom->GetLogName());
+        return false;
+    }
+
+    // Insert latest transactions just sent over
+    for (auto &tx : recoveryResponse.vMissingTxs)
+    {
+        uint256 hash = tx.GetHash();
+        uint64_t cheapHash = pblock->grapheneblock->pGrapheneSet->GetShortID(hash);
+
+        mapTxFromPools[cheapHash] = hash;
+        pblock->grapheneblock->mapMissingTx[cheapHash] = MakeTransactionRef(tx);
+    }
+
+    // Determine which txs pass filter and populate IBLT
+    std::set<uint64_t> setSenderFilterPositiveCheapHashes;
+    for (auto &pair : mapTxFromPools)
+    {
+        if ((pblock->grapheneblock->pGrapheneSet->GetComputeOptimized() &&
+                pblock->grapheneblock->pGrapheneSet->GetFastFilter()->contains(pair.second)) ||
+            (!pblock->grapheneblock->pGrapheneSet->GetComputeOptimized() &&
+                pblock->grapheneblock->pGrapheneSet->GetRegularFilter()->contains(pair.second)))
+        {
+            localIblt.insert(pair.first, IBLT_NULL_VALUE);
+            setSenderFilterPositiveCheapHashes.insert(pair.first);
+        }
+    }
+
+    // Attempt to reconcile IBLT
+    static std::vector<uint64_t> blockCheapHashes;
+    try
+    {
+        blockCheapHashes = CGrapheneSet::Reconcile(setSenderFilterPositiveCheapHashes, localIblt,
+            recoveryResponse.pRevisedIblt, pblock->grapheneblock->pGrapheneSet->GetEncodedRank(),
+            pblock->grapheneblock->pGrapheneSet->GetOrdered());
+    }
+    catch (const std::runtime_error &error)
+    {
+        // Graphene set still could not be reconciled
+        LOG(GRAPHENE, "Could not reconcile failure recovery Graphene set from peer=%s; requesting failover block\n",
+            pfrom->GetLogName());
+        RequestFailoverBlock(pfrom, pblock);
+        return true;
+    }
+
+    LOG(GRAPHENE, "Successfully reconciled failure recovery Graphene set from peer=%s\n", pfrom->GetLogName());
+
+    std::set<uint64_t> setHashesToRequest = pblock->grapheneblock->UpdateResolvedTxsAndIdentifyMissing(
+        mapTxFromPools, blockCheapHashes, NegotiateGrapheneVersion(pfrom));
+    pblock->grapheneblock->SituateCoinbase(coinbase);
+
+    // If there are missing transactions, we must request them here
+    if (setHashesToRequest.size() > 0)
+    {
+        pblock->grapheneblock->nWaitingFor = setHashesToRequest.size();
+        CRequestGrapheneBlockTx grapheneBlockTx(recoveryResponse.blockhash, setHashesToRequest);
+        pfrom->PushMessage(NetMsgType::GET_GRAPHENETX, grapheneBlockTx);
+
+        // Update run-time statistics of graphene block bandwidth savings
+        graphenedata.UpdateInBoundReRequestedTx(grapheneBlock.nWaitingFor);
+
+        return true;
+    }
+
+    int missingCount = 0;
+    int unnecessaryCount = 0;
+    pblock->grapheneblock->ValidateAndRecontructBlock(missingCount, unnecessaryCount, recoveryResponse.blockhash,
+        pblock, NetMsgType::GRAPHENE_RECOVERY, pfrom, vRecv);
+
+    if (missingCount > 0)
+    {
+        // This should never happen except in the event of attack or lost transactions from memory pool.
+        RequestFailoverBlock(pfrom, pblock);
+        return error("Failure recovery still missing transactions after reconstructing block from peer=%s: requesting "
+                     "failover block",
+            pfrom->GetLogName());
+    }
+
+    return true;
+}
+
+CRequestGrapheneReceiverRecover::CRequestGrapheneReceiverRecover(std::vector<uint256> &relevantHashes,
+    CGrapheneBlock &grapheneBlock,
+    uint64_t _nSenderFilterPositives)
+{
+    uint64_t grapheneSetVersion = CGrapheneBlock::GetGrapheneSetVersion(GRAPHENE_MAX_VERSION_SUPPORTED);
+    nSenderFilterPositives = _nSenderFilterPositives;
+    blockhash = grapheneBlock.header.GetHash();
+    uint64_t nReceiverUniverseItems = (uint64_t)std::max(_nSenderFilterPositives,
+        GetGrapheneMempoolInfo().nTx); // _nSenderFilterPositives could be larger when it contains the coinbase
+    uint64_t nItems = grapheneBlock.nBlockTxs;
+    pReceiverFilter = std::make_shared<CVariableFastFilter>(
+        grapheneBlock.pGrapheneSet->FailureRecoveryFilter(relevantHashes, nItems, nSenderFilterPositives,
+            nReceiverUniverseItems, FAILURE_RECOVERY_SUCCESS_RATE, grapheneBlock.fpr, grapheneSetVersion));
+}
+
+CGrapheneReceiverRecover::CGrapheneReceiverRecover(CVariableFastFilter &receiverFilter,
+    CGrapheneBlock &grapheneBlock,
+    uint64_t nSenderFilterPositiveItems,
+    CNode *pfrom)
+{
+    blockhash = grapheneBlock.header.GetHash();
+    uint64_t grapheneSetVersion = CGrapheneBlock::GetGrapheneSetVersion(GRAPHENE_MAX_VERSION_SUPPORTED);
+    uint64_t nReceiverUniverseItems = grapheneBlock.pGrapheneSet->GetNReceiverUniverseItems();
+    uint64_t nItems = grapheneBlock.nBlockTxs;
+
+    std::vector<uint256> vMissingTxIds;
+    std::set<uint64_t> vAllCheapHashes;
+    std::set<uint64_t> vMissingCheapHashes;
+    for (auto &hash : grapheneBlock.vTxHashes256)
+    {
+        if (!receiverFilter.contains(hash))
+            vMissingTxIds.push_back(hash);
+        else
+            vMissingCheapHashes.insert(grapheneBlock.pGrapheneSet->GetShortID(hash));
+
+        vAllCheapHashes.insert(grapheneBlock.pGrapheneSet->GetShortID(hash));
+    }
+
+    pRevisedIblt = std::make_shared<CIblt>(grapheneBlock.pGrapheneSet->FailureRecoveryIblt(vAllCheapHashes, nItems,
+        nSenderFilterPositiveItems, nReceiverUniverseItems, FAILURE_RECOVERY_SUCCESS_RATE, grapheneBlock.fpr,
+        grapheneSetVersion, (uint32_t)grapheneBlock.shorttxidk0));
+    std::vector<CTransaction> vTx = TransactionsFromBlockByCheapHash(vMissingCheapHashes, blockhash, pfrom);
+    std::copy(vTx.begin(), vTx.end(), back_inserter(vMissingTxs));
+}
+
 CMemPoolInfo GetGrapheneMempoolInfo()
 {
     // We need the number of transactions in the mempool and orphanpools but also the number
@@ -1345,6 +1619,17 @@ CMemPoolInfo GetGrapheneMempoolInfo()
     }
     return CMemPoolInfo(mempool.size() + orphanpool.GetOrphanPoolSize() + nCommitQ);
 }
+
+void RequestFailureRecovery(CNode *pfrom,
+    std::shared_ptr<CGrapheneBlock> grapheneBlock,
+    std::vector<uint256> vSenderFilterPositiveHahses)
+{
+    CRequestGrapheneReceiverRecover recoveryRequest = CRequestGrapheneReceiverRecover(
+        vSenderFilterPositiveHahses, *grapheneBlock, vSenderFilterPositiveHahses.size());
+
+    pfrom->PushMessage(NetMsgType::GET_GRAPHENE_RECOVERY, recoveryRequest);
+}
+
 void RequestFailoverBlock(CNode *pfrom, std::shared_ptr<CBlockThinRelay> pblock)
 {
     // Since we were unable process this graphene block then clear out the data and the graphene
@@ -1395,6 +1680,48 @@ void RequestFailoverBlock(CNode *pfrom, std::shared_ptr<CBlockThinRelay> pblock)
         LOG(GRAPHENE, "Requesting full block %s as failover from peer %s\n", blockhash.ToString(), pfrom->GetLogName());
         thinrelay.RequestBlock(pfrom, blockhash);
     }
+}
+
+std::vector<CTransaction> TransactionsFromBlockByCheapHash(std::set<uint64_t> &vCheapHashes,
+    uint256 blockhash,
+    CNode *pfrom)
+{
+    std::vector<CTransaction> vTx;
+    CBlockIndex *hdr = LookupBlockIndex(blockhash);
+    if (!hdr)
+    {
+        dosMan.Misbehaving(pfrom, 20);
+        throw std::runtime_error("Requested block is not available");
+    }
+    else
+    {
+        if (hdr->nHeight < (chainActive.Tip()->nHeight - DEFAULT_BLOCKS_FROM_TIP))
+            throw std::runtime_error("get_grblocktx request too far from the tip");
+
+        CBlock block;
+        const Consensus::Params &consensusParams = Params().GetConsensus();
+        if (!ReadBlockFromDisk(block, hdr, consensusParams))
+        {
+            // We do not assign misbehavior for not being able to read a block from disk because we already
+            // know that the block is in the block index from the step above. Secondly, a failure to read may
+            // be our own issue or the remote peer's issue in requesting too early.  We can't know at this point.
+            throw std::runtime_error(
+                "Cannot load block from disk -- Block txn request possibly received before assembled");
+        }
+        else
+        {
+            for (auto &tx : block.vtx)
+            {
+                uint64_t cheapHash = GetShortID(
+                    pfrom->gr_shorttxidk0, pfrom->gr_shorttxidk1, tx->GetHash(), NegotiateGrapheneVersion(pfrom));
+
+                if (vCheapHashes.count(cheapHash))
+                    vTx.push_back(*tx);
+            }
+        }
+    }
+
+    return vTx;
 }
 
 // Generate cheap hash from seeds using SipHash

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -409,7 +409,7 @@ extern CGrapheneBlockData graphenedata; // Singleton class
 
 /**
  * If CGrapheneSet fails to decode, then receiver communicates relevant contents of mempool by sending
- * a Bloom filter which contains all transactions from her mempool that passed through the sender's
+ * a Bloom filter which contains all transactions from its mempool that passed through the sender's
  * Bloom filter.
  **/
 class CRequestGrapheneReceiverRecover

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -10,6 +10,7 @@
 #include "bloom.h"
 #include "config.h"
 #include "consensus/validation.h"
+#include "fastfilter.h"
 #include "iblt.h"
 #include "primitives/block.h"
 #include "protocol.h"
@@ -31,9 +32,10 @@ enum FastFilterSupport
 
 const uint8_t GRAPHENE_FAST_FILTER_SUPPORT = EITHER;
 const uint64_t GRAPHENE_MIN_VERSION_SUPPORTED = 0;
-const uint64_t GRAPHENE_MAX_VERSION_SUPPORTED = 5;
+const uint64_t GRAPHENE_MAX_VERSION_SUPPORTED = 6;
 const unsigned char MIN_MEMPOOL_INFO_BYTES = 8;
 const uint8_t SHORTTXIDS_LENGTH = 8;
+const double FAILURE_RECOVERY_SUCCESS_RATE = 0.999;
 
 class CDataStream;
 class CNode;
@@ -85,6 +87,7 @@ public:
     std::shared_ptr<CGrapheneSet> pGrapheneSet;
     uint64_t version;
     bool computeOptimized;
+    double fpr;
 
 public:
     CGrapheneBlock(const CBlockRef pblock,
@@ -111,6 +114,23 @@ public:
     // Create seeds for SipHash using the sipHashNonce generated in the constructor
     // Note that this must be called any time members header or sipHashNonce are changed
     void FillShortTxIDSelector();
+
+    // Adds a new set of transactins after rerequesting or during failure recovery
+    void AddNewTransactions(std::vector<CTransaction> vMissingTx, CNode *pfrom);
+
+    // Order hashes in vTxHashes256
+    void OrderTxHashes(CNode *pfrom);
+
+    // Validates header and, if possible, determines if there are any missing or unnecessary transactions
+    // in the block
+    bool ValidateAndRecontructBlock(int &missingCount,
+        int &unnecessaryCount,
+        uint256 blockhash,
+        std::shared_ptr<CBlockThinRelay> pblock,
+        std::string command,
+        CNode *pfrom,
+        CDataStream &vRecv);
+
     /**
      * Handle an incoming Graphene block
      * Once the block is validated apart from the Merkle root, forward the Xpedited block with a hop count of nHops.
@@ -162,6 +182,8 @@ public:
                     std::make_shared<CGrapheneSet>(CGrapheneSet(CGrapheneBlock::GetGrapheneSetVersion(version)));
         }
         READWRITE(*pGrapheneSet);
+        if (version >= 6)
+            READWRITE(fpr);
     }
     uint64_t GetAdditionalTxSerializationSize()
     {
@@ -177,6 +199,12 @@ public:
 
     CInv GetInv() { return CInv(MSG_BLOCK, header.GetHash()); }
     bool process(CNode *pfrom, std::string strCommand, std::shared_ptr<CBlockThinRelay> pblock);
+    void FillTxMapFromPools(std::map<uint64_t, uint256> &mapTxFromPools);
+    void SituateCoinbase(std::vector<uint64_t> blockCheapHashes, CTransactionRef coinbase, uint64_t grapheneVersion);
+    void SituateCoinbase(CTransactionRef coinbase);
+    std::set<uint64_t> UpdateResolvedTxsAndIdentifyMissing(std::map<uint64_t, uint256> mapPartialTxHash,
+        std::vector<uint64_t> blockCheapHashes,
+        uint64_t grapheneVersion);
     bool CheckBlockHeader(const CBlockHeader &block, CValidationState &state);
 };
 
@@ -379,13 +407,104 @@ public:
 };
 extern CGrapheneBlockData graphenedata; // Singleton class
 
+/**
+ * If CGrapheneSet fails to decode, then receiver communicates relevant contents of mempool by sending
+ * a Bloom filter which contains all transactions from her mempool that passed through the sender's
+ * Bloom filter.
+ **/
+class CRequestGrapheneReceiverRecover
+{
+public:
+    /** Bloom filter containing transaction hashes that passed through sender's Bloom filter. */
+    std::shared_ptr<CVariableFastFilter> pReceiverFilter;
+    uint64_t nSenderFilterPositives;
+    uint256 blockhash;
+
+public:
+    CRequestGrapheneReceiverRecover(std::vector<uint256> &relevantHashes,
+        CGrapheneBlock &grapheneBlock,
+        uint64_t _nSenderFilterPositives);
+    CRequestGrapheneReceiverRecover() {}
+    ~CRequestGrapheneReceiverRecover() { pReceiverFilter = nullptr; }
+    /**
+     * Issue outgoing request for graphene recovery
+     * @param[in] vRecv        The raw binary message
+     * @param[in] pFrom        The node the message was from
+     * @return True if handling succeeded
+     */
+    static bool HandleMessage(CDataStream &vRecv, CNode *pfrom);
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action)
+    {
+        if (!pReceiverFilter)
+            pReceiverFilter = std::make_shared<CVariableFastFilter>();
+        READWRITE(*pReceiverFilter);
+        READWRITE(nSenderFilterPositives);
+        READWRITE(blockhash);
+    }
+};
+
+/**
+ * Respond to receiver's request for Graphene failure recovery. Using the filter sent by the
+ * receiver, formulate 1) the array of transactions from the block that the receiver is definitely
+ * missing and 2) a new IBLT that accounts for false positives in both the sender and receiver
+ * filters.
+ **/
+class CGrapheneReceiverRecover
+{
+public:
+    /** Transactions that receiver is definitely missing */
+    // FIXME: Consider not making these shared_ptrs
+    std::vector<CTransaction> vMissingTxs;
+    /** Revised IBLT that accounts for false positives */
+    std::shared_ptr<CIblt> pRevisedIblt;
+    uint256 blockhash;
+
+public:
+    CGrapheneReceiverRecover(CVariableFastFilter &receiverFilter,
+        CGrapheneBlock &grapheneBlock,
+        uint64_t _nSenderFilterPositives,
+        CNode *pfrom);
+    CGrapheneReceiverRecover() {}
+    ~CGrapheneReceiverRecover() { pRevisedIblt = nullptr; }
+    /**
+     * Issue outgoing response for graphene recovery
+     * @param[in] vRecv        The raw binary message
+     * @param[in] pFrom        The node the message was from
+     * @return True if handling succeeded
+     */
+    static bool HandleMessage(CDataStream &vRecv, CNode *pfrom);
+    ADD_SERIALIZE_METHODS;
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream &s, Operation ser_action)
+    {
+        READWRITE(vMissingTxs);
+
+        if (!pRevisedIblt)
+            pRevisedIblt = std::make_shared<CIblt>(CIblt());
+        READWRITE(*pRevisedIblt);
+        READWRITE(blockhash);
+    }
+};
 
 bool IsGrapheneBlockEnabled();
 void SendGrapheneBlock(CBlockRef pblock, CNode *pfrom, const CInv &inv, const CMemPoolInfo &mempoolinfo);
 bool IsGrapheneBlockValid(CNode *pfrom, const CBlockHeader &header);
 bool HandleGrapheneBlockRequest(CDataStream &vRecv, CNode *pfrom, const CChainParams &chainparams);
+bool HandleGrapheneBlockRecoveryResponse(CDataStream &vRecv, CNode *pfrom, const CChainParams &chainparams);
+bool HandleGrapheneBlockRecoveryRequest(CDataStream &vRecv, CNode *pfrom, const CChainParams &chainparams);
 CMemPoolInfo GetGrapheneMempoolInfo();
+void RequestFailureRecovery(CNode *pfrom,
+    std::shared_ptr<CGrapheneBlock> pblock,
+    std::vector<uint256> vSenderFilterPositiveHahses);
 void RequestFailoverBlock(CNode *pfrom, std::shared_ptr<CBlockThinRelay> pblock);
+// Load subset of transactions from block according to cheap hashes
+std::vector<CTransaction> TransactionsFromBlockByCheapHash(std::set<uint64_t> &vCheapHashes,
+    uint256 blockhash,
+    CNode *pfrom);
 // Generate cheap hash from seeds using SipHash
 uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &txhash, uint64_t grapheneVersion);
 // This method decides on the value of computeOptimized depending on what modes are supported

--- a/src/blockrelay/graphene_set.cpp
+++ b/src/blockrelay/graphene_set.cpp
@@ -430,14 +430,6 @@ uint64_t CGrapheneSet::UpperBoundFalsePositives(uint64_t nTargetItems,
         (1 + margin) * (nReceiverUniverseItems - nLowerBoundTruePositives) * senderBloomFpr);
 }
 
-double CGrapheneSet::FailureRecoveryFpr(uint64_t nItems,
-    uint64_t nReceiverUniverseItems,
-    double senderBloomFpr,
-    double successRate)
-{
-    return 1;
-}
-
 CVariableFastFilter CGrapheneSet::FailureRecoveryFilter(std::vector<uint256> &relevantHashes,
     uint64_t nItems,
     uint64_t nSenderFilterPositiveItems,

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -214,11 +214,6 @@ public:
         double senderBloomFpr,
         double successRate);
 
-    static double FailureRecoveryFpr(uint64_t nItems,
-        uint64_t nReceiverUniverseItems,
-        double senderBloomFpr,
-        double successRate);
-
     CVariableFastFilter FailureRecoveryFilter(std::vector<uint256> &relevantHashes,
         uint64_t nItems,
         uint64_t nSenderFilterPositiveItems,

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -40,7 +40,7 @@ struct GrapheneSetOptimizationParams
     uint64_t nReceiverExcessItems;
     uint64_t nReceiverMissingItems;
     double optSymDiff;
-    double fBloomFPR;
+    double bloomFPR;
 };
 
 class CGrapheneSet
@@ -56,7 +56,7 @@ private:
     std::shared_ptr<CBloomFilter> pSetFilter;
     std::shared_ptr<CVariableFastFilter> pFastFilter;
     std::shared_ptr<CIblt> pSetIblt;
-    double fBloomFPR;
+    double bloomFPR;
 
     static const uint8_t SHORTTXIDS_LENGTH = 8;
 
@@ -74,18 +74,18 @@ public:
     // The default constructor is for 2-phase construction via deserialization
     CGrapheneSet()
         : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), version(1), ibltSalt(0),
-          computeOptimized(false), pSetFilter(nullptr), pFastFilter(nullptr), pSetIblt(nullptr), fBloomFPR(1.0)
+          computeOptimized(false), pSetFilter(nullptr), pFastFilter(nullptr), pSetIblt(nullptr), bloomFPR(1.0)
     {
     }
     CGrapheneSet(uint64_t _version)
         : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), version(_version), ibltSalt(0),
-          computeOptimized(false), pSetFilter(nullptr), pFastFilter(nullptr), pSetIblt(nullptr), fBloomFPR(1.0)
+          computeOptimized(false), pSetFilter(nullptr), pFastFilter(nullptr), pSetIblt(nullptr), bloomFPR(1.0)
     {
     }
     CGrapheneSet(uint64_t _version, bool _computeOptimized)
         : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), version(_version), ibltSalt(0),
           computeOptimized(_computeOptimized), pSetFilter(nullptr), pFastFilter(nullptr), pSetIblt(nullptr),
-          fBloomFPR(1.0)
+          bloomFPR(1.0)
     {
     }
     CGrapheneSet(size_t _nReceiverUniverseItems,
@@ -176,7 +176,7 @@ public:
 
     static CIblt ConstructIblt(uint64_t nReceiverUniverseItems,
         double optSymDiff,
-        double fBloomFPR,
+        double bloomFPR,
         uint32_t ibltSalt,
         uint64_t graphenSetVersion,
         uint64_t nOverrideValue);
@@ -189,34 +189,34 @@ public:
 
     static double TruePositiveMargin(uint64_t nSenderFilterPositiveItems,
         uint64_t nReceiverUniverseItems,
-        double fSenderBloomFpr,
+        double senderBloomFpr,
         uint64_t nLowerBoundTruePositives);
 
     static double TruePositiveProbability(uint64_t nSenderFilterPositiveItems,
         uint64_t nReceiverUniverseItems,
-        double fSenderBloomFpr,
+        double senderBloomFpr,
         uint64_t nLowerBoundTruePositives);
 
     static uint64_t LowerBoundTruePositives(uint64_t nTargetItems,
         uint64_t nSenderFilterPositiveItems,
         uint64_t nReceiverUniverseItems,
-        double fSenderBloomFpr,
+        double senderBloomFpr,
         double successRate);
 
     static double FalsePositiveMargin(uint64_t nLowerBoundTruePositives,
         uint64_t nReceiverUniverseItems,
-        double fSenderBloomFpr,
+        double senderBloomFpr,
         double successRate);
 
     static uint64_t UpperBoundFalsePositives(uint64_t nTargetItems,
         uint64_t nSenderFilterPositiveItems,
         uint64_t nReceiverUniverseItems,
-        double fSenderBloomFpr,
+        double senderBloomFpr,
         double successRate);
 
     static double FailureRecoveryFpr(uint64_t nItems,
         uint64_t nReceiverUniverseItems,
-        double fSenderBloomFpr,
+        double senderBloomFpr,
         double successRate);
 
     CVariableFastFilter FailureRecoveryFilter(std::vector<uint256> &relevantHashes,
@@ -224,7 +224,7 @@ public:
         uint64_t nSenderFilterPositiveItems,
         uint64_t nReceiverRevisedUniverseItems,
         double successRate,
-        double fSenderBloomFPR,
+        double senderBloomFpr,
         uint64_t grapheneSetVersion);
 
     CIblt FailureRecoveryIblt(std::set<uint64_t> &relevantCheapHashes,
@@ -232,7 +232,7 @@ public:
         uint64_t nSenderFilterPositiveItems,
         uint64_t nReceiverRevisedUniverseItems,
         double successRate,
-        double fSenderBloomFPR,
+        double senderBloomFpr,
         uint64_t grapheneSetVersion,
         uint32_t ibltSaltRevised);
 
@@ -243,7 +243,7 @@ public:
     static uint8_t NChecksumBits(size_t nIbltEntries,
         uint8_t nIbltHashFuncs,
         uint64_t nReceiverUniverseItems,
-        double fBloomFPR,
+        double bloomFPR,
         double fUncheckedErrorTol);
 
     uint64_t GetFilterSerializationSize()
@@ -307,7 +307,7 @@ public:
             pSetIblt = std::make_shared<CIblt>(CIblt(CGrapheneSet::GetCIbltVersion(version)));
         READWRITE(*pSetIblt);
         if (version >= 5)
-            READWRITE(fBloomFPR);
+            READWRITE(bloomFPR);
     }
 };
 

--- a/src/blockrelay/graphene_set.h
+++ b/src/blockrelay/graphene_set.h
@@ -35,6 +35,14 @@ const uint8_t MIN_CHECKSUM_BITS = 10;
 const uint8_t MAX_CHECKSUM_BITS = 32;
 
 
+struct GrapheneSetOptimizationParams
+{
+    uint64_t nReceiverExcessItems;
+    uint64_t nReceiverMissingItems;
+    double optSymDiff;
+    double fBloomFPR;
+};
+
 class CGrapheneSet
 {
 private:
@@ -48,6 +56,7 @@ private:
     std::shared_ptr<CBloomFilter> pSetFilter;
     std::shared_ptr<CVariableFastFilter> pFastFilter;
     std::shared_ptr<CIblt> pSetIblt;
+    double fBloomFPR;
 
     static const uint8_t SHORTTXIDS_LENGTH = 8;
 
@@ -65,17 +74,18 @@ public:
     // The default constructor is for 2-phase construction via deserialization
     CGrapheneSet()
         : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), version(1), ibltSalt(0),
-          computeOptimized(false), pSetFilter(nullptr), pFastFilter(nullptr), pSetIblt(nullptr)
+          computeOptimized(false), pSetFilter(nullptr), pFastFilter(nullptr), pSetIblt(nullptr), fBloomFPR(1.0)
     {
     }
     CGrapheneSet(uint64_t _version)
         : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), version(_version), ibltSalt(0),
-          computeOptimized(false), pSetFilter(nullptr), pFastFilter(nullptr), pSetIblt(nullptr)
+          computeOptimized(false), pSetFilter(nullptr), pFastFilter(nullptr), pSetIblt(nullptr), fBloomFPR(1.0)
     {
     }
     CGrapheneSet(uint64_t _version, bool _computeOptimized)
         : ordered(false), nReceiverUniverseItems(0), shorttxidk0(0), shorttxidk1(0), version(_version), ibltSalt(0),
-          computeOptimized(_computeOptimized), pSetFilter(nullptr), pFastFilter(nullptr), pSetIblt(nullptr)
+          computeOptimized(_computeOptimized), pSetFilter(nullptr), pFastFilter(nullptr), pSetIblt(nullptr),
+          fBloomFPR(1.0)
     {
     }
     CGrapheneSet(size_t _nReceiverUniverseItems,
@@ -91,11 +101,18 @@ public:
 
     // Generate cheap hash from seeds using SipHash
     uint64_t GetShortID(const uint256 &txhash) const;
-
+    uint64_t GetNReceiverUniverseItems() const { return nReceiverUniverseItems; }
+    bool GetOrdered() const { return ordered; }
+    bool GetComputeOptimized() const { return computeOptimized; }
+    std::vector<unsigned char> GetEncodedRank() const { return encodedRank; }
+    std::shared_ptr<CIblt> GetIblt() const { return pSetIblt; }
+    std::shared_ptr<CBloomFilter> GetRegularFilter() const { return pSetFilter; }
+    std::shared_ptr<CVariableFastFilter> GetFastFilter() const { return pFastFilter; }
     /* Optimal symmetric difference between block txs and receiver mempool txs passing
      * though filter to use for IBLT.
      */
-    double OptimalSymDiff(uint64_t nBlockTxs,
+    static double OptimalSymDiff(uint64_t version,
+        uint64_t nBlockTxs,
         uint64_t nReceiverPoolTx,
         uint64_t nReceiverExcessTxs = 0,
         uint64_t nReceiverMissingTxs = 1);
@@ -110,7 +127,7 @@ public:
      * For details see
      * https://github.com/bissias/graphene-experiments/blob/master/jupyter/graphene_size_optimization.ipynb
      */
-    double ApproxOptimalSymDiff(uint64_t nBlockTxs, uint8_t nChecksumBits = MAX_CHECKSUM_BITS);
+    static double ApproxOptimalSymDiff(uint64_t version, uint64_t nBlockTxs, uint8_t nChecksumBits = MAX_CHECKSUM_BITS);
 
     /* Brute force search for optimal symmetric difference between block txs and receiver
      * mempool txs passing though filter to use for IBLT.
@@ -121,7 +138,7 @@ public:
      * The total size in bytes of a graphene block is given by T(a) = F(a) + L(a) as defined
      * in the code below. (Note that meta parameters for the Bloom Filter and IBLT are ignored).
      */
-    double BruteForceSymDiff(uint64_t nBlockTxs,
+    static double BruteForceSymDiff(uint64_t nBlockTxs,
         uint64_t nReceiverPoolTx,
         uint64_t nReceiverExcessTxs,
         uint64_t nReceiverMissingTxs,
@@ -131,17 +148,93 @@ public:
     // of cheap hashes in the block in the correct order
     std::vector<uint64_t> Reconcile(const std::vector<uint256> &receiverItemHashes);
 
+    // This version assumes that we know the set that have passed through the sender Bloom filter
+    std::vector<uint64_t> Reconcile(const std::set<uint64_t> &setSenderFilterPositiveCheapHashes);
+
     // Pass a map of cheap hash to transaction hashes that the local machine has to reconcile with the remote and
     // return a list of cheap hashes in the block in the correct order
     std::vector<uint64_t> Reconcile(const std::map<uint64_t, uint256> &mapCheapHashes);
 
-    std::vector<uint64_t> Reconcile(std::set<uint64_t> &receiverSet, const CIblt &localIblt);
+    static std::vector<uint64_t> Reconcile(const std::map<uint64_t, uint256> &mapCheapHashes,
+        std::shared_ptr<CIblt> _pSetIblt,
+        std::shared_ptr<CBloomFilter> _pSetFilter,
+        std::shared_ptr<CVariableFastFilter> _pFastFilter,
+        std::vector<unsigned char> _encodedRank,
+        bool _computeOptimized,
+        bool _ordered);
+
+    static std::vector<uint64_t> Reconcile(const std::set<uint64_t> &setSenderFilterPositiveCheapHashes,
+        const CIblt &localIblt,
+        std::shared_ptr<CIblt> _pSetIblt,
+        std::vector<unsigned char> _encodedRank,
+        bool _ordered);
+
+    static GrapheneSetOptimizationParams DetermineGrapheneSetOptimizationParams(uint64_t nReceiverUniverseItems,
+        uint64_t nSenderUniverseItems,
+        uint64_t nItems,
+        uint64_t version);
+
+    static CIblt ConstructIblt(uint64_t nReceiverUniverseItems,
+        double optSymDiff,
+        double fBloomFPR,
+        uint32_t ibltSalt,
+        uint64_t graphenSetVersion,
+        uint64_t nOverrideValue);
 
     static std::vector<unsigned char> EncodeRank(std::vector<uint64_t> items, uint16_t nBitsPerItem);
 
     static std::vector<uint64_t> DecodeRank(std::vector<unsigned char> encoded, size_t nItems, uint16_t nBitsPerItem);
 
     static double BloomFalsePositiveRate(double optSymDiff, uint64_t nReceiverExcessItems);
+
+    static double TruePositiveMargin(uint64_t nSenderFilterPositiveItems,
+        uint64_t nReceiverUniverseItems,
+        double fSenderBloomFpr,
+        uint64_t nLowerBoundTruePositives);
+
+    static double TruePositiveProbability(uint64_t nSenderFilterPositiveItems,
+        uint64_t nReceiverUniverseItems,
+        double fSenderBloomFpr,
+        uint64_t nLowerBoundTruePositives);
+
+    static uint64_t LowerBoundTruePositives(uint64_t nTargetItems,
+        uint64_t nSenderFilterPositiveItems,
+        uint64_t nReceiverUniverseItems,
+        double fSenderBloomFpr,
+        double successRate);
+
+    static double FalsePositiveMargin(uint64_t nLowerBoundTruePositives,
+        uint64_t nReceiverUniverseItems,
+        double fSenderBloomFpr,
+        double successRate);
+
+    static uint64_t UpperBoundFalsePositives(uint64_t nTargetItems,
+        uint64_t nSenderFilterPositiveItems,
+        uint64_t nReceiverUniverseItems,
+        double fSenderBloomFpr,
+        double successRate);
+
+    static double FailureRecoveryFpr(uint64_t nItems,
+        uint64_t nReceiverUniverseItems,
+        double fSenderBloomFpr,
+        double successRate);
+
+    CVariableFastFilter FailureRecoveryFilter(std::vector<uint256> &relevantHashes,
+        uint64_t nItems,
+        uint64_t nSenderFilterPositiveItems,
+        uint64_t nReceiverRevisedUniverseItems,
+        double successRate,
+        double fSenderBloomFPR,
+        uint64_t grapheneSetVersion);
+
+    CIblt FailureRecoveryIblt(std::set<uint64_t> &relevantCheapHashes,
+        uint64_t nItems,
+        uint64_t nSenderFilterPositiveItems,
+        uint64_t nReceiverRevisedUniverseItems,
+        double successRate,
+        double fSenderBloomFPR,
+        uint64_t grapheneSetVersion,
+        uint32_t ibltSaltRevised);
 
     /* This method calculates the number of bits required for the IBLT cell checksum in order to
      * achieve unchecked error tolerance fUncheckedErrorTol. Details can be found at the link below.
@@ -213,6 +306,8 @@ public:
         if (!pSetIblt)
             pSetIblt = std::make_shared<CIblt>(CIblt(CGrapheneSet::GetCIbltVersion(version)));
         READWRITE(*pSetIblt);
+        if (version >= 5)
+            READWRITE(fBloomFPR);
     }
 };
 

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -439,6 +439,22 @@ CTweak<uint64_t> grapheneFastFilterCompatibility("net.grapheneFastFilterCompatib
     "Support fast Bloom filter: 0 - either, 1 - fast only, 2 - regular only (default: either)",
     GRAPHENE_FAST_FILTER_SUPPORT);
 
+/** This setting overrides the number of cells (excluding overhead) in the initial IBLT
+ * sent using Graphene. The intent is to enable the first stage of the Graphene protocol
+ * to fail in order to test the second stage.
+ */
+CTweak<uint64_t> grapheneIbltSizeOverride("net.grapheneIbltSizeOverride",
+    "Override size of Iblt to the indicated value (greater than 0): 0 for optimal (default: 0)",
+    0);
+
+/** This setting overrides the false positive rate in the initial Bloom filter sent using
+ * Graphene. The intent is to enable the first stage of the Graphene protocol to fail in
+ * order to test the second stage.
+ */
+CTweak<double> grapheneBloomFprOverride("net.grapheneBloomFprOverride",
+    "Override size of Bloom filter to the indicated value (greater than 0.0): 0.0 for optimal (default: 0.0)",
+    0.0);
+
 CTweak<bool> syncMempoolWithPeers("net.syncMempoolWithPeers", "Synchronize mempool with peers", false);
 
 /** This setting specifies the minimum supported mempool sync version (inclusive).
@@ -510,6 +526,8 @@ CStatHistory<uint64_t> nBlockValidationTime("blockValidationTime", STAT_OP_MAX |
 // Single classes for gather thin type block relay statistics
 CThinBlockData thindata;
 CGrapheneBlockData graphenedata;
+CCriticalSection cs_graphenerecovery;
+std::map<NodeId, CGrapheneBlock> grapheneRecoveryBlock GUARDED_BY(cs_graphenerecovery);
 CCompactBlockData compactdata;
 ThinTypeRelay thinrelay;
 CCriticalSection cs_mempoolsync;

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -526,8 +526,6 @@ CStatHistory<uint64_t> nBlockValidationTime("blockValidationTime", STAT_OP_MAX |
 // Single classes for gather thin type block relay statistics
 CThinBlockData thindata;
 CGrapheneBlockData graphenedata;
-CCriticalSection cs_graphenerecovery;
-std::map<NodeId, CGrapheneBlock> grapheneRecoveryBlock GUARDED_BY(cs_graphenerecovery);
 CCompactBlockData compactdata;
 ThinTypeRelay thinrelay;
 CCriticalSection cs_mempoolsync;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -161,6 +161,9 @@ void FinalizeNode(NodeId nodeid)
     thinrelay.ClearAllBlocksToReconstruct(nodeid);
     thinrelay.ClearAllBlocksInFlight(nodeid);
 
+    // Clear Graphene blocks held by sender for this receiver
+    thinrelay.ClearSentGrapheneBlocks(nodeid);
+
     // Update block sync counters
     {
         CNodeStateAccessor state(nodestate, nodeid);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,9 +105,6 @@ extern std::map<uint256, NodeId> mapBlockSource;
 extern std::set<int> setDirtyFileInfo;
 extern uint64_t nBlockSequenceId;
 
-extern CCriticalSection cs_graphenerecovery;
-extern std::map<NodeId, CGrapheneBlock> grapheneRecoveryBlock;
-
 
 /** Number of nodes with fSyncStarted. */
 int nSyncStarted = 0;
@@ -148,12 +145,6 @@ void InitializeNode(const CNode *pnode)
 
 void FinalizeNode(NodeId nodeid)
 {
-    // Clear graphene block kept around for failure recovery
-    {
-        LOCK(cs_graphenerecovery);
-        grapheneRecoveryBlock.erase(nodeid);
-    }
-
     // Clean up the sync maps
     ClearDisconnectedFromMempoolSyncMaps(nodeid);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,6 +105,9 @@ extern std::map<uint256, NodeId> mapBlockSource;
 extern std::set<int> setDirtyFileInfo;
 extern uint64_t nBlockSequenceId;
 
+extern CCriticalSection cs_graphenerecovery;
+extern std::map<NodeId, CGrapheneBlock> grapheneRecoveryBlock;
+
 
 /** Number of nodes with fSyncStarted. */
 int nSyncStarted = 0;
@@ -145,6 +148,12 @@ void InitializeNode(const CNode *pnode)
 
 void FinalizeNode(NodeId nodeid)
 {
+    // Clear graphene block kept around for failure recovery
+    {
+        LOCK(cs_graphenerecovery);
+        grapheneRecoveryBlock.erase(nodeid);
+    }
+
     // Clean up the sync maps
     ClearDisconnectedFromMempoolSyncMaps(nodeid);
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1700,6 +1700,24 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         return CGrapheneBlockTx::HandleMessage(vRecv, pfrom);
     }
 
+    else if (strCommand == NetMsgType::GET_GRAPHENE_RECOVERY && IsGrapheneBlockEnabled() && grapheneVersionCompatible)
+    {
+        if (!requester.CheckForRequestDOS(pfrom, chainparams))
+            return false;
+
+        LOCK(pfrom->cs_graphene);
+        return HandleGrapheneBlockRecoveryRequest(vRecv, pfrom, chainparams);
+    }
+
+    else if (strCommand == NetMsgType::GRAPHENE_RECOVERY && IsGrapheneBlockEnabled() && grapheneVersionCompatible)
+    {
+        if (!requester.CheckForRequestDOS(pfrom, chainparams))
+            return false;
+
+        LOCK(pfrom->cs_graphene);
+        return HandleGrapheneBlockRecoveryResponse(vRecv, pfrom, chainparams);
+    }
+
     // Handle Compact Blocks
     else if (strCommand == NetMsgType::CMPCTBLOCK && !fImporting && !fReindex && !IsInitialBlockDownload() &&
              IsCompactBlocksEnabled())

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -50,6 +50,8 @@ const char *GRAPHENEBLOCK = "grblk";
 const char *GRAPHENETX = "grblktx";
 const char *GET_GRAPHENETX = "get_grblktx";
 const char *GET_GRAPHENE = "get_grblk";
+const char *GET_GRAPHENE_RECOVERY = "get_grrec";
+const char *GRAPHENE_RECOVERY = "grrec";
 // BUIPXXX Graphene - end section
 // Mempool sync - begin section
 const char *MEMPOOLSYNC = "memsync";
@@ -94,6 +96,7 @@ const static std::string allNetMessageTypes[] = {
     NetMsgType::XPEDITEDREQUEST, NetMsgType::XPEDITEDBLK, NetMsgType::XPEDITEDTXN, NetMsgType::BUVERSION,
     NetMsgType::BUVERACK, NetMsgType::XVERSION, NetMsgType::XVERACK, NetMsgType::XUPDATE, NetMsgType::SENDCMPCT,
     NetMsgType::SENDCMPCT, NetMsgType::CMPCTBLOCK, NetMsgType::GETBLOCKTXN, NetMsgType::BLOCKTXN,
+    NetMsgType::GET_GRAPHENE_RECOVERY, NetMsgType::GRAPHENE_RECOVERY,
 
 };
 const static std::vector<std::string> allNetMessageTypesVec(allNetMessageTypes,

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -180,6 +180,16 @@ extern const char *GET_GRAPHENETX;
  */
 extern const char *GET_GRAPHENE;
 /**
+ * The get_graphene_recovery message transmits a single serialized
+ * RequestGrapheneReceiverRecover object.
+ */
+extern const char *GET_GRAPHENE_RECOVERY;
+/**
+ * The graphene_recovery message transmits a single serialized
+ * CGrapheneReceiverRecover object.
+ */
+extern const char *GRAPHENE_RECOVERY;
+/**
  * The mempoolsync message transmits a single serialized get_memsync.
  */
 extern const char *MEMPOOLSYNC;

--- a/src/test/test_bitcoin_fuzzy.cpp
+++ b/src/test/test_bitcoin_fuzzy.cpp
@@ -529,6 +529,7 @@ protected:
 
         try
         {
+            uint64_t gs_version = CGrapheneBlock::GetGrapheneSetVersion(GRAPHENE_MAX_VERSION_SUPPORTED);
             gs = std::make_shared<CGrapheneSet>(
                 nReceiverUniverseItems, nReceiverUniverseItems, itemHashes, 0, 0, true, ordered, fDeterministic);
 
@@ -544,7 +545,7 @@ protected:
                     *ds >> nBlockTx;
                     *ds >> nReceiverPoolTx;
                     if ((nReceiverPoolTx >= nBlockTx - 1))
-                        out << gs->OptimalSymDiff(nBlockTx, nReceiverPoolTx);
+                        out << CGrapheneSet::OptimalSymDiff(gs_version, nBlockTx, nReceiverPoolTx);
                 }
                 break;
                 case 1:


### PR DESCRIPTION
Graphene is a probabilistic set reconciliation protocol that trades smaller block sizes for an increase in failure rate. Currently, Graphene is tuned so that one block is expected to fail each day, but far fewer failures are observed in practice. Nevertheless, failures do occur and the remedy is to restart the block download process using an alternative protocol such as XThin or Compact Blocks. The goal of this PR is to implement the failure recovery scheme introduced in the [most recent](https://people.cs.umass.edu/~gbiss/graphene.sigcomm.pdf) Graphene paper in order to salvage the block instead of starting over.

**Parameter estimation**. The failure recovery protocol uses a second Bloom filter and IBLT. One of the most important aspects to achieving optimal failure recovery size and performance is in properly setting the parameters for these data structures as detailed in the paper. I have made a [separate effort](https://github.com/bissias/graphene-experiments/blob/master/jupyter/graphene_v2_param_estimates.ipynb) to the translate the equations from the paper into python code, which I then compared against the paper's numerical results for several representative examples. For this PR, I translated the python code to C++ and also implemented a unit test to ensure that output for one example test point matches that of the python code.

**Other testing**. In addition to the unit test above, I have added CTweak hooks that allow the first stage of Graphene to be deliberately failed. A QA test in the python test framework uses these tweaks to verify that failure recovery works end-to-end. Finally, I have been running this branch on mainnet for almost 100 blocks without issue, but have not yet seen a failure in the first stage of Graphene, so more time is needed to verify that failure recovery is working in a full deployment.

Edit: After roughly 700 blocks, there have been 7 decode failures. Each failure has been successfully recovered by the failure recovery mechanism.