### PR TITLE
DSP from flowee

### DIFF
--- a/doc/double-spend-proof-specification.md
+++ b/doc/double-spend-proof-specification.md
@@ -1,0 +1,197 @@
+<pre>
+  Layer: p2p
+  Title: Double Spend Proofs
+  Author: Tom Zander <tomz@freedommail.ch>, @im\_uname
+  Created: 2019-08-07
+  Last Revised: 2019-08-07
+  License: CC-BY-SA-4.0
+</pre>
+
+## Abstract
+
+This document describes a way to inform participants of attempts of double
+spending an unconfirmed transaction by providing cryptographic provable
+evidence that one UTXO entry was spent twice by the owner(s) of the funds.
+
+The ability to get informed of such an event can assist greatly in the
+confident acceptance of unconfirmed transactions as payment. We expect this
+will help with countering undetected attempts of double spends.
+
+## Summary
+
+A double spend attack can be used, for instance, to redirect payments meant for a specific
+merchant to a different target and thus defraud the merchant we want to pay to. The basic
+concept of a double spend is that (at least) one unspent output is spent
+twice in different transactions which forces miners to pick one of them to mine.
+
+At its most basic we can detect this by finding two signed inputs both
+spending the same output. In the case of pay-to-public-key-hash (P2PKH)
+this means two signatures signing the same public key.
+
+Cryptographic signatures in Bitcoin Cash follow the 'fork-id' algorithm described
+[here](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/replay-protected-sighash.md),
+which explains a change made to the Satoshi designed algorithm, a change after which the containing transaction itself is not signed, but a unique hash of that
+transaction is being signed. This gives us the opportunity to send only
+the intermediate hashes instead of the whole transaction while allowing
+receivers to still validate both signatures of the same public
+key. And therefore prove that a double spend has taken place.
+
+## Limitation and risks
+
+Not all types and all combinations of transactions are supported. Wallets
+and point-of-sale applications are suggested to give a rating of how secure
+an unconfirmed transaction is based on various factors.
+
+Transactions that spend all, confirmed, P2PKH outputs with all inputs
+signed SIGHASH\_ALL without ANYONECANPAY, are double-spend-proof's
+"protected transactions".
+
+For more details see "*Using Double Spend Alerts: Merchant considerations*"
+below.
+
+## Motivation
+
+The chance of defrauding a merchant by double spending the transaction that is being
+paid to him is real and the main problem we have today is the fact that
+without significant infrastructure the merchant won't find out until the
+block is confirmed.
+
+The low risk of getting caught will make this a problem as Bitcoin Cash
+becomes more mainstream.
+
+The double-spend-proof is a means with which network participants that have
+the infrastructure to detect double spends can share that fact so merchants
+can receive information on their payment app (typically SPV based) in short enough
+time that the merchant can refuse to provide service or goods to their
+customer.
+
+
+## Network specification
+
+A node that finds itself in possession of a correct double-spend-proof
+shall notify its peers using the INV message, using a 'type' field with
+number **0x94a0**. This will be changed to another number as this spec
+is finalized.
+
+The hash-ID for the double-spend-proof is a double sha256 over the entire
+serialized content of the proof, as defined next.
+
+In response to an INV any peer can issue a `getdata` message which will
+cause a reply with the following message. The name of the message (until
+this spec is finalized) is **`dsproof-beta`**.
+
+
+| Field Size | Description | Data Type  | Comments |
+| -----------|:-----------:| ----------:|---------:|
+| 32 | TxInPrevHash | sha256 | The txid being spent |
+| 4  | TxInPrevIndex | int | The output being spent |
+| | FirstSpender | spender | the first sorted spender |
+| | DoubleSpender | spender | the second spender |
+
+A double-spend-proof essentially describes two inputs, both spending the
+same output. As such the prev-hash and prev-index point to the output and
+the spenders each describe inputs.
+
+The details required to validate one input are provided in the spender field;
+
+| Field Size | Description | Data Type  | Comments |
+| -----------|:-----------:| ----------:|---------:|
+| 4 | tx-version | unsigned int | Copy of the transactions version field |
+| 4 | sequence | unsigned int | Copy of the sequence field of the input |
+| 4 | locktime | unsigned int | Copy of the transactions locktime field |
+| 32 | hash-prevoutputs | sha256 | Transaction hash of prevoutputs |
+| 32 | hash-sequence | sha256 | Transaction hash of sequences |
+| 32 | hash-outputs | sha256 | Transaction hash of outputs |
+| 1-9 | list-size | var-int | Number of items in the push-data list |
+|  | push-data | byte-array | Raw byte-array of a push-data. For instance a signature |
+
+## Validation
+
+It is required that nodes validate the proof before using it or forward it to other
+nodes. Please check against the matching transaction in your mempool for
+addresses so you can limit sending the proof only to interested nodes that
+have registered a bloom filter.
+
+Validation includes a short list of requirements;
+
+1. The DSP message is well-formed and contains all fields. It is allowed (by
+   nature of Bitcoin Cash) for some hashes to be all-zeros.
+2. The two spenders are different, specifically the signature (push data)
+   has to be different.
+3. The first & double spenders are sorted with two hashes as keys.  
+   Compare on the hash-outputs, and if those are equal, then compare on
+   hash-prevoutputs.
+   The sorting order is in numerically ascending order of the hash,
+   interpreted as 256-bit little endian integers.
+4. The double spent output is still available in the UTXO database,
+   implying no spending transaction has been mined.
+5. No other valid proof is known.
+
+Further validation can be done by essentially validating the signature that
+was copied from the inputs of both transactions against the output a node
+should have in either its memory pool or its UTXO database.
+
+To validate a spender of the proof, a node requires to have;
+
+* The output being spent (mempool or UTXO)
+* One of the transactions trying to spend the output.
+* The double-spend-proof.
+
+As the forkid
+[specification](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/replay-protected-sighash.md)
+details, the digest algorithm hashes 10 items in order to receive a sha256
+hash, which is then signed.
+
+These 10 items are;
+
+1.  nVersion of the transaction (4-byte little endian)
+2.  hashPrevouts (32-byte hash)
+3.  hashSequence (32-byte hash)
+4.  outpoint (32-byte hash + 4-byte little endian)
+5.  scriptCode of the input (serialized as scripts inside CTxOuts)
+6.  value of the output spent by this input (8-byte little endian)
+7.  nSequence of the input (4-byte little endian)
+8.  hashOutputs (32-byte hash)
+9.  nLocktime of the transaction (4-byte little endian)
+10. sighash type of the signature (4-byte little endian)
+
+In the double spend message we include items: 1, 2, 3, 4, 7, 8, 9 and 10.
+
+From the output we are trying to spend you can further obtain items: 5 & 6
+
+The full transaction also spending the same output which you found in your
+mempool, can be used to get the public key which you can use to validate
+that the signature is actually correct.
+
+When all rules are followed, the proof is valid.
+
+## Deployment
+
+There will be an immediate benefit to each extra node on the network
+creating or propagating these messages.
+
+As the amount of nodes that propagate them reaches around 20% then
+statistically there is a very good chance of each node having at least one
+participating peer leaving your node fully informed of all double spends.
+
+### Using Double Spend Alerts: Merchant considerations
+
+A merchant node which utilizes double-spend-proofs is advised to follow the following general procedure, when receiving a transaction that pays them whether through network or direct connection (e.g. BIP70):
+
+1. Evaluate the transaction that pays them. If the transaction does not pay sufficient fee or is otherwise unfit as defined by the merchant independent of the criteria below, apply remedial action either by rejecting transaction or custom negotiations with the customer - fast transaction becomes irrelevant.
+
+2. If the transaction does not fit any of the following criteria, do not rely on double-spend-proof, and instead either wait for confirmation or apply more stringent risk management:
+
+The transaction must contain all P2PKH.  
+The transaction must either be spending only from confirmed UTXOs, or all of its ancestors in mempool must also be all-P2PKH transactions (Optional, requires BIP62).  
+All of the inputs in the relevant transaction, and its mempool ancestor chain (Optional, requires BIP62), must be signed SIGHASH\_ALL without ANYONECANPAY.
+
+3. After affirming that the transaction fits the critera for applying double-spend-proofs, the merchant then waits T seconds, T being a variable adjusted to risk tolerance, for a proof to arrive. If a double-spend-proof corresponding to the paying transaction or any of its ancestors arrive, the merchant shall either decline the payment, or wait for confirmation. If no proof arrives within T seconds, the merchant hands out goods or services.
+
+Note that in the case of an unconfirmed chain, if BIP62 fixes are not implemented in full, transactions can be malleated by third parties to invalidate descendents without triggering double-spend-proof - and any attempt at making proof against this will be vulnerable to false positive attacks. Double-spend-proof against unconfirmed proofs should therefore only be activated after implementation of the full set of BIP62 fixes (https://github.com/bitcoin/bips/blob/master/bip-0062.mediawiki).
+
+## References
+
+The 'forkid' spec Bitcoin Cash uses to validate signatures in transactions;
+https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/replay-protected-sighash.md
+

--- a/src/DoubleSpendProof.cpp
+++ b/src/DoubleSpendProof.cpp
@@ -1,0 +1,293 @@
+// Copyright (C) 2019-2020 Tom Zander <tomz@freedommail.ch>
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "DoubleSpendProof.h"
+#include "hashwrapper.h"
+#include "main.h"
+#include "pubkey.h"
+#include "script/interpreter.h"
+#include "txmempool.h"
+
+namespace {
+    enum ScriptType {
+        P2PKH
+    };
+
+    void getP2PKHSignature(const CScript &script, std::vector<uint8_t> &vchRet)
+    {
+        auto scriptIter = script.begin();
+        opcodetype type;
+        script.GetOp(scriptIter, type, vchRet);
+    }
+
+    void hashTx(DoubleSpendProof::Spender &spender, const CTransaction &tx, int inputIndex)
+    {
+        assert(!spender.pushData.empty());
+        assert(!spender.pushData.front().empty());
+        auto hashType = spender.pushData.front().back();
+        if (!(hashType & SIGHASH_ANYONECANPAY)) {
+            CHashWriter ss(SER_GETHASH, 0);
+            for (size_t n = 0; n < tx.vin.size(); ++n) {
+                ss << tx.vin[n].prevout;
+            }
+            spender.hashPrevOutputs = ss.GetHash();
+        }
+        if (!(hashType & SIGHASH_ANYONECANPAY) && (hashType & 0x1f) != SIGHASH_SINGLE
+                && (hashType & 0x1f) != SIGHASH_NONE) {
+            CHashWriter ss(SER_GETHASH, 0);
+            for (size_t n = 0; n < tx.vin.size(); ++n) {
+                ss << tx.vin[n].nSequence;
+            }
+            spender.hashSequence = ss.GetHash();
+        }
+        if ((hashType & 0x1f) != SIGHASH_SINGLE && (hashType & 0x1f) != SIGHASH_NONE) {
+            CHashWriter ss(SER_GETHASH, 0);
+            for (size_t n = 0; n < tx.vout.size(); ++n) {
+                ss << tx.vout[n];
+            }
+            spender.hashOutputs = ss.GetHash();
+        } else if ((hashType & 0x1f) == SIGHASH_SINGLE && inputIndex < tx.vout.size()) {
+            CHashWriter ss(SER_GETHASH, 0);
+            ss << tx.vout[inputIndex];
+            spender.hashOutputs = ss.GetHash();
+        }
+    }
+
+    class DSPSignatureChecker : public BaseSignatureChecker {
+    public:
+        DSPSignatureChecker(const DoubleSpendProof *proof, const DoubleSpendProof::Spender &spender, int64_t amount)
+            : m_proof(proof),
+              m_spender(spender),
+              m_amount(amount)
+        {
+        }
+
+        bool CheckSig(const std::vector<uint8_t> &vchSigIn, const std::vector<uint8_t> &vchPubKey, const CScript &scriptCode) const override {
+            CPubKey pubkey(vchPubKey);
+            if (!pubkey.IsValid())
+                return false;
+
+            std::vector<uint8_t> vchSig(vchSigIn);
+            if (vchSig.empty())
+                return false;
+            vchSig.pop_back(); // drop the hashtype byte tacked on to the end of the signature
+
+            CHashWriter ss(SER_GETHASH, 0);
+            ss << m_spender.txVersion << m_spender.hashPrevOutputs << m_spender.hashSequence;
+            ss <<  COutPoint(m_proof->prevTxId(), m_proof->prevOutIndex());
+            ss << static_cast<const CScriptBase &>(scriptCode);
+            ss << m_amount << m_spender.outSequence << m_spender.hashOutputs;
+            ss << m_spender.lockTime << (int) m_spender.pushData.front().back();
+            const uint256 sighash = ss.GetHash();
+
+            if (vchSig.size() == 64)
+                return pubkey.VerifySchnorr(sighash, vchSig);
+            return pubkey.VerifyECDSA(sighash, vchSig);
+        }
+        bool CheckLockTime(const CScriptNum&) const override {
+            return true;
+        }
+        bool CheckSequence(const CScriptNum&) const override {
+            return true;
+        }
+
+        const DoubleSpendProof *m_proof;
+        const DoubleSpendProof::Spender &m_spender;
+        const int64_t m_amount;
+    };
+}
+
+// static
+DoubleSpendProof DoubleSpendProof::create(const CTransaction &t1, const CTransaction &t2)
+{
+    DoubleSpendProof answer;
+    Spender &s1 = answer.m_spender1;
+    Spender &s2 = answer.m_spender2;
+
+    size_t inputIndex1 = 0;
+    size_t inputIndex2 = 0;
+    for (; inputIndex1 < t1.vin.size(); ++inputIndex1) {
+        const CTxIn &in1 = t1.vin.at(inputIndex1);
+        for (;inputIndex2 < t2.vin.size(); ++inputIndex2) {
+            const CTxIn &in2 = t2.vin.at(inputIndex2);
+            if (in1.prevout == in2.prevout) {
+                answer.m_prevOutIndex = in1.prevout.n;
+                answer.m_prevTxId = in1.prevout.hash;
+
+                s1.outSequence = in1.nSequence;
+                s2.outSequence = in2.nSequence;
+
+                // TODO pass in the mempool and find the prev-tx we spend
+                // then we can determine what script type we are dealing with and
+                // be smarter about finding the signature.
+                // Assume p2pkh for now.
+
+                s1.pushData.resize(1);
+                getP2PKHSignature(in1.scriptSig, s1.pushData.front());
+                s2.pushData.resize(1);
+                getP2PKHSignature(in2.scriptSig, s2.pushData.front());
+
+                auto hashType = s1.pushData.front().back();
+                if (!(hashType & SIGHASH_FORKID))
+                    throw std::runtime_error("Tx1 Not a Bitcoin Cash transaction");
+                hashType = s2.pushData.front().back();
+                if (!(hashType & SIGHASH_FORKID))
+                    throw std::runtime_error("Tx2 Not a Bitcoin Cash transaction");
+
+                break;
+            }
+        }
+    }
+
+    if (answer.m_prevOutIndex == -1)
+        throw std::runtime_error("Transactions do not double spend each other");
+    if (s1.pushData.front().empty() || s2.pushData.front().empty())
+        throw std::runtime_error("Transactions not using known payment type. Could not find sig");
+
+    s1.txVersion = t1.nVersion;
+    s2.txVersion = t2.nVersion;
+    s1.lockTime = t1.nLockTime;
+    s2.lockTime = t2.nLockTime;
+
+    hashTx(s1, t1, inputIndex1);
+    hashTx(s2, t2, inputIndex2);
+
+    // sort the spenders to have proof be independent of the order of txs coming in
+    int diff = s1.hashOutputs.Compare(s2.hashOutputs);
+    if (diff == 0)
+        diff = s1.hashPrevOutputs.Compare(s2.hashPrevOutputs);
+    if (diff > 0)
+        std::swap(s1, s2);
+
+    return answer;
+}
+
+DoubleSpendProof::DoubleSpendProof()
+{
+}
+
+bool DoubleSpendProof::isEmpty() const
+{
+    return m_prevOutIndex == -1 || m_prevTxId.IsNull();
+}
+
+DoubleSpendProof::Validity DoubleSpendProof::validate() const
+{
+    if (m_prevTxId.IsNull() || m_prevOutIndex < 0)
+        return Invalid;
+    if (m_spender1.pushData.empty() || m_spender1.pushData.front().empty()
+            || m_spender2.pushData.empty() || m_spender2.pushData.front().empty())
+        return Invalid;
+
+    // check if ordering is proper
+    int diff = m_spender1.hashOutputs.Compare(m_spender2.hashOutputs);
+    if (diff == 0)
+        diff = m_spender1.hashPrevOutputs.Compare(m_spender2.hashPrevOutputs);
+    if (diff > 0)
+        return Invalid;
+
+    // Get the previous output we are spending.
+    int64_t amount;
+    CScript prevOutScript;
+    auto prevTx = mempool.get(m_prevTxId);
+    if (prevTx.get()) {
+        if (prevTx->vout.size() <= m_prevOutIndex)
+            return Invalid;
+        auto output = prevTx->vout.at(m_prevOutIndex);
+        amount = output.nValue;
+        prevOutScript = output.scriptPubKey;
+    } else {
+        Coin coin;
+        if (!pcoinsTip->GetCoin({m_prevTxId, m_prevOutIndex}, coin)) {
+            /* if the output we spend is missing then either the tx just got mined
+             * or, more likely, our mempool just doesn't have it.
+             */
+            return MissingUTXO;
+        }
+        amount = coin.out.nValue;
+        prevOutScript = coin.out.scriptPubKey;
+    }
+
+    /*
+     * Find the matching transaction spending this. Possibly identical to one
+     * of the sides of this DSP.
+     * We need this because we want the public key that it contains.
+     */
+    CTransaction tx;
+    {
+        READLOCK(mempool.cs_txmempool);
+        auto it = mempool.mapNextTx.find({m_prevTxId, m_prevOutIndex});
+        if (it == mempool.mapNextTx.end() || m_prevOutIndex >= it->second.ptx->vout.size()) {
+            return MissingTransaction;
+        }
+        tx = *(it->second.ptx);
+    }
+
+    /*
+     * TomZ: At this point (2019-07) we only support P2PKH payments.
+     *
+     * Since we have an actually spending tx, we could trivially support various other
+     * types of scripts because all we need to do is replace the signature from our 'tx'
+     * with the one that comes from the DSP.
+     */
+    ScriptType scriptType = P2PKH; // FUTURE: look at prevTx to find out script-type
+
+    std::vector<uint8_t> pubkey;
+    for (size_t i = 0; i < tx.vin.size(); ++i) {
+        if (tx.vin[i].prevout.n == m_prevOutIndex
+                && tx.vin[i].prevout.hash == m_prevTxId) {
+
+            // Found the input script we need!
+
+            CScript inScript = tx.vin[i].scriptSig;
+            auto scriptIter = inScript.begin();
+            opcodetype type;
+            inScript.GetOp(scriptIter, type); // P2PKH: first signature
+            inScript.GetOp(scriptIter, type, pubkey); // then pubkey
+            break;
+        }
+    }
+
+    if (pubkey.empty())
+        return Invalid;
+
+    CScript inScript;
+    if (scriptType == P2PKH) {
+        inScript << m_spender1.pushData.front();
+        inScript << pubkey;
+    }
+    DSPSignatureChecker checker1(this, m_spender1, amount);
+    ScriptError_t error;
+    if (!VerifyScript(inScript, prevOutScript, 0 /*flags*/, MAX_OPS_PER_SCRIPT, checker1, &error)) {
+        LOGA("DoubleSpendProof failed validating first tx due to %s\n", ScriptErrorString(error));
+        return Invalid;
+    }
+
+    inScript.clear();
+    if (scriptType == P2PKH) {
+        inScript << m_spender2.pushData.front();
+        inScript << pubkey;
+    }
+    DSPSignatureChecker checker2(this, m_spender2, amount);
+    if (!VerifyScript(inScript, prevOutScript, 0 /*flags*/, MAX_OPS_PER_SCRIPT, checker2, &error)) {
+        LOGA("DoubleSpendProof failed validating second tx due to %s\n", ScriptErrorString(error));
+        return Invalid;
+    }
+    return Valid;
+}
+
+uint256 DoubleSpendProof::prevTxId() const
+{
+    return m_prevTxId;
+}
+
+int DoubleSpendProof::prevOutIndex() const
+{
+    return m_prevOutIndex;
+}
+
+uint256 DoubleSpendProof::createHash() const
+{
+    return SerializeHash(*this);
+}

--- a/src/DoubleSpendProof.cpp
+++ b/src/DoubleSpendProof.cpp
@@ -109,7 +109,7 @@ DoubleSpendProof DoubleSpendProof::create(const CTransaction &t1, const CTransac
     size_t inputIndex2 = 0;
     for (; inputIndex1 < t1.vin.size(); ++inputIndex1) {
         const CTxIn &in1 = t1.vin.at(inputIndex1);
-        for (;inputIndex2 < t2.vin.size(); ++inputIndex2) {
+        for (inputIndex2 = 0;inputIndex2 < t2.vin.size(); ++inputIndex2) {
             const CTxIn &in2 = t2.vin.at(inputIndex2);
             if (in1.prevout == in2.prevout) {
                 answer.m_prevOutIndex = in1.prevout.n;

--- a/src/DoubleSpendProof.h
+++ b/src/DoubleSpendProof.h
@@ -1,0 +1,82 @@
+// Copyright (C) 2019-2020 Tom Zander <tomz@freedommail.ch>
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef DOUBLESPENDPROOF_H
+#define DOUBLESPENDPROOF_H
+
+#include <uint256.h>
+#include "serialize.h"
+#include <deque>
+
+class CTxMemPool;
+class CTransaction;
+
+class DoubleSpendProof
+{
+public:
+    DoubleSpendProof();
+
+    static DoubleSpendProof create(const CTransaction &tx1, const CTransaction &tx2);
+
+    bool isEmpty() const;
+
+    enum Validity {
+        Valid,
+        MissingTransaction,
+        MissingUTXO,
+        Invalid
+    };
+
+    Validity validate() const;
+
+    uint256 prevTxId() const;
+    int prevOutIndex() const;
+
+    struct Spender {
+        uint32_t txVersion = 0, outSequence = 0, lockTime = 0;
+        uint256 hashPrevOutputs, hashSequence, hashOutputs;
+        std::vector<std::vector<uint8_t>> pushData;
+    };
+
+    Spender firstSpender() const {
+        return m_spender1;
+    }
+    Spender doubleSpender() const {
+        return m_spender2;
+    }
+
+    // old fashioned serialization.
+    ADD_SERIALIZE_METHODS
+
+    template <typename Stream, typename Operation>
+    inline void SerializationOp(Stream& s, Operation ser_action) {
+        READWRITE(m_prevTxId);
+        READWRITE(m_prevOutIndex);
+
+        READWRITE(m_spender1.txVersion);
+        READWRITE(m_spender1.outSequence);
+        READWRITE(m_spender1.lockTime);
+        READWRITE(m_spender1.hashPrevOutputs);
+        READWRITE(m_spender1.hashSequence);
+        READWRITE(m_spender1.hashOutputs);
+        READWRITE(m_spender1.pushData);
+
+        READWRITE(m_spender2.txVersion);
+        READWRITE(m_spender2.outSequence);
+        READWRITE(m_spender2.lockTime);
+        READWRITE(m_spender2.hashPrevOutputs);
+        READWRITE(m_spender2.hashSequence);
+        READWRITE(m_spender2.hashOutputs);
+        READWRITE(m_spender2.pushData);
+    }
+
+    uint256 createHash() const;
+
+private:
+    uint256 m_prevTxId;
+    int32_t m_prevOutIndex = -1;
+
+    Spender m_spender1, m_spender2;
+};
+
+#endif

--- a/src/DoubleSpendProofStorage.cpp
+++ b/src/DoubleSpendProofStorage.cpp
@@ -1,0 +1,204 @@
+// Copyright (C) 2019-2020 Tom Zander <tomz@freedommail.ch>
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#include "DoubleSpendProofStorage.h"
+#include <utiltime.h>
+#include <primitives/transaction.h>
+#include "hashwrapper.h"
+#include "util.h"
+#include "dosman.h"
+
+#define SECONDS_TO_KEEP_ORPHANS 90
+
+extern boost::asio::io_service stat_io_service;
+
+DoubleSpendProofStorage::DoubleSpendProofStorage()
+    : m_recentRejects(120000, 0.000001),
+    m_timer(stat_io_service)
+{
+    m_timer.expires_from_now(boost::posix_time::minutes(2));
+    m_timer.async_wait(std::bind(&DoubleSpendProofStorage::periodicCleanup, this, std::placeholders::_1));
+}
+
+DoubleSpendProofStorage::~DoubleSpendProofStorage()
+{
+    m_timer.cancel();
+}
+
+DoubleSpendProof DoubleSpendProofStorage::proof(int proof) const
+{
+    std::lock_guard<std::recursive_mutex> lock(m_lock);
+    auto iter = m_proofs.find(proof);
+    if (iter != m_proofs.end())
+        return iter->second;
+    return DoubleSpendProof();
+}
+
+int DoubleSpendProofStorage::add(const DoubleSpendProof &proof)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_lock);
+
+    uint256 hash = proof.createHash();
+    auto lookupIter = m_dspIdLookupTable.find(hash);
+    if (lookupIter != m_dspIdLookupTable.end())
+        return lookupIter->second;
+
+    auto iter = m_proofs.find(m_nextId);
+    while (iter != m_proofs.end()) {
+        if (++m_nextId < 0)
+            m_nextId = 1;
+        iter = m_proofs.find(m_nextId);
+    }
+    m_proofs.insert(std::make_pair(m_nextId, proof));
+    m_dspIdLookupTable.insert(std::make_pair(hash, m_nextId));
+
+    return m_nextId++;
+}
+
+void DoubleSpendProofStorage::addOrphan(const DoubleSpendProof &proof, int peerId)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_lock);
+    const int next = m_nextId;
+    const int id = add(proof);
+    if (id != next) // it was already in the storage
+        return;
+
+    m_orphans.insert(std::make_pair(id, std::make_pair(peerId, GetTime())));
+    m_prevTxIdLookupTable[proof.prevTxId().GetCheapHash()].push_back(id);
+}
+
+std::list<std::pair<int, int>> DoubleSpendProofStorage::findOrphans(const COutPoint &prevOut)
+{
+    std::list<std::pair<int, int>> answer;
+    std::lock_guard<std::recursive_mutex> lock(m_lock);
+    auto iter = m_prevTxIdLookupTable.find(prevOut.hash.GetCheapHash());
+    if (iter == m_prevTxIdLookupTable.end())
+        return answer;
+
+    std::deque<int> &q = iter->second;
+    for (auto proofId = q.begin(); proofId != q.end(); ++proofId) {
+        auto proofIter = m_proofs.find(*proofId);
+        assert (proofIter != m_proofs.end());
+        if (proofIter->second.prevOutIndex() != int(prevOut.n))
+            continue;
+        if (proofIter->second.prevTxId() == prevOut.hash) {
+            auto orphanIter = m_orphans.find(*proofId);
+            if (orphanIter != m_orphans.end()) {
+                answer.push_back(std::make_pair(*proofId, orphanIter->second.first));
+            }
+        }
+    }
+    return answer;
+}
+
+void DoubleSpendProofStorage::claimOrphan(int proofId)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_lock);
+    auto orphan = m_orphans.find(proofId);
+    if (orphan != m_orphans.end()) {
+        m_orphans.erase(orphan);
+
+        for (auto iter = m_prevTxIdLookupTable.begin(); iter != m_prevTxIdLookupTable.end(); ++iter) {
+            auto &list = iter->second;
+            for (auto i = list.begin(); i != list.end(); ++i) {
+                if (*i == proofId) {
+                    list.erase(i);
+                    if (list.size() == 0)
+                        m_prevTxIdLookupTable.erase(iter);
+                    return;
+                }
+            }
+        }
+    }
+}
+
+void DoubleSpendProofStorage::remove(int proof)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_lock);
+    auto iter = m_proofs.find(proof);
+    if (iter == m_proofs.end())
+        return;
+
+    auto orphan = m_orphans.find(iter->first);
+    if (orphan != m_orphans.end()) {
+        m_orphans.erase(orphan);
+        auto orphanLookup = m_prevTxIdLookupTable.find(iter->second.prevTxId().GetCheapHash());
+        if (orphanLookup != m_prevTxIdLookupTable.end()) {
+            std::deque<int> &queue = orphanLookup->second;
+            if (queue.size() == 1) {
+                assert(queue.front() == proof);
+                m_prevTxIdLookupTable.erase(orphanLookup);
+            }
+            else {
+                for (auto i = queue.begin(); i != queue.end(); ++i) {
+                    if (*i == proof) {
+                        queue.erase(i);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    auto hash = iter->second.createHash();
+    m_dspIdLookupTable.erase(hash);
+    m_proofs.erase(iter);
+}
+
+DoubleSpendProof DoubleSpendProofStorage::lookup(const uint256 &proofId) const
+{
+    std::lock_guard<std::recursive_mutex> lock(m_lock);
+    auto lookupIter = m_dspIdLookupTable.find(proofId);
+    if (lookupIter == m_dspIdLookupTable.end())
+        return DoubleSpendProof();
+    return m_proofs.at(lookupIter->second);
+}
+
+bool DoubleSpendProofStorage::exists(const uint256 &proofId) const
+{
+    std::lock_guard<std::recursive_mutex> lock(m_lock);
+    return m_dspIdLookupTable.find(proofId) != m_dspIdLookupTable.end();
+}
+
+void DoubleSpendProofStorage::periodicCleanup(const boost::system::error_code &error)
+{
+    if (error)
+        return;
+    m_timer.expires_from_now(boost::posix_time::minutes(1));
+    m_timer.async_wait(std::bind(&DoubleSpendProofStorage::periodicCleanup, this, std::placeholders::_1));
+
+    std::lock_guard<std::recursive_mutex> lock(m_lock);
+    auto expire = GetTime() - SECONDS_TO_KEEP_ORPHANS;
+    auto iter = m_orphans.begin();
+    while (iter != m_orphans.end()) {
+        if (iter->second.second <= expire) {
+            const int peerId = iter->second.first;
+            const int proofId = iter->first;
+            iter = m_orphans.erase(iter);
+            remove(proofId);
+
+            dosMan.Misbehaving(peerId, 1);
+        }
+        else {
+            ++iter;
+        }
+    }
+    LOG(DSPROOF, "DSP orphan count: %d DSProof count: %d\n", m_orphans.size(), m_proofs.size());
+}
+
+bool DoubleSpendProofStorage::isRecentlyRejectedProof(const uint256 &proofHash) const
+{
+    std::lock_guard<std::recursive_mutex> lock(m_lock);
+    return m_recentRejects.contains(proofHash);
+}
+
+void DoubleSpendProofStorage::markProofRejected(const uint256 &proofHash)
+{
+    std::lock_guard<std::recursive_mutex> lock(m_lock);
+    m_recentRejects.insert(proofHash);
+}
+
+void DoubleSpendProofStorage::newBlockFound()
+{
+    std::lock_guard<std::recursive_mutex> lock(m_lock);
+    m_recentRejects.reset();
+}

--- a/src/DoubleSpendProofStorage.h
+++ b/src/DoubleSpendProofStorage.h
@@ -1,0 +1,65 @@
+// Copyright (C) 2019-2020 Tom Zander <tomz@freedommail.ch>
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef DOUBLESPENDPROOFSTORAGE_H
+#define DOUBLESPENDPROOFSTORAGE_H
+
+#include "DoubleSpendProof.h"
+#include "bloom.h"
+#include <boost/unordered_map.hpp>
+#include <boost/asio.hpp>
+
+#include <map>
+#include <set>
+#include <mutex>
+
+class COutPoint;
+
+class DoubleSpendProofStorage
+{
+public:
+    DoubleSpendProofStorage();
+    ~DoubleSpendProofStorage();
+
+    /// returns a double spend proof based on proof-id
+    DoubleSpendProof proof(int proof) const;
+    /// adds a proof, returns an internal proof-id that proof is known under.
+    /// notice that if the proof (by hash) was known, that proof-id is returned instead.
+    int add(const DoubleSpendProof &proof);
+    /// remove by proof-id
+    void remove(int proof);
+
+    /// this add()s and additionally registers this is an orphan.
+    /// you can fetch those upto 90s using 'claim()'.
+    void addOrphan(const DoubleSpendProof &proof, int peerId);
+    /// Returns all (not yet verified) orphans matching prevOut.
+    /// Each item is a pair of a proofId and the nodeId that send the proof to us
+    std::list<std::pair<int, int> > findOrphans(const COutPoint &prevOut);
+
+    void claimOrphan(int proofId);
+
+    DoubleSpendProof lookup(const uint256 &proofId) const;
+    bool exists(const uint256 &proofId) const;
+
+    // called every minute
+    void periodicCleanup(const boost::system::error_code &error);
+
+    bool isRecentlyRejectedProof(const uint256 &proofHash) const;
+    void markProofRejected(const uint256 &proofHash);
+    void newBlockFound();
+
+private:
+    std::map<int, DoubleSpendProof> m_proofs;
+    int m_nextId = 1;
+    std::map<int, std::pair<int, int64_t> > m_orphans;
+
+    typedef boost::unordered_map<uint256, int, HashShortener> LookupTable;
+    LookupTable m_dspIdLookupTable;
+    std::map<uint64_t, std::deque<int> > m_prevTxIdLookupTable;
+    mutable std::recursive_mutex m_lock;
+
+    CRollingBloomFilter m_recentRejects;
+    boost::asio::deadline_timer m_timer;
+};
+
+#endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -143,6 +143,8 @@ BITCOIN_CORE_H = \
   core_io.h \
   core_memusage.h \
   cuckoocache.h \
+  DoubleSpendProof.h \
+  DoubleSpendProofStorage.h \
   deadlock-detection/locklocation.h \
   deadlock-detection/lockorder.h \
   deadlock-detection/threaddeadlock.h \
@@ -276,6 +278,8 @@ libbitcoin_server_a_SOURCES = \
   checkpoints.cpp \
   connmgr.cpp \
   consensus/tx_verify.cpp \
+  DoubleSpendProof.cpp \
+  DoubleSpendProofStorage.cpp \
   dosman.cpp \
   expedited.cpp \
   electrum/electrs.cpp \

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -197,11 +197,11 @@ const char *sampleNames[] = {"sec10", "min5", "hourly", "daily", "monthly"};
 int operateSampleCount[] = {30, 12, 24, 30};
 int interruptIntervals[] = {30, 30 * 12, 30 * 12 * 24, 30 * 12 * 24 * 30};
 
-CTxMemPool mempool(::minRelayTxFee);
-CTxOrphanPool orphanpool;
-
 std::chrono::milliseconds statMinInterval(10000);
 boost::asio::io_service stat_io_service;
+
+CTxMemPool mempool(::minRelayTxFee);
+CTxOrphanPool orphanpool;
 
 std::list<CStatBase *> mallocedStats;
 CStatMap statistics;

--- a/src/protocol.cpp
+++ b/src/protocol.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 // Copyright (c) 2015-2019 The Bitcoin Unlimited developers
+// Copyright (C) 2020 Tom Zander <tomz@freedommail.ch>
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -69,6 +70,8 @@ const char *SENDCMPCT = "sendcmpct";
 const char *CMPCTBLOCK = "cmpctblock";
 const char *GETBLOCKTXN = "getblocktxn";
 const char *BLOCKTXN = "blocktxn";
+
+const char *DSPROOF="dsproof-beta";
 };
 
 static const char *ppszTypeName[] = {
@@ -196,11 +199,17 @@ CInv::CInv(const std::string &strType, const uint256 &hashIn)
 }
 
 bool operator<(const CInv &a, const CInv &b) { return (a.type < b.type || (a.type == b.type && a.hash < b.hash)); }
-bool CInv::IsKnownType() const { return (type >= 1 && type < (int)ARRAYLEN(ppszTypeName)); }
+bool CInv::IsKnownType() const
+{
+    return (type >= 1 && type < 8) || type == MSG_DOUBLESPENDPROOF;
+}
+
 const char *CInv::GetCommand() const
 {
     if (!IsKnownType())
         throw std::out_of_range(strprintf("CInv::GetCommand(): type=%d unknown type", type));
+    if (type == MSG_DOUBLESPENDPROOF)
+        return NetMsgType::DSPROOF;
     return ppszTypeName[type];
 }
 

--- a/src/protocol.h
+++ b/src/protocol.h
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 // Copyright (c) 2015-2019 The Bitcoin Unlimited developers
+// Copyright (C) 2020 Tom Zander <tomz@freedommail.ch>
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -350,6 +351,11 @@ extern const char *GETBLOCKTXN;
  * @since protocol version 70014 as described by BIP 152
  */
 extern const char *BLOCKTXN;
+
+/**
+ * Double spend proof
+ */
+extern const char *DSPROOF;
 };
 
 
@@ -499,6 +505,8 @@ enum
     MSG_THINBLOCK = MSG_CMPCT_BLOCK,
     // Uses Graphene set reconciliation to syncronize mempools between two peers.
     MSG_MEMPOOLSYNC,
+
+    MSG_DOUBLESPENDPROOF = 0x94a0
 };
 
 #endif // BITCOIN_PROTOCOL_H

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -1,4 +1,5 @@
 // Copyright (c) 2018-2019 The Bitcoin Unlimited developers
+// Copyright (C) 2019-2020 Tom Zander <tomz@freedommail.ch>
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -9,6 +10,8 @@
 #include "consensus/tx_verify.h"
 #include "core_io.h"
 #include "dosman.h"
+#include "DoubleSpendProof.h"
+#include "DoubleSpendProofStorage.h"
 #include "fastfilter.h"
 #include "init.h"
 #include "main.h"
@@ -29,6 +32,29 @@
 
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/thread/thread.hpp>
+
+namespace {
+
+void broadcastDspInv(const CTransactionRef &dspTx, const uint256 &hash)
+{
+    // send INV to all peers
+    CInv inv(MSG_DOUBLESPENDPROOF, hash);
+    LOCK(cs_vNodes);
+    for (CNode* pnode : vNodes) {
+        if(!pnode->fRelayTxes)
+            continue;
+        LOCK(pnode->cs_filter);
+        if (pnode->pfilter) {
+            // For nodes that we sent this Tx before, send a proof.
+            if (pnode->pfilter->IsRelevantAndUpdate(dspTx))
+                pnode->PushInventory(inv);
+        } else {
+            pnode->PushInventory(inv);
+        }
+    }
+
+}
+}
 
 using namespace std;
 
@@ -206,6 +232,9 @@ unsigned int TxAlreadyHave(const CInv &inv)
             return 4;
         return 0;
     }
