### PR TITLE
[Minor enhancement]  Startup txindex after ActivateBestChain

### DIFF
--- a/qa/rpc-tests/txindex.py
+++ b/qa/rpc-tests/txindex.py
@@ -34,6 +34,7 @@ class TxIndexTest(BitcoinTestFramework):
 
         # Check that node0 has no txindex available.
         logging.info("Checking non txindex on node0...")
+        waitFor(30, lambda: self.nodes[0].getinfo()["txindex"] == "not ready")
         for i in range(1, self.nodes[0].getblockcount()):
             blockhash = self.nodes[0].getblockhash(i)
             txns = self.nodes[0].getblock(blockhash)['tx']
@@ -45,6 +46,7 @@ class TxIndexTest(BitcoinTestFramework):
 
         # Check node1 can find all blockchain txns in the txindex
         logging.info("Checking txindex on node1...")
+        waitFor(30, lambda: self.nodes[1].getinfo()["txindex"] == "synced")
         for i in range(self.nodes[1].getblockcount()):
             blockhash = self.nodes[1].getblockhash(i)
             txns = self.nodes[1].getblock(blockhash)['tx']
@@ -96,6 +98,7 @@ class TxIndexTest(BitcoinTestFramework):
         self.sync_all()
 
         logging.info("Checking txindex on node1...")
+        waitFor(30, lambda: self.nodes[1].getinfo()["txindex"] == "synced")
         for i in range(self.nodes[1].getblockcount()):
             blockhash = self.nodes[1].getblockhash(i)
             txns = self.nodes[1].getblock(blockhash)['tx']
@@ -135,6 +138,7 @@ class TxIndexTest(BitcoinTestFramework):
 
         # Check that node0 has no txindex available.
         logging.info("Checking non txindex on node0...")
+        waitFor(30, lambda: self.nodes[0].getinfo()["txindex"] == "not ready")
         for i in range(self.nodes[0].getblockcount()):
             blockhash = self.nodes[0].getblockhash(i)
             txns = self.nodes[0].getblock(blockhash)['tx']
@@ -146,6 +150,7 @@ class TxIndexTest(BitcoinTestFramework):
 
         # Check node1 can find all blockchain txns in the txindex
         logging.info("Checking txindex on node1...")
+        waitFor(30, lambda: self.nodes[1].getinfo()["txindex"] == "synced")
         for i in range(self.nodes[1].getblockcount()):
             blockhash = self.nodes[1].getblockhash(i)
             txns = self.nodes[1].getblock(blockhash)['tx']
@@ -169,6 +174,7 @@ class TxIndexTest(BitcoinTestFramework):
 
         # Check node0 can find all blockchain txns in the txindex
         logging.info("Checking txindex on node0...")
+        waitFor(30, lambda: self.nodes[0].getinfo()["txindex"] == "synced")
         for i in range(self.nodes[0].getblockcount()):
             blockhash = self.nodes[0].getblockhash(i)
             txns = self.nodes[0].getblock(blockhash)['tx']
@@ -180,6 +186,7 @@ class TxIndexTest(BitcoinTestFramework):
 
         # Check node1 can find all blockchain txns in the txindex
         logging.info("Checking txindex on node1...")
+        waitFor(30, lambda: self.nodes[1].getinfo()["txindex"] == "synced")
         for i in range(self.nodes[1].getblockcount()):
             blockhash = self.nodes[1].getblockhash(i)
             txns = self.nodes[1].getblock(blockhash)['tx']

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -229,16 +229,7 @@ void TxIndex::BlockConnected(const CBlock &block, CBlockIndex *pindex)
     }
 }
 
