### PR TITLE
do not use smart pointer references

### DIFF
--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -1549,7 +1549,7 @@ void BuildSeededBloomFilter(CBloomFilter &filterMemPool,
             uint64_t nBlockSize = 0;
             while (mi != mempool.mapTx.get<3>().end())
             {
-                const CTransactionRef &tx = mi->GetSharedTx();
+                const CTransactionRef tx = mi->GetSharedTx();
                 const uint256 &txHash = tx->GetHash();
 
                 if (!IsFinalTx(tx, nHeight, nLockTimeCutoff))

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -20,7 +20,7 @@
 #include <boost/scope_exit.hpp>
 
 
-bool IsFinalTx(const CTransactionRef &tx, int nBlockHeight, int64_t nBlockTime)
+bool IsFinalTx(const CTransactionRef tx, int nBlockHeight, int64_t nBlockTime)
 {
     if (tx->nLockTime == 0)
         return true;
@@ -34,7 +34,7 @@ bool IsFinalTx(const CTransactionRef &tx, int nBlockHeight, int64_t nBlockTime)
     return true;
 }
 
-std::pair<int, int64_t> CalculateSequenceLocks(const CTransactionRef &tx,
+std::pair<int, int64_t> CalculateSequenceLocks(const CTransactionRef tx,
     int flags,
     std::vector<int> *prevHeights,
     const CBlockIndex &block)
@@ -116,7 +116,7 @@ bool EvaluateSequenceLocks(const CBlockIndex &block, std::pair<int, int64_t> loc
     return true;
 }
 
-bool SequenceLocks(const CTransactionRef &tx, int flags, std::vector<int> *prevHeights, const CBlockIndex &block)
+bool SequenceLocks(const CTransactionRef tx, int flags, std::vector<int> *prevHeights, const CBlockIndex &block)
 {
     return EvaluateSequenceLocks(block, CalculateSequenceLocks(tx, flags, prevHeights, block));
 }
@@ -126,7 +126,7 @@ bool SequenceLocks(const CTransactionRef &tx, int flags, std::vector<int> *prevH
 // previous outputs are the most relevant, but not actually checked.
 // The purpose of this is to limit the outputs of transactions so that other transactions' "prevout"
 // is reasonably sized.
-unsigned int GetLegacySigOpCount(const CTransactionRef &tx, const uint32_t flags)
+unsigned int GetLegacySigOpCount(const CTransactionRef tx, const uint32_t flags)
 {
     unsigned int nSigOps = 0;
     for (const auto &txin : tx->vin)
@@ -140,7 +140,7 @@ unsigned int GetLegacySigOpCount(const CTransactionRef &tx, const uint32_t flags
     return nSigOps;
 }
 
-unsigned int GetP2SHSigOpCount(const CTransactionRef &tx, const CCoinsViewCache &inputs, const uint32_t flags)
+unsigned int GetP2SHSigOpCount(const CTransactionRef tx, const CCoinsViewCache &inputs, const uint32_t flags)
 {
     if ((flags & SCRIPT_VERIFY_P2SH) == 0 || tx->IsCoinBase())
         return 0;
@@ -157,7 +157,7 @@ unsigned int GetP2SHSigOpCount(const CTransactionRef &tx, const CCoinsViewCache 
     return nSigOps;
 }
 
-bool CheckTransaction(const CTransactionRef &tx, CValidationState &state)
+bool CheckTransaction(const CTransactionRef tx, CValidationState &state)
 {
     // Basic checks that don't depend on any context
     if (tx->vin.empty())
@@ -234,7 +234,7 @@ static int GetSpendHeight(const CCoinsViewCache &inputs)
     throw std::runtime_error("GetSpendHeight(): best block does not exist");
 }
 
-bool Consensus::CheckTxInputs(const CTransactionRef &tx, CValidationState &state, const CCoinsViewCache &inputs)
+bool Consensus::CheckTxInputs(const CTransactionRef tx, CValidationState &state, const CCoinsViewCache &inputs)
 {
     // This doesn't trigger the DoS code on purpose; if it did, it would make it easier
     // for an attacker to attempt to split the network.

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -18,7 +18,7 @@ class CValidationState;
 /** Transaction validation functions */
 
 /** Context-independent validity checks */
-bool CheckTransaction(const CTransactionRef &tx, CValidationState &state);
+bool CheckTransaction(const CTransactionRef tx, CValidationState &state);
 
 namespace Consensus
 {
@@ -27,7 +27,7 @@ namespace Consensus
  * This does not modify the UTXO set. This does not check scripts and sigs.
  * Preconditions: tx.IsCoinBase() is false.
  */
-bool CheckTxInputs(const CTransactionRef &tx, CValidationState &state, const CCoinsViewCache &inputs);
+bool CheckTxInputs(const CTransactionRef tx, CValidationState &state, const CCoinsViewCache &inputs);
 } // namespace Consensus
 
 /** Auxiliary functions for transaction validation (ideally should not be exposed) */
@@ -37,7 +37,7 @@ bool CheckTxInputs(const CTransactionRef &tx, CValidationState &state, const CCo
  * @return number of sigops this transaction's outputs will produce when spent
  * @see CTransaction::FetchInputs
  */
-unsigned int GetLegacySigOpCount(const CTransactionRef &tx, const uint32_t flags);
+unsigned int GetLegacySigOpCount(const CTransactionRef tx, const uint32_t flags);
 
 /**
  * Count ECDSA signature operations in pay-to-script-hash inputs.
@@ -46,13 +46,13 @@ unsigned int GetLegacySigOpCount(const CTransactionRef &tx, const uint32_t flags
  * @return maximum number of sigops required to validate this transaction's inputs
  * @see CTransaction::FetchInputs
  */
-unsigned int GetP2SHSigOpCount(const CTransactionRef &tx, const CCoinsViewCache &mapInputs, const uint32_t flags);
+unsigned int GetP2SHSigOpCount(const CTransactionRef tx, const CCoinsViewCache &mapInputs, const uint32_t flags);
 
 /**
  * Check if transaction is final and can be included in a block with the
  * specified height and time. Consensus critical.
  */
-bool IsFinalTx(const CTransactionRef &tx, int nBlockHeight, int64_t nBlockTime);
+bool IsFinalTx(const CTransactionRef tx, int nBlockHeight, int64_t nBlockTime);
 
 /**
  * Calculates the block height and previous block's median time past at
@@ -60,7 +60,7 @@ bool IsFinalTx(const CTransactionRef &tx, int nBlockHeight, int64_t nBlockTime);
  * Also removes from the vector of input heights any entries which did not
  * correspond to sequence locked inputs as they do not affect the calculation.
  */
-std::pair<int, int64_t> CalculateSequenceLocks(const CTransactionRef &tx,
+std::pair<int, int64_t> CalculateSequenceLocks(const CTransactionRef tx,
     int flags,
     std::vector<int> *prevHeights,
     const CBlockIndex &block);
@@ -70,7 +70,7 @@ bool EvaluateSequenceLocks(const CBlockIndex &block, std::pair<int, int64_t> loc
  * Check if transaction is final per BIP 68 sequence numbers and can be included in a block.
  * Consensus critical. Takes as input a list of heights at which tx's inputs (in order) confirmed.
  */
-bool SequenceLocks(const CTransactionRef &tx, int flags, std::vector<int> *prevHeights, const CBlockIndex &block);
+bool SequenceLocks(const CTransactionRef tx, int flags, std::vector<int> *prevHeights, const CBlockIndex &block);
 
 uint64_t GetTransactionSigOpCount(const CTransaction &tx, const CCoinsViewCache &coins, const uint32_t flags);
 

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2695,7 +2695,7 @@ void NetCleanup()
 }
 
 
-void RelayTransaction(const CTransactionRef &ptx, const bool fRespend, const CTxProperties *txProperties)
+void RelayTransaction(const CTransactionRef ptx, const bool fRespend, const CTxProperties *txProperties)
 {
     if (ptx->GetTxSize() > maxTxSize.Value())
     {

--- a/src/net.h
+++ b/src/net.h
@@ -1053,7 +1053,7 @@ private:
 typedef std::vector<CNodeRef> VNodeRefs;
 
 class CTransaction;
-void RelayTransaction(const CTransactionRef &ptx,
+void RelayTransaction(const CTransactionRef ptx,
     const bool fRespend = false,
     const CTxProperties *txproperties = nullptr);
 

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -62,7 +62,7 @@ bool IsStandard(const CScript &scriptPubKey, txnouttype &whichType)
     return whichType != TX_NONSTANDARD;
 }
 
-bool IsStandardTx(const CTransactionRef &tx, std::string &reason)
+bool IsStandardTx(const CTransactionRef tx, std::string &reason)
 {
     if (tx->nVersion > CTransaction::MAX_STANDARD_VERSION || tx->nVersion < 1)
     {
@@ -135,7 +135,7 @@ bool IsStandardTx(const CTransactionRef &tx, std::string &reason)
     return true;
 }
 
-bool AreInputsStandard(const CTransactionRef &tx, const CCoinsViewCache &mapInputs)
+bool AreInputsStandard(const CTransactionRef tx, const CCoinsViewCache &mapInputs)
 {
     if (tx->IsCoinBase())
         return true; // Coinbases don't use vin normally

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -69,12 +69,12 @@ bool IsStandard(const CScript &scriptPubKey, txnouttype &whichType);
  * Check for standard transaction types
  * @return True if all outputs (scriptPubKeys) use only standard transaction forms
  */
-bool IsStandardTx(const CTransactionRef &tx, std::string &reason);
+bool IsStandardTx(const CTransactionRef tx, std::string &reason);
 /**
  * Check for standard transaction types
  * @param[in] mapInputs    Map of previous transactions that have outputs we're spending
  * @return True if all inputs (scriptSigs) use only standard transaction forms
  */
-bool AreInputsStandard(const CTransactionRef &tx, const CCoinsViewCache &mapInputs);
+bool AreInputsStandard(const CTransactionRef tx, const CCoinsViewCache &mapInputs);
 
 #endif // BITCOIN_POLICY_POLICY_H

--- a/src/respend/respendaction.h
+++ b/src/respend/respendaction.h
@@ -24,7 +24,7 @@ public:
         // Existing mempool entry
         const CTxMemPool::txiter mempoolEntry,
         // Current TX that is respending
-        const CTransactionRef &pRespendTx,
+        const CTransactionRef pRespendTx,
         // If we've seen a valid tx respending this output before
         bool seenBefore,
         // If original and respend tx only differ in script

--- a/src/respend/respenddetector.cpp
+++ b/src/respend/respenddetector.cpp
@@ -32,7 +32,7 @@ std::vector<RespendActionPtr> CreateDefaultActions()
 }
 
 RespendDetector::RespendDetector(const CTxMemPool &pool,
-    const CTransactionRef &ptx,
+    const CTransactionRef ptx,
     std::vector<RespendActionPtr> _actions)
     : actions(_actions)
 {
@@ -63,7 +63,7 @@ RespendDetector::~RespendDetector()
     }
 }
 
-void RespendDetector::CheckForRespend(const CTxMemPool &pool, const CTransactionRef &ptx)
+void RespendDetector::CheckForRespend(const CTxMemPool &pool, const CTransactionRef ptx)
 {
     READLOCK(pool.cs_txmempool); // protect pool.mapNextTx
 

--- a/src/respend/respenddetector.h
+++ b/src/respend/respenddetector.h
@@ -23,11 +23,11 @@ class RespendDetector
 {
 public:
     RespendDetector(const CTxMemPool &pool,
-        const CTransactionRef &ptx,
+        const CTransactionRef ptx,
         std::vector<RespendActionPtr> = CreateDefaultActions());
 
     ~RespendDetector();
-    void CheckForRespend(const CTxMemPool &pool, const CTransactionRef &ptx);
+    void CheckForRespend(const CTxMemPool &pool, const CTransactionRef ptx);
     void SetValid(bool valid);
     bool IsRespend() const;
 

--- a/src/respend/respendlogger.cpp
+++ b/src/respend/respendlogger.cpp
@@ -11,7 +11,7 @@ namespace respend
 RespendLogger::RespendLogger() : equivalent(false), valid("indeterminate"), newConflict(false) {}
 bool RespendLogger::AddOutpointConflict(const COutPoint &,
     const CTxMemPool::txiter mempoolEntry,
-    const CTransactionRef &pRespendTx,
+    const CTransactionRef pRespendTx,
     bool seen,
     bool isEquivalent)
 {

--- a/src/respend/respendlogger.h
+++ b/src/respend/respendlogger.h
@@ -17,7 +17,7 @@ public:
 
     bool AddOutpointConflict(const COutPoint &,
         const CTxMemPool::txiter mempoolEntry,
-        const CTransactionRef &pRespendTx,
+        const CTransactionRef pRespendTx,
         bool seen,
         bool isEquivalent) override;
 

--- a/src/respend/respendrelayer.cpp
+++ b/src/respend/respendrelayer.cpp
@@ -32,7 +32,7 @@ class RelayLimiter
 {
 public:
     RelayLimiter() : respendCount(0), lastRespendTime(0) {}
-    bool HasLimitExceeded(const CTransactionRef &pDoubleSpend)
+    bool HasLimitExceeded(const CTransactionRef pDoubleSpend)
     {
         unsigned int size = pDoubleSpend->GetTxSize();
 
@@ -59,7 +59,7 @@ private:
 RespendRelayer::RespendRelayer() : interesting(false), valid(false) {}
 bool RespendRelayer::AddOutpointConflict(const COutPoint &,
     const CTxMemPool::txiter,
-    const CTransactionRef &pRespendTx,
+    const CTransactionRef pRespendTx,
     bool seenBefore,
     bool isEquivalent)
 {

--- a/src/respend/respendrelayer.h
+++ b/src/respend/respendrelayer.h
@@ -19,7 +19,7 @@ public:
 
     bool AddOutpointConflict(const COutPoint &,
         const CTxMemPool::txiter,
-        const CTransactionRef &pRespendTx,
+        const CTransactionRef pRespendTx,
         bool seenBefore,
         bool isEquivalent) override;
 

--- a/src/respend/test/respenddetector_tests.cpp
+++ b/src/respend/test/respenddetector_tests.cpp
@@ -27,7 +27,7 @@ public:
 
     bool AddOutpointConflict(const COutPoint &out,
         const CTxMemPool::txiter mempoolEntry,
-        const CTransactionRef &respendTx,
+        const CTransactionRef respendTx,
         bool fRespentBefore,
         bool fIsEquivalent) override
     {

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -443,7 +443,7 @@ void ThreadTxAdmission()
                     txInQ.pop();
                 }
 
-                CTransactionRef &tx = txd.tx;
+                CTransactionRef tx = txd.tx;
                 CInv inv(MSG_TX, tx->GetHash());
 
                 if (!TxAlreadyHave(inv))
@@ -1393,7 +1393,7 @@ void Snapshot::Load(void)
     cvMempool = new CCoinsViewMemPool(coins, mempool);
 }
 
-bool CheckSequenceLocks(const CTransactionRef &tx,
+bool CheckSequenceLocks(const CTransactionRef tx,
     int flags,
     LockPoints *lp,
     bool useExistingLockPoints,
@@ -1479,7 +1479,7 @@ bool CheckSequenceLocks(const CTransactionRef &tx,
     return EvaluateSequenceLocks(index, lockPair);
 }
 
-bool CheckFinalTx(const CTransactionRef &tx, int flags, const Snapshot *ss)
+bool CheckFinalTx(const CTransactionRef tx, int flags, const Snapshot *ss)
 {
     // By convention a negative value for flags indicates that the
     // current network-enforced consensus rules should be used. In

--- a/src/txadmission.h
+++ b/src/txadmission.h
@@ -211,7 +211,7 @@ void CommitTxToMempool();
  *
  * See consensus/consensus.h for flag definitions.
  */
-bool CheckFinalTx(const CTransactionRef &tx, int flags = -1, const Snapshot *ss = nullptr);
+bool CheckFinalTx(const CTransactionRef tx, int flags = -1, const Snapshot *ss = nullptr);
 
 /*
  * Check if transaction will be BIP 68 final in the next block to be created.
@@ -224,7 +224,7 @@ bool CheckFinalTx(const CTransactionRef &tx, int flags = -1, const Snapshot *ss 
  *
  * See consensus/consensus.h for flag definitions.
  */
-bool CheckSequenceLocks(const CTransactionRef &tx,
+bool CheckSequenceLocks(const CTransactionRef tx,
     int flags,
     LockPoints *lp = nullptr,
     bool useExistingLockPoints = false,

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -35,7 +35,7 @@ CTxMemPoolEntry::CTxMemPoolEntry()
     sighashType = 0;
 }
 
-CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef &_tx,
+CTxMemPoolEntry::CTxMemPoolEntry(const CTransactionRef _tx,
     const CAmount &_nFee,
     int64_t _nTime,
     double _entryPriority,

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -119,7 +119,7 @@ private:
 public:
     unsigned char sighashType;
     CTxMemPoolEntry();
-    CTxMemPoolEntry(const CTransactionRef &_tx,
+    CTxMemPoolEntry(const CTransactionRef _tx,
         const CAmount &_nFee,
         int64_t _nTime,
         double _entryPriority,

--- a/src/txorphanpool.cpp
+++ b/src/txorphanpool.cpp
@@ -19,7 +19,7 @@ bool CTxOrphanPool::AlreadyHaveOrphan(const uint256 &hash)
     return false;
 }
 
-bool CTxOrphanPool::AddOrphanTx(const CTransactionRef &ptx, NodeId peer)
+bool CTxOrphanPool::AddOrphanTx(const CTransactionRef ptx, NodeId peer)
 {
     AssertWriteLockHeld(cs_orphanpool);
 

--- a/src/txorphanpool.h
+++ b/src/txorphanpool.h
@@ -43,7 +43,7 @@ public:
     bool AlreadyHaveOrphan(const uint256 &hash);
 
     //! Add a transaction to the orphan pool
-    bool AddOrphanTx(const CTransactionRef &ptx, NodeId peer);
+    bool AddOrphanTx(const CTransactionRef ptx, NodeId peer);
 
     //! Erase an ophan tx from the orphan pool
     //! @return true if an orphan matching the hash was found in the orphanpool and successfully erased.


### PR DESCRIPTION
Not sure if I'm being a bit pedantic here but I think it's a bad practice to be using references to smart pointers in a multi-threaded environment, otherwise why bother using smart pointers? I think we'll just end up getting bitten by it down the road when someone thinks they've got a valid object but it's already gone out of scope in some other thread..