### PR TITLE
Fix a warning in cashlib.cpp

### DIFF
--- a/src/cashlib/cashlib.cpp
+++ b/src/cashlib/cashlib.cpp
@@ -67,7 +67,7 @@ typedef enum {
     AddrBlockchainNol = 4,
 } ChainSelector;
 
-static CChainParams *GetChainParams(ChainSelector chainSelector)
+CChainParams *GetChainParams(ChainSelector chainSelector)
 {
     if (chainSelector == AddrBlockchainBCH)
         return &Params(CBaseChainParams::MAIN);


### PR DESCRIPTION
```
../../src/cashlib/cashlib.cpp:69:22: warning: ‘CChainParams* GetChainParams(ChainSelector)’ defined but not used [-Wunused-function]
 static CChainParams *GetChainParams(ChainSelector chainSelector)
                       ^~~~~~~~~~~~~~
```

fix issue #1996