### PR TITLE
Build info

### DIFF
--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -1,0 +1,104 @@
+# OpenBSD build guide
+(updated for FreeBSD 12.1)
+
+This guide describes how to build bitcoind and command-line utilities on FreeBSD.
+
+We will not cover building the GUI.
+
+**Important**: use `gmake`, not `make`. The non-GNU `make` will exit with a horrible error.
+
+## Preparation
+
+Run the following as root to install the base dependencies for building:
+
+```bash
+pkg install autoconf automake gmake git libevent libtool boost-libs pkgconf openssl
+pkg install python
+```
+
+See [dependencies.md](dependencies.md) for a complete overview.
+
+
+## Building Bitcoin Unlimited
+
+As your normal (non root) user, go through the steps below
+
+### Fetch the code
+
+```bash
+git clone https://github.com/BitcoinUnlimited/BitcoinUnlimited.git
+cd BitcoinUnlimited/
+```
+
+### Preparation
+
+```bash
+export MAKE=gmake
+```
+
+Now you need to choose to build without or with wallet functionality. If you just require a running node, you generally don't need wallet functionality
+
+### To build without wallet
+
+While in the `BitcoinUnlimited` directory
+
+```bash
+./autogen.sh
+./configure --disable-wallet --with-gui=no
+gmake # You may get an error with one of the tests.
+```
+
+You will find the `bitcoind` binary in the `src/` folder.
+
+
+### To build with wallet
+
+To stay backwards compatible with old walletfiles we specifically need BerkeleyDB 4.8.
+You cannot use the BerkeleyDB library from ports.
+
+
+#### Building BerkeleyDB
+
+BerkeleyDB is only necessary for the wallet functionality. To skip this, pass `--disable-wallet` to `./configure`. See above.
+
+To build Berkeley DB 4.8:
+
+```bash
+# Pick some path to install BDB to, here we create a directory within the bitcoin directory
+BDB_PREFIX=$(pwd)/db4
+mkdir -p $BDB_PREFIX
+
+# Fetch the source and verify that it is not tampered with
+curl 'https://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz' -o db-4.8.30.NC.tar.gz
+echo '12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz' | sha256 -c
+# MUST output: (SHA256) db-4.8.30.NC.tar.gz: OK
+tar -xzf db-4.8.30.NC.tar.gz
+
+# Fetch, verify that it is not tampered with and apply clang related patch
+cd db-4.8.30.NC/
+curl 'https://gist.githubusercontent.com/LnL7/5153b251fd525fe15de69b67e63a6075/raw/7778e9364679093a32dec2908656738e16b6bdcb/clang.patch' -o clang.patch
+echo '7a9a47b03fd5fb93a16ef42235fa9512db9b0829cfc3bdf90edd3ec1f44d637c  clang.patch' | sha256 -c
+# MUST output: (SHA256) clang.patch: OK
+patch -p2 < clang.patch
+
+# Build the library and install to specified prefix
+cd build_unix/
+../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
+gmake install
+cd ../..
+```
+
+You should now have the required files in `db4/lib/` and `db4/include/`.
+
+### To build with wallet
+
+Make sure `BDB_PREFIX` is set to the appropriate path from building BDB. See above.
+
+While in the `BitcoinUnlimited` directory.
+
+```bash
+./autogen.sh
+./configure LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/" --with-gui=no
+gmake
+```
+

--- a/doc/build-freebsd.md
+++ b/doc/build-freebsd.md
@@ -12,8 +12,7 @@ We will not cover building the GUI.
 Run the following as root to install the base dependencies for building:
 
 ```bash
-pkg install autoconf automake gmake git libevent libtool boost-libs pkgconf openssl
-pkg install python
+pkg install autoconf automake gmake git libevent libtool boost-libs pkgconf openssl python
 ```
 
 See [dependencies.md](dependencies.md) for a complete overview.
@@ -70,20 +69,20 @@ mkdir -p $BDB_PREFIX
 
 # Fetch the source and verify that it is not tampered with
 curl 'https://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz' -o db-4.8.30.NC.tar.gz
-echo '12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz' | sha256 -c
-# MUST output: (SHA256) db-4.8.30.NC.tar.gz: OK
+echo '12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz' | shasum -c
+# MUST output: db-4.8.30.NC.tar.gz: OK
 tar -xzf db-4.8.30.NC.tar.gz
 
 # Fetch, verify that it is not tampered with and apply clang related patch
 cd db-4.8.30.NC/
 curl 'https://gist.githubusercontent.com/LnL7/5153b251fd525fe15de69b67e63a6075/raw/7778e9364679093a32dec2908656738e16b6bdcb/clang.patch' -o clang.patch
-echo '7a9a47b03fd5fb93a16ef42235fa9512db9b0829cfc3bdf90edd3ec1f44d637c  clang.patch' | sha256 -c
-# MUST output: (SHA256) clang.patch: OK
+echo '7a9a47b03fd5fb93a16ef42235fa9512db9b0829cfc3bdf90edd3ec1f44d637c  clang.patch' | shasum -c
+# MUST output: clang.patch: OK
 patch -p2 < clang.patch
 
 # Build the library and install to specified prefix
 cd build_unix/
