### PR TITLE
Flush the blockindex at regular intervals during IBD

### DIFF
--- a/src/blockstorage/blockstorage.cpp
+++ b/src/blockstorage/blockstorage.cpp
@@ -600,7 +600,8 @@ bool FlushStateToDiskInternal(CValidationState &state,
     // It's been a while since we wrote the block index to disk. Do this frequently, so we don't need to redownload
     // after a crash.
     bool fPeriodicWrite =
-        mode == FLUSH_STATE_PERIODIC && nNow > nLastWrite + (int64_t)DATABASE_WRITE_INTERVAL * 1000000;
+        (mode == FLUSH_STATE_PERIODIC && nNow > nLastWrite + (int64_t)DATABASE_WRITE_INTERVAL * 1000000) ||
+        (IsInitialBlockDownload() && nNow > nLastWrite + (int64_t)IBD_DATABASE_WRITE_INTERVAL * 1000000);
     // It's been very long since we flushed the cache. Do this infrequently, to optimize cache usage.
     bool fPeriodicFlush =
         mode == FLUSH_STATE_PERIODIC && nNow > nLastFlush + (int64_t)DATABASE_FLUSH_INTERVAL * 1000000;

--- a/src/main.h
+++ b/src/main.h
@@ -71,7 +71,10 @@ static const unsigned int VERACK_TIMEOUT = 60;
 /** Number of headers sent in one getheaders result. We rely on the assumption that if a peer sends
  *  less than this number, we reached its tip. Changing this value is a protocol upgrade. */
 static const unsigned int MAX_HEADERS_RESULTS = 2000;
+/** Time to wait (in seconds) between flushing the blocks and the blockindex to disk */
 static const unsigned int DATABASE_WRITE_INTERVAL = 60 * 60;
+/** Time to wait (in seconds) between flushing the blocks and the blockindex to disk during IBD */
+static const unsigned int IBD_DATABASE_WRITE_INTERVAL = 5 * 60;
 /** Time to wait (in seconds) between flushing chainstate to disk. */
 static const unsigned int DATABASE_FLUSH_INTERVAL = 24 * 60 * 60;
 /** Maximum length of reject messages. */


### PR DESCRIPTION
This prevents us from having to redownload all the blocks again
in the event we've had a crash during IBD.