### PR TITLE
Get the subver string earlier when we track inbound connections

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -955,7 +955,6 @@ static bool AttemptToEvictConnection(bool fPreferNewConnection)
         {
             int nHoursToBan = 4;
             std::string userAgent = vEvictionCandidatesByActivity[0]->cleanSubVer;
-            mapInboundConnectionTracker[ipAddress].userAgent = userAgent;
             dosMan.Ban(ipAddress, userAgent, BanReasonTooManyEvictions, nHoursToBan * 60 * 60);
             LOGA("Banning %s for %d hours: Too many evictions - connection dropped\n",
                 vEvictionCandidatesByActivity[0]->addr.ToString(), nHoursToBan);

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2104,6 +2104,13 @@ bool ProcessMessages(CNode *pfrom)
         // Scan for message start
         if (memcmp(msg.hdr.pchMessageStart, pfrom->GetMagic(chainparams), MESSAGE_START_SIZE) != 0)
         {
+            // Setting the cleanSubVer string allows us to present this peer in the bantable
+            // with a likely peer type if it uses the BitcoinCore network magic.
+            if (memcmp(msg.hdr.pchMessageStart, chainparams.MessageStart(), MESSAGE_START_SIZE) == 0)
+            {
+                pfrom->cleanSubVer = "BitcoinCore Network application";
+            }
+
             LOG(NET, "PROCESSMESSAGE: INVALID MESSAGESTART %s peer=%s\n", SanitizeString(msg.hdr.GetCommand()),
                 pfrom->GetLogName());
             if (!pfrom->fWhitelisted)

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -483,6 +483,12 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
             vRecv >> LIMITED_STRING(pfrom->strSubVer, MAX_SUBVERSION_LENGTH);
             pfrom->cleanSubVer = SanitizeString(pfrom->strSubVer);
 
+            // Track the user agent string
+            {
+                LOCK(cs_mapInboundConnectionTracker);
+                mapInboundConnectionTracker[(CNetAddr)pfrom->addr].userAgent = pfrom->cleanSubVer;
+            }
+
             // ban SV peers
             if (pfrom->strSubVer.find("Bitcoin SV") != std::string::npos ||
                 pfrom->strSubVer.find("(SV;") != std::string::npos)


### PR DESCRIPTION
We were sometimes not displaying the user agent string when we
banned a peer for too many connection attempts. In short we were
getting the user agent string too late and should simply have gotten
it after the connection was first made.