### PR TITLE
[port][rpc] Add getchaintxstats and uptime RPC calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-sudo: required
 dist: xenial
 os: linux
-language: minimal
+language: shell
 cache:
   ccache: true
   directories:
@@ -31,7 +30,7 @@ env:
     - DIST=DEB
     - CACHE_ERR_MSG="Error! Initial build successful, but not enough time remains to run later build stages and tests. Please manually re-run this job by using the travis restart button or asking a bitcoin maintainer to restart.  The next run should not time out because the build cache has been saved."
 
-matrix:
+jobs:
   include:
     #x86_64 Linux + deps as via system lib
     - compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,9 +146,9 @@ before_script:
     - set -o errexit; source .travis/before_script.sh
 script:
     - export CONTINUE=1
-    - if [ $SECONDS -gt 1980 ]; then export CONTINUE=0; fi  # Likely the depends build took very long
+    - if [ $SECONDS -gt 1200 ]; then export CONTINUE=0; fi  # Likely the depends build took very long
     - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/script_a.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
-    - if [ $SECONDS -gt 2300 -a "$RUN_TESTS"="true" ]; then export CONTINUE=0; echo "$SECONDS"; fi  # Likely the build took very long
+    - if [ $SECONDS -gt 2000 -a "$RUN_TESTS"="true" ]; then export CONTINUE=0; echo "$SECONDS"; fi  # Likely the build took very long
     - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/script_b.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
 
 after_script:

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -263,6 +263,7 @@ testScripts = [ RpcTest(t) for t in [
     'rpc_getblockstats',
     'minimaldata-activation',
     'schnorrmultisig_activation',
+    'uptime'
 ] ]
 
 testScriptsExt = [ RpcTest(t) for t in [

--- a/qa/rpc-tests/uptime.py
+++ b/qa/rpc-tests/uptime.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+"""Test the RPC call related to the uptime command.
+
+Test corresponds to code in rpc/server.cpp.
+"""
+
+import time
+
+from test_framework.test_framework import BitcoinTestFramework
+
+
+class UptimeTest(BitcoinTestFramework):
+    def __init__(self):
+        super().__init__()
+
+        self.num_nodes = 1
+        self.setup_clean_chain = True
+
+    def run_test(self):
+        self._test_uptime()
+
+    def _test_uptime(self):
+        wait_time = 10
+        self.nodes[0].setmocktime(int(time.time() + wait_time))
+        assert(self.nodes[0].uptime() >= wait_time)
+
+
+if __name__ == '__main__':
+    UptimeTest().main()

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -164,7 +164,8 @@ QString ClientModel::clientName() const { return QString::fromStdString(CLIENT_N
 QString ClientModel::formatClientStartupTime() const
 {
     QString time_format = "MMM d yyyy, HH:mm:ss";
-    return QDateTime::fromTime_t(nClientStartupTime).toString(time_format);
+    // return QDateTime::fromTime_t(GetStartupTime()).toString(time_format);
+    return QDateTime::fromTime_t(GetStartupTime()).toString();
 }
 
 QString ClientModel::dataDir() const { return QString::fromStdString(GetDataDir().string()); }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1981,10 +1981,104 @@ UniValue savemempool(const UniValue &params, bool fHelp)
     return NullUniValue;
 }
 
+UniValue getchaintxstats(const UniValue &params, bool fHelp)
+{
+    if (fHelp || params.size() > 2)
+    {
+        throw std::runtime_error(
+            "getchaintxstats ( nblocks blockhash )\n"
+            "\nCompute statistics about the total number and rate of transactions in the chain.\n"
+            "\nArguments:\n"
+            "1. nblocks      (numeric, optional) Size of the window in number of blocks (default: one month).\n"
+            "2. \"blockhash\"  (string, optional) The hash of the block that ends the window.\n"
+            "\nResult:\n"
+            "{\n"
+            "  \"time\": xxxxx,        (numeric) The timestamp for the statistics in UNIX format.\n"
+            "  \"window_final_block_hash\": \"...\",      (string) The hash of the final block in the window.\n"
+            "  \"window_final_block_height\": xxxxx,    (numeric) The height of the final block in the window.\n"
+            "  \"window_block_count\": xxxxx,           (numeric) Size of the window in number of blocks.\n"
+            "  \"window_tx_count\": xxxxx,              (numeric) The number of transactions in the window. Only "
+            "returned if \"window_block_count\" is > 0.\n"
+            "  \"window_interval\": xxxxx,              (numeric) The elapsed time in the window in seconds. Only "
+            "returned if \"window_block_count\" is > 0.\n"
+            "  \"txcount\": xxxxx,     (numeric) The total number of transactions in the chain up to that point.\n"
+            "  \"txrate\": x.xx,       (numeric) The average rate of transactions per second in the window.\n"
+            "}\n"
+            "\nExamples:\n" +
+            HelpExampleCli("getchaintxstats", "") + HelpExampleRpc("getchaintxstats", "2016"));
+    }
+    const CBlockIndex *pindex;
+    int blockcount = 30 * 24 * 60 * 60 / Params().GetConsensus().nPowTargetSpacing; // By default: 1 month
+
+    if (params.size() > 0 && !params[0].isNull())
+    {
+        blockcount = params[0].get_int();
+    }
+
+    bool havehash = params.size() > 1 && !params[1].isNull();
+    uint256 hash;
+    if (havehash)
+    {
+        hash = uint256S(params[1].get_str());
+    }
+
+    {
+        LOCK(cs_main);
+        if (havehash)
+        {
+            auto it = mapBlockIndex.find(hash);
+            if (it == mapBlockIndex.end())
+            {
+                throw JSONRPCError(RPC_INVALID_ADDRESS_OR_KEY, "Block not found");
+            }
+            pindex = it->second;
+            if (!chainActive.Contains(pindex))
+            {
+                throw JSONRPCError(RPC_INVALID_PARAMETER, "Block is not in main chain");
+            }
+        }
+        else
+        {
+            pindex = chainActive.Tip();
+        }
+    }
+
+    DbgAssert(pindex != nullptr, );
+
+    if (blockcount < 1 || blockcount >= pindex->nHeight)
+    {
+        throw JSONRPCError(RPC_INVALID_PARAMETER, "Invalid block count: should be between 1 and the block's height");
+    }
+
+    const CBlockIndex *pindexPast = pindex->GetAncestor(pindex->nHeight - blockcount);
+    int nTimeDiff = pindex->GetMedianTimePast() - pindexPast->GetMedianTimePast();
+    int nTxDiff = pindex->nChainTx - pindexPast->nChainTx;
+
+    UniValue ret(UniValue::VOBJ);
+    ret.pushKV("time", (int64_t)pindex->nTime);
+    ret.pushKV("txcount", (int64_t)pindex->nChainTx);
+    ret.pushKV("txrate", ((double)nTxDiff) / nTimeDiff);
+    ret.pushKV("window_final_block_hash", pindex->GetBlockHash().GetHex());
+    ret.pushKV("window_final_block_height", pindex->nHeight);
+    ret.pushKV("window_block_count", blockcount);
+    if (blockcount > 0)
+    {
+        ret.pushKV("window_tx_count", nTxDiff);
+        ret.pushKV("window_interval", nTimeDiff);
+        if (nTimeDiff > 0)
+        {
+            ret.pushKV("txrate", ((double)nTxDiff) / nTimeDiff);
+        }
+    }
+    return ret;
+}
+
+
 static const CRPCCommand commands[] = {
     //  category              name                      actor (function)         okSafeMode
     //  --------------------- ------------------------  -----------------------  ----------
     {"blockchain", "getblockchaininfo", &getblockchaininfo, true},
+    {"blockchain", "getchaintxstats", &getchaintxstats, true},
     {"blockchain", "getbestblockhash", &getbestblockhash, true}, {"blockchain", "getblockcount", &getblockcount, true},
     {"blockchain", "getblock", &getblock, true}, {"blockchain", "getblockhash", &getblockhash, true},
     {"blockchain", "getblockheader", &getblockheader, true}, {"blockchain", "getchaintips", &getchaintips, true},

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -33,6 +33,36 @@ extern CTweak<double> dMaxLimiterTxFee;
 
 using namespace std;
 
+//* Helper function
+/** Returns, given services flags, a list of humanly readable (known) network services */
+UniValue GetServicesNames(uint64_t services)
+{
+    UniValue servicesNames(UniValue::VARR);
+
+    if (services & NODE_NETWORK)
+        servicesNames.push_back("NETWORK");
+    if (services & NODE_GETUTXO)
+        servicesNames.push_back("GETUTXO");
+    if (services & NODE_BLOOM)
+        servicesNames.push_back("BLOOM");
+    if (services & NODE_WITNESS)
+        servicesNames.push_back("WITNESS");
+    if (services & NODE_XTHIN)
+        servicesNames.push_back("XTHIN");
+    if (services & NODE_BITCOIN_CASH)
+        servicesNames.push_back("CASH");
+    if (services & NODE_GRAPHENE)
+        servicesNames.push_back("GRAPHENE");
+    if (services & NODE_WEAKBLOCKS)
+        servicesNames.push_back("WEAKBLOCKS");
+    if (services & NODE_CF)
+        servicesNames.push_back("CF");
+    if (services & NODE_NETWORK_LIMITED)
+        servicesNames.push_back("NETWORK_LIMITED");
+
+    return servicesNames;
+}
+
 UniValue getconnectioncount(const UniValue &params, bool fHelp)
 {
     if (fHelp || params.size() != 0)
@@ -97,6 +127,11 @@ UniValue getpeerinfo(const UniValue &params, bool fHelp)
             "    \"addr\":\"host:port\",            (string) The ip address and port of the peer\n"
             "    \"addrlocal\":\"ip:port\",         (string) local address\n"
             "    \"services\":\"xxxxxxxxxxxxxxxx\", (string) The services offered\n"
+            "    \"services\":\"xxxxxxxxxxxxxxxx\", (string) The services offered\n"
+            "    \"servicesnames\":[              (array) the services offered, in human-readable form\n"
+            "        \"SERVICE_NAME\",         (string) the service name if it is recognised\n"
+            "         ...\n"
+            "     ],\n"
             "    \"relaytxes\":true|false,        (boolean) Whether peer has asked us to relay transactions to it\n"
             "    \"lastsend\": ttt,               (numeric) The time in seconds since epoch (Jan 1 1970 GMT) of the "
             "last send\n"
@@ -157,6 +192,7 @@ UniValue getpeerinfo(const UniValue &params, bool fHelp)
             if (!(stats.addrLocal.empty()))
                 obj.pushKV("addrlocal", stats.addrLocal);
             obj.pushKV("services", strprintf("%016x", stats.nServices));
+            obj.pushKV("servicesnames", GetServicesNames(stats.nServices));
             obj.pushKV("relaytxes", stats.fRelayTxes);
             obj.pushKV("lastsend", stats.nLastSend);
             obj.pushKV("lastrecv", stats.nLastRecv);
@@ -535,6 +571,11 @@ UniValue getnetworkinfo(const UniValue &params, bool fHelp)
             "  \"subversion\": \"/BUCash:x.x.x/\",      (string) the server subversion string\n"
             "  \"protocolversion\": xxxxx,            (numeric) the protocol version\n"
             "  \"localservices\": \"xxxxxxxxxxxxxxxx\", (string) the services we offer to the network\n"
+            "  \"localservicesnames\": [                (array) the services we offer to the network, in "
+            "human-readable form\n"
+            "      \"SERVICE_NAME\",                    (string) the service name\n"
+            "       ...\n"
+            "   ],\n"
             "  \"timeoffset\": xxxxx,                 (numeric) the time offset\n"
             "  \"connections\": xxxxx,                (numeric) the number of connections\n"
             "  \"networks\": [                        (array) information per network\n"
@@ -581,6 +622,7 @@ UniValue getnetworkinfo(const UniValue &params, bool fHelp)
     obj.pushKV("subversion", FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, BUComments));
     obj.pushKV("protocolversion", PROTOCOL_VERSION);
     obj.pushKV("localservices", strprintf("%016x", nLocalServices));
+    obj.pushKV("localservicesnames", GetServicesNames(nLocalServices));
     obj.pushKV("timeoffset", GetTimeOffset());
     obj.pushKV("connections", (int)vNodes.size());
     obj.pushKV("networks", GetNetworksInfo());

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -121,6 +121,7 @@ static const CRPCConvertParam vRPCConvertParams[] =
     {"getblock", 1},
     {"getblock", 2},
     {"getblockheader", 1},
+    { "getchaintxstats", 0},
     {"gettransaction", 1},
     {"getrawtransaction", 1},
     {"createrawtransaction", 0},

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -421,6 +421,21 @@ UniValue stop(const UniValue &params, bool fHelp)
     return "Bitcoin server stopping";
 }
 
+UniValue uptime(const UniValue &params, bool fHelp)
+{
+    if (fHelp || params.size() > 1)
+    {
+        throw std::runtime_error("uptime\n"
+                                 "\nReturns the total uptime of the server.\n"
+                                 "\nResult:\n"
+                                 "ttt        (numeric) The number of seconds that the server has been running\n"
+                                 "\nExamples:\n" +
+                                 HelpExampleCli("uptime", "") + HelpExampleRpc("uptime", ""));
+    }
+    return GetTime() - GetStartupTime();
+}
+
+
 /**
  * Call Table
  */
@@ -428,8 +443,7 @@ static const CRPCCommand vRPCCommands[] = {
     //  category              name                      actor (function)         okSafeMode
     //  --------------------- ------------------------  -----------------------  ----------
     /* Overall control/query calls */
-    {"control", "help", &help, true}, {"control", "stop", &stop, true},
-};
+    {"control", "help", &help, true}, {"control", "stop", &stop, true}, {"control", "uptime", &uptime, true}};
 
 CRPCTable::CRPCTable()
 {

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -247,6 +247,8 @@ void LogInit()
 const char *const BITCOIN_CONF_FILENAME = "bitcoin.conf";
 const char *const BITCOIN_PID_FILENAME = "bitcoind.pid";
 const char *const FORKS_CSV_FILENAME = "forks.csv"; // bip135 added
+// Application startup time (used for uptime calculation)
+const int64_t nStartupTime = GetTime();
 
 std::map<std::string, std::string> mapArgs;
 std::map<std::string, std::vector<std::string> > mapMultiArgs;
@@ -1030,6 +1032,8 @@ std::string CopyrightHolders(const std::string &strPrefix)
     return strCopyrightHolders;
 }
 
+// Obtain the application startup time (used for uptime calculation)
+int64_t GetStartupTime() { return nStartupTime; }
 bool IsStringTrue(const std::string &str)
 {
     static const std::set<std::string> strOn = {"enable", "1", "true", "True", "on"};

--- a/src/util.h
+++ b/src/util.h
@@ -6,7 +6,7 @@
 
 /**
  * Server/client environment: argument handling, config file parsing,
- * logging, thread wrappers
+ * logging, thread wrappers, startup time
  */
 #ifndef BITCOIN_UTIL_H
 #define BITCOIN_UTIL_H
@@ -110,6 +110,9 @@ extern "C" void DbgResume();
 /// UNIQUIFY is a macro that appends the current file's line number to the passed prefix, creating a symbol
 // that is unique in this file.
 #define UNIQUIFY(pfx) UNIQUE1(pfx, __LINE__)
+
+// Application startup time (used for uptime calculation)
+int64_t GetStartupTime();
 
 static const bool DEFAULT_LOGTIMEMICROS = false;
 static const bool DEFAULT_LOGIPS = true;


### PR DESCRIPTION
Initial lists of ported RPC

- [RPC] Add an uptime command that displays the amount of time that bitcoind has been running (this a port of bitcoin/bitcoin/pull/10400)
- Add getchaintxstats RPC (this is a port of bitcoin/bitcoin/pull/9733)


Later added also more info to `getnetworkinfo` and `getpeerinfo`:

- rpc/net: decode the services flags in a new entry (port of bitcoin/bitcoin/pull/16787)
