### PR TITLE
Make IsAlreadyValidating() more granular by checking for hash

### DIFF
--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -553,8 +553,12 @@ bool CGrapheneBlock::process(CNode *pfrom, std::string strCommand, std::shared_p
     // In PV we must prevent two graphene blocks from simulaneously processing from that were recieved from the
     // same peer. This would only happen as in the example of an expedited block coming in
     // after an graphene request, because we would never explicitly request two graphene blocks from the same peer.
-    if (PV->IsAlreadyValidating(pfrom->id))
+    if (PV->IsAlreadyValidating(pfrom->id, pblock->GetHash()))
+    {
+        LOGA("Not processing this graphenblock because %s is already validating in another thread\n",
+            pblock->GetHash().ToString().c_str());
         return false;
+    }
 
     DbgAssert(pblock->grapheneblock != nullptr, return false);
     DbgAssert(pblock->grapheneblock.get() == this, return false);

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -590,8 +590,12 @@ bool CXThinBlock::process(CNode *pfrom, std::string strCommand, std::shared_ptr<
     // In PV we must prevent two thinblocks from simulaneously processing from that were recieved from the
     // same peer. This would only happen as in the example of an expedited block coming in
     // after an xthin request, because we would never explicitly request two xthins from the same peer.
-    if (PV->IsAlreadyValidating(pfrom->id))
+    if (PV->IsAlreadyValidating(pfrom->id, pblock->GetHash()))
+    {
+        LOGA("Not processing this xthin because %s is already validating in another thread\n",
+            pblock->GetHash().ToString().c_str());
         return false;
+    }
 
     pblock->nVersion = header.nVersion;
     pblock->nBits = header.nBits;

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -232,7 +232,7 @@ void CParallelValidation::QuitCompetingThreads(const uint256 &prevBlockHash)
     }
 }
 
-bool CParallelValidation::IsAlreadyValidating(const NodeId nodeid)
+bool CParallelValidation::IsAlreadyValidating(const NodeId nodeid, const uint256 blockhash)
 {
     // Don't allow a second thinblock to validate if this node is already in the process of validating a block.
     LOCK(cs_blockvalidationthread);
@@ -240,7 +240,7 @@ bool CParallelValidation::IsAlreadyValidating(const NodeId nodeid)
         mapBlockValidationThreads.begin();
     while (iter != mapBlockValidationThreads.end())
     {
-        if ((*iter).second.nodeid == nodeid)
+        if ((*iter).second.nodeid == nodeid && (*iter).second.hash == blockhash)
         {
             return true;
         }

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -171,7 +171,7 @@ public:
     void QuitCompetingThreads(const uint256 &prevBlockHash);
 
     /** Is this block already running a validation thread? */
-    bool IsAlreadyValidating(const NodeId id);
+    bool IsAlreadyValidating(const NodeId id, const uint256 blockhash);
 
     /** Terminate all currently running Block Validation threads, except the passed thread */
     void StopAllValidationThreads(const boost::thread::id this_id = boost::thread::id());


### PR DESCRIPTION
We don't want to prevent another block from being processed which
has a different hash but came from the same peer.  (Now that multi
thinbblocks in flight is active it's possible to have two blocks
with differeing hashes coming from the same peer)