### PR TITLE
Reduce the retry interval during IBD

### DIFF
--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -659,12 +659,15 @@ void CRequestManager::SendRequests()
     // those blocks and txns can take much longer to download.
     unsigned int _blkReqRetryInterval = MIN_BLK_REQUEST_RETRY_INTERVAL;
     unsigned int _txReqRetryInterval = MIN_TX_REQUEST_RETRY_INTERVAL;
-    if ((!IsChainNearlySyncd() && Params().NetworkIDString() != "regtest") || IsTrafficShapingEnabled())
+    if (IsTrafficShapingEnabled())
     {
         _blkReqRetryInterval *= 6;
-        // we want to optimise block DL during IBD (and give lots of time for shaped nodes) so push the TX retry up to 2
-        // minutes (default val of MIN_TX is 5 sec)
         _txReqRetryInterval *= (12 * 2);
+    }
+    else if ((!IsChainNearlySyncd() && Params().NetworkIDString() != "regtest"))
+    {
+        _blkReqRetryInterval *= 2;
+        _txReqRetryInterval *= 8;
     }
 
     // When we are still doing an initial sync we want to batch request the blocks instead of just


### PR DESCRIPTION
Having the current 30 second retry interval is rather long and
unnecessary during IBD, it's only when traffic shaping is on that
it really matters that much so brining it down 10 seconds for blocks
makes IBD much smother, particularly at the beginning where we sometimes
have slow or bad peers that take a while to prune.

Testing this out you can see clearly there are much smaller gaps at the beginning of IBD, whereas before you had quite large gaps that gave the impression that something was not working correctly.