### PR TITLE
[gui] Fix input validation for traffic shaping parameters

### DIFF
--- a/src/qt/unlimiteddialog.h
+++ b/src/qt/unlimiteddialog.h
@@ -59,8 +59,10 @@ private Q_SLOTS:
     void validateBlockSize();
     // Pushes the traffic shaping slider changes into the traffic shaping edit boxes
     void shapingSliderChanged();
-    void shapingMaxEditFinished(void); // auto-corrects cases where max is lower then average
-    void shapingAveEditFinished(void); // auto-corrects cases where max is lower then average
+    // auto-corrects cases where max is lower then average and force the input for those
+    // fields to be greater than zero
+    bool shapingMaxEditFinished(void);
+    bool shapingAveEditFinished(void);
     // Pushes the traffic shaping slider changes into the traffic shaping edit boxes
     void shapingEnableChanged(bool val);
 


### PR DESCRIPTION
Previously it was possbile to set 0 as value for both max and avg fields
by just let the fields blank. What's worse is that in these cases not even
the "avg must be lower or equal than max" was enforced.

As a summary this is the list of constraints enforced on traffic shaping
parameters:

- avg and max have to be equal than 0
- avg and max can't be blank
- avg has to be less than or equal to max