-bool TxIndex::IsSynced()
-{
-    if (!fSynced.load())
-    {
-        LOGA("%s: txindex is catching up on block notifications\n", __func__);
-        return false;
-    }
-    return true;
-}
-
+bool TxIndex::IsSynced() { return fSynced.load(); }
 bool TxIndex::FindTx(const uint256 &txhash, uint256 &blockhash, CTransactionRef &ptx) const
 {
     CDiskTxPos postx;

--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -65,7 +65,6 @@ bool TxIndex::Init()
             return false;
     }
 
-    fSynced = pbestindex.load() == chainActive.Tip();
     return true;
 }
 
@@ -109,7 +108,7 @@ static const CBlockIndex *NextSyncBlock(const CBlockIndex *pindex_prev)
 
 void TxIndex::ThreadSync()
 {
-    while (fReindex)
+    while (fReindex || fImporting || IsInitialBlockDownload())
     {
         MilliSleep(1000);
         if (shutdown_threads.load() == true)

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -12,6 +12,8 @@
 
 class CBlockIndex;
 
+bool IsTxIndexReady();
+
 /**
  * TxIndex is used to look up transactions included in the blockchain by hash.
  * The index is written to a LevelDB database and records the filesystem

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1053,7 +1053,6 @@ bool AppInit2(Config &config, thread_group &threadGroup)
     // ********************************************************* Step 6: load block chain
 
     fReindex = GetBoolArg("-reindex", DEFAULT_REINDEX);
-    fTxIndex = GetBoolArg("-txindex", DEFAULT_TXINDEX);
     int64_t requested_block_mode = GetArg("-useblockdb", DEFAULT_BLOCK_DB_MODE);
     if (requested_block_mode >= 0 && requested_block_mode < END_STORAGE_OPTIONS)
     {
@@ -1111,12 +1110,6 @@ bool AppInit2(Config &config, thread_group &threadGroup)
 
     bool fLoaded = false;
     StartTxAdmission(threadGroup);
-
-    if (fTxIndex)
-    {
-        auto txindex_db = new TxIndexDB(cacheConfig.nTxIndexCache, false, fReindex);
-        g_txindex = std::make_unique<TxIndex>(txindex_db);
-    }
 
     while (!fLoaded)
     {
@@ -1319,10 +1312,6 @@ bool AppInit2(Config &config, thread_group &threadGroup)
 #endif // !ENABLE_WALLET
 
     // ********************************************************* Step 8: data directory maintenance
-    if (g_txindex)
-    {
-        g_txindex->Start();
-    }
 
     // if pruning, unset the service bit and perform the initial blockstore prune
     // after any wallet rescanning has taken place.
@@ -1576,6 +1565,18 @@ bool AppInit2(Config &config, thread_group &threadGroup)
     if (GetBoolArg("-listenonion", DEFAULT_LISTEN_ONION))
         StartTorControl(threadGroup);
 
+    // Startup txindex just before StartNode. If we start it earlier and before ActivateBestChain
+    // we can end up grinding slowly through ActivateBestChain when txindex still has unfinished
+    // compaction to do from a prior run.
+    fTxIndex = GetBoolArg("-txindex", DEFAULT_TXINDEX);
+    if (fTxIndex)
+    {
+        uiInterface.InitMessage(_("Starting txindex"));
+        auto txindex_db = new TxIndexDB(cacheConfig.nTxIndexCache, false, fReindex);
+        g_txindex = std::make_unique<TxIndex>(txindex_db);
+        g_txindex->Start();
+    }
+
     StartNode(threadGroup);
 
 // Monitor the chain, and alert if we get blocks much quicker or slower than expected
@@ -1609,6 +1610,7 @@ bool AppInit2(Config &config, thread_group &threadGroup)
 #endif
 
     uiInterface.InitMessage(_("Done loading"));
+
 
     // This should be done last in init. If not, then RPC's could be allowed before the wallet
     // is ready.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1572,7 +1572,7 @@ bool AppInit2(Config &config, thread_group &threadGroup)
     if (fTxIndex)
     {
         uiInterface.InitMessage(_("Starting txindex"));
-        auto txindex_db = new TxIndexDB(cacheConfig.nTxIndexCache, false, fReindex);
+        auto txindex_db = new TxIndexDB(cacheConfig.nTxIndexCache, false, GetBoolArg("-reindex", DEFAULT_REINDEX));
         g_txindex = std::make_unique<TxIndex>(txindex_db);
         g_txindex->Start();
     }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1572,7 +1572,14 @@ bool AppInit2(Config &config, thread_group &threadGroup)
     if (fTxIndex)
     {
         uiInterface.InitMessage(_("Starting txindex"));
-        auto txindex_db = new TxIndexDB(cacheConfig.nTxIndexCache, false, GetBoolArg("-reindex", DEFAULT_REINDEX));
+
+        // When reindexing we want to wipe the previous txindex database however we don't want to
+        // rely on the fReindex flag since it's possible that by the time we get to this point in the
+        // node startup that the reindex is already completed (in the case of a very small reindex) and
+        // therefore fReindex would already be false and the txindex would not get rebuilt.
+        bool fWipeDatabase = GetBoolArg("-reindex", DEFAULT_REINDEX);
+        auto txindex_db = new TxIndexDB(cacheConfig.nTxIndexCache, false, fWipeDatabase);
+
         g_txindex = std::make_unique<TxIndex>(txindex_db);
         g_txindex->Start();
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -295,7 +295,7 @@ bool GetTransaction(const uint256 &hash,
         return true;
     }
 
-    if (fTxIndex)
+    if (g_txindex)
     {
         if (g_txindex->FindTx(hash, hashBlock, txOut))
         {

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -6,6 +6,7 @@
 
 #include "blockrelay/blockrelay_common.h"
 #include "dstencode.h"
+#include "index/txindex.h"
 #include "init.h"
 #include "main.h"
 #include "net.h"
@@ -128,6 +129,7 @@ UniValue getinfo(const UniValue &params, bool fHelp)
 #endif
     obj.pushKV("relayfee", ValueFromAmount(::minRelayTxFee.GetFeePerK()));
     obj.pushKV("status", statusStrings.GetPrintable());
+    obj.pushKV("txindex", IsTxIndexReady() ? "synced" : "not ready");
     obj.pushKV("errors", GetWarnings("statusbar"));
     obj.pushKV("fork", "Bitcoin Cash");
 

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -128,16 +128,6 @@ void TxToJSON(const CTransaction &tx, const uint256 hashBlock, UniValue &entry)
     entry.pushKV("hex", EncodeHexTx(tx));
 }
 
-static bool IsTxIndexReady()
-{
-    bool fReady = false;
-    if (g_txindex)
-    {
-        fReady = g_txindex->IsSynced();
-    }
-    return fReady;
-}
-
 UniValue getrawtransaction(const UniValue &params, bool fHelp)
 {
     if (fHelp || params.size() < 1 || params.size() > 3)

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -633,7 +633,9 @@ bool InitBlockIndex(const CChainParams &chainparams)
     LOGA("Initializing databases...\n");
 
     // Only add the genesis block if not reindexing (in which case we reuse the one already on disk)
-    if (!fReindex)
+    bool fReindexing = false;
+    pblocktree->ReadReindexing(fReindexing);
+    if (!fReindexing)
     {
         try
         {
@@ -2726,7 +2728,7 @@ bool ConnectBlock(const CBlock &block,
     }
 
     // Write transaction data to the txindex
-    if (fTxIndex)
+    if (IsTxIndexReady())
     {
         g_txindex->BlockConnected(block, pindex);
     }


### PR DESCRIPTION
In some cases, when someone is doing IBD on spinning disk with txindex enabled, then stops halfway through IBD and restarts later, then the ActivateBestChain step can take a very long time because of the disk contention with txindex needing to do a lot of compaction from the previous IBD run.  So here we startup txindex only after ActiveBestChain is complete which allows the node to startup much faster.