### PR TITLE
Remove handling for xthin versions < 2

### DIFF
--- a/qa/rpc-tests/compactblocks_2.py
+++ b/qa/rpc-tests/compactblocks_2.py
@@ -644,7 +644,7 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         # Test logic begins here
         self.test_node.wait_for_verack()
-        self.test_node.send_message(msg_xversion({131075:2}), True) #BU_XTHIN_VERSION = 2
+        self.test_node.send_message(msg_xversion(), True)
         self.test_node.wait_for_xverack()
 
         # We will need UTXOs to construct transactions in later tests.

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -1395,14 +1395,7 @@ void SendXThinBlock(ConstCBlockRef pblock, CNode *pfrom, const CInv &inv)
 void RequestThinBlock(CNode *pfrom, const uint256 &hash)
 {
     CInv inv(MSG_THINBLOCK, hash);
-    if (pfrom->xVersion.as_u64c(XVer::BU_XTHIN_VERSION) >= 2)
-    {
-        pfrom->PushMessage(NetMsgType::GET_THIN, inv);
-    }
-    else
-    {
-        pfrom->PushMessage(NetMsgType::GETDATA, inv);
-    }
+    pfrom->PushMessage(NetMsgType::GET_THIN, inv);
 }
 
 bool IsThinBlockValid(CNode *pfrom,


### PR DESCRIPTION
There are no longer any peers on the network that support xthin versions
less than 2, so we can remove the last remaining code which was
accidentally left behind.