### PR TITLE
Do not reset the pblock smart pointer when clearing data

### DIFF
--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -369,16 +369,9 @@ void ThinTypeRelay::AddBlockBytes(uint64_t bytes, std::shared_ptr<CBlockThinRela
 }
 
 uint64_t ThinTypeRelay::GetMaxAllowedBlockSize() { return maxMessageSizeMultiplier * excessiveBlockSize; }
-void ThinTypeRelay::ClearAllBlockData(CNode *pnode, std::shared_ptr<CBlockThinRelay> pblock)
+void ThinTypeRelay::ClearAllBlockData(CNode *pnode, const uint256 &hash)
 {
-    // We must make sure to clear the block data first before clearing the thinblock in flight.
-    uint256 hash = pblock->GetBlockHeader().GetHash();
+    // Clear the entries for block to reconstruct and block in flight
     ClearBlockToReconstruct(pnode->GetId(), hash);
-
-    // Clear block data
-    if (pblock)
-        pblock->SetNull();
-
-    // Now clear the block in flight.
     ClearBlockInFlight(pnode, hash);
 }

--- a/src/blockrelay/blockrelay_common.cpp
+++ b/src/blockrelay/blockrelay_common.cpp
@@ -236,10 +236,10 @@ bool ThinTypeRelay::AddBlockInFlight(CNode *pfrom, const uint256 &hash, const st
     }
 }
 
