### PR TITLE
Don't add more than one unique thintype block in flight

### DIFF
--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -222,10 +222,18 @@ bool ThinTypeRelay::AddBlockInFlight(CNode *pfrom, const uint256 &hash, const st
     if (AreTooManyBlocksInFlight(pfrom, thinType))
         return false;
 
-    mapThinTypeBlocksInFlight.insert(
-        std::pair<const NodeId, CThinTypeBlockInFlight>(pfrom->GetId(), {hash, GetTime(), false, thinType}));
-
-    return true;
+    // Verify that we haven't already added this entry before since mapThinTypeBlocksInFlight
+    // is a multi-map and we could end up adding two identical entries.
+    if (!IsBlockInFlight(pfrom, thinType, &hash))
+    {
+        mapThinTypeBlocksInFlight.insert(
+            std::pair<const NodeId, CThinTypeBlockInFlight>(pfrom->GetId(), {hash, GetTime(), false, thinType}));
+        return true;
+    }
+    else
+    {
+        return false;
+    }
 }
 
 void ThinTypeRelay::ClearBlockInFlight(CNode *pfrom, const uint256 &hash)

--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -173,7 +173,7 @@ void ThinTypeRelay::ClearBlockRelayTimer(const uint256 &hash)
     }
 }
 
-bool ThinTypeRelay::AreTooManyBlocksInFlight(CNode *pfrom, const std::string thinType)
+bool ThinTypeRelay::AreTooManyBlocksInFlight()
 {
     // check if we've exceed the max thintype blocks in flight allowed.
     LOCK(cs_inflight);
@@ -219,12 +219,12 @@ void ThinTypeRelay::BlockWasReceived(CNode *pfrom, const uint256 &hash)
 bool ThinTypeRelay::AddBlockInFlight(CNode *pfrom, const uint256 &hash, const std::string thinType)
 {
     LOCK(cs_inflight);
-    if (AreTooManyBlocksInFlight(pfrom, thinType))
+    if (AreTooManyBlocksInFlight())
         return false;
 
     // Verify that we haven't already added this entry before since mapThinTypeBlocksInFlight
     // is a multi-map and we could end up adding two identical entries.
-    if (!IsBlockInFlight(pfrom, thinType, &hash))
+    if (!IsBlockInFlight(pfrom, thinType, hash))
     {
         mapThinTypeBlocksInFlight.insert(
             std::pair<const NodeId, CThinTypeBlockInFlight>(pfrom->GetId(), {hash, GetTime(), false, thinType}));

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -64,7 +64,7 @@ public:
     bool HasBlockRelayTimerExpired(const uint256 &hash);
     bool IsBlockRelayTimerEnabled();
     void ClearBlockRelayTimer(const uint256 &hash);
-    bool AreTooManyBlocksInFlight(CNode *pfrom, const std::string thinType);
+    bool AreTooManyBlocksInFlight();
     bool IsBlockInFlight(CNode *pfrom, const std::string thinType, const uint256 &hash);
     unsigned int TotalBlocksInFlight();
     void BlockWasReceived(CNode *pfrom, const uint256 &hash);

--- a/src/test/requestmanager_tests.cpp
+++ b/src/test/requestmanager_tests.cpp
@@ -153,12 +153,13 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     dosMan.ClearBanned();
 
     /** Block in flight tests */
-    // Try to add the same block twice. We shoul only be allowed one unique thintype block in flight
+    // Try to add the same block twice which will fail the second attempt.
+    // We should only be allowed one unique thintype block in flight
     thinrelay.AddBlockInFlight(&dummyNodeGraphene, hash, NetMsgType::GRAPHENEBLOCK);
-    BOOST_CHECK(thinrelay.AreTooManyBlocksInFlight());
-    BOOST_CHECK(thinrelay.AddBlockInFlight(&dummyNodeGraphene, hash, NetMsgType::GRAPHENEBLOCK));
+    BOOST_CHECK(!thinrelay.AreTooManyBlocksInFlight());
+    BOOST_CHECK(!thinrelay.AddBlockInFlight(&dummyNodeGraphene, hash, NetMsgType::GRAPHENEBLOCK));
 
-    // Add 4 blocks in flight
+    // Add 4 more blocks in flight
     thinrelay.AddBlockInFlight(&dummyNodeGraphene, GetRandHash(), NetMsgType::GRAPHENEBLOCK);
     thinrelay.AddBlockInFlight(&dummyNodeGraphene, GetRandHash(), NetMsgType::GRAPHENEBLOCK);
     thinrelay.AddBlockInFlight(&dummyNodeGraphene, GetRandHash(), NetMsgType::GRAPHENEBLOCK);
@@ -167,8 +168,12 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
 
     // Add one more which is the max blocks in flight. A call to TooManyBlocksInFlight() will now
     // return false.
-    thinrelay.AddBlockInFlight(&dummyNodeGraphene, hash, NetMsgType::GRAPHENEBLOCK);
+    BOOST_CHECK(thinrelay.AddBlockInFlight(&dummyNodeGraphene, GetRandHash(), NetMsgType::GRAPHENEBLOCK));
     BOOST_CHECK(thinrelay.AreTooManyBlocksInFlight());
+
+    // Try to add one beyond the maximum which should fail
+    BOOST_CHECK(!thinrelay.AddBlockInFlight(&dummyNodeGraphene, GetRandHash(), NetMsgType::GRAPHENEBLOCK));
+    CleanupAll(vNodes);
 
 
     // Test the General Case: Chain synced, graphene ON, Thinblocks ON, Cmpct ON

--- a/src/test/requestmanager_tests.cpp
+++ b/src/test/requestmanager_tests.cpp
@@ -152,6 +152,25 @@ BOOST_AUTO_TEST_CASE(blockrequest_tests)
     uint64_t nTime = GetTime();
     dosMan.ClearBanned();
 
+    /** Block in flight tests */
+    // Try to add the same block twice. We shoul only be allowed one unique thintype block in flight
+    thinrelay.AddBlockInFlight(&dummyNodeGraphene, hash, NetMsgType::GRAPHENEBLOCK);
+    BOOST_CHECK(thinrelay.AreTooManyBlocksInFlight());
+    BOOST_CHECK(thinrelay.AddBlockInFlight(&dummyNodeGraphene, hash, NetMsgType::GRAPHENEBLOCK));
+
+    // Add 4 blocks in flight
+    thinrelay.AddBlockInFlight(&dummyNodeGraphene, GetRandHash(), NetMsgType::GRAPHENEBLOCK);
+    thinrelay.AddBlockInFlight(&dummyNodeGraphene, GetRandHash(), NetMsgType::GRAPHENEBLOCK);
+    thinrelay.AddBlockInFlight(&dummyNodeGraphene, GetRandHash(), NetMsgType::GRAPHENEBLOCK);
+    thinrelay.AddBlockInFlight(&dummyNodeGraphene, GetRandHash(), NetMsgType::GRAPHENEBLOCK);
+    BOOST_CHECK(!thinrelay.AreTooManyBlocksInFlight());
+
+    // Add one more which is the max blocks in flight. A call to TooManyBlocksInFlight() will now
+    // return false.
+    thinrelay.AddBlockInFlight(&dummyNodeGraphene, hash, NetMsgType::GRAPHENEBLOCK);
+    BOOST_CHECK(thinrelay.AreTooManyBlocksInFlight());
+
+
     // Test the General Case: Chain synced, graphene ON, Thinblocks ON, Cmpct ON
     // This should return a Graphene block.
     IsChainNearlySyncdSet(true);


### PR DESCRIPTION
mapThinTypeBlocksInFlight is a multi map which could allow multiple identical entries.  By checking in IsBlockInFlight() within AddBlockInFlight() we can prevent this from happening. This potential problem was introduced when we allowed multiple thintype blocks in flight which was merged a few weeks/months back.

Also added a few tests.