### PR TITLE
update all seenLockOrder maps when a new lock is seen

### DIFF
--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -12,6 +12,7 @@
 #include "util.h"
 
 #ifdef DEBUG_LOCKORDER
+std::atomic<bool> lockdataDestructed {false};
 LockData lockdata;
 #endif
 

--- a/src/bench/bench_bitcoin.cpp
+++ b/src/bench/bench_bitcoin.cpp
@@ -12,7 +12,7 @@
 #include "util.h"
 
 #ifdef DEBUG_LOCKORDER
-std::atomic<bool> lockdataDestructed {false};
+std::atomic<bool> lockdataDestructed{false};
 LockData lockdata;
 #endif
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -28,6 +28,7 @@
 #include <univalue.h>
 
 #ifdef DEBUG_LOCKORDER
+std::atomic<bool> lockdataDestructed {false};
 LockData lockdata;
 #endif
 

--- a/src/bitcoin-cli.cpp
+++ b/src/bitcoin-cli.cpp
@@ -28,7 +28,7 @@
 #include <univalue.h>
 
 #ifdef DEBUG_LOCKORDER
-std::atomic<bool> lockdataDestructed {false};
+std::atomic<bool> lockdataDestructed{false};
 LockData lockdata;
 #endif
 

--- a/src/bitcoin-miner.cpp
+++ b/src/bitcoin-miner.cpp
@@ -38,7 +38,7 @@
 #include <random>
 
 #ifdef DEBUG_LOCKORDER
-std::atomic<bool> lockdataDestructed {false};
+std::atomic<bool> lockdataDestructed{false};
 LockData lockdata;
 #endif
 

--- a/src/bitcoin-miner.cpp
+++ b/src/bitcoin-miner.cpp
@@ -38,6 +38,7 @@
 #include <random>
 
 #ifdef DEBUG_LOCKORDER
+std::atomic<bool> lockdataDestructed {false};
 LockData lockdata;
 #endif
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -31,7 +31,7 @@
 #include <boost/assign/list_of.hpp>
 
 #ifdef DEBUG_LOCKORDER
-std::atomic<bool> lockdataDestructed {false};
+std::atomic<bool> lockdataDestructed{false};
 LockData lockdata;
 #endif
 

--- a/src/bitcoin-tx.cpp
+++ b/src/bitcoin-tx.cpp
@@ -31,6 +31,7 @@
 #include <boost/assign/list_of.hpp>
 
 #ifdef DEBUG_LOCKORDER
+std::atomic<bool> lockdataDestructed {false};
 LockData lockdata;
 #endif
 

