### PR TITLE
[merge 2117 first] enforce lock ordering by checking pointer values instead of mutex name

### DIFF
--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -85,6 +85,7 @@ BITCOIN_TESTS =\
   test/deadlock_tests/test6.cpp \
   test/deadlock_tests/test7.cpp \
   test/deadlock_tests/test8.cpp \
+  test/deadlock_tests/test9.cpp \
   test/deadlock_tests/test10.cpp \
   test/deadlock_tests/suite.h \
   test/DoS_tests.cpp \

--- a/src/deadlock-detection/locklocation.cpp
+++ b/src/deadlock-detection/locklocation.cpp
@@ -20,20 +20,16 @@ CLockLocation::CLockLocation(const char *pszName,
     fTry = fTryIn;
     eOwnership = eOwnershipIn;
     eLockType = eLockTypeIn;
-    fWaiting = true;
 }
 
 std::string CLockLocation::ToString() const
 {
     return mutexName + "  " + sourceFile + ":" + std::to_string(sourceLine) + (fTry ? " (TRY)" : "") +
-           (eOwnership == OwnershipType::EXCLUSIVE ? " (EXCLUSIVE)" : "(SHARED)") +
-           (fWaiting ? " (WAITING)" : "(HELD)");
+           (eOwnership == OwnershipType::EXCLUSIVE ? " (EXCLUSIVE)" : "(SHARED)") + "(HELD)";
 }
 
 bool CLockLocation::GetTry() const { return fTry; }
 OwnershipType CLockLocation::GetExclusive() const { return eOwnership; }
-bool CLockLocation::GetWaiting() const { return fWaiting; }
-void CLockLocation::ChangeWaitingToHeld() { fWaiting = false; }
 LockType CLockLocation::GetLockType() const { return eLockType; }
 std::string CLockLocation::GetFileName() const { return sourceFile; }
 int CLockLocation::GetLineNumber() const { return sourceLine; }

--- a/src/deadlock-detection/locklocation.h
+++ b/src/deadlock-detection/locklocation.h
@@ -75,18 +75,6 @@ struct CLockLocation
     OwnershipType GetExclusive() const;
 
     /**
-     * Returns a boolean that describes if this lock is held or is waiting
-     *
-     * @return boolean
-     */
-    bool GetWaiting() const;
-
-    /**
-     * Changes the status of the lock from waiting to held
-     */
-    void ChangeWaitingToHeld();
-
-    /**
      * Returns the tpye of lock being locked
      *
      * @return LockType

--- a/src/deadlock-detection/lockorder.cpp
+++ b/src/deadlock-detection/lockorder.cpp
@@ -143,7 +143,7 @@ void CLockOrderTracker::AddNewLockInfo(const LockStackEntry &this_lock, const st
     // add a new key to track locks locked after this one
     if (seenLockOrders.find(this_lock.first) == seenLockOrders.end())
     {
-        seenLockOrders.emplace(this_lock.first, std::set<void*>());
+        seenLockOrders.emplace(this_lock.first, std::set<void *>());
     }
 }
 

--- a/src/deadlock-detection/lockorder.h
+++ b/src/deadlock-detection/lockorder.h
@@ -29,8 +29,9 @@ protected:
     /// mutex that is required to be locked before any method accesses any of this classes data members
     std::mutex lot_mutex;
     /// @var std::map<void*, std::pair<std::string, boolean> >
-    /// map for attempting to track the name of the mutex based on its reference. might not always be accurate, boolean will denote this
-    std::map<void*, std::pair<std::string, bool> > mapMutexToName;
+    /// map for attempting to track the name of the mutex based on its reference. might not always be accurate, boolean
+    /// will denote this
+    std::map<void *, std::pair<std::string, bool> > mapMutexToName;
     /// @var std::map<std::string, std::set<std::string> > seenLockOrders
     /// key is mutex, value is set of mutexes that have ever been locked while key was locked
     std::map<void *, std::set<void *> > seenLockOrders;
@@ -63,9 +64,7 @@ public:
      * @param a std::vector of LockStackEntry that are the held locks held by a thread
      * @param a uitn64_t that is the thread id of the calling thread
      */
