### PR TITLE
Add missing locks and fix false positive clang warnings - part 2

### DIFF
--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1783,10 +1783,14 @@ bool NegotiateFastFilterSupport(CNode *pfrom)
 
 uint64_t NegotiateGrapheneVersion(CNode *pfrom)
 {
-    uint64_t peerMin = pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_MIN_VERSION_SUPPORTED);
-    uint64_t selfMin = grapheneMinVersionSupported.Value();
-    uint64_t peerMax = pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_MAX_VERSION_SUPPORTED);
     uint64_t selfMax = grapheneMaxVersionSupported.Value();
+    uint64_t selfMin = grapheneMinVersionSupported.Value();
+    uint64_t peerMin, peerMax;
+    {
+        LOCK(pfrom->cs_xversion);
+        peerMin = pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_MIN_VERSION_SUPPORTED);
+        peerMax = pfrom->xVersion.as_u64c(XVer::BU_GRAPHENE_MAX_VERSION_SUPPORTED);
+    }
 
     uint64_t upper = (uint64_t)std::min(peerMax, selfMax);
     uint64_t lower = (uint64_t)std::max(peerMin, selfMin);

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3427,6 +3427,7 @@ void CNode::DisconnectIfBanned()
 void CNode::ReadConfigFromXVersion()
 {
     xVersionEnabled = true;
+    LOCK(cs_xversion);
     skipChecksum = (xVersion.as_u64c(XVer::BU_MSG_IGNORE_CHECKSUM) == 1);
     if (addrFromPort == 0)
     {

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -547,7 +547,10 @@ bool ProcessMessage(CNode *pfrom, std::string strCommand, CDataStream &vRecv, in
         pfrom->PushMessage(NetMsgType::VERACK);
 
         // Change version
-        pfrom->ssSend.SetVersion(std::min(pfrom->nVersion, PROTOCOL_VERSION));
+        {
+            LOCK(pfrom->cs_vSend);
+            pfrom->ssSend.SetVersion(std::min(pfrom->nVersion, PROTOCOL_VERSION));
+        }
 
         LOG(NET, "receive version message: %s: version %d, blocks=%d, us=%s, peer=%s\n", pfrom->cleanSubVer,
             pfrom->nVersion, pfrom->nStartingHeight, addrMe.ToString(), pfrom->GetLogName());

--- a/src/nodestate.cpp
+++ b/src/nodestate.cpp
@@ -35,10 +35,20 @@ CNodeState::CNodeState(CAddress addrIn, std::string addrNameIn) : address(addrIn
 */
 CNodeState *CState::_GetNodeState(const NodeId id)
 {
+// no need to lock explictly here cause CNodeStateAccessor
+// hence we are using clang pragma to silence it when it will be used
+// from CNodeStateAccessor
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
     std::map<NodeId, CNodeState>::iterator it = mapNodeState.find(id);
     if (it == mapNodeState.end())
         return nullptr;
     return &it->second;
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 }
 
 /**

--- a/src/nodestate.h
+++ b/src/nodestate.h
@@ -59,7 +59,9 @@ protected:
     friend class CNodeStateAccessor;
 
 public:
-    /** Return a node pointer for an node id (does not lock -- use CNodeStateAccessor) */
+    /** Return a node pointer for an node id (does not lock -- use CNodeStateAccessor)
+     * Do not use it directly, this is meant to be used through CNodeStateAccessor
+     **/
     CNodeState *_GetNodeState(const NodeId id);
 
     /** Add a nodestate from the map */


### PR DESCRIPTION
- Lock pfrom->ssSend while setting peer version
- Annotate *CState::_GetNodeState() with clang pragma
- Add missing locks around cs_xversion