+    case MSG_DOUBLESPENDPROOF:
+        return mempool.doubleSpendProofStorage()->exists(inv.hash)
+                || mempool.doubleSpendProofStorage()->isRecentlyRejectedProof(inv.hash);
     }
     DbgAssert(0, return false); // this fn should only be called if CInv is a tx
 }
@@ -292,7 +321,38 @@ void CommitTxToMempool()
         for (auto &it : *txCommitQFinal)
         {
             CTxCommitData &data = it.second;
+            assert(data.entry.dsproof == -1);
             mempool._addUnchecked(it.first, data.entry, !IsInitialBlockDownload());
+
+            for (auto i = data.rescuedOrphans.begin(); i != data.rescuedOrphans.end(); ++i) {
+                const int proofId = i->first;
+                auto dsp = mempool.doubleSpendProofStorage()->proof(proofId);
+                LOG(DSPROOF, "Rescued a DSP orphan %d\n", proofId);
+                auto rc = dsp.validate();
+
+                // it can't be missing utxo or transaction, assert we are internally consistent.
+                assert(rc == DoubleSpendProof::Valid
+                       || rc == DoubleSpendProof::Invalid);
+
+                if (rc == DoubleSpendProof::Valid) {
+                    LOG(DSPROOF, "  Using DSP, it validated just fine\n");
+                    mempool.doubleSpendProofStorage()->claimOrphan(proofId);
+                    data.entry.dsproof = proofId;
+                    auto iter = mempool.mapTx.find(data.hash);
+                    mempool.mapTx.replace(iter, data.entry);
+
+                    while (++i != data.rescuedOrphans.end()) {
+                        LOG(DSPROOF, "Killing DSP orphan, we don't need more than one\n");
+                        mempool.doubleSpendProofStorage()->remove(i->first);
+                    }
+                    break;
+                } else {
+                    LOG(DSPROOF, "  DSP didn't validate! %s\n", dsp.createHash().ToString());
+                    mempool.doubleSpendProofStorage()->remove(proofId);
+                    dosMan.Misbehaving(i->second, 10);
+                }
+            }
+
             vWhatChanged.push_back(data.hash);
 
             // Indicate that this tx was fully processed/accepted and can now be removed from the
@@ -306,13 +366,19 @@ void CommitTxToMempool()
         txCommitQFinal = new std::map<uint256, CTxCommitData>;
     }
 
