### PR TITLE
Start pruning slow peers before we get to the max outbound connections

### DIFF
--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -37,6 +37,9 @@ successful receipt, "requester.Rejected(...)" to indicate a bad object (request 
 // Max requests allowed in a 10 minute window
 static const uint8_t MAX_THINTYPE_OBJECT_REQUESTS = 100;
 
+// How many peers are connected before we start looking for slow peers to disconnect.
+static const uint32_t BEGIN_PRUNING_PEERS = 4;
+
 // When should I request a tx from someone else (in microseconds). cmdline/bitcoin.conf: -txretryinterval
 extern unsigned int txReqRetryInterval;
 extern unsigned int MIN_TX_REQUEST_RETRY_INTERVAL;


### PR DESCRIPTION
During IBD it can take quite a while to get all 16 default outbound
connections established, so here we start pruning slow peers once we
get to 4 connections. And if we prune one then we increase the next
pruning point to 5 connections, and then 6 and so on. This way we
don't abruptly prune many peers suddenly but only prune one peer at
at time while also allowing us to prune slow peers earlier in the
startup of IBD.

NOTE: there is still one outstanding startup issue which this PR doesn't address, and that is, what do we do when we request blocks but we didn't get a single one back. This will require some kind of re-request tracking in the requestmanager which is beyond the scope of this PR, but still something that would be good to have.