### PR TITLE
Fix edge case in request manager

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -514,22 +514,24 @@ public:
     bool fShouldBan;
     BanReason nBanType = (BanReason)-1;
 
+    // General thintype critical section to ensure that no
+    // two thintype blocks from the "same" peer can be processed at
+    // the same time.
+    CCriticalSection cs_thintype;
+
     // Xtreme Thinblocks
-    CCriticalSection cs_xthinblock;
     /** Max xthin bloom filter size (in bytes) that our peer will accept */
     std::atomic<uint32_t> nXthinBloomfilterSize;
 
     // Graphene blocks
-    CCriticalSection cs_graphene;
     /** Stores the grapheneblock salt to be used for this peer */
-    uint64_t gr_shorttxidk0 GUARDED_BY(cs_graphene);
-    uint64_t gr_shorttxidk1 GUARDED_BY(cs_graphene);
+    uint64_t gr_shorttxidk0 GUARDED_BY(cs_thintype);
+    uint64_t gr_shorttxidk1 GUARDED_BY(cs_thintype);
 
     // Compact Blocks
-    CCriticalSection cs_compactblock;
     /** Stores the compactblock salt to be used for this peer */
-    uint64_t shorttxidk0 GUARDED_BY(cs_compactblock);
-    uint64_t shorttxidk1 GUARDED_BY(cs_compactblock);
+    uint64_t shorttxidk0 GUARDED_BY(cs_thintype);
+    uint64_t shorttxidk1 GUARDED_BY(cs_thintype);
     /** Does this peer support CompactBlocks */
     std::atomic<bool> fSupportsCompactBlocks;
 

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1623,7 +1623,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         // ignore the expedited message unless we are at the chain tip...
         if (!fImporting && !fReindex && !IsInitialBlockDownload())
         {
-            LOCK(pfrom->cs_xthinblock);
+            LOCK(pfrom->cs_thintype);
             if (!HandleExpeditedBlock(vRecv, pfrom))
                 return false;
         }
@@ -1632,7 +1632,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
     else if (strCommand == NetMsgType::XTHINBLOCK && !fImporting && !fReindex && !IsInitialBlockDownload() &&
              IsThinBlocksEnabled())
     {
-        LOCK(pfrom->cs_xthinblock);
+        LOCK(pfrom->cs_thintype);
         return CXThinBlock::HandleMessage(vRecv, pfrom, strCommand, 0);
     }
 
@@ -1640,7 +1640,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
     else if (strCommand == NetMsgType::THINBLOCK && !fImporting && !fReindex && !IsInitialBlockDownload() &&
              IsThinBlocksEnabled())
     {
-        LOCK(pfrom->cs_xthinblock);
+        LOCK(pfrom->cs_thintype);
         return CThinBlock::HandleMessage(vRecv, pfrom);
     }
 
@@ -1651,7 +1651,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         if (!requester.CheckForRequestDOS(pfrom, chainparams))
             return false;
 
-        LOCK(pfrom->cs_xthinblock);
+        LOCK(pfrom->cs_thintype);
         return CXRequestThinBlockTx::HandleMessage(vRecv, pfrom);
     }
 
@@ -1659,7 +1659,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
     else if (strCommand == NetMsgType::XBLOCKTX && !fImporting && !fReindex && !IsInitialBlockDownload() &&
              IsThinBlocksEnabled())
     {
-        LOCK(pfrom->cs_xthinblock);
+        LOCK(pfrom->cs_thintype);
         return CXThinBlockTx::HandleMessage(vRecv, pfrom);
     }
 
@@ -1670,14 +1670,14 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         if (!requester.CheckForRequestDOS(pfrom, chainparams))
             return false;
 
