### PR TITLE
Use current syntax for travis conf file + decreased threshold timeout 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
-sudo: required
 dist: xenial
 os: linux
-language: minimal
+language: shell
 cache:
   ccache: true
   directories:
@@ -31,7 +30,7 @@ env:
     - DIST=DEB
     - CACHE_ERR_MSG="Error! Initial build successful, but not enough time remains to run later build stages and tests. Please manually re-run this job by using the travis restart button or asking a bitcoin maintainer to restart.  The next run should not time out because the build cache has been saved."
 
-matrix:
+jobs:
   include:
     #x86_64 Linux + deps as via system lib
     - compiler: gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,9 +146,9 @@ before_script:
     - set -o errexit; source .travis/before_script.sh
 script:
     - export CONTINUE=1
-    - if [ $SECONDS -gt 1980 ]; then export CONTINUE=0; fi  # Likely the depends build took very long
+    - if [ $SECONDS -gt 1200 ]; then export CONTINUE=0; fi  # Likely the depends build took very long
     - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/script_a.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
-    - if [ $SECONDS -gt 2300 -a "$RUN_TESTS"="true" ]; then export CONTINUE=0; echo "$SECONDS"; fi  # Likely the build took very long
+    - if [ $SECONDS -gt 2000 -a "$RUN_TESTS"="true" ]; then export CONTINUE=0; echo "$SECONDS"; fi  # Likely the build took very long
     - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/script_b.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
 
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -148,7 +148,7 @@ script:
     - export CONTINUE=1
     - if [ $SECONDS -gt 1200 ]; then export CONTINUE=0; fi  # Likely the depends build took very long
     - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/script_a.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
-    - if [ $SECONDS -gt 2000 -a "$RUN_TESTS"="true" ]; then export CONTINUE=0; echo "$SECONDS"; fi  # Likely the build took very long
+    - if [ $SECONDS -gt 2100 -a "$RUN_TESTS"="true" ]; then export CONTINUE=0; echo "$SECONDS"; fi  # Likely the build took very long
     - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/script_b.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
 
 after_script:


### PR DESCRIPTION
Reduce time thresholds to force travis to save cache and abort

Update travis.yml according to travis backend errors and warns, namely:

- root: deprecated key sudo (The key `sudo` has no effect anymore.)
- language: value minimal is an alias for shell, using shell
- root: key matrix is an alias for jobs, using jobs