-#ifdef ENABLE_WALLET
     for (auto &it : *q)
     {
         CTxCommitData &data = it.second;
+#ifdef ENABLE_WALLET
         SyncWithWallets(data.entry.GetSharedTx(), nullptr, -1);
-    }
 #endif
+
+        if (data.entry.dsproof != -1) {
+            auto dsp = mempool.doubleSpendProofStorage()->proof(data.entry.dsproof);
+            if (!dsp.isEmpty())
+                broadcastDspInv(data.entry.GetSharedTx(), dsp.createHash());
+        }
+    }
     q->clear();
     delete q;
 
@@ -772,7 +838,7 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
     respend::RespendDetector respend(pool, tx);
     *isRespend = respend.IsRespend();
 
-    if (respend.IsRespend() && !respend.IsInteresting())
+    if (false && respend.IsRespend() && !respend.IsInteresting())
     {
         if (debugger)
         {
@@ -1244,6 +1310,47 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
             }
         }
 
+        // check each input for a double-spend.
+        WRITELOCK(mempool.cs_txmempool);
+        std::list<std::pair<int, int> > rescuedOrphans; // <proofId,nodeId>
+        for (const CTxIn &txin : entry.GetTx().vin) {
+            auto orphans = mempool.doubleSpendProofStorage()->findOrphans(txin.prevout);
+            if (!orphans.empty()) {
+                for (auto o : orphans)
+                    rescuedOrphans.push_back(o);
+                // if we find the DSP here, AS AN ORPHAN, then nothing has entered the mempool yet
+                // that claimed it. As such we don't have to check for conflicts.
+                continue;
+            }
+
+            auto oldTx = mempool.mapNextTx.find(txin.prevout);
+            if (oldTx != mempool.mapNextTx.end()) { // double spend detected!
+                auto iter = mempool.mapTx.find(oldTx->second.ptx->GetHash());
+                assert(mempool.mapTx.end() != iter);
+                if (iter->dsproof == -1) { // no DS proof exists, lets make one.
+                    try {
+                        auto item = *iter;
+                        const auto dsp = DoubleSpendProof::create(*oldTx->second.ptx, entry.GetTx());
+                        item.dsproof = mempool.doubleSpendProofStorage()->add(dsp);
+                        LOG(DSPROOF, "Double spend found, creating double spend proof %d\n", item.dsproof);
+                        mempool.mapTx.replace(iter, item);
+
+                        broadcastDspInv(mempool._get(oldTx->second.ptx->GetHash()), dsp.createHash()); // send INV to all peers
+                    } catch (const std::exception &e) {
+                        LOG(DSPROOF, "Double spend creation failed: %s\n", e.what());
+                    }
+                }
+                if (debugger)
+                {
+                    debugger->AddInvalidReason("txn-mempool-conflict");
+                }
+                else
+                {
+                    return state.Invalid(false, REJECT_CONFLICT, "txn-mempool-conflict");
+                }
+            }
+        }
+
         respend.SetValid(true);
         if (respend.IsRespend())
         {
@@ -1263,6 +1370,7 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
             CTxCommitData eData;
             eData.entry = std::move(entry);
             eData.hash = hash;
+            eData.rescuedOrphans = rescuedOrphans;
 
             boost::unique_lock<boost::mutex> lock(csCommitQ);
             (*txCommitQ).emplace(eData.hash, eData);

--- a/src/txadmission.h
+++ b/src/txadmission.h
@@ -95,6 +95,7 @@ class CTxCommitData
 public:
     CTxMemPoolEntry entry;
     uint256 hash;
+    std::list<std::pair<int, int>> rescuedOrphans;
 };
 
 /** Communicate what class of transaction is acceptable to add to the memory pool

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 // Copyright (c) 2015-2018 The Bitcoin Unlimited developers
+// Copyright (C) 2019-2020 Tom Zander <tomz@freedommail.ch>
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -26,6 +27,8 @@ class CAutoFile;
 class CBlockIndex;
 class TxMempoolOriginalState;
 class CTxChange;
+class DoubleSpendProofStorage;
+class DoubleSpendProof;
 
 inline double AllowFreeThreshold() { return COIN * 144 / 250; }
 inline bool AllowFree(double dPriority)
@@ -118,6 +121,7 @@ private:
 
 public:
     unsigned char sighashType;
+    int dsproof = -1;
     CTxMemPoolEntry();
     CTxMemPoolEntry(const CTransactionRef _tx,
         const CAmount &_nFee,
@@ -558,6 +562,14 @@ public:
     /** Return the set of mempool children for this entry */
     const setEntries &GetMemPoolChildren(txiter entry) const;
 
