### PR TITLE
A few IBD tweaks

### DIFF
--- a/src/blockstorage/blockleveldb.cpp
+++ b/src/blockstorage/blockleveldb.cpp
@@ -12,7 +12,7 @@ CBlockLevelDB::CBlockLevelDB(size_t nCacheSizeBlock, size_t nCacheSizeUndo, bool
 {
     COverrideOptions overrideblock;
     // we want to have much larger file sizes for the blocks db so override the default.
-    overrideblock.max_file_size = nCacheSizeBlock / 2;
+    overrideblock.max_file_size = nCacheSizeBlock / 15;
     pwrapperblock =
         new CDBWrapper(GetDataDir() / "blockdb" / "blocks", nCacheSizeBlock, fMemory, fWipe, obfuscate, &overrideblock);
 

--- a/src/blockstorage/blockleveldb.cpp
+++ b/src/blockstorage/blockleveldb.cpp
@@ -13,6 +13,7 @@ CBlockLevelDB::CBlockLevelDB(size_t nCacheSizeBlock, size_t nCacheSizeUndo, bool
     COverrideOptions overrideblock;
     // we want to have much larger file sizes for the blocks db so override the default.
     overrideblock.max_file_size = nCacheSizeBlock / 15;
+    overrideblock.block_size = 40960;
     pwrapperblock =
         new CDBWrapper(GetDataDir() / "blockdb" / "blocks", nCacheSizeBlock, fMemory, fWipe, obfuscate, &overrideblock);
 

--- a/src/blockstorage/blockstorage.cpp
+++ b/src/blockstorage/blockstorage.cpp
@@ -623,7 +623,9 @@ bool FlushStateToDiskInternal(CValidationState &state,
         else
         {
             if (pblockdb)
+            {
                 pblockdb->Flush();
+            }
         }
         // Then update all block file information (which may refer to block and undo files).
         {

--- a/src/dbwrapper.cpp
+++ b/src/dbwrapper.cpp
@@ -85,6 +85,7 @@ CDBWrapper::CDBWrapper(const fs::path &path,
 {
     penv = nullptr;
     readoptions.verify_checksums = true;
+    readoptions.fill_cache = true;
     iteroptions.verify_checksums = true;
     iteroptions.fill_cache = false;
     syncoptions.sync = true;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1141,7 +1141,10 @@ bool AppInit2(Config &config, thread_group &threadGroup)
                     cacheConfig.nBlockTreeDBCache, cacheConfig.nBlockDBCache, cacheConfig.nBlockUndoDBCache);
 
                 uiInterface.InitMessage(_("Opening UTXO database..."));
-                pcoinsdbview = new CCoinsViewDB(cacheConfig.nCoinDBCache, false, fReindex);
+                COverrideOptions overridecache;
+                overridecache.block_size = 128;
+                pcoinsdbview = new CCoinsViewDB(cacheConfig.nCoinDBCache, false, fReindex, true, &overridecache);
+
                 pcoinscatcher = new CCoinsViewErrorCatcher(pcoinsdbview);
                 uiInterface.InitMessage(_("Opening Coins Cache database..."));
                 pcoinsTip = new CCoinsViewCache(pcoinscatcher);

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -110,8 +110,8 @@ BOOST_FIXTURE_TEST_CASE(cache_configuration, TestChain100Setup)
     BOOST_CHECK(cacheConfig1.nBlockUndoDBCache == 0);
     BOOST_CHECK(cacheConfig1.nBlockTreeDBCache == 2097152);
     BOOST_CHECK(cacheConfig1.nTxIndexCache == 0);
-    BOOST_CHECK(cacheConfig1.nCoinDBCache == 138936320);
-    BOOST_CHECK(nCoinCacheMaxSize == 383254528);
+    BOOST_CHECK(cacheConfig1.nCoinDBCache == 73662464);
+    BOOST_CHECK(nCoinCacheMaxSize == 448528384);
 
     // Check non-default values are returned
     CacheConfig cacheConfig2 = DiscoverCacheConfiguration();
@@ -119,39 +119,39 @@ BOOST_FIXTURE_TEST_CASE(cache_configuration, TestChain100Setup)
     BOOST_CHECK(cacheConfig2.nBlockUndoDBCache == 0);
     BOOST_CHECK(cacheConfig2.nBlockTreeDBCache == 655360);
     BOOST_CHECK(cacheConfig2.nTxIndexCache == 0);
-    BOOST_CHECK(cacheConfig2.nCoinDBCache == 2293760);
-    BOOST_CHECK(nCoinCacheMaxSize == 2293760);
+    BOOST_CHECK(cacheConfig2.nCoinDBCache == 1146880);
+    BOOST_CHECK(nCoinCacheMaxSize == 3440640);
 
 
     // check default values are honored if blockdb storage is on
     BLOCK_DB_MODE = LEVELDB_BLOCK_STORAGE;
     cacheConfig1 = DiscoverCacheConfiguration(true);
-    BOOST_CHECK(cacheConfig1.nBlockDBCache == 26109542);
-    BOOST_CHECK(cacheConfig1.nBlockUndoDBCache == 5221908);
+    BOOST_CHECK(cacheConfig1.nBlockDBCache == 52219084);
+    BOOST_CHECK(cacheConfig1.nBlockUndoDBCache == 10443816);
     BOOST_CHECK(cacheConfig1.nBlockTreeDBCache == 2097152);
     BOOST_CHECK(cacheConfig1.nTxIndexCache == 0);
-    BOOST_CHECK(cacheConfig1.nCoinDBCache == 131103457);
-    BOOST_CHECK(nCoinCacheMaxSize == 359755941);
+    BOOST_CHECK(cacheConfig1.nCoinDBCache == 65829601);
+    BOOST_CHECK(nCoinCacheMaxSize == 393698347);
 
     // check settings when txindex is on
     bool nTemp = GetBoolArg("-txindex", 0);
     SetBoolArg("-txindex", true);
     cacheConfig1 = DiscoverCacheConfiguration(true);
-    BOOST_CHECK(cacheConfig1.nBlockDBCache == 26109542);
-    BOOST_CHECK(cacheConfig1.nBlockUndoDBCache == 5221908);
+    BOOST_CHECK(cacheConfig1.nBlockDBCache == 52219084);
+    BOOST_CHECK(cacheConfig1.nBlockUndoDBCache == 10443816);
     BOOST_CHECK(cacheConfig1.nBlockTreeDBCache == 2097152);
-    BOOST_CHECK(cacheConfig1.nTxIndexCache == 65551728);
-    BOOST_CHECK(cacheConfig1.nCoinDBCache == 65551728);
-    BOOST_CHECK(nCoinCacheMaxSize == 359755942);
+    BOOST_CHECK(cacheConfig1.nTxIndexCache == 32914800);
+    BOOST_CHECK(cacheConfig1.nCoinDBCache == 32914800);
+    BOOST_CHECK(nCoinCacheMaxSize == 393698348);
 
     // Check non-default values are returned
     cacheConfig2 = DiscoverCacheConfiguration();
     BOOST_CHECK(cacheConfig2.nBlockDBCache == 655360);
     BOOST_CHECK(cacheConfig2.nBlockUndoDBCache == 655360);
     BOOST_CHECK(cacheConfig2.nBlockTreeDBCache == 655360);
-    BOOST_CHECK(cacheConfig2.nTxIndexCache == 819200);
-    BOOST_CHECK(cacheConfig2.nCoinDBCache == 819200);
-    BOOST_CHECK(nCoinCacheMaxSize == 1638400);
+    BOOST_CHECK(cacheConfig2.nTxIndexCache == 409600);
+    BOOST_CHECK(cacheConfig2.nCoinDBCache == 409600);
+    BOOST_CHECK(nCoinCacheMaxSize == 2457600);
 
     // Cleanup
     SetBoolArg("-txindex", nTemp);

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -57,8 +57,13 @@ struct CoinEntry
 };
 }
 
-CCoinsViewDB::CCoinsViewDB(size_t nCacheSize, bool fMemory, bool fWipe)
-    : db(GetDataDir() / "chainstate", nCacheSize, fMemory, fWipe, true)
+
+CCoinsViewDB::CCoinsViewDB(size_t nCacheSize,
+    bool fMemory,
+    bool fWipe,
+    bool fObfuscate,
+    COverrideOptions *overridecache)
+    : db(GetDataDir() / "chainstate", nCacheSize, fMemory, fWipe, fObfuscate, overridecache)
 {
 }
 

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -758,25 +758,25 @@ CacheConfig CacheSizeCalculations(int64_t _nTotalCache)
     _nTotalCache -= cache.nBlockTreeDBCache;
     if (BLOCK_DB_MODE == LEVELDB_BLOCK_STORAGE)
     {
-        // use up to 5% for the level db block cache but no bigger than 256MB
-        cache.nBlockDBCache = _nTotalCache * 0.05;
+        // use up to 10% for the level db block cache but no bigger than 256MB
+        cache.nBlockDBCache = _nTotalCache * 0.10;
         if (cache.nBlockDBCache < cache.nBlockTreeDBCache)
             cache.nBlockDBCache = cache.nBlockTreeDBCache;
-        else if (cache.nBlockDBCache > 256 << 20)
-            cache.nBlockDBCache = 256 << 20;
+        else if (cache.nBlockDBCache > 1024 << 20)
+            cache.nBlockDBCache = 1024 << 20;
 
-        // use up to 1% for the level db undo cache but no bigger than 64MB
-        cache.nBlockUndoDBCache = _nTotalCache * 0.01;
+        // use up to 2% for the level db undo cache but no bigger than 64MB
+        cache.nBlockUndoDBCache = _nTotalCache * 0.02;
         if (cache.nBlockUndoDBCache < cache.nBlockTreeDBCache)
             cache.nBlockUndoDBCache = cache.nBlockTreeDBCache;
-        else if (cache.nBlockUndoDBCache > 64 << 20)
-            cache.nBlockUndoDBCache = 64 << 20;
+        else if (cache.nBlockUndoDBCache > 128 << 20)
+            cache.nBlockUndoDBCache = 128 << 20;
     }
 
-    // use 25%-50% of the remainder for the utxo leveldb disk cache
+    // use 12.5%-25% of the remainder for the utxo leveldb disk cache
     _nTotalCache -= cache.nBlockDBCache;
     _nTotalCache -= cache.nBlockUndoDBCache;
-    cache.nCoinDBCache = std::min(_nTotalCache / 2, (_nTotalCache / 4) + (1 << 23));
+    cache.nCoinDBCache = std::min(_nTotalCache / 4, (_nTotalCache / 8) + (1 << 23));
     if (!GetBoolArg("-txindex", DEFAULT_TXINDEX))
     {
         cache.nTxIndexCache = 0;

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -763,14 +763,14 @@ CacheConfig CacheSizeCalculations(int64_t _nTotalCache)
     _nTotalCache -= cache.nBlockTreeDBCache;
     if (BLOCK_DB_MODE == LEVELDB_BLOCK_STORAGE)
     {
-        // use up to 10% for the level db block cache but no bigger than 256MB
+        // use up to 10% for the level db block cache but no bigger than 1GB
         cache.nBlockDBCache = _nTotalCache * 0.10;
         if (cache.nBlockDBCache < cache.nBlockTreeDBCache)
             cache.nBlockDBCache = cache.nBlockTreeDBCache;
         else if (cache.nBlockDBCache > 1024 << 20)
             cache.nBlockDBCache = 1024 << 20;
 
-        // use up to 2% for the level db undo cache but no bigger than 64MB
+        // use up to 2% for the level db undo cache but no bigger than 128MB
         cache.nBlockUndoDBCache = _nTotalCache * 0.02;
         if (cache.nBlockUndoDBCache < cache.nBlockTreeDBCache)
             cache.nBlockUndoDBCache = cache.nBlockTreeDBCache;

--- a/src/txdb.h
+++ b/src/txdb.h
@@ -123,7 +123,11 @@ protected:
     CDBWrapper db;
 
 public:
-    CCoinsViewDB(size_t nCacheSize, bool fMemory = false, bool fWipe = false);
+    CCoinsViewDB(size_t nCacheSize,
+        bool fMemory = false,
+        bool fWipe = false,
+        bool fObfuscate = false,
+        COverrideOptions *overridecache = nullptr);
 
     bool GetCoin(const COutPoint &outpoint, Coin &coin) const override;
     bool HaveCoin(const COutPoint &outpoint) const override;


### PR DESCRIPTION
These make for some decent gains.

The first commit is for blockdb which helps shave about 20 mins off IBD for blocksdb, the second is for nodes that are configured with small dbcaches and  improvements are very good.  Using a 700Mb dbcache the time reduction in IBD is roughly 35%.