### PR TITLE
set the mempoolminfee to be the max of either the minrelaytxfee

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1335,8 +1335,9 @@ UniValue mempoolInfoToJSON()
     ret.pushKV("usage", (int64_t)mempool.DynamicMemoryUsage());
     size_t maxmempool = GetArg("-maxmempool", DEFAULT_MAX_MEMPOOL_SIZE) * 1000000;
     ret.pushKV("maxmempool", (int64_t)maxmempool);
-    ret.pushKV("mempoolminfee", ValueFromAmount(mempool.GetMinFee(maxmempool).GetFeePerK()));
-
+    int64_t minfee =
+        std::max((int64_t)::minRelayTxFee.GetFeePerK(), (int64_t)mempool.GetMinFee(maxmempool).GetFeePerK());
+    ret.pushKV("mempoolminfee", ValueFromAmount(minfee));
     double smoothedTps = 0.0, instantaneousTps = 0.0, peakTps = 0.0;
     mempool.GetTransactionRateStatistics(smoothedTps, instantaneousTps, peakTps);
     try


### PR DESCRIPTION
or the fee that would cause the mempool to start evicting transactions.

Currently the minrelaytxfee is not considered however we limit
mempool entry by this value so it makes sense to report it as the
minfee if it is indeed the higher limiting value.