### PR TITLE
Add missing locks and fix false positive clang warnings - part 3

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -802,8 +802,9 @@ int CNetMessage::readData(const char *pch, unsigned int nBytes)
 
 
 // requires LOCK(cs_vSend), BU: returns > 0 if any data was sent, 0 if nothing accomplished.
-int SocketSendData(CNode *pnode, bool fSendTwo)
+int SocketSendData(CNode *pnode, bool fSendTwo = false) EXCLUSIVE_LOCKS_REQUIRED(pnode->cs_vSend)
 {
+    AssertLockHeld(pnode->cs_vSend);
     // BU This variable is incremented if something happens.  If it is zero at the bottom of the loop, we delay.  This
     // solves spin loop issues where the select does not block but no bytes can be transferred (traffic shaping limited,
     // for example).

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -3012,6 +3012,7 @@ uint64_t CNode::GetTotalBytesRecv() { return nTotalBytesRecv; }
 uint64_t CNode::GetTotalBytesSent() { return nTotalBytesSent; }
 void CNode::Fuzz(int nChance)
 {
+    AssertLockHeld(cs_vSend);
     if (!successfullyConnected())
         return; // Don't fuzz initial handshake
     if (GetRand(nChance) != 0)

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -2803,9 +2803,15 @@ void NetCleanup()
         {
             // Since we are quitting, disconnect abruptly from the node rather than finishing up our conversation
             // with it.
-            pnode->vRecvMsg.clear();
-            pnode->ssSend.clear();
-            pnode->nSendSize = 0;
+            {
+                LOCK(pnode->cs_vRecvMsg);
+                pnode->vRecvMsg.clear();
+            }
+            {
+                LOCK(pnode->cs_vSend);
+                pnode->ssSend.clear();
+            }
+            pnode->nSendSize.store(0);
             // Now close communications with the other node
             pnode->CloseSocketDisconnect();
         }

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -593,8 +593,14 @@ void CNode::copyStats(CNodeStats &stats)
     X(cleanSubVer);
     X(fInbound);
     X(nStartingHeight);
-    X(nSendBytes);
-    X(nRecvBytes);
+    {
+        LOCK(cs_vSend);
+        X(nSendBytes);
+    }
+    {
+        LOCK(cs_vRecvMsg);
+        X(nRecvBytes);
+    }
     X(fWhitelisted);
     X(fSupportsCompactBlocks);
 

--- a/src/net.h
+++ b/src/net.h
@@ -136,7 +136,6 @@ unsigned short GetListenPort();
 bool BindListenPort(const CService &bindAddr, std::string &strError, bool fWhitelisted = false);
 void StartNode(thread_group &threadGroup);
 bool StopNode();
-int SocketSendData(CNode *pnode, bool fSendTwo = false);
 
 struct CombinerAll
 {
@@ -666,7 +665,7 @@ public:
     }
 
     // requires LOCK(cs_vRecvMsg)
-    bool ReceiveMsgBytes(const char *pch, unsigned int nBytes);
+    bool ReceiveMsgBytes(const char *pch, unsigned int nBytes) EXCLUSIVE_LOCKS_REQUIRED(cs_vRecvMsg);
 
     void SetRecvVersion(int nVersionIn)
     {

--- a/src/sync.h
+++ b/src/sync.h
@@ -188,13 +188,14 @@ void EnterCritical(const char *pszName,
     bool fTry = false);
 void LeaveCritical(void *cs);
 /** Asserts in debug builds if a critical section is not held. */
-void AssertLockHeldInternal(const char *pszName, const char *pszFile, unsigned int nLine, void *cs);
+void AssertLockHeldInternal(const char *pszName, const char *pszFile, unsigned int nLine, void *cs)
+    ASSERT_EXCLUSIVE_LOCK(cs);
 void AssertLockNotHeldInternal(const char *pszName, const char *pszFile, unsigned int nLine, void *cs);
 /** Asserts in debug builds if a shared critical section is not exclusively held. */
 void AssertWriteLockHeldInternal(const char *pszName,
     const char *pszFile,
     unsigned int nLine,
-    CSharedCriticalSection *cs);
+    CSharedCriticalSection *cs) ASSERT_EXCLUSIVE_LOCK(cs);
 void AssertRecursiveWriteLockHeldinternal(const char *pszName,
     const char *pszFile,
     unsigned int nLine,
@@ -210,12 +211,13 @@ void static inline EnterCritical(const char *pszName,
 {
 }
 void static inline LeaveCritical(void *cs) {}
-void static inline AssertLockHeldInternal(const char *pszName, const char *pszFile, unsigned int nLine, void *cs) {}
+void static inline AssertLockHeldInternal(const char *pszName, const char *pszFile, unsigned int nLine, void *cs)
+    ASSERT_EXCLUSIVE_LOCK(cs){};
 void static inline AssertLockNotHeldInternal(const char *pszName, const char *pszFile, unsigned int nLine, void *cs) {}
 void static inline AssertWriteLockHeldInternal(const char *pszName,
     const char *pszFile,
     unsigned int nLine,
-    CSharedCriticalSection *cs)
+    CSharedCriticalSection *cs) ASSERT_EXCLUSIVE_LOCK(cs)
 {
 }
 void static inline AssertRecursiveWriteLockHeldinternal(const char *pszName,

--- a/src/test/deadlock_tests/test1-4.cpp
+++ b/src/test/deadlock_tests/test1-4.cpp
@@ -20,6 +20,10 @@ BOOST_FIXTURE_TEST_SUITE(self_deadlock_tests, EmptySuite)
 
 #ifdef DEBUG_LOCKORDER // this ifdef covers the rest of the file
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wthread-safety-analysis"
+#endif
 // shared lock a shared mutex
 // then try to exclusive lock the same shared mutex while holding shared lock,
 // should self deadlock
@@ -70,6 +74,9 @@ BOOST_AUTO_TEST_CASE(TEST_4)
     BOOST_CHECK_THROW(WRITELOCK(shared_mutex), std::logic_error);
     lockdata.ordertracker.clear();
 }
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif // end clang ifdef
 
 #else
 

--- a/src/threadsafety.h
+++ b/src/threadsafety.h
@@ -32,6 +32,7 @@
 #define EXCLUSIVE_LOCKS_REQUIRED(...) __attribute__((exclusive_locks_required(__VA_ARGS__)))
 #define SHARED_LOCKS_REQUIRED(...) __attribute__((shared_locks_required(__VA_ARGS__)))
 #define NO_THREAD_SAFETY_ANALYSIS __attribute__((no_thread_safety_analysis))
+#define ASSERT_EXCLUSIVE_LOCK(...) __attribute((assert_exclusive_lock(__VA_ARGS__)))
 #else
 #define LOCKABLE
 #define SCOPED_LOCKABLE
@@ -51,6 +52,7 @@
 #define EXCLUSIVE_LOCKS_REQUIRED(...)
 #define SHARED_LOCKS_REQUIRED(...)
 #define NO_THREAD_SAFETY_ANALYSIS
+#define ASSERT_EXCLUSIVE_LOCK(...)
 #endif // __GNUC__
 
 #endif // BITCOIN_THREADSAFETY_H

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1842,7 +1842,6 @@ void CTxMemPool::GetTransactionRateStatistics(double &smoothedTps, double &insta
 }
 
 void CTxMemPool::UpdateTransactionsPerSecondImpl(bool fAddTxn, const std::lock_guard<std::mutex> &lock)
-    EXCLUSIVE_LOCKS_REQUIRED(cs_txPerSec)
 {
     static uint64_t nCount = 0;
     static int64_t nLastTime = GetTime();


### PR DESCRIPTION
- Silence clang warning in deadlock detector test
- Annotate AssertLockHeld() with ASSERT_CAPABILITY() for thread safety analysis (partial core port of bitcoin/bitcoin#13423) 
- Lock nSendBytes and nRecvBytes while copying nodes stats
- Add cs_vSend lock annotation to SocketSendData()
- Add explicitly lock around pnode->vRecvMsg and pnode->ssSend in NetCleanup
- Add AssertLockHeld(cs_vSend) in CNode::Fuzz
- Remove EXCLUSIVE_LOCKS_REQUIRED annotation from UpdateTransactionsPerSecondImpl definition

Based on to top of #2124