-    void CheckForConflict(LockStackEntry& this_lock,
-        std::vector<LockStackEntry> &heldLocks,
-        const uint64_t &tid);
+    void CheckForConflict(LockStackEntry &this_lock, std::vector<LockStackEntry> &heldLocks, const uint64_t &tid);
 
     /**
      * Adds information to seenLockOrders about an ordering seen by a given thread
@@ -73,7 +72,7 @@ public:
      * @param LockStackEntry that is the name of the lock being added
      * @param a std::vector of LockStackEntry that are the held locks held by this thread
      */
-    void AddNewLockInfo(const LockStackEntry& this_lock, const std::vector<LockStackEntry> &heldLocks);
+    void AddNewLockInfo(const LockStackEntry &this_lock, const std::vector<LockStackEntry> &heldLocks);
 
     /**
      * Adds information to seenLockLocations about an ordering seen by a given thread

--- a/src/deadlock-detection/lockorder.h
+++ b/src/deadlock-detection/lockorder.h
@@ -32,8 +32,8 @@ protected:
     /// map for attempting to track the name of the mutex based on its reference. might not always be accurate, boolean
     /// will denote this
     std::map<void *, std::pair<std::string, bool> > mapMutexToName;
-    /// @var std::map<std::string, std::set<std::string> > seenLockOrders
-    /// key is mutex, value is set of mutexes that have ever been locked while key was locked
+    /// @var std::map<void*, std::set<void*> > seenLockOrders
+    /// key is mutex, value is set of mutex that have ever been locked while key was locked
     std::map<void *, std::set<void *> > seenLockOrders;
     /// @var std::map<std::pair<std::string, std::string>, std::set<std::tuple<std::string, std::string, uint64_t> > >
     /// seenLockLocations

--- a/src/deadlock-detection/threaddeadlock.cpp
+++ b/src/deadlock-detection/threaddeadlock.cpp
@@ -23,7 +23,6 @@ void _remove_lock_critical_exit(void *cs)
         throw std::logic_error("unlock order inconsistant with lock order");
     }
     LockType type = it->second.back().second.GetLockType();
-    OwnershipType ownership = it->second.back().second.GetExclusive();
     // assuming we unlock in the reverse order of locks, we can simply pop back
     it->second.pop_back();
     // if we have no more locks on this critical section...
@@ -35,33 +34,6 @@ void _remove_lock_critical_exit(void *cs)
             {
                 // we have another lock on this critical section
                 return;
-            }
-        }
-    }
-    // remove from the other maps
-    if (ownership == OwnershipType::EXCLUSIVE)
-    {
-        auto iter = lockdata.writelocksheld.find(cs);
-        if (iter != lockdata.writelocksheld.end())
-        {
-            if (iter->second.empty())
-                return;
-            if (iter->second.count(tid) != 0)
-            {
-                iter->second.erase(tid);
-            }
-        }
-    }
-    else // !isExclusive
-    {
-        auto iter = lockdata.readlocksheld.find(cs);
-        if (iter != lockdata.readlocksheld.end())
-        {
-            if (iter->second.empty())
-                return;
-            if (iter->second.count(tid) != 0)
-            {
-                iter->second.erase(tid);
             }
         }
     }
@@ -91,139 +63,6 @@ void AddNewLock(LockStackEntry newEntry, const uint64_t &tid)
     }
 }
 
-void AddNewHeldLock(void *c, const uint64_t &tid, OwnershipType ownership)
-{
-    if (ownership == OwnershipType::EXCLUSIVE)
-    {
-        auto it = lockdata.writelocksheld.find(c);
-        if (it == lockdata.writelocksheld.end())
-        {
-            std::set<uint64_t> holders;
-            holders.emplace(tid);
-            lockdata.writelocksheld.emplace(c, holders);
-        }
-        else
-        {
-            it->second.emplace(tid);
-        }
-    }
-    else //  !isExclusive
-    {
-        auto it = lockdata.readlocksheld.find(c);
-        if (it == lockdata.readlocksheld.end())
-        {
-            std::set<uint64_t> holders;
-            holders.emplace(tid);
-            lockdata.readlocksheld.emplace(c, holders);
-        }
-        else
-        {
-            it->second.emplace(tid);
-        }
-    }
-}
-
-void AddNewWaitingLock(void *c, const uint64_t &tid, OwnershipType ownership)
-{
-    if (ownership == OwnershipType::EXCLUSIVE)
-    {
-        auto it = lockdata.writelockswaiting.find(c);
-        if (it == lockdata.writelockswaiting.end())
-        {
-            std::set<uint64_t> holders;
-            holders.emplace(tid);
-            lockdata.writelockswaiting.emplace(c, holders);
-        }
-        else
-        {
-            it->second.emplace(tid);
-        }
-    }
-    else //  !isExclusive
-    {
-        auto it = lockdata.readlockswaiting.find(c);
-        if (it == lockdata.readlockswaiting.end())
-        {
-            std::set<uint64_t> holders;
-            holders.emplace(tid);
-            lockdata.readlockswaiting.emplace(c, holders);
-        }
-        else
-        {
-            it->second.emplace(tid);
-        }
-    }
-}
-
-void SetWaitingToHeld(void *c, OwnershipType ownership)
-{
-    std::lock_guard<std::mutex> lock(lockdata.dd_mutex);
-
-    const uint64_t tid = getTid();
-    // we do this first so changes are still made for trylocks which dont have
-    // a waiting lock to be edited
-    auto itheld = lockdata.locksheldbythread.find(tid);
-    if (itheld != lockdata.locksheldbythread.end())
-    {
-        for (auto rit = itheld->second.rbegin(); rit != itheld->second.rend(); ++rit)
-        {
-            if (rit->first == c)
-            {
-                rit->second.ChangeWaitingToHeld();
-                break;
-            }
-        }
-    }
-
-
-    if (ownership == OwnershipType::EXCLUSIVE)
-    {
-        auto it = lockdata.writelockswaiting.find(c);
-        if (it != lockdata.writelockswaiting.end())
-        {
-            it->second.erase(tid);
-        }
-        else
-        {
-            DbgAssert(!"Missing write lock waiting", );
-        }
-        auto iter = lockdata.writelocksheld.find(c);
-        if (iter == lockdata.writelocksheld.end())
-        {
-            std::set<uint64_t> holders;
-            holders.emplace(tid);
-            lockdata.writelocksheld.emplace(c, holders);
-        }
-        else
-        {
-            iter->second.emplace(tid);
-        }
-    }
-    else //  !isExclusive
-    {
-        auto it = lockdata.readlockswaiting.find(c);
-        if (it != lockdata.readlockswaiting.end())
-        {
-            it->second.erase(tid);
-        }
-        else
-        {
-            DbgAssert(!"Missing read lock waiting", );
-        }
-        auto iter = lockdata.readlocksheld.find(c);
-        if (iter == lockdata.readlocksheld.end())
-        {
-            std::set<uint64_t> holders;
-            holders.emplace(tid);
-            lockdata.readlocksheld.emplace(c, holders);
-        }
-        else
-        {
-            iter->second.emplace(tid);
-        }
-    }
-}
-
 // c = the cs
 // isExclusive = is the current lock exclusive, for a recursive mutex (CCriticalSection) this value should always be
 // true
@@ -232,11 +71,6 @@ void push_lock(void *c, const CLockLocation &locklocation, LockType locktype, Ow
     std::lock_guard<std::mutex> lock(lockdata.dd_mutex);
 
     LockStackEntry now = std::make_pair(c, locklocation);
-    if (fTry)
-    {
-        // try locks can not be waiting
-        now.second.ChangeWaitingToHeld();
-    }
     // tid of the originating request
     const uint64_t tid = getTid();
     // If this is a blocking lock operation, we want to make sure that the locking order between 2 mutexes is consistent
@@ -246,8 +80,6 @@ void push_lock(void *c, const CLockLocation &locklocation, LockType locktype, Ow
         // a try lock will either get it, or it wont. so just add it for now.
         // if we dont get the lock these added locks will be removed before the end of the TRY_LOCK function
         AddNewLock(now, tid);
-        // we need to add a held lock
-        AddNewHeldLock(c, tid, ownership);
         return;
     }
     // first check lock specific issues
@@ -363,7 +195,6 @@ void push_lock(void *c, const CLockLocation &locklocation, LockType locktype, Ow
         // and self deadlocks were checked earlier
         return;
     }
-    AddNewWaitingLock(c, tid, ownership);
 }
 
 // removes all instances of the critical section
@@ -373,10 +204,6 @@ void DeleteCritical(void *cs)
         return;
     // remove all instances of the critical section from lockdata
     std::lock_guard<std::mutex> lock(lockdata.dd_mutex);
-    lockdata.readlockswaiting.erase(cs);
-    lockdata.writelockswaiting.erase(cs);
-    lockdata.readlocksheld.erase(cs);
-    lockdata.writelocksheld.erase(cs);
     for (auto &iter : lockdata.locksheldbythread)
     {
         LockStack newStack;

--- a/src/deadlock-detection/threaddeadlock.cpp
+++ b/src/deadlock-detection/threaddeadlock.cpp
@@ -339,7 +339,6 @@ void push_lock(void *c, const CLockLocation &locklocation, LockType locktype, Ow
             {
                 heldLocks.push_back(entry.second);
             }
-            // we havent seen this lock before, add generic data for it
             lockdata.ordertracker.AddNewLockInfo(lockname, heldLocks);
             // track this locks exactly locking order info
             lockdata.ordertracker.TrackLockOrderHistory(locklocation, heldLocks, tid);
@@ -352,7 +351,6 @@ void push_lock(void *c, const CLockLocation &locklocation, LockType locktype, Ow
         }
         else
         {
-            // we havent seen this lock before, add generic data for it
             lockdata.ordertracker.AddNewLockInfo(lockname, heldLocks);
             // track this locks exactly locking order info
             lockdata.ordertracker.TrackLockOrderHistory(locklocation, heldLocks, tid);

--- a/src/deadlock-detection/threaddeadlock.cpp
+++ b/src/deadlock-detection/threaddeadlock.cpp
@@ -67,28 +67,6 @@ void _remove_lock_critical_exit(void *cs)
     }
 }
 
-bool HasAnyOwners(void *c)
-{
-    auto iter = lockdata.writelocksheld.find(c);
-    if (iter != lockdata.writelocksheld.end())
-    {
-        if (!iter->second.empty())
-        {
-            return true;
-        }
-    }
-    auto iter2 = lockdata.readlocksheld.find(c);
-    if (iter2 != lockdata.readlocksheld.end())
-    {
-        if (!iter2->second.empty())
-        {
-            return true;
-        }
-    }
-
-    return false;
-}
-
 // for recrusive locking issues with a non recrusive mutex
 static void self_deadlock_detected(LockStackEntry now, LockStackEntry previous)
 {

--- a/src/deadlock-detection/threaddeadlock.cpp
+++ b/src/deadlock-detection/threaddeadlock.cpp
@@ -171,7 +171,7 @@ void push_lock(void *c, const CLockLocation &locklocation, LockType locktype, Ow
                 heldLocks.push_back(entry);
             }
             lockdata.ordertracker.AddNewLockInfo(now, heldLocks);
-            // track this locks exactl locking order info
+            // track this locks exactly locking order info
             lockdata.ordertracker.TrackLockOrderHistory(locklocation, heldLocks, tid);
             // we have seen the lock we are trying to lock before, check ordering
             lockdata.ordertracker.CheckForConflict(now, heldLocks, tid);
@@ -179,7 +179,7 @@ void push_lock(void *c, const CLockLocation &locklocation, LockType locktype, Ow
         else
         {
             lockdata.ordertracker.AddNewLockInfo(now, heldLocks);
-            // track this locks exactl locking order info
+            // track this locks exactly locking order info
             lockdata.ordertracker.TrackLockOrderHistory(locklocation, heldLocks, tid);
         }
     }

--- a/src/deadlock-detection/threaddeadlock.h
+++ b/src/deadlock-detection/threaddeadlock.h
@@ -43,20 +43,6 @@ extern std::atomic<bool> lockdataDestructed;
 
 struct LockData
 {
-    /// @var ReadLocksWaiting readlockswaiting
-    /// holds information about threads waiting on shared ownership of mutexes
-    ReadLocksWaiting readlockswaiting;
-    /// @var WriteLocksWaiting writelockswaiting
-    /// holds information about threads waiting on exclusive ownership of mutexes
-    WriteLocksWaiting writelockswaiting;
-
-    /// @var ReadLocksHeld readlocksheld
-    /// holds information about threads holding shared ownership of mutexes
-    ReadLocksHeld readlocksheld;
-    /// @var WriteLocksHeld writelocksheld
-    /// holds information about threads holding exclusive ownership of mutexes
-    WriteLocksHeld writelocksheld;
-
     /// @var LocksHeldByThread locksheldbythread
     /// holds information about which locks are held by which threads
     LocksHeldByThread locksheldbythread;
@@ -111,18 +97,6 @@ void remove_lock_critical_exit(void *cs);
  * @return std::string of all locks held by the calling thread
  */
 std::string LocksHeld();
