### PR TITLE
Implement two more ban reason codes

### DIFF
--- a/src/banentry.cpp
+++ b/src/banentry.cpp
@@ -58,6 +58,10 @@ std::string CBanEntry::banReasonToString()
         return "Too Many Connection Attempts";
     case BanReasonInvalidMessageStart:
         return "Invalid Message Start";
+    case BanReasonInvalidInventory:
+        return "Invalid Inventory";
+    case BanReasonInvalidPeer:
+        return "Invalid Peer for this Network";
     default:
         return "unknown";
     }

--- a/src/banentry.cpp
+++ b/src/banentry.cpp
@@ -37,6 +37,7 @@ void CBanEntry::SetNull()
     nCreateTime = 0;
     nBanUntil = 0;
     banReason = BanReasonUnknown;
+    userAgent.clear();
 }
 
 /**

--- a/src/banentry.h
+++ b/src/banentry.h
@@ -29,6 +29,7 @@ public:
     int64_t nCreateTime;
     int64_t nBanUntil;
     uint8_t banReason;
+    std::string userAgent;
 
     CBanEntry();
     CBanEntry(int64_t nCreateTimeIn);
@@ -42,6 +43,7 @@ public:
         READWRITE(nCreateTime);
         READWRITE(nBanUntil);
         READWRITE(banReason);
+        READWRITE(userAgent);
     }
 
     void SetNull();

--- a/src/banentry.h
+++ b/src/banentry.h
@@ -16,7 +16,9 @@ typedef enum BanReason {
     BanReasonManuallyAdded = 2,
     BanReasonTooManyEvictions = 3,
     BanReasonTooManyConnectionAttempts = 4,
-    BanReasonInvalidMessageStart = 5
+    BanReasonInvalidMessageStart = 5,
+    BanReasonInvalidInventory = 6,
+    BanReasonInvalidPeer = 7
 } BanReason;
 
 class CBanEntry

--- a/src/dosman.cpp
+++ b/src/dosman.cpp
@@ -108,10 +108,14 @@ bool CDoSManager::IsBanned(CSubNet subnet)
 * @param[in] bantimeoffset   The duration of the ban in seconds, either a duration or an absolute time
 * @param[in] sinceUnixEpoch  Whether or not the bantimeoffset is a relative duration, or absolute time
 */
-void CDoSManager::Ban(const CNetAddr &addr, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch)
+void CDoSManager::Ban(const CNetAddr &addr,
+    const std::string &userAgent,
+    const BanReason &banReason,
+    int64_t bantimeoffset,
+    bool sinceUnixEpoch)
 {
     CSubNet subNet(addr);
-    Ban(subNet, banReason, bantimeoffset, sinceUnixEpoch);
+    Ban(subNet, userAgent, banReason, bantimeoffset, sinceUnixEpoch);
 }
 
 /**
@@ -123,9 +127,14 @@ void CDoSManager::Ban(const CNetAddr &addr, const BanReason &banReason, int64_t 
 * @param[in] bantimeoffset   The duration of the ban in seconds, either a duration or an absolute time
 * @param[in] sinceUnixEpoch  Whether or not the bantimeoffset is a relative duration, or absolute time
 */