+    /**
+     * Add a double spend proof we received elsewhere to an existing mempool-entry.
+     * Return CTransaction of the mempool entry we added this to.
+     */
+    CTransactionRef addDoubleSpendProof(const DoubleSpendProof &proof);
+
+    DoubleSpendProofStorage *doubleSpendProofStorage() const;
+
 private:
     typedef std::map<txiter, setEntries, CompareIteratorByHash> cacheMap;
 
@@ -881,6 +893,8 @@ private:
      *  removal.
      */
     void removeUnchecked(txiter entry);
+
+    DoubleSpendProofStorage *m_dspStorage;
 };
 
 /** This internal class holds the original state of mempool state values.

--- a/src/uint256.h
+++ b/src/uint256.h
@@ -1,6 +1,7 @@
 // Copyright (c) 2009-2010 Satoshi Nakamoto
 // Copyright (c) 2009-2015 The Bitcoin Core developers
 // Copyright (c) 2015-2019 The Bitcoin Unlimited developers
+// Copyright (C) 2020 Tom Zander <tomz@freedommail.ch>
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
@@ -191,4 +192,18 @@ inline uint160 uint160S(const std::string &str)
     rv.SetHex(str);
     return rv;
 }
+
+/**
+ * Useful structure to use for maps.
+ * For instance:
+ *
+ *  typedef boost::unordered_map<uint256, int, HashShortener> MyMap;
+ */
+struct HashShortener
+{
+    inline size_t operator()(const uint256& hash) const {
+        return hash.GetCheapHash();
+    }
+};
+
 #endif // BITCOIN_UINT256_H

