### PR TITLE
Fix a bunch of issues around `cs_vRecvMsg` critical section

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -405,10 +405,10 @@ public:
     std::deque<CInv> vRecvGetData GUARDED_BY(csRecvGetData);
 
     CCriticalSection cs_vRecvMsg;
-    uint64_t nRecvBytes GUARDED_BY(vRecvMsg);
-    std::deque<CNetMessage> vRecvMsg GUARDED_BY(vRecvMsg);
+    uint64_t nRecvBytes GUARDED_BY(cs_vRecvMsg);
+    std::deque<CNetMessage> vRecvMsg GUARDED_BY(cs_vRecvMsg);
     // the next message we receive from the socket
-    CNetMessage msg GUARDED_BY(vRecvMsg);
+    CNetMessage msg GUARDED_BY(cs_vRecvMsg);
     CStatHistory<uint64_t> currentRecvMsgSize;
 
     uint64_t nServices;

--- a/src/net.h
+++ b/src/net.h
@@ -644,7 +644,7 @@ public:
     void ReadConfigFromXVersion();
 
     // requires LOCK(cs_vRecvMsg)
-    unsigned int GetTotalRecvSize()
+    unsigned int GetTotalRecvSize() EXCLUSIVE_LOCKS_REQUIRED(cs_vRecvMsg)
     {
         AssertLockHeld(cs_vRecvMsg);
         unsigned int total = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -653,6 +653,12 @@ public:
         return total;
     }
 
+    unsigned int GetSendMsgSize()
+    {
+        LOCK(cs_vSend);
+        return vSendMsg.size();
+    }
+
     // requires LOCK(cs_vRecvMsg)
     bool ReceiveMsgBytes(const char *pch, unsigned int nBytes);
 

--- a/src/sync.h
+++ b/src/sync.h
@@ -132,6 +132,10 @@ class CDeferredSharedLocker
     LockState state;
 
 public:
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
     CDeferredSharedLocker(CSharedCriticalSection &scsp) : scs(scsp), state(LockState::UNLOCKED) {}
     void lock_shared()
     {
@@ -159,6 +163,9 @@ public:
         state = LockState::UNLOCKED;
     }
     ~CDeferredSharedLocker() { unlock(); }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 };
 
 


### PR DESCRIPTION
- Use correct critical section name in `net.h` `GUARDED_BY` macro (`src/net.h`)
- Annotate `GetTotalRecvSize` with `EXCLUSIVE_LOCKS_REQUIRED(cs_vRecvMsg)`
- `Add missing cs_vSend while accessing vSendMsg.size()` (`requestmanager_tests.cpp`)

based on top of #2118
