### PR TITLE
[travis] Revert back BU timeout special cases and travs_wait workaround

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -147,10 +147,8 @@ before_script:
 script:
     - export CONTINUE=1
     - if [ $SECONDS -gt 1200 ]; then export CONTINUE=0; fi  # Likely the depends build took very long
-    - if [ $TRAVIS_REPO_SLUG = "BitcoinUnlimited/BitcoinUnlimited" ]; then export CONTINUE=1; fi  # Whitelisted repo (180 minutes build time)
     - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/script_a.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
     - if [ $SECONDS -gt 2100 -a "$RUN_TESTS"="true" ]; then export CONTINUE=0; echo "$SECONDS"; fi  # Likely the build took very long
-    - if [ $TRAVIS_REPO_SLUG = "BitcoinUnlimited/BitcoinUnlimited" ]; then export CONTINUE=1; fi  # Whitelisted repo (180 minutes build time)
     - if [ $CONTINUE = "1" ]; then set -o errexit; source .travis/script_b.sh; else set +o errexit; echo "$CACHE_ERR_MSG"; false; fi
 
 after_script:

--- a/.travis/script_b.sh
+++ b/.travis/script_b.sh
@@ -23,7 +23,7 @@ if [ "$RUN_TESTS" = "true" ]; then
     if [ $HOST != "x86_64-w64-mingw32" ]; then
         # use travis_wait work around fork problem (https://github.com/travis-ci/travis-ci/issues/6934)
         travis_wait 30 sleep infinity &
-        DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make $MAKEJOBS check VERBOSE=1;
+        DOCKER_EXEC LD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/depends/$HOST/lib make check VERBOSE=1;
     fi
     END_FOLD
 fi


### PR DESCRIPTION
[travis] remove BU special casing to avoid exiting before the timeout
revert "[travis] Give more time to run unit tests (#2108)"