-        LOCK(pfrom->cs_graphene);
+        LOCK(pfrom->cs_thintype);
         return HandleGrapheneBlockRequest(vRecv, pfrom, chainparams);
     }
 
     else if (strCommand == NetMsgType::GRAPHENEBLOCK && !fImporting && !fReindex && !IsInitialBlockDownload() &&
              IsGrapheneBlockEnabled() && grapheneVersionCompatible)
     {
-        LOCK(pfrom->cs_graphene);
+        LOCK(pfrom->cs_thintype);
         return CGrapheneBlock::HandleMessage(vRecv, pfrom, strCommand, 0);
     }
 
@@ -1688,7 +1688,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         if (!requester.CheckForRequestDOS(pfrom, chainparams))
             return false;
 
-        LOCK(pfrom->cs_graphene);
+        LOCK(pfrom->cs_thintype);
         return CRequestGrapheneBlockTx::HandleMessage(vRecv, pfrom);
     }
 
@@ -1696,7 +1696,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
     else if (strCommand == NetMsgType::GRAPHENETX && !fImporting && !fReindex && !IsInitialBlockDownload() &&
              IsGrapheneBlockEnabled() && grapheneVersionCompatible)
     {
-        LOCK(pfrom->cs_graphene);
+        LOCK(pfrom->cs_thintype);
         return CGrapheneBlockTx::HandleMessage(vRecv, pfrom);
     }
 
@@ -1705,7 +1705,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         if (!requester.CheckForRequestDOS(pfrom, chainparams))
             return false;
 
-        LOCK(pfrom->cs_graphene);
+        LOCK(pfrom->cs_thintype);
         return HandleGrapheneBlockRecoveryRequest(vRecv, pfrom, chainparams);
     }
 
@@ -1714,7 +1714,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         if (!requester.CheckForRequestDOS(pfrom, chainparams))
             return false;
 
-        LOCK(pfrom->cs_graphene);
+        LOCK(pfrom->cs_thintype);
         return HandleGrapheneBlockRecoveryResponse(vRecv, pfrom, chainparams);
     }
 
@@ -1722,7 +1722,7 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
     else if (strCommand == NetMsgType::CMPCTBLOCK && !fImporting && !fReindex && !IsInitialBlockDownload() &&
              IsCompactBlocksEnabled())
     {
-        LOCK(pfrom->cs_compactblock);
+        LOCK(pfrom->cs_thintype);
         return CompactBlock::HandleMessage(vRecv, pfrom);
     }
     else if (strCommand == NetMsgType::GETBLOCKTXN && !fImporting && !fReindex && !IsInitialBlockDownload() &&
@@ -1731,13 +1731,13 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         if (!requester.CheckForRequestDOS(pfrom, chainparams))
             return false;
 
-        LOCK(pfrom->cs_compactblock);
+        LOCK(pfrom->cs_thintype);
         return CompactReRequest::HandleMessage(vRecv, pfrom);
     }
     else if (strCommand == NetMsgType::BLOCKTXN && !fImporting && !fReindex && !IsInitialBlockDownload() &&
              IsCompactBlocksEnabled())
     {
-        LOCK(pfrom->cs_compactblock);
+        LOCK(pfrom->cs_thintype);
         return CompactReReqResponse::HandleMessage(vRecv, pfrom);
     }
 

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -538,6 +538,19 @@ void CRequestManager::RequestCorruptedBlock(const uint256 &blockHash)
     AskForDuringIBD(vGetBlocks, nullptr);
 }
 