-
-/**
- * Moves a lock that is currently in one of the waiting maps to the corresponding held map
- *
- * @param void pointer to the critical section that is to be moved from waiting to held
- * @param OwnershipType enum value that is the OwnershipType for the critical section
- */
-void SetWaitingToHeld(void *c, OwnershipType ownership);
-
-#else // NOT DEBUG_LOCKORDER
-
-static inline void SetWaitingToHeld(void *c, OwnershipType ownership) {}
 
 #endif // END DEBUG_LOCKORDER
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -303,8 +303,8 @@ public:
         bool fTry = false) EXCLUSIVE_LOCK_FUNCTION(mutexIn)
         : lock(mutexIn, boost::defer_lock)
     {
-        // we no longer allow naming critical sections cs, please name it something more meaningful
         assert(pszName != nullptr);
+        // we no longer allow naming critical sections cs, please name it something more meaningful
         assert(std::string(pszName) != "cs");
         if (fTry)
             TryEnter(pszName, pszFile, nLine, type);
@@ -322,8 +322,8 @@ public:
         if (!pmutexIn)
             return;
 
-        // we no longer allow naming critical sections cs, please name it something more meaningful
         assert(pszName != nullptr);
+        // we no longer allow naming critical sections cs, please name it something more meaningful
         assert(std::string(pszName) != "cs");
         lock = boost::unique_lock<Mutex>(*pmutexIn, boost::defer_lock);
         if (fTry)
@@ -424,8 +424,8 @@ public:
         bool fTry = false) SHARED_LOCK_FUNCTION(mutexIn)
         : lock(mutexIn, boost::defer_lock)
     {
-        // we no longer allow naming critical sections cs, please name it something more meaningful
         assert(pszName != nullptr);
+        // we no longer allow naming critical sections cs, please name it something more meaningful
         assert(std::string(pszName) != "cs");
         if (fTry)
             TryEnter(pszName, pszFile, nLine, type);
@@ -443,8 +443,8 @@ public:
         if (!pmutexIn)
             return;
 
-        // we no longer allow naming critical sections cs, please name it something more meaningful
         assert(pszName != nullptr);
+        // we no longer allow naming critical sections cs, please name it something more meaningful
         assert(std::string(pszName) != "cs");
         lock = boost::shared_lock<Mutex>(*pmutexIn, boost::defer_lock);
         if (fTry)

--- a/src/sync.h
+++ b/src/sync.h
@@ -259,7 +259,6 @@ private:
             PrintLockContention(pszName, pszFile, nLine);
 #endif
             lock.lock();
-            SetWaitingToHeld((void *)(lock.mutex()), OwnershipType::EXCLUSIVE);
 #ifdef DEBUG_LOCKCONTENTION
         }
 #endif
