### PR TITLE
Turn off PV for compactblocks_2.py

### DIFF
--- a/qa/rpc-tests/compactblocks_2.py
+++ b/qa/rpc-tests/compactblocks_2.py
@@ -161,7 +161,14 @@ class CompactBlocksTest(BitcoinTestFramework):
 
     def setup_network(self):
         self.nodes = []
-        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, [["-consensus.enableCanonicalTxOrder=1", "-debug=net", "-debug=thin", "-debug=cmpctblocks", "-debug=mempool", "-net.msgHandlerThreads=1"]])
+        self.nodes = start_nodes(self.num_nodes, self.options.tmpdir,
+            [["-consensus.enableCanonicalTxOrder=1",
+              "-debug=net",
+              "-debug=thin",
+              "-debug=cmpctblocks",
+              "-debug=mempool",
+              "-net.msgHandlerThreads=1",
+              "-parallel=0"]])
 
 
     def build_block_on_tip(self):


### PR DESCRIPTION
Occassionaly in a debug build the chaintip will be slow to update
causing build_block_on_tip() to build a block on the previous
chaintip and causing the test to fail. Turning PV off keeps the
messages processing in sequential order so we don't have a header
getting processed before the previous block has finished procesing.