--- a/src/util.h
+++ b/src/util.h
@@ -199,7 +199,9 @@ enum
     CMPCT = 0x80000000, // compact blocks
 
     ELECTRUM = 0x100000000,
-    MPOOLSYNC = 0x200000000
+    MPOOLSYNC = 0x200000000,
+
+    DSPROOF = 0x400000000
 };
 
 namespace Logging
@@ -209,7 +211,7 @@ extern uint64_t categoriesEnabled;
 /*
 To add a new log category:
 1) Create a unique 1 bit category mask. (Easiest is to 2* the last enum entry.)
-   Put it at the end of enum below.
+   Put it at the end of enum above.
 2) Add an category/string pair to LOGLABELMAP macro below.
 */
 
@@ -223,7 +225,7 @@ To add a new log category:
             {REQ, "req"}, {BLOOM, "bloom"}, {LCK, "lck"}, {PROXY, "proxy"}, {DBASE, "dbase"},                   \
             {SELECTCOINS, "selectcoins"}, {ESTIMATEFEE, "estimatefee"}, {QT, "qt"}, {IBD, "ibd"},               \
             {GRAPHENE, "graphene"}, {RESPEND, "respend"}, {WB, "weakblocks"}, {CMPCT, "cmpctblock"},            \
-            {ELECTRUM, "electrum"}, {MPOOLSYNC, "mempoolsync"},                                                 \
+            {ELECTRUM, "electrum"}, {MPOOLSYNC, "mempoolsync"}, {DSPROOF, "dsproof"},                           \
         {                                                                                                       \
             ZMQ, "zmq"                                                                                          \
         }                                                                                                       \


### PR DESCRIPTION
Import DoubleSpendProof support
    
This takes the Double Spend Proof functionality written by Tom Zander
elsewhere and imports it into Bitcoin Unlimited, granting BU the ability
to create, validate, store and propagate DSPs.
