### PR TITLE
Turn variables that store CB/GR salt used for any given peers into atomics

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -525,13 +525,13 @@ public:
 
     // Graphene blocks
     /** Stores the grapheneblock salt to be used for this peer */
-    uint64_t gr_shorttxidk0 GUARDED_BY(cs_thintype);
-    uint64_t gr_shorttxidk1 GUARDED_BY(cs_thintype);
+    std::atomic<uint64_t> gr_shorttxidk0;
+    std::atomic<uint64_t> gr_shorttxidk1;
 
     // Compact Blocks
     /** Stores the compactblock salt to be used for this peer */
-    uint64_t shorttxidk0 GUARDED_BY(cs_thintype);
-    uint64_t shorttxidk1 GUARDED_BY(cs_thintype);
+    std::atomic<uint64_t> shorttxidk0;
+    std::atomic<uint64_t> shorttxidk1;
     /** Does this peer support CompactBlocks */
     std::atomic<bool> fSupportsCompactBlocks;
 


### PR DESCRIPTION
Every peer connected to us that use graphene or compact block to propagate
blocks use a specific salt used to produce short transaction id.

That salt is stored into a uint64_t variable "guarded by" cs_thintype, fact
is that in a bunch of places we simply don't lock those var before changing
or accessing.

This behavior generate the following warning:

```
 warning: writing variable 'shorttxidk0' requires holding mutex 'pfrom->cs_thintype' exclusively
 pfrom->shorttxidk0 = shorttxidk0;
```

Using std::atomic and related methods (load()/store()) should solve the problem.