### PR TITLE
Silence sync.h warning we got when compiling with clang `-Wthread-safety-analysis` 

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -132,6 +132,10 @@ class CDeferredSharedLocker
     LockState state;
 
 public:
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
     CDeferredSharedLocker(CSharedCriticalSection &scsp) : scs(scsp), state(LockState::UNLOCKED) {}
     void lock_shared()
     {
@@ -159,6 +163,9 @@ public:
         state = LockState::UNLOCKED;
     }
     ~CDeferredSharedLocker() { unlock(); }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 };
 
 


### PR DESCRIPTION
The warning is related to the code in `CDeferredSharedLocker` and this is the text:

```
../../src/sync.h:151:5: warning: mutex 'scs' is not held on every path through here [-Wthread-safety-analysis]
    }
    ^
../../src/sync.h:148:17: note: mutex acquired here
            scs.lock();
                ^
../../src/sync.h:158:17: warning: releasing mutex 'scs' that was not held [-Wthread-safety-analysis]
            scs.unlock();
                ^
```

This seems like a false positive to me but I defer to @gandrewstone and @Greg-Griffith opinion on that. Pragma will be used only when the code is compiled via clang.