### PR TITLE
Remove EC for sigops

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -16,8 +16,8 @@
 static const unsigned int BLOCKSTREAM_CORE_MAX_BLOCK_SIZE = 1000000;
 /** The maximum allowed number of signature check operations in a 1MB block (network rule), and the suggested max sigops
  * per (MB rounded up) in blocks > 1MB. */
-static const unsigned int BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS = 20000;
-static const unsigned int MAX_TX_SIGOPS = 20000;
+static const unsigned int MAX_BLOCK_SIGOPS_PER_MB = 20000;
+static const unsigned int MAX_TX_SIGOPS_COUNT = 20000;
 /** The maximum suggested length of a transaction.  If greater, the transaction is not relayed, and the > 1MB block is
    considered "excessive".
     For blocks < 1MB, there is no largest transaction so it is defacto 1MB.
@@ -48,7 +48,7 @@ static const unsigned int DEFAULT_MAX_MESSAGE_SIZE_MULTIPLIER = 2;
 inline uint64_t GetMaxBlockSigOpsCount(uint64_t nBlockSize)
 {
     auto nMbRoundedUp = 1 + ((nBlockSize - 1) / 1000000);
-    return nMbRoundedUp * BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS;
+    return nMbRoundedUp * MAX_BLOCK_SIGOPS_PER_MB;
 }
 
 /** Flags for nSequence and nLockTime locks */

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -7,15 +7,17 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
+#include "uint256.h"
+
 /** The maximum allowed size for a serialized block, in bytes (network rule) */
 // BU: this constant is deprecated but is still used in a few areas such as allocation of memory.  Removing it is a
 // tradeoff between being perfect and changing more code. TODO: remove this entirely
 // static const unsigned int BU_MAX_BLOCK_SIZE = 32000000;
 static const unsigned int BLOCKSTREAM_CORE_MAX_BLOCK_SIZE = 1000000;
 /** The maximum allowed number of signature check operations in a 1MB block (network rule), and the suggested max sigops
- * per (MB rounded up) in blocks > 1MB.  If greater, the block is considered excessive */
-static const unsigned int BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS = BLOCKSTREAM_CORE_MAX_BLOCK_SIZE / 50;
-static const unsigned int MAX_TX_SIGOPS = BLOCKSTREAM_CORE_MAX_BLOCK_SIZE / 50;
+ * per (MB rounded up) in blocks > 1MB. */
+static const unsigned int BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS = 20000;
+static const unsigned int MAX_TX_SIGOPS = 20000;
 /** The maximum suggested length of a transaction.  If greater, the transaction is not relayed, and the > 1MB block is
    considered "excessive".
     For blocks < 1MB, there is no largest transaction so it is defacto 1MB.
@@ -42,6 +44,12 @@ static const unsigned int DEFAULT_EXCESSIVE_BLOCK_SIZE = MIN_EXCESSIVE_BLOCK_SIZ
 /** Allowed messages lengths will be this * the excessive block size */
 static const unsigned int DEFAULT_MAX_MESSAGE_SIZE_MULTIPLIER = 2;
 
+/** Compute the maximum sigops allowed in a block given the block size. */
+inline uint64_t GetMaxBlockSigOpsCount(uint64_t nBlockSize)
+{
+    auto nMbRoundedUp = 1 + ((nBlockSize - 1) / 1000000);
+    return nMbRoundedUp * BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS;
+}
 
 /** Flags for nSequence and nLockTime locks */
 enum

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -300,7 +300,7 @@ bool Consensus::CheckTxInputs(const CTransactionRef tx, CValidationState &state,
     return true;
 }
 
-uint64_t GetTransactionSigOpCount(const CTransaction &tx, const CCoinsViewCache &coins, const uint32_t flags)
+uint64_t GetTransactionSigOpCount(const CTransactionRef ptx, const CCoinsViewCache &coins, const uint32_t flags)
 {
-    return GetLegacySigOpCount(MakeTransactionRef(tx), flags) + GetP2SHSigOpCount(MakeTransactionRef(tx), coins, flags);
+    return GetLegacySigOpCount(ptx, flags) + GetP2SHSigOpCount(ptx, coins, flags);
 }