-../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
+./../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
 gmake install
 cd ../..
 ```

--- a/doc/build-openbsd.md
+++ b/doc/build-openbsd.md
@@ -7,7 +7,7 @@ As OpenBSD is most common as a server OS, we will not bother with the GUI.
 
 **Important**: use `gmake`, not `make`. The non-GNU `make` will exit with a horrible error.
 
-## Preparation
+## Installing dependencies
 
 Run the following as root to install the base dependencies for building:
 

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -305,13 +305,14 @@ scanelf -e ./bitcoind
 
 If you want to build statically linked binaries so that you could compile in one machine
 and deploy in same parch/platform boxes without the need of installing all the dependencies
-just follow these steps:
+just follow these steps. You will need to install `curl`.
 
 ```bash
 git clone https://github.com/BitcoinUnlimited/BitcoinUnlimited.git BU
 cd BU/depends
 make HOST=x86_64-pc-linux-gnu NO_QT=1 -j4
 cd ..
+./autogen.sh
 ./configure --prefix=$PWD/depends/x86_64-pc-linux-gnu --without-gui
 make -j4
 ```
@@ -338,6 +339,7 @@ To build executables for ARM:
 cd depends
 make HOST=arm-linux-gnueabihf NO_QT=1
 cd ..
+./autogen.sh
 ./configure --prefix=$PWD/depends/arm-linux-gnueabihf --enable-glibc-back-compat --enable-reduce-exports LDFLAGS=-static-libstdc++
 make
 ```

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -186,14 +186,22 @@ mkdir -p $BDB_PREFIX
 # Fetch the source and verify that it is not tampered with
 wget 'https://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
 echo '12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef  db-4.8.30.NC.tar.gz' | sha256sum -c
-# -> db-4.8.30.NC.tar.gz: OK
+# MUST output: db-4.8.30.NC.tar.gz: OK
 tar -xzvf db-4.8.30.NC.tar.gz
 
+# Fetch, verify that it is not tampered with and apply clang related patch
+cd db-4.8.30.NC
+wget 'https://gist.githubusercontent.com/LnL7/5153b251fd525fe15de69b67e63a6075/raw/7778e9364679093a32dec2908656738e16b6bdcb/clang.patch'
+echo '7a9a47b03fd5fb93a16ef42235fa9512db9b0829cfc3bdf90edd3ec1f44d637c clang.patch' | sha256sum -c
+# MUTST output: clang.patch: OK
+
 # Build the library and install to our prefix
-cd db-4.8.30.NC/build_unix/
+cd build_unix/
 #  Note: Do a static build so that it can be embedded into the executable, instead of having to find a .so at runtime
 ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=$BDB_PREFIX
 make install
+
+# Build Bitcoin Unlimited with the BDB you just compiled.
 cd $BITCOIN_ROOT
 ./autogen.sh
 ./configure LDFLAGS="-L${BDB_PREFIX}/lib/" CPPFLAGS="-I${BDB_PREFIX}/include/" # (other args...)

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -273,10 +273,10 @@ Hardening enables the following features:
     On an AMD64 processor where a library was not compiled with -fPIC, this will cause an error
     such as: "relocation R_X86_64_32 against `......' can not be used when making a shared object;"
 
-    To test that you have built PIE executable, install scanelf, part of paxutils, and use:
+    To test that you have built PIE executable, install `scanelf`, part of `pax-utils`, and use:
 
 ```bash
-scanelf -e ./bitcoin
+scanelf -e ./bitcoind
 ```
 
     The output should contain:
@@ -292,7 +292,7 @@ scanelf -e ./bitcoin
     executable without the non-executable stack protection.
 
     To verify that the stack is non-executable after compiling use:
-    `scanelf -e ./bitcoin`
+    `scanelf -e ./bitcoind`
 
     the output should contain:
 	STK/REL/PTL

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -13,7 +13,7 @@ Run the following to install the base dependencies for building:
 
 
 ```bash
-sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils
+sudo apt-get install build-essential libtool autotools-dev automake pkg-config libssl-dev libevent-dev bsdmainutils git
 ```
 
 On at least Ubuntu 14.04+ and Debian 7+ there are generic names for the
@@ -158,7 +158,7 @@ You will find the `bitcoind` binary in the `src/` folder.
 
 It is recommended to use Berkeley DB 4.8.
 
-If you install the package from the BU Launchpad ppa, as descibed (above)[## Installing dependencies for wallet support] you can build with
+If you install the package from the BU Launchpad ppa, as descibed [above](#installing-dependencies-for-wallet-support) you can build with
 
 
 ```bash

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -168,7 +168,8 @@ make
 make install # optional
 ```
 
-You will find the `bitcoind` binary in the `src/` folder. This will build `bitcoin-qt` as well, if the dependencies are met.
+You will find the `bitcoind` binary in the `src/` folder. This will build `bitcoin-qt` as well (in `src/qt`), if the dependencies are met.
+
 
 
 ### Berkeley DB

--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -246,14 +246,6 @@ The release is built with GCC and then `strip bitcoind` to strip the debug
 symbols, which reduces the executable size by about 90%.
 
 
-## Boost
-
-If you need to build Boost yourself:
-```bash
-sudo su
-./bootstrap.sh
-./bjam install
-```
 
 ## Security
 


### PR DESCRIPTION
Add freebsd build guide.
Cleanup the unix (ubuntu) build instructions.


PS. The launchpad ppa for db4.8 is not updated for Eoan, Ubuntu 19.10.