### PR TITLE
Updating bitcoinforks.org operetade seeders.

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -166,7 +166,7 @@ public:
         // List of Bitcoin Cash compatible seeders
         vSeeds.push_back(CDNSSeedData("bitcoinunlimited.info", "btccash-seeder.bitcoinunlimited.info", true));
         vSeeds.push_back(CDNSSeedData("bitcoinabc.org", "seed.bitcoinabc.org", true));
-        vSeeds.push_back(CDNSSeedData("bitcoinforks.org", "seed-abc.bitcoinforks.org", true));
+        vSeeds.push_back(CDNSSeedData("bitcoinforks.org", "seed-bch.bitcoinforks.org", true));
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1, 0);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1, 5);
@@ -382,7 +382,7 @@ public:
         // Bitcoin ABC seeder
         vSeeds.push_back(CDNSSeedData("bitcoinabc.org", "testnet-seed.bitcoinabc.org", true));
         // bitcoinforks seeders
-        vSeeds.push_back(CDNSSeedData("bitcoinforks.org", "testnet-seed-abc.bitcoinforks.org", true));
+        vSeeds.push_back(CDNSSeedData("bitcoinforks.org", "testnet-seed-bch.bitcoinforks.org", true));
         // BU seeder
         vSeeds.push_back(CDNSSeedData("bitcoinunlimited.info", "testnet-seed.bitcoinunlimited.info", true));
 


### PR DESCRIPTION
According to the operator of the above seeders, those are already reachable
by using these 2 new DNS name:

- seed-bch.bitcoinforks.org
- testnet-seed-bch.bitcoinforks.org

I've tested both of them and both are returning working mainnet and
testnet nodes.

See the announcement for more details:
https://read.cash/@btcfork/replacement-notice-testnet-seed-abcbitcoinforksorg-eb620338