### PR TITLE
Don't run CheckBlock() more than once during IBD

### DIFF
--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -2009,8 +2009,13 @@ bool ConnectBlockPrevalidations(const CBlock &block,
     // then setBlockAlreadyChecked would be empty and we'd have to run CheckBlock() at least one time, which is
     // correct behavior.
     {
-        LOCK(cs_BlocksAlreadyChecked);
-        if (!setBlocksAlreadyChecked.count(block.GetHash()))
+        bool fAlreadyChecked = true;
+        {
+            LOCK(cs_BlocksAlreadyChecked);
+            if (!setBlocksAlreadyChecked.count(block.GetHash()))
+                fAlreadyChecked = false;
+        }
+        if (!fAlreadyChecked)
         {
             if (!CheckBlock(block, state, !fJustCheck, !fJustCheck))
             {
@@ -2018,7 +2023,10 @@ bool ConnectBlockPrevalidations(const CBlock &block,
             }
         }
         else
+        {
+            LOCK(cs_BlocksAlreadyChecked);
             setBlocksAlreadyChecked.erase(block.GetHash());
+        }
     }
 
     // verify that the view's current state corresponds to the previous block

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -26,12 +26,24 @@
 #include "validationinterface.h"
 
 #include <boost/scope_exit.hpp>
+#include <unordered_set>
 
 extern CTweak<unsigned int> unconfPushAction;
 
+class Hasher
+{
+private:
+    /** Salt */
+    const uint64_t k0, k1;
+
+public:
+    Hasher() : k0(GetRand(std::numeric_limits<uint64_t>::max())), k1(GetRand(std::numeric_limits<uint64_t>::max())) {}
+    uint64_t operator()(const uint256 &hash) const { return SipHashUint256(k0, k1, hash); }
+};
+
 // Stores hashes of blocks that have already successfully passed CheckBlock().
 CCriticalSection cs_BlocksAlreadyChecked;
-std::set<uint256> setBlocksAlreadyChecked GUARDED_BY(cs_BlocksAlreadyChecked);
+std::unordered_set<uint256, Hasher> setBlocksAlreadyChecked GUARDED_BY(cs_BlocksAlreadyChecked);
 // We don't let this set grow unbounded just in case we forget to erase values later.
 const unsigned int MAX_SETBLOCKSALREADYCHECKED_SIZE = 5000;
 


### PR DESCRIPTION
CheckBlock() is generally limited from running more than once by
using the fChecked flag which is stored internally to the block however
during IBD we store the blocks to disk 1000 blocks in advance which
ends up clearing the flag so when the block is read again from disk
we end up doing CheckBlock() again. This is an expensive operation
and takes up 10% of the total time for IBD to run. So by temporarily
storing the hash of any block we have run CheckBlock() on during IBD
we can then avoid re-running CheckBlock() after that block is read
again from disk.

Verify by testing that this indeed saved almost 10% of time to do IBD, which was 14 minutes on my machine.
previous IBD: 2hr 30min
with this PR: 2hr 16min