+static bool IsGrapheneVersionSupported(CNode *pfrom)
+{
+    try
+    {
+        NegotiateGrapheneVersion(pfrom);
+        return true;
+    }
+    catch (const std::runtime_error &error)
+    {
+        return false;
+    }
+}
+
 bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
 {
     CInv inv2(obj);
@@ -548,7 +561,7 @@ bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
     {
         // Ask for Graphene blocks
         // Must download a graphene block from a graphene enabled peer.
-        if (IsGrapheneBlockEnabled() && pfrom->GrapheneCapable())
+        if (IsGrapheneBlockEnabled() && pfrom->GrapheneCapable() && IsGrapheneVersionSupported(pfrom))
         {
             if (thinrelay.AddBlockInFlight(pfrom, inv2.hash, NetMsgType::GRAPHENEBLOCK))
             {

--- a/src/requestManager.cpp
+++ b/src/requestManager.cpp
@@ -550,7 +550,6 @@ bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
         // Must download a graphene block from a graphene enabled peer.
         if (IsGrapheneBlockEnabled() && pfrom->GrapheneCapable())
         {
-            // We can only request one thin type block per peer at a time.
             if (thinrelay.AddBlockInFlight(pfrom, inv2.hash, NetMsgType::GRAPHENEBLOCK))
             {
                 MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
@@ -575,7 +574,6 @@ bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
         // Must download an xthinblock from a xthin peer.
         if (IsThinBlocksEnabled() && pfrom->ThinBlockCapable())
         {
-            // We can only request one thin type block per peer at a time.
             if (thinrelay.AddBlockInFlight(pfrom, inv2.hash, NetMsgType::XTHINBLOCK))
             {
                 MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
@@ -602,7 +600,6 @@ bool CRequestManager::RequestBlock(CNode *pfrom, CInv obj)
         // Must download an xthinblock from a xthin peer.
         if (IsCompactBlocksEnabled() && pfrom->CompactBlockCapable())
         {
-            // We can only request one thin type block per peer at a time.
             if (thinrelay.AddBlockInFlight(pfrom, inv2.hash, NetMsgType::CMPCTBLOCK))
             {
                 MarkBlockAsInFlight(pfrom->GetId(), obj.hash);
@@ -1087,10 +1084,35 @@ void CRequestManager::RequestNextBlocksToDownload(CNode *pto)
         }
         if (!vGetBlocks.empty())
         {
+            std::vector<CInv> vToFetchNew;
+            {
+                LOCK(cs_objDownloader);
+                for (CInv &inv : vGetBlocks)
+                {
+                    // If this block is already in flight then don't ask for it again during the IBD process.
+                    //
+                    // If it's an additional source for a new peer then it would have been added already in
+                    // FindNextBlocksToDownload().
+                    std::map<uint256, std::map<NodeId, std::list<QueuedBlock>::iterator> >::iterator itInFlight =
+                        mapBlocksInFlight.find(inv.hash);
+                    if (itInFlight != mapBlocksInFlight.end())
+                    {
+                        continue;
+                    }
+
+                    vToFetchNew.push_back(inv);
+                }
+            }
+            vGetBlocks.swap(vToFetchNew);
+
             if (!IsInitialBlockDownload())
+            {
                 AskFor(vGetBlocks, pto);
+            }
             else
+            {
                 AskForDuringIBD(vGetBlocks, pto);
+            }
         }
     }
 }
@@ -1164,8 +1186,17 @@ void CRequestManager::FindNextBlocksToDownload(CNode *node, unsigned int count, 
             uint256 blockHash = pindex->GetBlockHash();
             if (AlreadyAskedForBlock(blockHash))
             {
-                AskFor(CInv(MSG_BLOCK, blockHash), node); // Add another source
-                continue;
+                // Only add a new source if there is a block in flight from a different peer. This prevents
+                // us from re-adding a source for the same peer and possibly downloading two duplicate blocks.
+                // This edge condition can typically happen when we were only connected to only one peer and we
+                // exceed the download timeout causing us to re-request the same block from the same peer.
+                std::map<uint256, std::map<NodeId, std::list<QueuedBlock>::iterator> >::iterator itInFlight =
+                    mapBlocksInFlight.find(blockHash);
+                if (itInFlight != mapBlocksInFlight.end() && !itInFlight->second.count(nodeid))
+                {
+                    AskFor(CInv(MSG_BLOCK, blockHash), node); // Add another source
+                    continue;
+                }
             }
 
             if (!pindex->IsValid(BLOCK_VALID_TREE))


### PR DESCRIPTION
This fixes an edge condition which happens when we have just one single peer connected and we request a block when a header comes in but then we request a duplicate block when the IBD process kicks in. This is caused by the fact that we've added a duplicate source for the same peer into the request manager when the block was already in flight.

