### PR TITLE
Add missing locks - part 1

### DIFF
--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1746,29 +1746,35 @@ uint64_t GetShortID(uint64_t shorttxidk0, uint64_t shorttxidk1, const uint256 &t
 
 bool NegotiateFastFilterSupport(CNode *pfrom)
 {
+    uint64_t peerFastFilterPref;
+    {
+        LOCK(pfrom->cs_xversion);
+        peerFastFilterPref = pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_FAST_FILTER_PREF);
+    }
+
     if (grapheneFastFilterCompatibility.Value() == EITHER)
     {
-        if (pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_FAST_FILTER_PREF) == EITHER)
+        if (peerFastFilterPref == EITHER)
             return true;
-        else if (pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_FAST_FILTER_PREF) == FAST)
+        else if (peerFastFilterPref == FAST)
             return true;
         else
             return false;
     }
     else if (grapheneFastFilterCompatibility.Value() == FAST)
     {
-        if (pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_FAST_FILTER_PREF) == EITHER)
+        if (peerFastFilterPref == EITHER)
             return true;
-        else if (pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_FAST_FILTER_PREF) == FAST)
+        else if (peerFastFilterPref == FAST)
             return true;
         else
             throw std::runtime_error("Sender and receiver have incompatible fast filter preferences");
     }
     else
     {
-        if (pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_FAST_FILTER_PREF) == EITHER)
+        if (peerFastFilterPref == EITHER)
             return false;
-        else if (pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_FAST_FILTER_PREF) == FAST)
+        else if (peerFastFilterPref == FAST)
             throw std::runtime_error("Sender and receiver have incompatible fast filter preferences");
         else
             return false;

--- a/src/net.h
+++ b/src/net.h
@@ -405,10 +405,10 @@ public:
     std::deque<CInv> vRecvGetData GUARDED_BY(csRecvGetData);
 
     CCriticalSection cs_vRecvMsg;
-    uint64_t nRecvBytes GUARDED_BY(vRecvMsg);
-    std::deque<CNetMessage> vRecvMsg GUARDED_BY(vRecvMsg);
+    uint64_t nRecvBytes GUARDED_BY(cs_vRecvMsg);
+    std::deque<CNetMessage> vRecvMsg GUARDED_BY(cs_vRecvMsg);
     // the next message we receive from the socket
-    CNetMessage msg GUARDED_BY(vRecvMsg);
+    CNetMessage msg GUARDED_BY(cs_vRecvMsg);
     CStatHistory<uint64_t> currentRecvMsgSize;
 
     uint64_t nServices;

--- a/src/net.h
+++ b/src/net.h
@@ -644,7 +644,7 @@ public:
     void ReadConfigFromXVersion();
 
     // requires LOCK(cs_vRecvMsg)
-    unsigned int GetTotalRecvSize()
+    unsigned int GetTotalRecvSize() EXCLUSIVE_LOCKS_REQUIRED(cs_vRecvMsg)
     {
         AssertLockHeld(cs_vRecvMsg);
         unsigned int total = 0;

--- a/src/net.h
+++ b/src/net.h
@@ -653,6 +653,12 @@ public:
         return total;
     }
 
+    unsigned int GetSendMsgSize()
+    {
+        LOCK(cs_vSend);
+        return vSendMsg.size();
+    }
+
     // requires LOCK(cs_vRecvMsg)
     bool ReceiveMsgBytes(const char *pch, unsigned int nBytes);
 

