### PR TITLE
Implement a release mode action for DbgAssert in `getchaintxstats`

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -2043,7 +2043,7 @@ UniValue getchaintxstats(const UniValue &params, bool fHelp)
         }
     }
 
-    DbgAssert(pindex != nullptr, );
+    DbgAssert(pindex != nullptr, throw std::runtime_error(__func__));
 
     if (blockcount < 1 || blockcount >= pindex->nHeight)
     {


### PR DESCRIPTION
The only way thast assert is triggered is if chainActive.Tip() is
equal to nullptr.