### PR TITLE
[travis] Give more time to run unit tests

### DIFF
--- a/.travis/script_b.sh
+++ b/.travis/script_b.sh
@@ -21,6 +21,8 @@ if [ "$RUN_TESTS" = "true" ]; then
     BEGIN_FOLD unit-tests
     echo "Unit tests"
     if [ $HOST != "x86_64-w64-mingw32" ]; then
+        # use travis_wait work around fork problem (https://github.com/travis-ci/travis-ci/issues/6934)
+        travis_wait 30 sleep infinity &
         DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1;
     fi
     END_FOLD


### PR DESCRIPTION
In some circumstances, which most of the time are transient, Travis
took longer then usual to run unit tests. To avoid timeout in these
occasions we are going to increase the log silence time out from 10
(default) to 30 minutes for this particular task (make check).

To make it so to avoid the same problem we had in the past and that
lead us to merge #1836, we are deploying the timeout increase using
a work around a problem travis_wait has in executing process forks
and execs another process.

See https://github.com/travis-ci/travis-ci/issues/6934 for more details.