-void ThinTypeRelay::ClearBlockInFlight(CNode *pfrom, const uint256 &hash)
+void ThinTypeRelay::ClearBlockInFlight(NodeId id, const uint256 &hash)
 {
     LOCK(cs_inflight);
-    auto range = mapThinTypeBlocksInFlight.equal_range(pfrom->GetId());
+    auto range = mapThinTypeBlocksInFlight.equal_range(id);
     while (range.first != range.second)
     {
         if (range.first->second.hash == hash)
@@ -373,5 +373,5 @@ void ThinTypeRelay::ClearAllBlockData(CNode *pnode, const uint256 &hash)
 {
     // Clear the entries for block to reconstruct and block in flight
     ClearBlockToReconstruct(pnode->GetId(), hash);
-    ClearBlockInFlight(pnode, hash);
+    ClearBlockInFlight(pnode->GetId(), hash);
 }

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -87,7 +87,7 @@ public:
     uint64_t GetMaxAllowedBlockSize();
 
     // Clear all block data
-    void ClearAllBlockData(CNode *pnode, std::shared_ptr<CBlockThinRelay> pblock);
+    void ClearAllBlockData(CNode *pnode, const uint256 &hash);
 };
 extern ThinTypeRelay thinrelay;
 

--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -69,7 +69,7 @@ public:
     unsigned int TotalBlocksInFlight();
     void BlockWasReceived(CNode *pfrom, const uint256 &hash);
     bool AddBlockInFlight(CNode *pfrom, const uint256 &hash, const std::string thinType);
-    void ClearBlockInFlight(CNode *pfrom, const uint256 &hash);
+    void ClearBlockInFlight(NodeId id, const uint256 &hash);
     void ClearAllBlocksInFlight(NodeId id);
     void CheckForDownloadTimeout(CNode *pfrom);
     void RequestBlock(CNode *pfrom, const uint256 &hash);

--- a/src/blockrelay/compactblock.cpp
+++ b/src/blockrelay/compactblock.cpp
@@ -139,7 +139,7 @@ bool CompactBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     if (!IsCompactBlockValid(pfrom, compactBlock))
     {
         dosMan.Misbehaving(pfrom, 100);
-        thinrelay.ClearAllBlockData(pfrom, pblock);
+        thinrelay.ClearAllBlockData(pfrom, pblock->GetHash());
         return error("Received an invalid compactblock from peer %s\n", pfrom->GetLogName());
     }
 
@@ -174,7 +174,7 @@ bool CompactBlock::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     if (AlreadyHaveBlock(inv))
     {
         requester.AlreadyReceived(pfrom, inv);
-        thinrelay.ClearAllBlockData(pfrom, pblock);
+        thinrelay.ClearAllBlockData(pfrom, inv.hash);
 
         LOG(CMPCT, "Received compactblock but returning because we already have this block %s on disk, peer=%s\n",
             inv.hash.ToString(), pfrom->GetLogName());
@@ -297,7 +297,7 @@ bool CompactBlock::process(CNode *pfrom, std::shared_ptr<CBlockThinRelay> pblock
                 if (setHashesToRequest.size() > std::numeric_limits<uint16_t>::max())
                 {
                     // Since we can't process this compactblock then clear out the data from memory
-                    thinrelay.ClearAllBlockData(pfrom, pblock);
+                    thinrelay.ClearAllBlockData(pfrom, pblock->GetHash());
 
                     thinrelay.RequestBlock(pfrom, header.GetHash());
                     return error("Too many re-requested hashes for compactblock: requesting a full block");
@@ -334,7 +334,7 @@ bool CompactBlock::process(CNode *pfrom, std::shared_ptr<CBlockThinRelay> pblock
     {
         return error("mismatched merkle root on compactblock: rerequesting a full block, peer=%s", pfrom->GetLogName());
 
-        thinrelay.ClearAllBlockData(pfrom, pblock);
+        thinrelay.ClearAllBlockData(pfrom, header.GetHash());
         thinrelay.RequestBlock(pfrom, header.GetHash());
         return true;
     }
@@ -373,7 +373,7 @@ bool CompactBlock::process(CNode *pfrom, std::shared_ptr<CBlockThinRelay> pblock
     if (missingCount > 0)
     {
         // Since we can't process this compactblock then clear out the data from memory
-        thinrelay.ClearAllBlockData(pfrom, pblock);
+        thinrelay.ClearAllBlockData(pfrom, header.GetHash());
 
         thinrelay.RequestBlock(pfrom, header.GetHash());
         return error("Still missing transactions for compactblock: re-requesting a full block");
@@ -477,7 +477,7 @@ bool CompactReReqResponse::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     if (AlreadyHaveBlock(inv))
     {
         requester.AlreadyReceived(pfrom, inv);
-        thinrelay.ClearAllBlockData(pfrom, pblock);
+        thinrelay.ClearAllBlockData(pfrom, inv.hash);
 
         LOG(CMPCT,
             "Received compactReReqResponse but returning because we already have this block %s on disk, peer=%s\n",
@@ -517,7 +517,7 @@ bool CompactReReqResponse::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     uint256 merkleroot = ComputeMerkleRoot(cmpctBlock->vTxHashes256, &mutated);
     if (pblock->hashMerkleRoot != merkleroot || mutated)
     {
-        thinrelay.ClearAllBlockData(pfrom, pblock);
+        thinrelay.ClearAllBlockData(pfrom, inv.hash);
         return error("Merkle root for %s does not match computed merkle root, peer=%s", inv.hash.ToString(),
             pfrom->GetLogName());
     }
@@ -538,7 +538,7 @@ bool CompactReReqResponse::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     if (missingCount > 0)
     {
         // Since we can't process this compactblock then clear out the data from memory
-        thinrelay.ClearAllBlockData(pfrom, pblock);
+        thinrelay.ClearAllBlockData(pfrom, inv.hash);
 
         thinrelay.RequestBlock(pfrom, inv.hash);
         return error("Still missing transactions after reconstructing block, peer=%s: re-requesting a full block",
@@ -582,7 +582,7 @@ static bool ReconstructBlock(CNode *pfrom,
         std::set<uint256> setHashes(pblock->cmpctblock->vTxHashes256.begin(), pblock->cmpctblock->vTxHashes256.end());
         if (setHashes.size() != pblock->cmpctblock->vTxHashes256.size())
         {
-            thinrelay.ClearAllBlockData(pfrom, pblock);
+            thinrelay.ClearAllBlockData(pfrom, pblock->GetHash());
             return error("Duplicate transaction ids, peer=%s", pfrom->GetLogName());
         }
     }
@@ -660,7 +660,7 @@ static bool ReconstructBlock(CNode *pfrom,
         if (pblock->nCurrentBlockSize > thinrelay.GetMaxAllowedBlockSize())
         {
             uint64_t nBlockBytes = pblock->nCurrentBlockSize;
-            thinrelay.ClearAllBlockData(pfrom, pblock);
+            thinrelay.ClearAllBlockData(pfrom, pblock->GetHash());
             pfrom->fDisconnect = true;
             return error("Reconstructed block %s (size:%llu) has caused max memory limit %llu bytes to be "
                          "exceeded, peer=%s",

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -626,9 +626,9 @@ void HandleBlockMessageThread(CNode *pfrom, const string strCommand, CBlockRef p
         }
 
         // When we request a thin type block we may get back a regular block if it is smaller than
-        // either of the former.  Therefore we have to remove the thintype block in flight if it
-        // exists and we also need to check that the block didn't arrive from some other peer.
-        thinrelay.ClearBlockInFlight(pfrom, inv.hash);
+        // either of the former.  Therefore we have to remove the thintype block in flight and any
+        // associated data.
+        thinrelay.ClearAllBlockData(pfrom, inv.hash);
 
         // Increment block counter
         pfrom->firstBlock += 1;

--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -1008,11 +1008,10 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         pblock6->xthinblock = std::make_shared<CXThinBlock>(xthin2);
         pblock6->xthinblock->process(&dummyNode6, NetMsgType::XTHINBLOCK, pblock6);
         BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
-        BOOST_CHECK(pblock6->IsNull());
 
         // clean up vNodes, mapthinblocksinflight and thinblock data
         vNodes.pop_back();
-        thinrelay.ClearAllBlockData(&dummyNode6, pblock6);
+        thinrelay.ClearAllBlockData(&dummyNode6, pblock6->GetHash());
 
         // Add the node to vNodes and also we need a thinblockinflight entry
         thinrelay.AddBlockInFlight(&dummyNode6, TestBlock1().GetHash(), NetMsgType::XTHINBLOCK);
@@ -1024,11 +1023,10 @@ BOOST_AUTO_TEST_CASE(thinblock_tests)
         pblock6->thinblock = std::make_shared<CThinBlock>(thin2);
         pblock6->thinblock->process(&dummyNode6, pblock6);
         BOOST_CHECK(dummyNode6.fDisconnect); // node should be disconnected
-        BOOST_CHECK(pblock6->IsNull());
 
         // clean up vNodes, mapthinblocksinflight and thinblock data
         vNodes.pop_back();
-        thinrelay.ClearAllBlockData(&dummyNode6, pblock6);
+        thinrelay.ClearAllBlockData(&dummyNode6, pblock6->GetHash());
 
         // TODO: it would be great to have a test with an excessiveBlockSize of one byte larger
         //       so we can prove that a disconnect wouldn't happen for the edge case however

--- a/src/test/requestmanager_tests.cpp
+++ b/src/test/requestmanager_tests.cpp
@@ -82,7 +82,7 @@ static std::string NetMessage(std::deque<CSerializeData> &_vSendMsg)
     return ss;
 }
 
-static void ClearThinBlocksInFlight(CNode &node, CInv &inv) { thinrelay.ClearBlockInFlight(&node, inv.hash); }
+static void ClearThinBlocksInFlight(CNode &node, CInv &inv) { thinrelay.ClearBlockInFlight(node.GetId(), inv.hash); }
 BOOST_FIXTURE_TEST_SUITE(requestmanager_tests, TestingSetup)
 
 BOOST_AUTO_TEST_CASE(blockrequest_tests)


### PR DESCRIPTION
Just let the smart pointer call it's own destructor after all references have been removed.

Also do some general cleanup