### PR TITLE
Change default params for BCH length of unconfirmed transaction chain at activation time  (25 -> 50)

### DIFF
--- a/qa/rpc-tests/mempool_push.py
+++ b/qa/rpc-tests/mempool_push.py
@@ -42,10 +42,8 @@ class MyTest (BitcoinTestFramework):
             ["-blockprioritysize=2000000", "-limitdescendantcount=1000", "-limitancestorcount=1000",
              "-limitancestorsize=1000", "-limitdescendantsize=1000", "-net.unconfChainResendAction=2",
              "-net.restrictInputs=0"],
-            ["-blockprioritysize=2000000", "-limitdescendantcount=25", "-limitancestorcount=25",
-             "-limitancestorsize=150","-limitdescendantsize=101", "-net.unconfChainResendAction=2"]
             ]
-        self.nodes = start_nodes(4, self.options.tmpdir, mempoolConf)
+        self.nodes = start_nodes(3, self.options.tmpdir, mempoolConf)
         connect_nodes_full(self.nodes)
         self.is_network_split=False
         self.sync_blocks()
@@ -88,7 +86,7 @@ class MyTest (BitcoinTestFramework):
         waitFor(DELAY_TIME, lambda: len(self.nodes[0].getblocktemplate()["transactions"])>=BCH_UNCONF_DEPTH)
         blk3 = self.nodes[0].generate(1)[0]
         blk3data = self.nodes[0].getblock(blk3)
-        # this would be ideal, but a particular block is not guaranteed to contain all tx in the mempool 
+        # this would be ideal, but a particular block is not guaranteed to contain all tx in the mempool
         # assert_equal(len(blk3data["tx"]), BCH_UNCONF_DEPTH + 1)  # chain of BCH_UNCONF_DEPTH unconfirmed + coinbase
         committedTxCount = len(blk3data["tx"])-1  # -1 to remove coinbase
         waitFor(DELAY_TIME, lambda: self.nodes[1].getbestblockhash() == blk3)
@@ -119,7 +117,7 @@ class MyTest (BitcoinTestFramework):
         # Wait for sync before issuing the tx chain so that no txes are rejected as nonfinal
         self.sync_blocks()
         logging.info("Block heights: %s" % str([x.getblockcount() for x in self.nodes]))
-        
+
         # Create an unconfirmed chain that exceeds what node 0 allows
         cumulativeTxSize = 0
         while cumulativeTxSize < BCH_UNCONF_SIZE:

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -308,6 +308,7 @@ libbitcoin_server_a_SOURCES = \
   parallel.cpp \
   policy/fees.cpp \
   policy/policy.cpp \
+  policy/mempool.cpp \
   pow.cpp \
   rest.cpp \
   rpc/blockchain.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -188,6 +188,7 @@ BITCOIN_CORE_H = \
   parallel.h \
   policy/fees.h \
   policy/policy.h \
+  policy/mempool.h \
   pow.h \
   protocol.h \
   random.h \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -107,6 +107,7 @@ BITCOIN_TESTS =\
   test/mempool_tests.cpp \
   test/mempool_sync_tests.cpp \
   test/merkle_tests.cpp \
+  test/mempool_policy_tests.cpp \
   test/miner_tests.cpp \
   test/multisig_tests.cpp \
   test/net_tests.cpp \

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -31,25 +31,6 @@ static const CAmount HIGH_MAX_TX_FEE = 100 * HIGH_TX_FEE_PER_KB;
  *  the have a need to.
  */
 static const unsigned int DEFAULT_MAX_ORPHAN_TRANSACTIONS = 1000000;
-/** BU's default for -limitancestorcount, max number of in-mempool ancestors */
-static const unsigned int BU_DEFAULT_ANCESTOR_LIMIT = 500;
-/** BU's default for -limitancestorsize, maximum kilobytes of tx + all in-mempool ancestors */
-static const unsigned int BU_DEFAULT_ANCESTOR_SIZE_LIMIT = 2020;
-/** BU's default for -limitdescendantcount, max number of in-mempool descendants */
-static const unsigned int BU_DEFAULT_DESCENDANT_LIMIT = 500;
-/** BU's default for -limitdescendantsize, maximum kilobytes of in-mempool descendants */
-static const unsigned int BU_DEFAULT_DESCENDANT_SIZE_LIMIT = 2020;
-
-/** Network default for the max number of in-mempool ancestors */
-static const unsigned int BCH_DEFAULT_ANCESTOR_LIMIT = 25;
-/** Network Default for the maximum kilobytes of tx + all in-mempool ancestors */
-static const unsigned int BCH_DEFAULT_ANCESTOR_SIZE_LIMIT = 101;
-/** Network default for the max number of in-mempool descendants */
-static const unsigned int BCH_DEFAULT_DESCENDANT_LIMIT = 25;
-/** Default for the maximum kilobytes of in-mempool descendants */
-static const unsigned int BCH_DEFAULT_DESCENDANT_SIZE_LIMIT = 101;
-
-
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static const unsigned int DEFAULT_MEMPOOL_EXPIRY = 72;
 /** Default for -orphanpoolexpiry, expiration time for orphan pool transactions in hours */

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -35,6 +35,7 @@
 #include "net.h"
 #include "parallel.h"
 #include "policy/fees.h"