-void CDoSManager::Ban(const CSubNet &subNet, const BanReason &banReason, int64_t bantimeoffset, bool sinceUnixEpoch)
+void CDoSManager::Ban(const CSubNet &subNet,
+    const std::string &userAgent,
+    const BanReason &banReason,
+    int64_t bantimeoffset,
+    bool sinceUnixEpoch)
 {
     CBanEntry banEntry(GetTime());
+    banEntry.userAgent = userAgent;
     banEntry.banReason = banReason;
     if (bantimeoffset <= 0)
     {
@@ -133,6 +142,7 @@ void CDoSManager::Ban(const CSubNet &subNet, const BanReason &banReason, int64_t
         sinceUnixEpoch = false;
     }
     banEntry.nBanUntil = (sinceUnixEpoch ? 0 : GetTime()) + bantimeoffset;
+
 
     LOCK(cs_setBanned);
     if (setBanned[subNet].nBanUntil < banEntry.nBanUntil)

--- a/src/dosman.cpp
+++ b/src/dosman.cpp
@@ -258,7 +258,7 @@ bool CDoSManager::BannedSetIsDirty()
  * Increment the misbehaving count score for this node.  If the ban threshold is reached, flag the node to be
  * banned.  No locks are needed to call this function.
  */
-void CDoSManager::Misbehaving(CNode *pNode, int howmuch)
+void CDoSManager::Misbehaving(CNode *pNode, int howmuch, BanReason reason)
 {
     if (howmuch == 0 || !pNode)
         return;
@@ -269,6 +269,7 @@ void CDoSManager::Misbehaving(CNode *pNode, int howmuch)
     {
         LOGA("%s: %s (%d -> %d) BAN THRESHOLD EXCEEDED\n", __func__, pNode->GetLogName(), prior, prior + howmuch);
         pNode->fShouldBan = true;
+        pNode->nBanType = reason;
     }
     else
         LOGA("%s: %s (%d -> %d)\n", __func__, pNode->GetLogName(), prior, prior + howmuch);

--- a/src/dosman.h
+++ b/src/dosman.h
@@ -86,8 +86,16 @@ public:
     void ClearBanned(); // needed for unit testing
     bool IsBanned(CNetAddr ip);
     bool IsBanned(CSubNet subnet);
-    void Ban(const CNetAddr &ip, const BanReason &banReason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
-    void Ban(const CSubNet &subNet, const BanReason &banReason, int64_t bantimeoffset = 0, bool sinceUnixEpoch = false);
+    void Ban(const CNetAddr &ip,
+        const std::string &userAgent,
+        const BanReason &banReason,
+        int64_t bantimeoffset = 0,
+        bool sinceUnixEpoch = false);
+    void Ban(const CSubNet &subNet,
+        const std::string &userAgent,
+        const BanReason &banReason,
+        int64_t bantimeoffset = 0,
+        bool sinceUnixEpoch = false);
     bool Unban(const CNetAddr &ip);
     bool Unban(const CSubNet &ip);
     void GetBanned(banmap_t &banmap);

--- a/src/dosman.h
+++ b/src/dosman.h
@@ -55,7 +55,7 @@ public:
      * @param[in] pNode    The node which is misbehaving.  No effect if nullptr.
      * @param[in] howmuch  Incremental misbehaving score for the latest infraction by this node.
      */
-    void Misbehaving(CNode *pNode, int howmuch);
+    void Misbehaving(CNode *pNode, int howmuch, BanReason reason = (BanReason)-1);
 
     /**
      * Increment the misbehaving score for this node.  If the ban threshold is reached, flag the node to be

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3244,12 +3244,13 @@ void CNode::DisconnectIfBanned()
         else if (addr.IsLocal())
         {
             nMisbehavior.store(0);
+            nBanType = (BanReason)-1;
             LOGA("Warning: not banning local peer %s!\n", GetLogName());
         }
         else
         {
             fDisconnect = true;
-            dosMan.Ban(addr, BanReasonNodeMisbehaving);
+            dosMan.Ban(addr, nBanType);
         }
     }
 }

--- a/src/net.h
+++ b/src/net.h
@@ -113,6 +113,8 @@ void AddOneShot(const std::string &strDest);
 CNodeRef FindNodeRef(const std::string &addrName);
 // Find a node by id.  Returns a null ref if no node found
 CNodeRef FindNodeRef(const NodeId id);
+// Find a node by ip.  Returns a null ref if no node found
+CNodeRef FindNodeRef(const CNetAddr &ip);
 int DisconnectSubNetNodes(const CSubNet &subNet);
 bool OpenNetworkConnection(const CAddress &addrConnect,
     bool fCountFailure,

--- a/src/net.h
+++ b/src/net.h
@@ -489,6 +489,7 @@ public:
     std::atomic<int> nMisbehavior;
     //! Whether this peer should be disconnected and banned (unless whitelisted).
     bool fShouldBan;
+    BanReason nBanType = (BanReason)-1;
 
     // BUIP010 Xtreme Thinblocks: begin section
     std::atomic<uint32_t> nXthinBloomfilterSize; // Max xthin bloom filter size (in bytes) that our peer will accept.

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -487,7 +487,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             if (pfrom->strSubVer.find("Bitcoin SV") != std::string::npos ||
                 pfrom->strSubVer.find("(SV;") != std::string::npos)
             {
-                dosMan.Misbehaving(pfrom, 100);
+                dosMan.Misbehaving(pfrom, 100, BanReasonInvalidPeer);
             }
         }
         if (!vRecv.empty())
@@ -957,7 +957,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             }
             else if (inv.hash.IsNull())
             {
-                dosMan.Misbehaving(pfrom, 20);
+                dosMan.Misbehaving(pfrom, 20, BanReasonInvalidInventory);
                 LOG(NET, "message inv has null hash %s", inv.type, inv.hash.ToString());
                 return false;
             }
@@ -1050,7 +1050,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             if (!((inv.type == MSG_TX) || (inv.type == MSG_BLOCK) || (inv.type == MSG_FILTERED_BLOCK) ||
                     (inv.type == MSG_CMPCT_BLOCK)))
             {
-                dosMan.Misbehaving(pfrom, 20);
+                dosMan.Misbehaving(pfrom, 20, BanReasonInvalidInventory);
                 return error("message inv invalid type = %u", inv.type);
             }
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -634,6 +634,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         CNetAddr ipAddress = (CNetAddr)pfrom->addr;
         mapInboundConnectionTracker[ipAddress].nEvictions += 1;
         mapInboundConnectionTracker[ipAddress].nLastEvictionTime = GetTime();
+        mapInboundConnectionTracker[ipAddress].userAgent = pfrom->cleanSubVer;
 
         return true; // return true so we don't get any process message failures in the log.
     }
@@ -2088,7 +2089,8 @@ bool ProcessMessages(CNode *pfrom)
                 pfrom->GetLogName());
             if (!pfrom->fWhitelisted)
             {
-                dosMan.Ban(pfrom->addr, BanReasonInvalidMessageStart, 4 * 60 * 60); // ban for 4 hours
+                // ban for 4 hours
+                dosMan.Ban(pfrom->addr, pfrom->cleanSubVer, BanReasonInvalidMessageStart, 4 * 60 * 60);
             }
             fOk = false;
             break;

--- a/src/qt/bantablemodel.cpp
+++ b/src/qt/bantablemodel.cpp
@@ -28,6 +28,8 @@ bool BannedNodeLessThan::operator()(const CCombinedBan &left, const CCombinedBan
     {
     case BanTableModel::Address:
         return pLeft->subnet.ToString().compare(pRight->subnet.ToString()) < 0;
+    case BanTableModel::UserAgent:
+        return pLeft->banEntry.userAgent < pRight->banEntry.userAgent;
     case BanTableModel::Bantime:
         return pLeft->banEntry.nBanUntil < pRight->banEntry.nBanUntil;
     case BanTableModel::BanReason:
@@ -81,7 +83,7 @@ public:
 
 BanTableModel::BanTableModel(ClientModel *parent) : QAbstractTableModel(parent), clientModel(parent)
 {
-    columns << tr("IP/Netmask") << tr("Banned Until") << tr("Ban Reason");
+    columns << tr("IP/Netmask") << tr("User Agent") << tr("Banned Until") << tr("Ban Reason");
     priv.reset(new BanTablePriv());
     // default to unsorted
     priv->sortColumn = -1;
@@ -121,6 +123,8 @@ QVariant BanTableModel::data(const QModelIndex &index, int role) const
         {
         case Address:
             return QString::fromStdString(rec->subnet.ToString());
+        case UserAgent:
+            return QString::fromStdString(rec->banEntry.userAgent);
         case BanReason:
             return QString::fromStdString(rec->banEntry.banReasonToString());
         case Bantime:

--- a/src/qt/bantablemodel.h
+++ b/src/qt/bantablemodel.h
@@ -48,8 +48,9 @@ public:
     enum ColumnIndex
     {
         Address = 0,
-        Bantime = 1,
-        BanReason = 2
+        UserAgent = 1,
+        Bantime = 2,
+        BanReason = 3
     };
 
     /** @name Methods overridden from QAbstractTableModel

--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -1127,7 +1127,7 @@ void RPCConsole::banSelectedNode(int bantime)
         int port = 0;
         SplitHostPort(nStr, port, addr);
 
-        dosMan.Ban(CNetAddr(addr), BanReasonManuallyAdded, bantime);
+        dosMan.Ban(CNetAddr(addr), bannedNode.get()->cleanSubVer, BanReasonManuallyAdded, bantime);
         bannedNode->fDisconnect = true;
 
         clearSelectedNode();

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -680,8 +680,12 @@ UniValue setban(const UniValue &params, bool fHelp)
         if (params.size() == 4 && params[3].isTrue())
             absolute = true;
 
-        isSubnet ? dosMan.Ban(subNet, BanReasonManuallyAdded, banTime, absolute) :
-                   dosMan.Ban(netAddr, BanReasonManuallyAdded, banTime, absolute);
+        std::string userAgent = "unknown";
+        CNodeRef bannedNode = FindNodeRef(netAddr);
+        if (bannedNode)
+            userAgent = bannedNode.get()->cleanSubVer;
+        isSubnet ? dosMan.Ban(subNet, userAgent, BanReasonManuallyAdded, banTime, absolute) :
+                   dosMan.Ban(netAddr, userAgent, BanReasonManuallyAdded, banTime, absolute);
 
         // disconnect possible nodes
         if (!isSubnet)

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -70,10 +70,10 @@ void SetKnownBanlistContents()
     dosMan.ClearBanned();
 
     // Add test ban of specific IP
-    dosMan.Ban(CNetAddr("192.168.1.1"), BanReasonNodeMisbehaving, DEFAULT_MISBEHAVING_BANTIME, false);
+    dosMan.Ban(CNetAddr("192.168.1.1"), "unknown", BanReasonNodeMisbehaving, DEFAULT_MISBEHAVING_BANTIME, false);
 
     // Add test ban of specific subnet
-    dosMan.Ban(CSubNet("10.168.1.0/28"), BanReasonManuallyAdded, DEFAULT_MISBEHAVING_BANTIME, false);
+    dosMan.Ban(CSubNet("10.168.1.0/28"), "unknown", BanReasonManuallyAdded, DEFAULT_MISBEHAVING_BANTIME, false);
 }
 
 BOOST_AUTO_TEST_CASE(DoS_persistence_tests)
@@ -147,11 +147,11 @@ BOOST_AUTO_TEST_CASE(DoS_basic_ban_tests)
     BOOST_CHECK(GetNumberBanEntries() == 0);
 
     // Add a CNetAddr entry to banlist
-    dosMan.Ban(CNetAddr("192.168.1.1"), BanReasonNodeMisbehaving, DEFAULT_MISBEHAVING_BANTIME, false);
+    dosMan.Ban(CNetAddr("192.168.1.1"), "unknown", BanReasonNodeMisbehaving, DEFAULT_MISBEHAVING_BANTIME, false);
     // Ensure we have exactly 1 entry in our banlist
     BOOST_CHECK(GetNumberBanEntries() == 1);
     // Add a CSubNet entry to banlist
-    dosMan.Ban(CSubNet("10.168.1.0/28"), BanReasonManuallyAdded, DEFAULT_MISBEHAVING_BANTIME, false);
+    dosMan.Ban(CSubNet("10.168.1.0/28"), "unknown", BanReasonManuallyAdded, DEFAULT_MISBEHAVING_BANTIME, false);
     // Ensure we have exactly 2 entries in our banlist
     BOOST_CHECK(GetNumberBanEntries() == 2);
 

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -257,6 +257,8 @@ struct ConnectionHistory
 
     double nEvictions; // number of times a connection was de-prioritized and disconnected in last 30 minutes
     int64_t nLastEvictionTime; // the time the last eviction occurred.
+
+    std::string userAgent;
 };
 extern std::map<CNetAddr, ConnectionHistory> mapInboundConnectionTracker;
 extern CCriticalSection cs_mapInboundConnectionTracker;


### PR DESCRIPTION
BanReasonInvalidInventory for incorrect or null inventory messages

and

BanReasonInvalidPeer or BitcoinSV peers or any other peer deemed
invalid.