--- a/src/deadlock-detection/lockorder.cpp
+++ b/src/deadlock-detection/lockorder.cpp
@@ -85,11 +85,30 @@ void CLockOrderTracker::AddNewLockInfo(const std::string &lockname, const std::v
     // we have not seen the lock we are trying to lock before, add data for it
     for (auto &heldLock : heldLocks)
     {
-        auto heldLockIter = seenLockOrders.find(heldLock.GetMutexName());
-        if (heldLockIter != seenLockOrders.end())
+        std::string heldLockName = heldLock.GetMutexName();
+        auto heldLockIter = seenLockOrders.find(heldLockName);
+        if (heldLockIter == seenLockOrders.end())
         {
-            // add information about this lock
-            heldLockIter->second.emplace(lockname);
+            continue;
+        }
+        // add information about this lock
+        heldLockIter->second.emplace(lockname);
+        for (auto &otherLock : seenLockOrders)
+        {
+            if (otherLock.first != lockname)
+            {
+                if (otherLock.second.count(heldLockName) != 0)
+                {
+                    otherLock.second.emplace(lockname);
+                }
+            }
+            else if (otherLock.first == lockname)
+            {
+                for (auto &other_element : otherLock.second)
+                {
+                    heldLockIter->second.emplace(other_element);
+                }
+            }
         }
     }
     // add a new key to track locks locked after this one

--- a/src/deadlock-detection/lockorder.cpp
+++ b/src/deadlock-detection/lockorder.cpp
@@ -8,6 +8,8 @@
 
 #ifdef DEBUG_LOCKORDER // this ifdef covers the rest of the file
 
+extern std::atomic<bool> lockdataDestructed;
+
 void CLockOrderTracker::potential_lock_order_issue_detected(const CLockLocation &thisLock,
     const CLockLocation &otherLock,
     const uint64_t &tid)

--- a/src/deadlock-detection/threaddeadlock.cpp
+++ b/src/deadlock-detection/threaddeadlock.cpp
@@ -8,8 +8,6 @@
 
 #ifdef DEBUG_LOCKORDER // this ifdef covers the rest of the file
 
-bool lockdataDestructed = false;
-
 // removes 1 lock for a critical section
 void _remove_lock_critical_exit(void *cs)
 {
@@ -395,7 +393,7 @@ void push_lock(void *c, const CLockLocation &locklocation, LockType locktype, Ow
 // removes all instances of the critical section
 void DeleteCritical(void *cs)
 {
-    if (lockdataDestructed)
+    if (lockdataDestructed.load())
         return;
     // remove all instances of the critical section from lockdata
     std::lock_guard<std::mutex> lock(lockdata.dd_mutex);

--- a/src/deadlock-detection/threaddeadlock.cpp
+++ b/src/deadlock-detection/threaddeadlock.cpp
@@ -518,18 +518,16 @@ void push_lock(void *c, const CLockLocation &locklocation, LockType locktype, Ow
             {
                 heldLocks.push_back(entry.second);
             }
+            // we havent seen this lock before, add generic data for it
+            lockdata.ordertracker.AddNewLockInfo(lockname, heldLocks);
+            // track this locks exactly locking order info
+            lockdata.ordertracker.TrackLockOrderHistory(locklocation, heldLocks, tid);
+
             if (lockdata.ordertracker.CanCheckForConflicts(lockname))
             {
                 // we have seen the lock we are trying to lock before, check ordering
                 lockdata.ordertracker.CheckForConflict(locklocation, heldLocks, tid);
             }
-            else
-            {
-                // we havent seen this lock before, add generic data for it
-                lockdata.ordertracker.AddNewLockInfo(lockname, heldLocks);
-            }
-            // track this locks exactly locking order info
-            lockdata.ordertracker.TrackLockOrderHistory(locklocation, heldLocks, tid);
         }
         else
         {

--- a/src/deadlock-detection/threaddeadlock.cpp
+++ b/src/deadlock-detection/threaddeadlock.cpp
@@ -69,70 +69,6 @@ void _remove_lock_critical_exit(void *cs)
     }
 }
 
-void deadlock_detected(LockStackEntry now, LockStack &deadlocks, std::set<uint64_t> &threads)
-{
-    LOGA("DEADLOCK DETECTED\n");
-    LOGA("This occurred while trying to lock: %s ", now.second.ToString().c_str());
-    LOGA("Which has:\n");
-
-    auto rlw = lockdata.readlockswaiting.find(now.first);
-    if (rlw != lockdata.readlockswaiting.end())
-    {
-        for (auto &entry : rlw->second)
-        {
-            LOGA("Read Lock Waiting for thread with id %" PRIu64 "\n", entry);
-        }
-    }
-
-    auto wlw = lockdata.writelockswaiting.find(now.first);
-    if (wlw != lockdata.writelockswaiting.end())
-    {
-        for (auto &entry : wlw->second)
-        {
-            LOGA("Write Lock Waiting for thread with id %" PRIu64 "\n", entry);
-        }
-    }
-
-    auto rlh = lockdata.readlocksheld.find(now.first);
-    if (rlh != lockdata.readlocksheld.end())
-    {
-        for (auto &entry : rlh->second)
-        {
-            LOGA("Read Lock Held for thread with id %" PRIu64 "\n", entry);
-        }
-    }
-
-    auto wlh = lockdata.writelocksheld.find(now.first);
-    if (wlh != lockdata.writelocksheld.end())
-    {
-        for (auto &entry : wlh->second)
-        {
-            LOGA("Write Lock Held for thread with id %" PRIu64 "\n", entry);
-        }
-    }
-
-    LOGA("\nThe locks involved are:\n");
-    for (auto &lock : deadlocks)
-    {
-        LOGA(" %s\n", lock.second.ToString().c_str());
-    }
-    for (auto &thread : threads)
-    {
-        LOGA("\nThread with tid %" PRIu64 " was involved. It held locks:\n", thread);
-        auto iterheld = lockdata.locksheldbythread.find(thread);
-        if (iterheld != lockdata.locksheldbythread.end())
-        {
-            for (auto &lockentry : iterheld->second)
-            {
-                LOGA(" %s\n", lockentry.second.ToString().c_str());
-            }
-        }
-    }
-    // clean up the lock before throwing
-    _remove_lock_critical_exit(now.first);
-    throw std::logic_error("potential deadlock detected");
-}
-
 bool HasAnyOwners(void *c)
 {
     auto iter = lockdata.writelocksheld.find(c);
@@ -152,97 +88,6 @@ bool HasAnyOwners(void *c)
         }
     }
 
-    return false;
-}
-
-static bool RecursiveCheck(const uint64_t &tid,
-    const void *c,
-    uint64_t lastTid,
-    void *lastLock,
-    bool firstRun,
-    LockStack &deadlocks,
-    std::set<uint64_t> &threads)
-{
-    if (!firstRun && c == lastLock && tid == lastTid)
-    {
-        // we are back where we started, infinite loop means there is a deadlock
-        return true;
-    }
-    // first check if we currently have any other ownerships
-    auto self_iter = lockdata.locksheldbythread.find(lastTid);
-    if (self_iter != lockdata.locksheldbythread.end())
-    {
-        if (self_iter->second.size() == 0)
-        {
-            // we cant deadlock if we dont own any other mutexs
-            return false;
-        }
-    }
-    // at this point we have at least 1 lock for a mutex somewhere
-
-    // check if a thread has an ownership of c
-    auto writeiter = lockdata.writelocksheld.find(lastLock);
-    auto readiter = lockdata.readlocksheld.find(lastLock);
-
-    // NOTE: be careful when adjusting these booleans, the order of the checks is important
-    bool isReadLocked = !((readiter == lockdata.readlocksheld.end()) || readiter->second.empty());
-    bool isWriteLocked = !((writeiter == lockdata.writelocksheld.end()) || writeiter->second.empty());
-    if (!isWriteLocked && !isReadLocked)
-    {
-        // no owners, no deadlock possible
-        return false;
-    }
-    // we have other locks, so check if we have any in common with the holder(s) of the other lock
-    std::set<uint64_t> otherLocks;
-    if (isWriteLocked)
-    {
-        otherLocks.insert(writeiter->second.begin(), writeiter->second.end());
-    }
-    if (isReadLocked)
-    {
-        otherLocks.insert(readiter->second.begin(), readiter->second.end());
-    }
-    for (auto &threadId : otherLocks)
-    {
-        if (threadId == lastTid)
-        {
-            // this continue fixes an infinite looping problem
-            continue;
-        }
-        auto other_iter = lockdata.locksheldbythread.find(threadId);
-        // we dont need to check empty here, other thread has at least 1 lock otherwise we wouldnt be checking it
-        if (other_iter->second.size() == 1)
-        {
-            // it does not have any locks aside from known exclusive, no deadlock possible
-            // we can just wait until that exclusive lock is released
-            return false;
-        }
-        // if the other thread has 1+ other locks aside from the known exclusive, check them for matches with our own
-        // locks
-        for (auto &lock : other_iter->second)
-        {
-            // if they have a lock that is on a lock that someone has a lock on
-            if (HasAnyOwners(lock.first))
-            {
-                // and their lock is waiting...
-                if (lock.second.GetWaiting() == true)
-                {
-                    deadlocks.push_back(lock);
-                    threads.emplace(other_iter->first);
-                    if (other_iter->first == tid && lock.first == c)
-                    {
-                        // we are back where we started and there is a deadlock
-                        return true;
-                    }
-                    if (RecursiveCheck(tid, c, other_iter->first, lock.first, false, deadlocks, threads))
-                    {
-                        return true;
-                    }
-                }
-                // no deadlock, other lock is not waiting, we simply have to wait until they release that lock
-            }
-        }
-    }
     return false;
 }
 
@@ -545,14 +390,6 @@ void push_lock(void *c, const CLockLocation &locklocation, LockType locktype, Ow
         return;
     }
     AddNewWaitingLock(c, tid, ownership);
-    /*
-    std::vector<LockStackEntry> deadlocks;
-    std::set<uint64_t> threads;
-    if (RecursiveCheck(tid, c, tid, c, true, deadlocks, threads))
-    {
-        deadlock_detected(now, deadlocks, threads);
-    }
-    */
 }
 
 // removes all instances of the critical section

