### PR TITLE
[electrum] More debug info in `getelectruminfo`

### DIFF
--- a/src/electrum/electrs.cpp
+++ b/src/electrum/electrs.cpp
@@ -192,7 +192,7 @@ std::map<std::string, int64_t> fetch_electrs_info()
 
     std::stringstream infostream = http_get(monitoring_host(), std::stoi(monitoring_port()), "/");
 
-    const std::regex keyval("^([a-z_]+)\\s(\\d+)\\s*$");
+    const std::regex keyval("^([a-z_{}=\"\\+]+)\\s(\\d+)\\s*$");
     std::map<std::string, int64_t> info;
     std::string line;
     std::smatch match;


### PR DESCRIPTION
This makes the key/value regex less strict, so it filters away less of the debug data.

Example output:
```
$ ./bitcoin-cli getelectruminfo
{
  "status": "ok",
  "index_progress": 100,
  "index_height": 1355281,
  "debuginfo": {
    "electrs_query_duration_count{type=\"confirmed_status\"}": 9389,
    "electrs_query_duration_count{type=\"get_headers\"}": 8,
    "electrs_query_duration_count{type=\"get_transaction\"}": 2988,
    "electrs_query_duration_count{type=\"load_txn\"}": 349,
    "electrs_query_duration_count{type=\"mempool_status\"}": 9389,
    "electrs_query_duration_count{type=\"update_mempool\"}": 99,
    "electrs_transactions_cache_size": 61262,
    "electrscash_blocktxids_cache_size": 40591168,
    "electrscash_blocktxids_cache{type=\"hit\"}": 91,
    "electrscash_blocktxids_cache{type=\"miss\"}": 2881,
    "electrscash_daemon_rpc_count{method=\"getbestblockhash\"}": 102,
    "electrscash_daemon_rpc_count{method=\"getblock\"}": 16436,
    "electrscash_daemon_rpc_count{method=\"getblockchaininfo\"}": 2,
    "electrscash_daemon_rpc_count{method=\"getblockhash\"}": 14,
    "electrscash_daemon_rpc_count{method=\"getblockheader\"}": 31,
    "electrscash_daemon_rpc_count{method=\"getmempoolentry\"}": 3,
    "electrscash_daemon_rpc_count{method=\"getnetworkinfo\"}": 8,
    "electrscash_daemon_rpc_count{method=\"getrawmempool\"}": 99,
    "electrscash_daemon_rpc_count{method=\"getrawtransaction\"}": 3182,
    "electrscash_electrum_subscriptions": 3280,
    "electrscash_index_blocks": 1355282,
    "electrscash_index_duration_count{step=\"fetch\"}": 13558,
    "electrscash_index_duration_count{step=\"flush\"}": 3,
    "electrscash_index_duration_count{step=\"index+write\"}": 13555,
    "electrscash_index_txns": 60005328,
    "electrscash_index_vsize": 38949404621,
    "electrscash_mempool_count": 3,
    "electrscash_mempool_update_count{step=\"add\"}": 99,
    "electrscash_mempool_update_count{step=\"fees\"}": 99,
    "electrscash_mempool_update_count{step=\"fetch\"}": 99,
    "electrscash_mempool_update_count{step=\"remove\"}": 99,
    "electrscash_process_memory_rss": 2535661568,
    "electrscash_process_open_fds": 54,
    "electrscash_transactions_cache{type=\"hit\"}": 156,
    "electrscash_transactions_cache{type=\"miss\"}": 193
  }
}
```