--- a/src/consensus/tx_verify.cpp
+++ b/src/consensus/tx_verify.cpp
@@ -166,7 +166,7 @@ bool CheckTransaction(const CTransactionRef tx, CValidationState &state)
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-vout-empty");
     // Check that the transaction doesn't have an excessive number of sigops
     unsigned int nSigOps = GetLegacySigOpCount(tx, STANDARD_SCRIPT_VERIFY_FLAGS);
-    if (nSigOps > MAX_TX_SIGOPS)
+    if (nSigOps > MAX_TX_SIGOPS_COUNT)
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-too-many-sigops");
 
     // Size limits

--- a/src/consensus/tx_verify.h
+++ b/src/consensus/tx_verify.h
@@ -72,6 +72,6 @@ bool EvaluateSequenceLocks(const CBlockIndex &block, std::pair<int, int64_t> loc
  */
 bool SequenceLocks(const CTransactionRef tx, int flags, std::vector<int> *prevHeights, const CBlockIndex &block);
 
-uint64_t GetTransactionSigOpCount(const CTransaction &tx, const CCoinsViewCache &coins, const uint32_t flags);
+uint64_t GetTransactionSigOpCount(const CTransactionRef ptx, const CCoinsViewCache &coins, const uint32_t flags);
 
 #endif // BITCOIN_CONSENSUS_TX_VERIFY_H

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -281,9 +281,6 @@ CTweakRef<uint64_t> ebTweak("net.excessiveBlock",
     "Excessive block size in bytes",
     &excessiveBlockSize,
     &ExcessiveBlockValidator);
-CTweak<uint64_t> blockSigopsPerMb("net.excessiveSigopsPerMb",
-    "Excessive effort per block, denoted in cost (# inputs * txsize) per MB",
-    BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS);
 CTweak<bool> ignoreNetTimeouts("net.ignoreTimeouts", "ignore inactivity timeouts, used during debugging", false);
 CTweakRef<bool> displayArchInSubver("net.displayArchInSubver",
     "Show box architecture, 32/64bit, in node user agent string (subver)",

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -292,9 +292,6 @@ CTweakRef<bool> displayArchInSubver("net.displayArchInSubver",
 CTweak<bool> miningCPFP("mining.childPaysForParent",
     "If enabled then we will mine ancestor packages and allow child pays for parent.",
     true);
-CTweak<uint64_t> blockMiningSigopsPerMb("mining.excessiveSigopsPerMb",
-    "Excessive effort per block, denoted in cost (# inputs * txsize) per MB",
-    BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS);
 CTweak<uint64_t> coinbaseReserve("mining.coinbaseReserve",
     "How much space to reserve for the coinbase transaction, in bytes",
     DEFAULT_COINBASE_RESERVE_SIZE);

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -351,8 +351,7 @@ bool BlockAssembler::isStillDependent(CTxMemPool::txiter iter)
 
 bool BlockAssembler::TestPackageSigOps(uint64_t packageSize, unsigned int packageSigOps)
 {
-    uint64_t blockMbSize = 1 + (nBlockSize + packageSize - 1) / 1000000;
-    uint64_t nMaxSigOpsAllowed = blockMiningSigopsPerMb.Value() * blockMbSize;
+    uint64_t nMaxSigOpsAllowed = GetMaxBlockSigOpsCount(nBlockSize + packageSize);
     if (nBlockSigOps + packageSigOps >= nMaxSigOpsAllowed)
         return false;
     return true;
@@ -408,10 +407,9 @@ bool BlockAssembler::IsIncrementallyGood(uint64_t nExtraSize, unsigned int nExtr
     }
     else
     {
-        uint64_t blockMbSize = 1 + (nBlockSize + nExtraSize - 1) / 1000000;
-        if (nBlockSigOps + nExtraSigOps > blockMiningSigopsPerMb.Value() * blockMbSize)
+        if (nBlockSigOps + nExtraSigOps > GetMaxBlockSigOpsCount(nBlockSize))
         {
-            if (nBlockSigOps > blockMiningSigopsPerMb.Value() * blockMbSize - 2)
+            if (nBlockSigOps > GetMaxBlockSigOpsCount(nBlockSize) - 2)
                 // very close to the limit, so the block is finished.  So a block that is near the sigops limit
                 // might be shorter than it could be if the high sigops tx was backed out and other tx added.
                 blockFinished = true;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -396,11 +396,11 @@ bool BlockAssembler::IsIncrementallyGood(uint64_t nExtraSize, unsigned int nExtr
     if (nBlockSize + nExtraSize <= BLOCKSTREAM_CORE_MAX_BLOCK_SIZE)
     {
         // BU: be conservative about what is generated
-        if (nBlockSigOps + nExtraSigOps >= BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS)
+        if (nBlockSigOps + nExtraSigOps >= MAX_BLOCK_SIGOPS_PER_MB)
         {
             // BU: so a block that is near the sigops limit might be shorter than it could be if
             // the high sigops tx was backed out and other tx added.
-            if (nBlockSigOps > BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS - 2)
+            if (nBlockSigOps > MAX_BLOCK_SIGOPS_PER_MB - 2)
                 blockFinished = true;
             return false;
         }

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -27,8 +27,7 @@ static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */
-static const unsigned int MAX_STANDARD_TX_SIGOPS = BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS / 5;
-// BU TODO: we chose: static const unsigned int MAX_STANDARD_TX_SIGOPS = 100*MAX_BLOCK_SIGOPS/5;
+static const unsigned int MAX_STANDARD_TX_SIGOPS = MAX_TX_SIGOPS_COUNT / 5;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /** Dust threshold in satoshis. Historically this value was calculated as

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -515,7 +515,7 @@ static UniValue MkFullMiningCandidateJson(std::set<std::string> setClientRules,
     result.pushKV("mintime", (int64_t)pindexPrev->GetMedianTimePast() + 1);
     result.pushKV("mutable", aMutable);
     result.pushKV("noncerange", "00000000ffffffff");
-    result.pushKV("sigoplimit", (int64_t)BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS);
+    result.pushKV("sigoplimit", (int64_t)MAX_BLOCK_SIGOPS_PER_MB);
     result.pushKV("sizelimit", (int64_t)maxGeneratedBlock);
     result.pushKV("curtime", pblock->GetBlockTime());
     result.pushKV("bits", strprintf("%08x", pblock->nBits));

--- a/src/test/excessiveblock_test.cpp
+++ b/src/test/excessiveblock_test.cpp
@@ -146,50 +146,18 @@ BOOST_AUTO_TEST_CASE(excessiveChecks)
 
     excessiveBlockSize = 16000000; // Ignore excessive block size when checking sigops and block effort
 
-    // Check sigops values
-
-    // Maintain compatibility with the old sigops calculator for blocks <= 1MB
-    BOOST_CHECK_MESSAGE(false == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE - 1,
-                                     MAX_BLOCK_SIGOPS_PER_MB, 100, 100),
-        "improper sigops");
-    BOOST_CHECK_MESSAGE(false == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE - 1,
-                                     MAX_BLOCK_SIGOPS_PER_MB, 100, 100),
-        "improper sigops");
-    BOOST_CHECK_MESSAGE(
-        false == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE, MAX_BLOCK_SIGOPS_PER_MB, 100, 100),
-        "improper sigops");
-
-    BOOST_CHECK_MESSAGE(true == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE - 1,
-                                    MAX_BLOCK_SIGOPS_PER_MB + 1, 100, 100),
-        "improper sigops");
-    BOOST_CHECK_MESSAGE(
-        true == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE, MAX_BLOCK_SIGOPS_PER_MB + 1, 100, 100),
-        "improper sigops");
-
-
-    // Check sigops > 1MB.
-    BOOST_CHECK_MESSAGE(
-        false == CheckExcessive(block, 1000000 + 1, (MAX_BLOCK_SIGOPS_PER_MB * 2), 100, 100), "improper sigops");
-    BOOST_CHECK_MESSAGE(
-        true == CheckExcessive(block, 1000000 + 1, (MAX_BLOCK_SIGOPS_PER_MB * 2) + 1, 100, 100), "improper sigops");
-    BOOST_CHECK_MESSAGE(
-        true == CheckExcessive(block, (2 * 1000000), (MAX_BLOCK_SIGOPS_PER_MB * 2) + 1, 100, 100), "improper sigops");
-    BOOST_CHECK_MESSAGE(false == CheckExcessive(block, (2 * 1000000) + 1, (MAX_BLOCK_SIGOPS_PER_MB * 2) + 1, 100, 100),
-        "improper sigops");
-
-
     // Check tx size values
     maxTxSize.Set(DEFAULT_LARGEST_TRANSACTION);
 
     // Within a 1 MB block, a 1MB transaction is not excessive
     BOOST_CHECK_MESSAGE(
-        false == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE, 1, 1, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE),
+        false == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE, 1, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE),
         "improper max tx");
 
     // With a > 1 MB block, use the maxTxSize to determine
-    BOOST_CHECK_MESSAGE(false == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE + 1, 1, 1, maxTxSize.Value()),
+    BOOST_CHECK_MESSAGE(false == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE + 1, 1, maxTxSize.Value()),
         "improper max tx");
-    BOOST_CHECK_MESSAGE(true == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE + 1, 1, 1, maxTxSize.Value() + 1),
+    BOOST_CHECK_MESSAGE(true == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE + 1, 1, maxTxSize.Value() + 1),
         "improper max tx");
 }
 

--- a/src/test/excessiveblock_test.cpp
+++ b/src/test/excessiveblock_test.cpp
@@ -155,8 +155,8 @@ BOOST_AUTO_TEST_CASE(excessiveChecks)
         "improper max tx");
 
     // With a > 1 MB block, use the maxTxSize to determine
-    BOOST_CHECK_MESSAGE(false == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE + 1, 1, maxTxSize.Value()),
-        "improper max tx");
+    BOOST_CHECK_MESSAGE(
+        false == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE + 1, 1, maxTxSize.Value()), "improper max tx");
     BOOST_CHECK_MESSAGE(true == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE + 1, 1, maxTxSize.Value() + 1),
         "improper max tx");
 }

--- a/src/test/excessiveblock_test.cpp
+++ b/src/test/excessiveblock_test.cpp
@@ -150,31 +150,31 @@ BOOST_AUTO_TEST_CASE(excessiveChecks)
 
     // Maintain compatibility with the old sigops calculator for blocks <= 1MB
     BOOST_CHECK_MESSAGE(false == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE - 1,
-                                     BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS, 100, 100),
+                                     MAX_BLOCK_SIGOPS_PER_MB, 100, 100),
         "improper sigops");
     BOOST_CHECK_MESSAGE(false == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE - 1,
-                                     BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS, 100, 100),
+                                     MAX_BLOCK_SIGOPS_PER_MB, 100, 100),
         "improper sigops");
     BOOST_CHECK_MESSAGE(
-        false == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE, BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS, 100, 100),
+        false == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE, MAX_BLOCK_SIGOPS_PER_MB, 100, 100),
         "improper sigops");
 
     BOOST_CHECK_MESSAGE(true == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE - 1,
-                                    BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS + 1, 100, 100),
+                                    MAX_BLOCK_SIGOPS_PER_MB + 1, 100, 100),
         "improper sigops");
     BOOST_CHECK_MESSAGE(
-        true == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE, BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS + 1, 100, 100),
+        true == CheckExcessive(block, BLOCKSTREAM_CORE_MAX_BLOCK_SIZE, MAX_BLOCK_SIGOPS_PER_MB + 1, 100, 100),
         "improper sigops");
 
 
     // Check sigops > 1MB.
     BOOST_CHECK_MESSAGE(
-        false == CheckExcessive(block, 1000000 + 1, (blockSigopsPerMb.Value() * 2), 100, 100), "improper sigops");
+        false == CheckExcessive(block, 1000000 + 1, (MAX_BLOCK_SIGOPS_PER_MB * 2), 100, 100), "improper sigops");
     BOOST_CHECK_MESSAGE(
-        true == CheckExcessive(block, 1000000 + 1, (blockSigopsPerMb.Value() * 2) + 1, 100, 100), "improper sigops");
+        true == CheckExcessive(block, 1000000 + 1, (MAX_BLOCK_SIGOPS_PER_MB * 2) + 1, 100, 100), "improper sigops");
     BOOST_CHECK_MESSAGE(
-        true == CheckExcessive(block, (2 * 1000000), (blockSigopsPerMb.Value() * 2) + 1, 100, 100), "improper sigops");
-    BOOST_CHECK_MESSAGE(false == CheckExcessive(block, (2 * 1000000) + 1, (blockSigopsPerMb.Value() * 2) + 1, 100, 100),
+        true == CheckExcessive(block, (2 * 1000000), (MAX_BLOCK_SIGOPS_PER_MB * 2) + 1, 100, 100), "improper sigops");
+    BOOST_CHECK_MESSAGE(false == CheckExcessive(block, (2 * 1000000) + 1, (MAX_BLOCK_SIGOPS_PER_MB * 2) + 1, 100, 100),
         "improper sigops");
 
 

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -170,19 +170,22 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         // scriptPubKeys of a transaction and does not take the actual executed
         // sig operations into account. spendingTx in itself does not contain a
         // signature operation.
-        BOOST_CHECK_EQUAL(GetTransactionSigOpCount(CTransaction(spendingTx), coins, flags), 0);
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCount(MakeTransactionRef(CTransaction(spendingTx)), coins, flags), 0);
         // creationTx contains two signature operations in its scriptPubKey, but
         // legacy counting is not accurate.
-        BOOST_CHECK_EQUAL(GetTransactionSigOpCount(CTransaction(creationTx), coins, flags), MAX_PUBKEYS_PER_MULTISIG);
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCount(MakeTransactionRef(CTransaction(creationTx)), coins, flags),
+            MAX_PUBKEYS_PER_MULTISIG);
         // Sanity check: script verification fails because of an invalid
         // signature.
         BOOST_CHECK_EQUAL(VerifyWithFlag(CTransaction(creationTx), spendingTx, flags), SCRIPT_ERR_CHECKMULTISIGVERIFY);
 
         // Make sure non P2SH sigops are counted even if the flag for P2SH is
         // not passed in.
-        BOOST_CHECK_EQUAL(GetTransactionSigOpCount(CTransaction(spendingTx), coins, SCRIPT_VERIFY_NONE), 0);
         BOOST_CHECK_EQUAL(
-            GetTransactionSigOpCount(CTransaction(creationTx), coins, SCRIPT_VERIFY_NONE), MAX_PUBKEYS_PER_MULTISIG);
+            GetTransactionSigOpCount(MakeTransactionRef(CTransaction(spendingTx)), coins, SCRIPT_VERIFY_NONE), 0);
+        BOOST_CHECK_EQUAL(
+            GetTransactionSigOpCount(MakeTransactionRef(CTransaction(creationTx)), coins, SCRIPT_VERIFY_NONE),
+            MAX_PUBKEYS_PER_MULTISIG);
     }
 
     // Multisig nested in P2SH
@@ -193,12 +196,13 @@ BOOST_AUTO_TEST_CASE(GetTxSigOpCost)
         CScript scriptSig = CScript() << OP_0 << OP_0 << ToByteVector(redeemScript);
 
         BuildTxs(spendingTx, coins, creationTx, scriptPubKey, scriptSig);
-        BOOST_CHECK_EQUAL(GetTransactionSigOpCount(CTransaction(spendingTx), coins, flags), 2);
+        BOOST_CHECK_EQUAL(GetTransactionSigOpCount(MakeTransactionRef(CTransaction(spendingTx)), coins, flags), 2);
         BOOST_CHECK_EQUAL(VerifyWithFlag(CTransaction(creationTx), spendingTx, flags), SCRIPT_ERR_CHECKMULTISIGVERIFY);
 
         // Make sure P2SH sigops are not counted if the flag for P2SH is not
         // passed in.
-        BOOST_CHECK_EQUAL(GetTransactionSigOpCount(CTransaction(spendingTx), coins, SCRIPT_VERIFY_NONE), 0);
+        BOOST_CHECK_EQUAL(
+            GetTransactionSigOpCount(MakeTransactionRef(CTransaction(spendingTx)), coins, SCRIPT_VERIFY_NONE), 0);
     }
 }
 

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -27,8 +27,6 @@ static std::vector<unsigned char> Serialize(const CScript &s)
     return sSerialized;
 }
 
-const uint64_t MAX_BLOCK_SIGOPS_PER_MB = BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS;
-
 BOOST_FIXTURE_TEST_SUITE(sigopcount_tests, BasicTestingSetup)
 
 void CheckScriptSigOps(const CScript &script, uint32_t accurate_sigops, uint32_t inaccurate_sigops, uint32_t datasigops)
@@ -234,7 +232,7 @@ BOOST_AUTO_TEST_CASE(test_max_sigops_per_tx)
     }
 
     // Get just before the limit.
-    for (size_t i = 0; i < MAX_TX_SIGOPS; i++)
+    for (size_t i = 0; i < MAX_TX_SIGOPS_COUNT; i++)
     {
         tx.vout[0].scriptPubKey << OP_CHECKSIG;
     }

--- a/src/test/sigopcount_tests.cpp
+++ b/src/test/sigopcount_tests.cpp
@@ -27,13 +27,6 @@ static std::vector<unsigned char> Serialize(const CScript &s)
     return sSerialized;
 }
 
-// FIXME: This should be properly factored out of unlimited.cpp as well
-uint64_t GetMaxBlockSigOpsCount(uint64_t blockSize)
-{
-    uint64_t blockMbSize = 1 + ((blockSize - 1) / 1000000);
-    return blockSigopsPerMb.Value() * blockMbSize;
-}
-
 const uint64_t MAX_BLOCK_SIGOPS_PER_MB = BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS;
 
 BOOST_FIXTURE_TEST_SUITE(sigopcount_tests, BasicTestingSetup)

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -933,7 +933,7 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
 
         // Check that the transaction doesn't have an excessive number of
         // sigops, making it impossible to mine.
-        if (nSigOps > MAX_TX_SIGOPS)
+        if (nSigOps > MAX_TX_SIGOPS_COUNT)
         {
             if (debugger)
             {

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -948,8 +948,8 @@ bool CheckExcessive(const CBlock &block, uint64_t blockSize, uint64_t nTx, uint6
 {
     if (blockSize > excessiveBlockSize)
     {
-        LOGA("Excessive block: ver:%x time:%d size: %" PRIu64 " Tx:%" PRIu64 "  :too many bytes\n",
-            block.nVersion, block.nTime, blockSize, nTx);
+        LOGA("Excessive block: ver:%x time:%d size: %" PRIu64 " Tx:%" PRIu64 "  :too many bytes\n", block.nVersion,
+            block.nTime, blockSize, nTx);
         return true;
     }
 
@@ -969,8 +969,8 @@ bool CheckExcessive(const CBlock &block, uint64_t blockSize, uint64_t nTx, uint6
         // Within a 1MB block transactions can be 1MB, so nothing to check WRT transaction size
     }
 
-    LOGA("Acceptable block: ver:%x time:%d size: %" PRIu64 " Tx:%" PRIu64 " \n", block.nVersion, block.nTime,
-        blockSize, nTx);
+    LOGA("Acceptable block: ver:%x time:%d size: %" PRIu64 " Tx:%" PRIu64 " \n", block.nVersion, block.nTime, blockSize,
+        nTx);
     return false;
 }
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -944,12 +944,12 @@ int isChainExcessive(const CBlockIndex *blk, unsigned int goBack)
     return (recentExcessive && !oldExcessive);
 }
 
-bool CheckExcessive(const CBlock &block, uint64_t blockSize, uint64_t nSigOps, uint64_t nTx, uint64_t largestTx)
+bool CheckExcessive(const CBlock &block, uint64_t blockSize, uint64_t nTx, uint64_t largestTx)
 {
     if (blockSize > excessiveBlockSize)
     {
-        LOGA("Excessive block: ver:%x time:%d size: %" PRIu64 " Tx:%" PRIu64 " Sig:%d  :too many bytes\n",
-            block.nVersion, block.nTime, blockSize, nTx, nSigOps);
+        LOGA("Excessive block: ver:%x time:%d size: %" PRIu64 " Tx:%" PRIu64 "  :too many bytes\n",
+            block.nVersion, block.nTime, blockSize, nTx);
         return true;
     }
 
@@ -963,32 +963,14 @@ bool CheckExcessive(const CBlock &block, uint64_t blockSize, uint64_t nSigOps, u
                 block.nVersion, block.nTime, blockSize, nTx, largestTx, maxTxSize.Value());
             return true;
         }
-
-        // check proportional sigops
-        if (nSigOps > GetMaxBlockSigOpsCount(blockSize))
-        {
-            LOGA("Excessive block: ver:%x time:%d size: %" PRIu64 " Tx:%" PRIu64
-                 " Sig:%d  :too many sigops.  Expected less than: %d\n",
-                block.nVersion, block.nTime, blockSize, nTx, nSigOps, GetMaxBlockSigOpsCount(blockSize));
-            return true;
-        }
     }
     else
     {
         // Within a 1MB block transactions can be 1MB, so nothing to check WRT transaction size
-
-        // Check max sigops
-        if (nSigOps > MAX_BLOCK_SIGOPS_PER_MB)
-        {
-            LOGA("Excessive block: ver:%x time:%d size: %" PRIu64 " Tx:%" PRIu64
-                 " Sig:%d  :too many sigops.  Expected < 1MB defined constant: %d\n",
-                block.nVersion, block.nTime, blockSize, nTx, nSigOps, MAX_BLOCK_SIGOPS_PER_MB);
-            return true;
-        }
     }
 
-    LOGA("Acceptable block: ver:%x time:%d size: %" PRIu64 " Tx:%" PRIu64 " Sig:%d\n", block.nVersion, block.nTime,
-        blockSize, nTx, nSigOps);
+    LOGA("Acceptable block: ver:%x time:%d size: %" PRIu64 " Tx:%" PRIu64 " \n", block.nVersion, block.nTime,
+        blockSize, nTx);
     return false;
 }
 

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -965,14 +965,11 @@ bool CheckExcessive(const CBlock &block, uint64_t blockSize, uint64_t nSigOps, u
         }
 
         // check proportional sigops
-        uint64_t blockMbSize =
-            1 + ((blockSize - 1) /
-                    1000000); // block size in megabytes rounded up. 1-1000000 -> 1, 1000001-2000000 -> 2, etc.
-        if (nSigOps > blockSigopsPerMb.Value() * blockMbSize)
+        if (nSigOps > GetMaxBlockSigOpsCount(blockSize))
         {
             LOGA("Excessive block: ver:%x time:%d size: %" PRIu64 " Tx:%" PRIu64
                  " Sig:%d  :too many sigops.  Expected less than: %d\n",
-                block.nVersion, block.nTime, blockSize, nTx, nSigOps, blockSigopsPerMb.Value() * blockMbSize);
+                block.nVersion, block.nTime, blockSize, nTx, nSigOps, GetMaxBlockSigOpsCount(blockSize));
             return true;
         }
     }
@@ -981,11 +978,11 @@ bool CheckExcessive(const CBlock &block, uint64_t blockSize, uint64_t nSigOps, u
         // Within a 1MB block transactions can be 1MB, so nothing to check WRT transaction size
 
         // Check max sigops
-        if (nSigOps > BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS)
+        if (nSigOps > MAX_BLOCK_SIGOPS_PER_MB)
         {
             LOGA("Excessive block: ver:%x time:%d size: %" PRIu64 " Tx:%" PRIu64
                  " Sig:%d  :too many sigops.  Expected < 1MB defined constant: %d\n",
-                block.nVersion, block.nTime, blockSize, nTx, nSigOps, BLOCKSTREAM_CORE_MAX_BLOCK_SIGOPS);
+                block.nVersion, block.nTime, blockSize, nTx, nSigOps, MAX_BLOCK_SIGOPS_PER_MB);
             return true;
         }
     }

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -147,7 +147,7 @@ extern bool TestConservativeBlockValidity(CValidationState &state,
     bool fCheckMerkleRoot);
 
 // Check whether this block is bigger in some metric than we really want to accept
-extern bool CheckExcessive(const CBlock &block, uint64_t blockSize, uint64_t nSigOps, uint64_t nTx, uint64_t largestTx);
+extern bool CheckExcessive(const CBlock &block, uint64_t blockSize, uint64_t nTx, uint64_t largestTx);
 
 // Check whether this chain qualifies as excessive.
 extern int isChainExcessive(const CBlockIndex *blk, unsigned int checkDepth = excessiveAcceptDepth);

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -1592,7 +1592,7 @@ bool ContextualCheckBlock(const CBlock &block,
     }
 
     // Check whether this block exceeds what we want to relay.
-    block.fExcessive = CheckExcessive(block, block.GetBlockSize(), 0, nTx, nLargestTx);
+    block.fExcessive = CheckExcessive(block, block.GetBlockSize(), nTx, nLargestTx);
 
 
     return true;

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -2231,8 +2231,7 @@ bool ConnectBlockDependencyOrdering(const CBlock &block,
             nInputs += tx.vin.size();
             nSigOps += GetLegacySigOpCount(txref, flags);
             if (nSigOps > GetMaxBlockSigOpsCount(block.GetBlockSize()))
-               return state.DoS(100, error("ConnectBlock(): too many sigops"),
-                               REJECT_INVALID, "bad-blk-sigops");
+                return state.DoS(100, error("ConnectBlock(): too many sigops"), REJECT_INVALID, "bad-blk-sigops");
 
             if (!tx.IsCoinBase())
             {
@@ -2277,8 +2276,8 @@ bool ConnectBlockDependencyOrdering(const CBlock &block,
                     // an incredibly-expensive-to-validate block.
                     nSigOps += GetP2SHSigOpCount(txref, view, flags);
                     if (nSigOps > GetMaxBlockSigOpsCount(block.GetBlockSize()))
-                        return state.DoS(100, error("ConnectBlock(): too many sigops"),
-                                        REJECT_INVALID, "bad-blk-sigops");
+                        return state.DoS(
+                            100, error("ConnectBlock(): too many sigops"), REJECT_INVALID, "bad-blk-sigops");
                 }
 
                 nFees += view.GetValueIn(tx) - tx.GetValueOut();
@@ -2474,8 +2473,7 @@ bool ConnectBlockCanonicalOrdering(const CBlock &block,
             nInputs += tx.vin.size();
             nSigOps += GetLegacySigOpCount(txref, flags);
             if (nSigOps > GetMaxBlockSigOpsCount(block.GetBlockSize()))
-               return state.DoS(100, error("ConnectBlock(): too many sigops"),
-                               REJECT_INVALID, "bad-blk-sigops");
+                return state.DoS(100, error("ConnectBlock(): too many sigops"), REJECT_INVALID, "bad-blk-sigops");
 
             if (!tx.IsCoinBase())
             {
@@ -2520,8 +2518,8 @@ bool ConnectBlockCanonicalOrdering(const CBlock &block,
                     // an incredibly-expensive-to-validate block.
                     nSigOps += GetP2SHSigOpCount(txref, view, flags);
                     if (nSigOps > GetMaxBlockSigOpsCount(block.GetBlockSize()))
-                        return state.DoS(100, error("ConnectBlock(): too many sigops"),
-                                        REJECT_INVALID, "bad-blk-sigops");
+                        return state.DoS(
+                            100, error("ConnectBlock(): too many sigops"), REJECT_INVALID, "bad-blk-sigops");
                 }
 
                 nFees += view.GetValueIn(tx) - tx.GetValueOut();


### PR DESCRIPTION
This has never been used and introduced some small performance hits.

Remove sigops from CheckExcessive() and also did a bit of updating to the naming of some vars.