### PR TITLE
Fix mempool_packages.py with long chained transactions

### DIFF
--- a/qa/rpc-tests/mempool_packages.py
+++ b/qa/rpc-tests/mempool_packages.py
@@ -17,8 +17,8 @@ class MempoolPackagesTest(BitcoinTestFramework):
 
     def setup_network(self):
         self.nodes = []
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-maxorphantx=1000", "-relaypriority=0", "-debug"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-maxorphantx=1000", "-relaypriority=0", "-limitancestorcount=5", "-debug"]))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-maxorphantx=1000", "-relaypriority=0", "-debug=mempool",  "-limitdescendantcount=25", "-limitancestorcount=25", "-limitancestorsize=101", "-limitdescendantsize=101"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-maxorphantx=1000", "-relaypriority=0", "-limitancestorcount=5", "-debug=mempool"]))
         connect_nodes(self.nodes[0], 1)
         self.is_network_split = False
         self.sync_all()


### PR DESCRIPTION
Set the max chainlength back to 25 so that the test works again.