### PR TITLE
Refactor ReconstructBlock in graphene

### DIFF
--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -803,7 +803,7 @@ static bool ReconstructBlock(CNode *pfrom,
         toVerify.insert(kv.second->GetHash());
     }
 
-    // Locate each transaction in prepoulated mapTxFromPools.
+    // Locate each transaction in pre-populated mapTxFromPools.
     int idx = -1;
     CTransactionRef ptx = nullptr;
     for (const uint256 &hash : grapheneBlock->vTxHashes256)

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -26,7 +26,7 @@
 #include <iomanip>
 static bool ReconstructBlock(CNode *pfrom,
     std::shared_ptr<CBlockThinRelay> pblock,
-    const std::map<uint64_t, CTransactionRef> mapTxFromPools);
+    const std::map<uint64_t, CTransactionRef> &mapTxFromPools);
 extern CTweak<uint64_t> grapheneMinVersionSupported;
 extern CTweak<uint64_t> grapheneMaxVersionSupported;
 extern CTweak<uint64_t> grapheneFastFilterCompatibility;
@@ -158,7 +158,7 @@ void CGrapheneBlock::OrderTxHashes(CNode *pfrom)
 
 bool CGrapheneBlock::ValidateAndRecontructBlock(uint256 blockhash,
     std::shared_ptr<CBlockThinRelay> pblock,
-    const std::map<uint64_t, CTransactionRef> mapCheapHashTx,
+    const std::map<uint64_t, CTransactionRef> &mapCheapHashTx,
     std::string command,
     CNode *pfrom,
     CDataStream &vRecv)
@@ -759,7 +759,7 @@ bool CGrapheneBlock::process(CNode *pfrom, std::string strCommand, std::shared_p
 
 static bool ReconstructBlock(CNode *pfrom,
     std::shared_ptr<CBlockThinRelay> pblock,
-    const std::map<uint64_t, CTransactionRef> mapTxFromPools)
+    const std::map<uint64_t, CTransactionRef> &mapTxFromPools)
 {
     std::shared_ptr<CGrapheneBlock> grapheneBlock = pblock->grapheneblock;
 

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -26,7 +26,7 @@
 #include <iomanip>
 static bool ReconstructBlock(CNode *pfrom,
     std::shared_ptr<CBlockThinRelay> pblock,
-    std::map<uint64_t, CTransactionRef> mapTxFromPools);
+    const std::map<uint64_t, CTransactionRef> mapTxFromPools);
 extern CTweak<uint64_t> grapheneMinVersionSupported;
 extern CTweak<uint64_t> grapheneMaxVersionSupported;
 extern CTweak<uint64_t> grapheneFastFilterCompatibility;
@@ -158,7 +158,7 @@ void CGrapheneBlock::OrderTxHashes(CNode *pfrom)
 
 bool CGrapheneBlock::ValidateAndRecontructBlock(uint256 blockhash,
     std::shared_ptr<CBlockThinRelay> pblock,
-    std::map<uint64_t, CTransactionRef> mapCheapHashTx,
+    const std::map<uint64_t, CTransactionRef> mapCheapHashTx,
     std::string command,
     CNode *pfrom,
     CDataStream &vRecv)