+#include "policy/mempool.h"
 #include "policy/policy.h"
 #include "requestManager.h"
 #include "rpc/register.h"

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3149,7 +3149,8 @@ bool CAddrDB::Read(CAddrMan &addr, CDataStream &ssPeers)
 unsigned int ReceiveFloodSize() { return 1000 * GetArg("-maxreceivebuffer", DEFAULT_MAXRECEIVEBUFFER); }
 unsigned int SendBufferSize() { return 1000 * GetArg("-maxsendbuffer", DEFAULT_MAXSENDBUFFER); }
 CNode::CNode(SOCKET hSocketIn, const CAddress &addrIn, const std::string &addrNameIn, bool fInboundIn)
-    : ssSend(SER_NETWORK, INIT_PROTO_VERSION), skipChecksum(false), id(connmgr->NextNodeId()), addrKnown(5000, 0.001)
+    : xVersionEnabled(false), skipChecksum(false), ssSend(SER_NETWORK, INIT_PROTO_VERSION), id(connmgr->NextNodeId()),
+      addrKnown(5000, 0.001)
 {
     nServices = 0;
     hSocket = hSocketIn;
@@ -3425,6 +3426,7 @@ void CNode::DisconnectIfBanned()
 
 void CNode::ReadConfigFromXVersion()
 {
+    xVersionEnabled = true;
     skipChecksum = (xVersion.as_u64c(XVer::BU_MSG_IGNORE_CHECKSUM) == 1);
     if (addrFromPort == 0)
     {

--- a/src/net.h
+++ b/src/net.h
@@ -7,6 +7,7 @@
 #ifndef BITCOIN_NET_H
 #define BITCOIN_NET_H
 
+#include "banentry.h"
 #include "blockrelay/compactblock.h"
 #include "bloom.h"
 #include "chainparams.h"
@@ -17,14 +18,18 @@
 #include "iblt.h"
 #include "limitedmap.h"
 #include "netbase.h"
+#include "policy/mempool.h"
 #include "primitives/block.h"
 #include "protocol.h"
 #include "random.h"
+#include "stat.h"
 #include "streams.h"
 #include "sync.h"
 #include "threadgroup.h"
 #include "uint256.h"
+#include "unlimited.h"
 #include "util.h" // FIXME: reduce scope
+#include "xversionmessage.h"
 
 #include <atomic>
 #include <deque>
@@ -36,10 +41,6 @@
 
 #include <boost/signals2/signal.hpp>
 
-#include "banentry.h"
-#include "stat.h"
-#include "unlimited.h"
-#include "xversionmessage.h"
 
 extern CTweak<uint32_t> netMagic;
 static CMessageHeader::MessageStartChars netOverride;

--- a/src/net.h
+++ b/src/net.h
@@ -43,6 +43,7 @@
 
 
 extern CTweak<uint32_t> netMagic;
+extern CChain chainActive;
 static CMessageHeader::MessageStartChars netOverride;
 class CAddrMan;
 class CSubNet;
@@ -370,13 +371,13 @@ class CNode
 public:
     /** This node's max acceptable number ancestor transactions.  Used to decide whether this node will accept a
      * particular transaction. */
-    size_t nLimitAncestorCount = BCH_DEFAULT_ANCESTOR_LIMIT;
+    size_t nLimitAncestorCount = GetBCHDefaultAncestorLimit(Params().GetConsensus(), chainActive.Tip());
     /** This node's max acceptable sum of all ancestor transaction sizes.  Used to decide whether this node will accept
      * a particular transaction. */
     size_t nLimitAncestorSize = BCH_DEFAULT_ANCESTOR_SIZE_LIMIT * 1000;
     /** This node's max acceptable number of descendants.  Used to decide whether this node will accept a particular
      * transaction. */
-    size_t nLimitDescendantCount = BCH_DEFAULT_DESCENDANT_LIMIT;
+    size_t nLimitDescendantCount = GetBCHDefaultDescendantLimit(Params().GetConsensus(), chainActive.Tip());
     /** This node's max acceptable sum of all descendant transaction sizes.  Used to decide whether this node will
      * accept a particular transaction. */
     size_t nLimitDescendantSize = BCH_DEFAULT_DESCENDANT_SIZE_LIMIT * 1000;
@@ -386,6 +387,11 @@ public:
     uint64_t nMempoolSyncMinVersionSupported = 0;
     /** Maximum supported mempool synchronization version */
     uint64_t nMempoolSyncMaxVersionSupported = 0;
+    /** set to true if this node support xVersion */
+    bool xVersionEnabled;
+    /** set to true if this node is ok with no message checksum */
+    bool skipChecksum;
+
 
     // This is shared-locked whenever messages are processed.
     // Take it exclusive-locked to finish all ongoing processing
@@ -430,9 +436,6 @@ public:
 
     /** The address of the remote peer */
     CAddress addr;
-
-    /** set to true if this node is ok with no message checksum */
-    bool skipChecksum;
 
     /** The address the remote peer advertised in its version message */
     CAddress addrFrom_advertised;
@@ -634,7 +637,9 @@ public:
     {
         // Checking the descendants makes no sense -- the target node can't have descendants in its mempool if it
         // doesn't have this transaction!
-        if (props.countWithAncestors > nLimitAncestorCount)
+        if ((xVersionEnabled && props.countWithAncestors > nLimitAncestorCount) ||
+            (!xVersionEnabled &&
+                props.countWithAncestors > GetBCHDefaultDescendantLimit(Params().GetConsensus(), chainActive.Tip())))
             return false;
         if (props.sizeWithAncestors > nLimitAncestorSize)
             return false;

--- a/src/policy/mempool.cpp
+++ b/src/policy/mempool.cpp
@@ -1,0 +1,19 @@
+// Copyright (c) 2020 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <policy/mempool.h>
+
+#include <validation/forks.h>
+
+uint32_t GetBCHDefaultAncestorLimit(const Consensus::Params &params, const CBlockIndex *pindexPrev)
+{
+    return IsMay2020Enabled(params, pindexPrev) ? BCH_DEFAULT_ANCESTOR_LIMIT_LONGER
+                                                : BCH_DEFAULT_ANCESTOR_LIMIT;
+}
+
+uint32_t GetBCHDefaultDescendantLimit(const Consensus::Params &params, const CBlockIndex *pindexPrev)
+{
+    return IsMay2020Enabled(params, pindexPrev) ? BCH_DEFAULT_DESCENDANT_LIMIT_LONGER
+                                                : BCH_DEFAULT_DESCENDANT_LIMIT;
+}

--- a/src/policy/mempool.h
+++ b/src/policy/mempool.h
@@ -4,6 +4,13 @@
 #ifndef BITCOIN_POLICY_MEMPOOL_H
 #define BITCOIN_POLICY_MEMPOOL_H
 
+#include <cstdint>
+
+class CBlockIndex;
+namespace Consensus {
+struct Params;
+}
+
 /** BU's default for -limitancestorcount, max number of in-mempool ancestors */
 static const unsigned int BU_DEFAULT_ANCESTOR_LIMIT = 500;
 /** BU's default for -limitancestorsize, maximum kilobytes of tx + all in-mempool ancestors. */
@@ -22,5 +29,13 @@ static const unsigned int BCH_DEFAULT_ANCESTOR_SIZE_LIMIT = 101;
 static const unsigned int BCH_DEFAULT_DESCENDANT_LIMIT = 25;
 /** Default for the maximum kilobytes of in-mempool descendants */
 static const unsigned int BCH_DEFAULT_DESCENDANT_SIZE_LIMIT = 101;
+
+/** New limit for chain of unconfirmed transaction that would be used once May 2020 upgrade will be active*/
+static const unsigned int BCH_DEFAULT_ANCESTOR_LIMIT_LONGER = 50;
+static const unsigned int BCH_DEFAULT_DESCENDANT_LIMIT_LONGER = 50;
+
+uint32_t GetBCHDefaultAncestorLimit(const Consensus::Params &params, const CBlockIndex *pindexPrev);
+uint32_t GetBCHDefaultDescendantLimit(const Consensus::Params &params, const CBlockIndex *pindexPrev);
+
 
 #endif // BITCOIN_POLICY_MEMPOOL_H

--- a/src/policy/mempool.h
+++ b/src/policy/mempool.h
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+#ifndef BITCOIN_POLICY_MEMPOOL_H
+#define BITCOIN_POLICY_MEMPOOL_H
+
+/** BU's default for -limitancestorcount, max number of in-mempool ancestors */
+static const unsigned int BU_DEFAULT_ANCESTOR_LIMIT = 500;
+/** BU's default for -limitancestorsize, maximum kilobytes of tx + all in-mempool ancestors. */
+static const unsigned int BU_DEFAULT_ANCESTOR_SIZE_LIMIT = 2020;
+/** BU's default for -limitdescendantcount, max number of in-mempool descendants */
+static const unsigned int BU_DEFAULT_DESCENDANT_LIMIT = 500;
+/** BU's default for -limitdescendantsize, maximum kilobytes of in-mempool descendants. */
+static const unsigned int BU_DEFAULT_DESCENDANT_SIZE_LIMIT = 2020;
+
+
+/** Network default for the max number of in-mempool ancestors */
+static const unsigned int BCH_DEFAULT_ANCESTOR_LIMIT = 25;
+/** Network Default for the maximum kilobytes of tx + all in-mempool ancestors */
+static const unsigned int BCH_DEFAULT_ANCESTOR_SIZE_LIMIT = 101;
+/** Network default for the max number of in-mempool descendants */
+static const unsigned int BCH_DEFAULT_DESCENDANT_LIMIT = 25;
+/** Default for the maximum kilobytes of in-mempool descendants */
+static const unsigned int BCH_DEFAULT_DESCENDANT_SIZE_LIMIT = 101;
+
+#endif // BITCOIN_POLICY_MEMPOOL_H

--- a/src/test/mempool_policy_tests.cpp
+++ b/src/test/mempool_policy_tests.cpp
@@ -1,0 +1,53 @@
+// Copyright (c) 2019-2020 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <chain.h>
+#include <chainparams.h>
+#include <validation/forks.h>
+#include <policy/mempool.h>
+
+#include <test/test_bitcoin.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(mempool_policy_tests, BasicTestingSetup)
+
+static void SetMTP(std::array<CBlockIndex, 12> &blocks, int64_t mtp)
+{
+    size_t len = blocks.size();
+
+    for (size_t i = 0; i < len; ++i)
+    {
+        blocks[i].nTime = mtp + (i - (len / 2));
+    }
+
+    BOOST_CHECK_EQUAL(blocks.back().GetMedianTimePast(), mtp);
+}
+
+BOOST_AUTO_TEST_CASE(mempool_policy_activation_tests)
+{
+    CBlockIndex prev;
+
+    const auto &params = Params(CBaseChainParams::REGTEST).GetConsensus();
+    const auto activation = params.may2020ActivationTime;
+
+    std::array<CBlockIndex, 12> blocks;
+    for (size_t i = 1; i < blocks.size(); ++i)
+    {
+        blocks[i].pprev = &blocks[i - 1];
+    }
+
+    SetMTP(blocks, activation - 1);
+    BOOST_CHECK(!IsMay2020Enabled(params, &blocks.back()));
+    BOOST_CHECK_EQUAL(BCH_DEFAULT_ANCESTOR_LIMIT, GetBCHDefaultAncestorLimit(params, &blocks.back()));
+    BOOST_CHECK_EQUAL(BCH_DEFAULT_DESCENDANT_LIMIT, GetBCHDefaultDescendantLimit(params, &blocks.back()));
+
+    SetMTP(blocks, activation);
+    BOOST_CHECK(IsMay2020Enabled(params, &blocks.back()));
+    BOOST_CHECK_EQUAL(BCH_DEFAULT_ANCESTOR_LIMIT_LONGER, GetBCHDefaultAncestorLimit(params, &blocks.back()));
+    BOOST_CHECK_EQUAL(BCH_DEFAULT_DESCENDANT_LIMIT_LONGER, GetBCHDefaultDescendantLimit(params, &blocks.back()));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -1152,7 +1152,8 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
         // If restrict inputs is enabled and we are extending a long unconfirmed chain past the network
         // default limit, then make sure to check that the txn only has one input. This prevents the reverse
         // double spend attack.
-        if (setAncestors.size() >= BCH_DEFAULT_ANCESTOR_LIMIT && restrictInputs.Value() == true)
+        if (setAncestors.size() >= GetBCHDefaultAncestorLimit(chainparams.GetConsensus(), chainActive.Tip()) &&
+            restrictInputs.Value() == true)
         {
             if (tx->vin.size() > 1)
                 return state.DoS(0, false, REJECT_NONSTANDARD, "bad-txn-too-many-inputs");

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -2,7 +2,6 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
-//#include "chainparams.h"
 #include "txadmission.h"
 #include "blockstorage/blockstorage.h"
 #include "connmgr.h"
@@ -14,6 +13,7 @@
 #include "main.h"
 #include "net.h"
 #include "parallel.h"
+#include "policy/mempool.h"
 #include "requestManager.h"
 #include "respend/respenddetector.h"
 #include "timedata.h"


### PR DESCRIPTION
This patch add code to bump BCH default values for the max number of ancestors and descendants and hook it to the May 2020 network upgrade activation.

Both params has been bumped from 25 to 50. The parameters that take care of the max size have not being changed due to the fact that ABC didn't include these changes in the 0.21.x releases (see https://github.com/Bitcoin-ABC/bitcoin-abc/blob/master/src/policy/mempool.h#L16 for more details). 

This is a port of reviews.bitcoinabc.org/D5242 and reviews.bitcoinabc.org/D5243
Build on top of #2104