--- a/src/deadlock-detection/threaddeadlock.h
+++ b/src/deadlock-detection/threaddeadlock.h
@@ -39,7 +39,7 @@ inline uint64_t getTid(void)
 // In your app, declare lockdata and all global lock variables in a single module so destruction order is controlled.
 // But for unit tests, these might be declared in separate files.  In this case we use a global boolean to indicate
 // whether lockdata has been destructed.
-extern bool lockdataDestructed;
+extern std::atomic<bool> lockdataDestructed;
 
 struct LockData
 {
@@ -69,7 +69,7 @@ struct LockData
     /// a mutex that protects all other data members of this struct
     std::mutex dd_mutex;
 
-    ~LockData() { lockdataDestructed = true; }
+    ~LockData() { lockdataDestructed.store(true); }
 };
 extern LockData lockdata;
 

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -60,6 +60,7 @@
 using namespace std;
 
 #ifdef DEBUG_LOCKORDER
+std::atomic<bool> lockdataDestructed {false};
 LockData lockdata;
 #endif
 

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -60,7 +60,7 @@
 using namespace std;
 
 #ifdef DEBUG_LOCKORDER
-std::atomic<bool> lockdataDestructed {false};
+std::atomic<bool> lockdataDestructed{false};
 LockData lockdata;
 #endif
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -304,6 +304,7 @@ public:
         : lock(mutexIn, boost::defer_lock)
     {
         // we no longer allow naming critical sections cs, please name it something more meaningful
+        assert(pszName != nullptr);
         assert(std::string(pszName) != "cs");
         if (fTry)
             TryEnter(pszName, pszFile, nLine, type);
@@ -322,6 +323,7 @@ public:
             return;
 
         // we no longer allow naming critical sections cs, please name it something more meaningful
+        assert(pszName != nullptr);
         assert(std::string(pszName) != "cs");
         lock = boost::unique_lock<Mutex>(*pmutexIn, boost::defer_lock);
         if (fTry)
@@ -423,6 +425,7 @@ public:
         : lock(mutexIn, boost::defer_lock)
     {
         // we no longer allow naming critical sections cs, please name it something more meaningful
+        assert(pszName != nullptr);
         assert(std::string(pszName) != "cs");
         if (fTry)
             TryEnter(pszName, pszFile, nLine, type);
@@ -441,6 +444,7 @@ public:
             return;
 
         // we no longer allow naming critical sections cs, please name it something more meaningful
+        assert(pszName != nullptr);
         assert(std::string(pszName) != "cs");
         lock = boost::shared_lock<Mutex>(*pmutexIn, boost::defer_lock);
         if (fTry)

--- a/src/test/deadlock_tests/test5.cpp
+++ b/src/test/deadlock_tests/test5.cpp
@@ -21,18 +21,36 @@ BOOST_FIXTURE_TEST_SUITE(deadlock_test5, EmptySuite)
 
 #ifdef DEBUG_LOCKORDER // this ifdef covers the rest of the file
 
+CSharedCriticalSection mutexA;
+CSharedCriticalSection mutexB;
 std::atomic<bool> done{false};
 std::atomic<int> lock_exceptions{0};
 std::atomic<int> writelocks{0};
 
-void TestThread(CSharedCriticalSection *mutexA, CSharedCriticalSection *mutexB)
+void TestThread1()
 {
-    WRITELOCK(*mutexA);
+    WRITELOCK(mutexA);
     writelocks++;
     while(writelocks != 2) ;
     try
     {
-        READLOCK(*mutexB);
+        READLOCK(mutexB);
+    }
+    catch (const std::logic_error&)
+    {
+        lock_exceptions++;
+    }
+    while (!done) ;
+}
+
+void TestThread2()
+{
+    WRITELOCK(mutexB);
+    writelocks++;
+    while(writelocks != 2) ;
+    try
+    {
+        READLOCK(mutexA);
     }
     catch (const std::logic_error&)
     {
@@ -43,19 +61,14 @@ void TestThread(CSharedCriticalSection *mutexA, CSharedCriticalSection *mutexB)
 
 BOOST_AUTO_TEST_CASE(TEST_5)
 {
-    /*
-    CSharedCriticalSection mutexA;
-    CSharedCriticalSection mutexB;
-
-    std::thread thread1(TestThread, &mutexA, &mutexB);
-    std::thread thread2(TestThread, &mutexB, &mutexA);
+    std::thread thread1(TestThread1);
+    std::thread thread2(TestThread2);
     while(!lock_exceptions) ;
     done = true;
     thread1.join();
     thread2.join();
     BOOST_CHECK(lock_exceptions == 1);
     lockdata.ordertracker.clear();
-    */
 }
 
 #else

--- a/src/test/deadlock_tests/test6.cpp
+++ b/src/test/deadlock_tests/test6.cpp
@@ -62,7 +62,6 @@ void Thread2()
 
 BOOST_AUTO_TEST_CASE(TEST_6)
 {
-    /*
     std::thread thread1(Thread1);
     std::thread thread2(Thread2);
     while(!lock_exceptions) ;
@@ -71,7 +70,6 @@ BOOST_AUTO_TEST_CASE(TEST_6)
     thread2.join();
     BOOST_CHECK(lock_exceptions == 1);
     lockdata.ordertracker.clear();
-    */
 }
 
 #else

--- a/src/test/deadlock_tests/test7.cpp
+++ b/src/test/deadlock_tests/test7.cpp
@@ -84,7 +84,6 @@ void Thread3()
 
 BOOST_AUTO_TEST_CASE(TEST_7)
 {
-    /*
     std::thread thread1(Thread1);
     std::thread thread2(Thread2);
     std::thread thread3(Thread3);
@@ -95,7 +94,6 @@ BOOST_AUTO_TEST_CASE(TEST_7)
     thread3.join();
     BOOST_CHECK(lock_exceptions == 1);
     lockdata.ordertracker.clear();
-    */
 }
 
 #else

--- a/src/test/deadlock_tests/test8.cpp
+++ b/src/test/deadlock_tests/test8.cpp
@@ -83,7 +83,6 @@ void Thread3()
 
 BOOST_AUTO_TEST_CASE(TEST_8)
 {
-    /*
     std::thread thread1(Thread1);
     std::thread thread2(Thread2);
     std::thread thread3(Thread3);
@@ -94,7 +93,6 @@ BOOST_AUTO_TEST_CASE(TEST_8)
     thread3.join();
     BOOST_CHECK(lock_exceptions == 1);
     lockdata.ordertracker.clear();
-    */
 }
 
 #else


### PR DESCRIPTION
This fixes an edgecase with the deadlock detector where it would not properly find a deadlock when first running due to a lack of locks previously seen.