### PR TITLE
Do not std::move(ptx) when passing a parameter in sendrawtransaction

### DIFF
--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -1470,7 +1470,7 @@ UniValue sendrawtransaction(const UniValue &params, bool fHelp)
         // push to local node and sync with wallets
         CValidationState state;
         bool fMissingInputs;
-        if (!AcceptToMemoryPool(mempool, state, std::move(ptx), false, &fMissingInputs, false, !fOverrideFees, txClass))
+        if (!AcceptToMemoryPool(mempool, state, ptx, false, &fMissingInputs, false, !fOverrideFees, txClass))
         {
             if (state.IsInvalid())
             {


### PR DESCRIPTION
This could cause some undefined behavior when ptx is again called
further down when the wallet is enabled.  Should only use std::move
when we're not going to use that object anymore.