@@ -381,7 +380,6 @@ private:
             PrintLockContention(pszName, pszFile, nLine);
 #endif
             lock.lock();
-            SetWaitingToHeld((void *)(lock.mutex()), OwnershipType::SHARED);
 #ifdef DEBUG_LOCKCONTENTION
         }
 #endif

--- a/src/test/deadlock_tests/test9.cpp
+++ b/src/test/deadlock_tests/test9.cpp
@@ -1,0 +1,69 @@
+// Copyright (c) 2019 Greg Griffith
+// Copyright (c) 2019 The Bitcoin Unlimited developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+
+#include "suite.h"
+
+#include <boost/thread/condition_variable.hpp>
+#include <boost/thread/locks.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/thread/recursive_mutex.hpp>
+#include <boost/thread/shared_mutex.hpp>
+
+#include <mutex>
+#include <shared_mutex>
+#include <thread>
+
+// this test is the same as test 5 but using pointers instead of global locks
+
+BOOST_FIXTURE_TEST_SUITE(deadlock_test9, EmptySuite)
+
+#ifdef DEBUG_LOCKORDER // this ifdef covers the rest of the file
+
+std::atomic<bool> done{false};
+std::atomic<int> lock_exceptions{0};
+std::atomic<int> writelocks{0};
+
+void TestThread(CSharedCriticalSection *mutexA, CSharedCriticalSection *mutexB)
+{
+    WRITELOCK(*mutexA);
+    writelocks++;
+    while(writelocks != 2) ;
+    try
+    {
+        READLOCK(*mutexB);
+    }
+    catch (const std::logic_error&)
+    {
+        lock_exceptions++;
+    }
+    while (!done) ;
+}
+
+BOOST_AUTO_TEST_CASE(TEST_9)
+{
+    CSharedCriticalSection mutexA;
+    CSharedCriticalSection mutexB;
+    std::thread thread1(TestThread, &mutexA, &mutexB);
+    std::thread thread2(TestThread, &mutexB, &mutexA);
+    while(!lock_exceptions) ;
+    done = true;
+    thread1.join();
+    thread2.join();
+    BOOST_CHECK(lock_exceptions == 1);
+    lockdata.ordertracker.clear();
+}
+
+#else
+
+BOOST_AUTO_TEST_CASE(EMPTY_TEST_9)
+{
+
+}
+
+#endif
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -2213,13 +2213,7 @@ extern UniValue getstructuresizes(const UniValue &params, bool fHelp)
 #ifdef DEBUG_LOCKORDER
     {
         std::lock_guard<std::mutex> lock(lockdata.dd_mutex);
-        uint64_t lockorderssize = 0;
-        lockorderssize += lockdata.readlockswaiting.size();
-        lockorderssize += lockdata.writelockswaiting.size();
-        lockorderssize += lockdata.readlocksheld.size();
-        lockorderssize += lockdata.writelocksheld.size();
-        lockorderssize *= 2;
-        ret.pushKV("lockorders", lockorderssize);
+        ret.pushKV("lockorders", lockdata.ordertracker.size());
     }
 #endif
     LOCK(cs_vNodes);

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -2222,26 +2222,32 @@ bool ConnectBlockDependencyOrdering(const CBlock &block,
                 // be in ConnectBlock because they require the UTXO set
                 prevheights.resize(tx.vin.size());
                 {
+                    bool abort = false;
                     for (size_t j = 0; j < tx.vin.size(); j++)
                     {
                         CoinAccessor coin(view, tx.vin[j].prevout);
                         // isSpend is true for empty coin object (coinEmpty)
                         if (coin->IsSpent())
                         {
-                            // If we were validating at the same time as another block and the other block wins the
-                            // validation race and updates the UTXO first, then we may end up here with missing inputs.
-                            // Therefore we check to see if the chainwork has advanced or if we recieved a quit and if
-                            // so return without DOSing the node.
-                            if (PV->ChainWorkHasChanged(nStartingChainWork) || PV->QuitReceived(this_id, fParallel))
-                            {
-                                return false;
-                            }
-                            return state.DoS(100, error("%s: block %s inputs missing/spent in tx %d %s", __func__,
-                                                      block.GetHash().ToString(), i, tx.GetHash().ToString()),
-                                REJECT_INVALID, "bad-txns-inputs-missingorspent");
+                            abort = true;
+                            break;
                         }
                         prevheights[j] = coin->nHeight;
                         nFees = nFees + coin->out.nValue;
+                    }
+                    if (abort)
+                    {
+                        // If we were validating at the same time as another block and the other block wins the
+                        // validation race and updates the UTXO first, then we may end up here with missing inputs.
+                        // Therefore we check to see if the chainwork has advanced or if we recieved a quit and if
+                        // so return without DOSing the node.
+                        if (PV->ChainWorkHasChanged(nStartingChainWork) || PV->QuitReceived(this_id, fParallel))
+                        {
+                            return false;
+                        }
+                        return state.DoS(100, error("%s: block %s inputs missing/spent in tx %d %s", __func__,
+                                                  block.GetHash().ToString(), i, tx.GetHash().ToString()),
+                            REJECT_INVALID, "bad-txns-inputs-missingorspent");
                     }
                 }
                 nFees = nFees - tx.GetValueOut();
@@ -2454,26 +2460,32 @@ bool ConnectBlockCanonicalOrdering(const CBlock &block,
                 // be in ConnectBlock because they require the UTXO set
                 prevheights.resize(tx.vin.size());
                 {
+                    bool abort = false;
                     for (size_t j = 0; j < tx.vin.size(); j++)
                     {
                         CoinAccessor coin(view, tx.vin[j].prevout);
                         // isSpend is true for empty coin object (coinEmpty)
                         if (coin->IsSpent())
                         {
-                            // If we were validating at the same time as another block and the other block wins the
-                            // validation race and updates the UTXO first, then we may end up here with missing inputs.
-                            // Therefore we check to see if the chainwork has advanced or if we recieved a quit and if
-                            // so return without DOSing the node.
-                            if (PV->ChainWorkHasChanged(nStartingChainWork) || PV->QuitReceived(this_id, fParallel))
-                            {
-                                return false;
-                            }
-                            return state.DoS(100, error("%s: block %s inputs missing/spent in tx %d %s", __func__,
-                                                      block.GetHash().ToString(), i, tx.GetHash().ToString()),
-                                REJECT_INVALID, "bad-txns-inputs-missingorspent");
+                            abort = true;
+                            break;
                         }
                         prevheights[j] = coin->nHeight;
                         nFees = nFees + coin->out.nValue;
+                    }
+                    if (abort)
+                    {
+                        // If we were validating at the same time as another block and the other block wins the
+                        // validation race and updates the UTXO first, then we may end up here with missing inputs.
+                        // Therefore we check to see if the chainwork has advanced or if we recieved a quit and if
+                        // so return without DOSing the node.
+                        if (PV->ChainWorkHasChanged(nStartingChainWork) || PV->QuitReceived(this_id, fParallel))
+                        {
+                            return false;
+                        }
+                        return state.DoS(100, error("%s: block %s inputs missing/spent in tx %d %s", __func__,
+                                                  block.GetHash().ToString(), i, tx.GetHash().ToString()),
+                            REJECT_INVALID, "bad-txns-inputs-missingorspent");
                     }
                 }
                 nFees = nFees - tx.GetValueOut();


### PR DESCRIPTION


edit by sickpig: rebase on top of #2117 