@@ -759,7 +759,7 @@ bool CGrapheneBlock::process(CNode *pfrom, std::string strCommand, std::shared_p
 
 static bool ReconstructBlock(CNode *pfrom,
     std::shared_ptr<CBlockThinRelay> pblock,
-    std::map<uint64_t, CTransactionRef> mapTxFromPools)
+    const std::map<uint64_t, CTransactionRef> mapTxFromPools)
 {
     std::shared_ptr<CGrapheneBlock> grapheneBlock = pblock->grapheneblock;
 
@@ -811,10 +811,11 @@ static bool ReconstructBlock(CNode *pfrom,
         idx++;
         uint64_t nShortId = GetShortID(
             pfrom->gr_shorttxidk0.load(), pfrom->gr_shorttxidk1.load(), hash, NegotiateGrapheneVersion(pfrom));
-        ptx = mapTxFromPools[nShortId];
+        const auto iter = mapTxFromPools.find(nShortId);
 
-        if (ptx != nullptr)
+        if (iter != mapTxFromPools.end())
         {
+            ptx = iter->second;
             pblock->vtx[idx] = ptx;
         }
         else

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -126,7 +126,7 @@ public:
     // in the block
     bool ValidateAndRecontructBlock(uint256 blockhash,
         std::shared_ptr<CBlockThinRelay> pblock,
-        const std::map<uint64_t, CTransactionRef> mapMissingTx,
+        const std::map<uint64_t, CTransactionRef> &mapMissingTx,
         std::string command,
         CNode *pfrom,
         CDataStream &vRecv);

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -124,7 +124,6 @@ public:
     // Validates header and, if possible, determines if there are any missing or unnecessary transactions
     // in the block
     bool ValidateAndRecontructBlock(int &missingCount,
-        int &unnecessaryCount,
         uint256 blockhash,
         std::shared_ptr<CBlockThinRelay> pblock,
         std::string command,

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -126,7 +126,7 @@ public:
     // in the block
     bool ValidateAndRecontructBlock(uint256 blockhash,
         std::shared_ptr<CBlockThinRelay> pblock,
-        std::map<uint64_t, CTransactionRef> mapMissingTx,
+        const std::map<uint64_t, CTransactionRef> mapMissingTx,
         std::string command,
         CNode *pfrom,
         CDataStream &vRecv);

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -76,6 +76,7 @@ public:
     std::vector<uint256> vTxHashes256; // List of all 256 bit transaction hashes in the block
     std::map<uint64_t, CTransactionRef> mapMissingTx; // Map of transactions that were re-requested
     std::vector<CTransactionRef> vAdditionalTxs; // vector of transactions receiver probably does not have
+    std::set<CTransactionRef> vRecoveredTxs; // set of transactions collected during failure recovery
     std::map<uint64_t, uint32_t> mapHashOrderIndex;
 
 public:
@@ -126,6 +127,7 @@ public:
     bool ValidateAndRecontructBlock(int &missingCount,
         uint256 blockhash,
         std::shared_ptr<CBlockThinRelay> pblock,
+        std::map<uint64_t, CTransactionRef> mapMissingTx,
         std::string command,
         CNode *pfrom,
         CDataStream &vRecv);

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -124,8 +124,7 @@ public:
 
     // Validates header and, if possible, determines if there are any missing or unnecessary transactions
     // in the block
-    bool ValidateAndRecontructBlock(int &missingCount,
-        uint256 blockhash,
+    bool ValidateAndRecontructBlock(uint256 blockhash,
         std::shared_ptr<CBlockThinRelay> pblock,
         std::map<uint64_t, CTransactionRef> mapMissingTx,
         std::string command,

--- a/src/blockrelay/graphene.h
+++ b/src/blockrelay/graphene.h
@@ -199,10 +199,10 @@ public:
 
     CInv GetInv() { return CInv(MSG_BLOCK, header.GetHash()); }
     bool process(CNode *pfrom, std::string strCommand, std::shared_ptr<CBlockThinRelay> pblock);
-    void FillTxMapFromPools(std::map<uint64_t, uint256> &mapTxFromPools);
+    void FillTxMapFromPools(std::map<uint64_t, CTransactionRef> &mapTxFromPools);
     void SituateCoinbase(std::vector<uint64_t> blockCheapHashes, CTransactionRef coinbase, uint64_t grapheneVersion);
     void SituateCoinbase(CTransactionRef coinbase);
-    std::set<uint64_t> UpdateResolvedTxsAndIdentifyMissing(const std::map<uint64_t, uint256> &mapPartialTxHash,
+    std::set<uint64_t> UpdateResolvedTxsAndIdentifyMissing(const std::map<uint64_t, CTransactionRef> &mapPartialTxHash,
         const std::vector<uint64_t> &blockCheapHashes,
         uint64_t grapheneVersion);
     bool CheckBlockHeader(const CBlockHeader &block, CValidationState &state);


### PR DESCRIPTION
This PR refactors graphene so that the ReconstructBlock method uses the same cache of transaction references as the one assembled while looking for missing transactions. This ensures that ReconstructBlock will always succeed when called. As a result, it is possible to remove counters missingCount and unnecessaryCount (the latter of which was not used anyhow). Several other checks can also be removed in places throughout the code.