--- a/src/rpc/net.cpp
+++ b/src/rpc/net.cpp
@@ -229,6 +229,7 @@ UniValue getpeerinfo(const UniValue &params, bool fHelp)
 
             if (snode)
             {
+                LOCK(snode->cs_xversion);
                 UniValue xmap_enc(UniValue::VOBJ);
                 for (auto kv : snode->xVersion.xmap)
                 {

--- a/src/sync.h
+++ b/src/sync.h
@@ -132,6 +132,10 @@ class CDeferredSharedLocker
     LockState state;
 
 public:
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
     CDeferredSharedLocker(CSharedCriticalSection &scsp) : scs(scsp), state(LockState::UNLOCKED) {}
     void lock_shared()
     {
@@ -159,6 +163,9 @@ public:
         state = LockState::UNLOCKED;
     }
     ~CDeferredSharedLocker() { unlock(); }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 };
 
 

--- a/src/test/DoS_tests.cpp
+++ b/src/test/DoS_tests.cpp
@@ -298,6 +298,7 @@ BOOST_AUTO_TEST_CASE(DoS_bantime_expiration)
 CTransaction RandomOrphan()
 {
     std::map<uint256, CTxOrphanPool::COrphanTx>::iterator it;
+    READLOCK(orphanpool.cs_orphanpool);
     it = orphanpool.mapOrphanTransactions.lower_bound(InsecureRand256());
     if (it == orphanpool.mapOrphanTransactions.end())
         it = orphanpool.mapOrphanTransactions.begin();

--- a/src/test/forkscsv_tests.cpp
+++ b/src/test/forkscsv_tests.cpp
@@ -106,9 +106,14 @@ BOOST_AUTO_TEST_CASE(forkscsv_validation_test)
     BOOST_CHECK(ValidateWindowSize(100));
     BOOST_CHECK(ValidateWindowSize(10000));
     BOOST_CHECK(ValidateWindowSize(std::numeric_limits<int>::max()));
+#ifdef __GNUC__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverflow"
+#endif
     BOOST_CHECK(!ValidateWindowSize(1 + std::numeric_limits<int>::max()));
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
     // threshold size (2nd param is window)
     BOOST_CHECK(!ValidateThreshold(1,1));   // 1 is not valid window size
@@ -146,9 +151,14 @@ BOOST_AUTO_TEST_CASE(forkscsv_validation_test)
     BOOST_CHECK(ValidateMinLockedBlocks(100));
     BOOST_CHECK(!ValidateMinLockedBlocks(-1));
     BOOST_CHECK(ValidateMinLockedBlocks(std::numeric_limits<int>::max()));
+#ifdef __GNUC__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverflow"
+#endif
     BOOST_CHECK(!ValidateMinLockedBlocks(1 + std::numeric_limits<int>::max()));
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 
     // minlockedtime
     BOOST_CHECK(ValidateMinLockedTime(0));   // zero is ok
@@ -156,9 +166,14 @@ BOOST_AUTO_TEST_CASE(forkscsv_validation_test)
     BOOST_CHECK(ValidateMinLockedTime(100));
     BOOST_CHECK(!ValidateMinLockedTime(-1));
     BOOST_CHECK(ValidateMinLockedTime(std::numeric_limits<int64_t>::max()));
+#ifdef __GNUC__
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Woverflow"
+#endif
     BOOST_CHECK(!ValidateMinLockedTime(1 + std::numeric_limits<int64_t>::max()));
+#ifdef __GNUC__
 #pragma GCC diagnostic pop
+#endif
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/testutil.h
+++ b/src/test/testutil.h
@@ -11,7 +11,7 @@
 
 #include "fs.h"
 
-class CMutableTransaction;
+struct CMutableTransaction;
 
 fs::path GetTempPath();
 CMutableTransaction CreateRandomTx();

--- a/src/test/txvalidationcache_tests.cpp
+++ b/src/test/txvalidationcache_tests.cpp
@@ -396,7 +396,10 @@ BOOST_FIXTURE_TEST_CASE(uncache_coins, TestChain100Setup)
 
     // cleanup
     mempool.clear();
-    orphanpool.mapOrphanTransactions.clear();
+    {
+        WRITELOCK(orphanpool.cs_orphanpool);
+        orphanpool.mapOrphanTransactions.clear();
+    }
     pcoinsTip->Flush();
     SetMockTime(0);
 }

--- a/src/wallet/coinselection.cpp
+++ b/src/wallet/coinselection.cpp
@@ -219,7 +219,6 @@ TxoGroup CoinSelection(/*const*/ SpendableTxos &available,
         excessModifier += loopCost;
 
         // Calculate the size of this new input
-        large->second.i;
         const CScript &scriptPubKey = large->second.tx->vout[large->second.i].scriptPubKey;
         CScript scriptSigRes; // = txNew.vin[nIn].scriptSig;
         CWallet dummyWallet;

--- a/src/wallet/wallet.cpp
+++ b/src/wallet/wallet.cpp
@@ -47,7 +47,6 @@ bool bSpendZeroConfChange = DEFAULT_SPEND_ZEROCONF_CHANGE;
 bool fSendFreeTransactions = DEFAULT_SEND_FREE_TRANSACTIONS;
 
 const unsigned int P2PKH_LEN = 34;
-const unsigned int TX_HEADER_LEN = 4;
 const unsigned int MIN_BYTES_IN_TX = 192;
 
 const char *DEFAULT_WALLET_DAT = "wallet.dat";


### PR DESCRIPTION
These are a series of changes to fix missing locks (read/write) spotted by clang compilers.

Based on #2118 and #2119

