### PR TITLE
[Requires #2020] Don't make copies of CTxMemPoolEntry's in RemoveForBlock()

### DIFF
--- a/src/policy/fees.cpp
+++ b/src/policy/fees.cpp
@@ -16,6 +16,7 @@
 #include "util.h"
 #include "utilmoneystr.h"
 
+
 void TxConfirmStats::Initialize(std::vector<double> &defaultBuckets,
     unsigned int maxConfirms,
     double _decay,
@@ -405,7 +406,7 @@ void CBlockPolicyEstimator::processBlockTx(unsigned int nBlockHeight, const CTxM
 }
 
 void CBlockPolicyEstimator::processBlock(unsigned int nBlockHeight,
-    std::vector<CTxMemPoolEntry> &entries,
+    const CTxMemPool::setEntries &setTxnsInBlock,
     bool fCurrentEstimate)
 {
     if (nBlockHeight <= nBestSeenHeight)
@@ -439,14 +440,14 @@ void CBlockPolicyEstimator::processBlock(unsigned int nBlockHeight,
     feeStats.ClearCurrent(nBlockHeight);
 
     // Repopulate the current block states
-    for (unsigned int i = 0; i < entries.size(); i++)
-        processBlockTx(nBlockHeight, entries[i]);
+    for (auto &it : setTxnsInBlock)
+        processBlockTx(nBlockHeight, *it);
 
     // Update all exponential averages with the current block states
     feeStats.UpdateMovingAverages();
 
     LOG(ESTIMATEFEE, "Blockpolicy after updating estimates for %u confirmed entries, new mempool map size %u\n",
-        entries.size(), mapMemPoolTxs.size());
+        setTxnsInBlock.size(), mapMemPoolTxs.size());
 }
 
 CFeeRate CBlockPolicyEstimator::estimateFee(int confTarget)

--- a/src/policy/fees.h
+++ b/src/policy/fees.h
@@ -8,6 +8,7 @@
 
 #include "amount.h"
 #include "random.h"
+#include "txmempool.h"
 #include "uint256.h"
 
 #include <deque>
@@ -17,8 +18,6 @@
 
 class CAutoFile;
 class CFeeRate;
-class CTxMemPoolEntry;
-class CTxMemPool;
 
 /** \class CBlockPolicyEstimator
  * The BlockPolicyEstimator is used for estimating the fee needed
@@ -215,7 +214,7 @@ public:
     CBlockPolicyEstimator(const CFeeRate &minRelayFeem);
 
     /** Process all the transactions that have been included in a block */
-    void processBlock(unsigned int nBlockHeight, std::vector<CTxMemPoolEntry> &entries, bool fCurrentEstimate);
+    void processBlock(unsigned int nBlockHeight, const CTxMemPool::setEntries &setTxnsInBlock, bool fCurrentEstimate);
 
     /** Process a transaction confirmed in a block*/
     void processBlockTx(unsigned int nBlockHeight, const CTxMemPoolEntry &entry);

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -1334,7 +1334,7 @@ bool CRequestManager::MarkBlockAsReceived(const uint256 &hash, CNode *pnode)
                 // disconnecting.
                 //
                 // We disconnect a peer only if their average response time is more than 4 times the overall average.
-                static uint32_t nStartDisconnections GUARDED_BY(cs_overallaverage) = BEGIN_PRUNING_PEERS;
+                static int nStartDisconnections GUARDED_BY(cs_overallaverage) = BEGIN_PRUNING_PEERS;
                 if (!pnode->fDisconnectRequest &&
                     (nOutbound >= nMaxOutConnections - 1 || nOutbound >= nStartDisconnections) &&
                     IsInitialBlockDownload() && nIterations > nOverallRange &&


### PR DESCRIPTION
Small performance TODO is fixed in this PR.