### PR TITLE
Do not process any more blocks if shutdown is requested

### DIFF
--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -3338,6 +3338,10 @@ bool ActivateBestChainStep(CValidationState &state,
                     */
                 }
             }
+
+            // If we're shutting down then don't connect any more blocks.
+            if (shutdown_threads.load())
+                return false;
         }
 
         // Notify the UI with the new block tip information.


### PR DESCRIPTION
Sometimes an operator will interrupt an initial sync and when
they restart there can be up to 1000 blocks to connect. The operator
sometimes thinks something is wrong because it's taking so long
to startup and then initiates a shutdown, but shutdown counldn't happen
until all the blocks were connected leading the operator to think
something is seriously wrong somewhere. This PR simply allows shutdown
to be called during ActivateBestChainStep() but always will connect
at least one block which prevents us from shutting down without
connecting a newly arrived block at the chain tip but also prevents
us from hanging when many blocks need to be connected during sync.

NOTE:  I tested this by syncing to around 300K blocks. Then shutdown and restarted.   When the "Activating Best Chain" message appears then I initiated a shutdown. It did shutdown very quickly...I repeated this several times.