### PR TITLE
Speed up the loading of the block index

### DIFF
--- a/src/test/checkblock_tests.cpp
+++ b/src/test/checkblock_tests.cpp
@@ -44,7 +44,8 @@ bool read_block(const std::string &filename, CBlock &block)
 bool LockAndContextualCheckBlock(CBlock &block, CValidationState &state)
 {
     LOCK(cs_main);
-    return ContextualCheckBlock(block, state, nullptr, false);
+    CCoinsViewCache view(pcoinsTip);
+    return ContextualCheckBlock(block, view, state, nullptr, false);
 }
 
 BOOST_FIXTURE_TEST_SUITE(checkblock_tests, BasicTestingSetup) // BU harmonize suite name with filename

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1473,7 +1473,7 @@ bool TestConservativeBlockValidity(CValidationState &state,
         return false;
     if (!CheckBlock(block, state, fCheckPOW, fCheckMerkleRoot))
         return false;
-    if (!ContextualCheckBlock(block, state, pindexPrev, true))
+    if (!ContextualCheckBlock(block, viewNew, state, pindexPrev, true))
         return false;
     if (!ConnectBlock(block, state, &indexDummy, viewNew, chainparams, true))
         return false;

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -1200,7 +1200,7 @@ bool TestBlockValidity(CValidationState &state,
         return false;
     if (!CheckBlock(block, state, fCheckPOW, fCheckMerkleRoot))
         return false;
-    if (!ContextualCheckBlock(block, state, pindexPrev))
+    if (!ContextualCheckBlock(block, viewNew, state, pindexPrev))
         return false;
     if (!ConnectBlock(block, state, &indexDummy, viewNew, chainparams, true))
         return false;
@@ -1506,6 +1506,7 @@ void InvalidChainFound(CBlockIndex *pindexNew)
 }
 
 bool ContextualCheckBlock(const CBlock &block,
+    CCoinsViewCache &view,
     CValidationState &state,
     CBlockIndex *const pindexPrev,
     const bool fConservative)
@@ -1593,7 +1594,8 @@ bool ContextualCheckBlock(const CBlock &block,
     {
         nTx++;
 
-        nSigOps += GetLegacySigOpCount(tx, flags);
+        nSigOps += GetLegacySigOpCount(tx, flags) + GetP2SHSigOpCount(tx, view, flags);
+
         if (tx->GetTxSize() > nLargestTx)
             nLargestTx = tx->GetTxSize();
     }
@@ -1781,19 +1783,24 @@ bool AcceptBlock(const CBlock &block,
         if (fTooFarAhead)
             return true; // Block height is too high
     }
-    if ((!CheckBlock(block, state)) || !ContextualCheckBlock(block, state, pindex->pprev))
+
     {
-        if (state.IsInvalid() && !state.CorruptionPossible())
+        CCoinsViewCache view(pcoinsTip);
+
+        if ((!CheckBlock(block, state)) || !ContextualCheckBlock(block, view, state, pindex->pprev))
         {
+            if (state.IsInvalid() && !state.CorruptionPossible())
             {
-                WRITELOCK(cs_mapBlockIndex);
-                pindex->nStatus |= BLOCK_FAILED_VALID;
-                setDirtyBlockIndex.insert(pindex);
+                {
+                    WRITELOCK(cs_mapBlockIndex);
+                    pindex->nStatus |= BLOCK_FAILED_VALID;
+                    setDirtyBlockIndex.insert(pindex);
+                }
+                // Now mark every block index on every chain that contains pindex as child of invalid
+                MarkAllContainingChainsInvalid(pindex);
             }
-            // Now mark every block index on every chain that contains pindex as child of invalid
-            MarkAllContainingChainsInvalid(pindex);
+            return false;
         }
-        return false;
     }
     int nHeight = pindex->nHeight;
     // Write block to history file
@@ -2186,12 +2193,10 @@ bool ConnectBlockDependencyOrdering(const CBlock &block,
 
     // Get the script flags for this block
     uint32_t flags = GetBlockScriptFlags(pindex, chainparams.GetConsensus());
-    bool fStrictPayToScriptHash = flags & SCRIPT_VERIFY_P2SH;
 
     ValidationResourceTracker resourceTracker;
     std::vector<int> prevheights;
     int nInputs = 0;
-    unsigned int nSigOps = 0;
     CDiskTxPos pos(pindex->GetBlockPos(), GetSizeOfCompactSize(block.vtx.size()));
     blockundo.vtxundo.reserve(block.vtx.size() - 1);
     int nChecked = 0;
@@ -2240,10 +2245,6 @@ bool ConnectBlockDependencyOrdering(const CBlock &block,
             const CTransactionRef &txref = block.vtx[i];
 
             nInputs += tx.vin.size();
-            nSigOps += GetLegacySigOpCount(txref, flags);
-            // if (nSigOps > MAX_BLOCK_SIGOPS)
-            //    return state.DoS(100, error("ConnectBlock(): too many sigops"),
-            //                    REJECT_INVALID, "bad-blk-sigops");
 
             if (!tx.IsCoinBase())
             {
@@ -2279,14 +2280,6 @@ bool ConnectBlockDependencyOrdering(const CBlock &block,
                     return state.DoS(100, error("%s: block %s contains a non-BIP68-final transaction", __func__,
                                               block.GetHash().ToString()),
                         REJECT_INVALID, "bad-txns-nonfinal");
-                }
-
-                if (fStrictPayToScriptHash)
-                {
-                    // Add in sigops done by pay-to-script-hash inputs;
-                    // this is to prevent a "rogue miner" from creating
-                    // an incredibly-expensive-to-validate block.
-                    nSigOps += GetP2SHSigOpCount(txref, view, flags);
                 }
 
                 nFees += view.GetValueIn(tx) - tx.GetValueOut();
@@ -2392,12 +2385,10 @@ bool ConnectBlockCanonicalOrdering(const CBlock &block,
 
     // Get the script flags for this block
     uint32_t flags = GetBlockScriptFlags(pindex, chainparams.GetConsensus());
-    bool fStrictPayToScriptHash = flags & SCRIPT_VERIFY_P2SH;
 
     ValidationResourceTracker resourceTracker;
     std::vector<int> prevheights;
     int nInputs = 0;
-    unsigned int nSigOps = 0;
     CDiskTxPos pos(pindex->GetBlockPos(), GetSizeOfCompactSize(block.vtx.size()));
     blockundo.vtxundo.reserve(block.vtx.size() - 1);
     int nChecked = 0;
@@ -2480,7 +2471,6 @@ bool ConnectBlockCanonicalOrdering(const CBlock &block,
             const CTransactionRef &txref = block.vtx[i];
 
             nInputs += tx.vin.size();
-            nSigOps += GetLegacySigOpCount(txref, flags);
 
             if (!tx.IsCoinBase())
             {
@@ -2516,14 +2506,6 @@ bool ConnectBlockCanonicalOrdering(const CBlock &block,
                     return state.DoS(100, error("%s: block %s contains a non-BIP68-final transaction", __func__,
                                               block.GetHash().ToString()),
                         REJECT_INVALID, "bad-txns-nonfinal");
-                }
-
-                if (fStrictPayToScriptHash)
-                {
-                    // Add in sigops done by pay-to-script-hash inputs;
-                    // this is to prevent a "rogue miner" from creating
-                    // an incredibly-expensive-to-validate block.
-                    nSigOps += GetP2SHSigOpCount(txref, view, flags);
                 }
 
                 nFees += view.GetValueIn(tx) - tx.GetValueOut();

--- a/src/validation/validation.h
+++ b/src/validation/validation.h
@@ -101,6 +101,7 @@ void InvalidChainFound(CBlockIndex *pindexNew);
 
 /** Context-dependent validity block checks */
 bool ContextualCheckBlock(const CBlock &block,
+    CCoinsViewCache &view,
     CValidationState &state,
     CBlockIndex *pindexPrev,
     const bool fConservative = false);


### PR DESCRIPTION
When an operator reboots their computer and starts up the node
it can take much longer to startup because the block index files
are not already in the OS cache. Startup times are improved by roughly
300% by first caching the leveldb files in memory. To effect this we
read the contents of each leveldb file before actually using leveldb
to iterate through the blockindex entries in those files. This way when
leveldb tries to access each entry it doesn't have to go to the disk
each time but rather can read directly from the OS file cache.

Testing:
1) To test this out you must first reboot your computer to clear the OS cache
2) Launch the release or dev branch version and wait for startup to complete
3) Go to the log file and find the time it took to load the index by viewing the two following
entries that define when we started and finished the loading of the block index and manually
calculate the time differential.
2020-01-29 15:41:19.141754 init message: Loading block index...
2020-01-29 15:41:44.571349 LoadBlockIndexDB: hashBestChain=000000000000000000c893b587f9509c947246d0d194df2e64d9f96846723721 height=619977 date=2020-01-29 15:30:31 progress=0.999963

4) Do the above 3 steps again using a build from this PR and note the difference.


My own results for mainnet are as follows:
1) Current dev branch:  25 seconds
2) This PR:  8 seconds

My own results for testnet are as follows:
1) Current dev branch:  49 seconds
2) This PR:  15 seconds
