### PR TITLE
Use MAX_THINTYPE_BLOCKS_IN_FLIGHT to determine the chain length cutoff

### DIFF
--- a/src/blockrelay/blockrelay_common.h
+++ b/src/blockrelay/blockrelay_common.h
@@ -40,6 +40,10 @@ public:
     CCriticalSection cs_reconstruct;
     CCriticalSection cs_graphene_sender;
 
+    // put a cap on the total number of thin type blocks we can have in flight. This lowers any possible
+    // attack surface.
+    size_t MAX_THINTYPE_BLOCKS_IN_FLIGHT = 6;
+
 private:
     // block relay timer
     CCriticalSection cs_blockrelaytimer;
@@ -51,10 +55,6 @@ private:
     // blocks that are currently being reconstructed.
     std::map<NodeId, std::map<uint256, std::shared_ptr<CBlockThinRelay> > > mapBlocksReconstruct GUARDED_BY(
         cs_reconstruct);
-
-    // put a cap on the total number of thin type blocks we can have in flight. This lowers any possible
-    // attack surface.
-    size_t MAX_THINTYPE_BLOCKS_IN_FLIGHT = 6;
 
     // Counters for how many of each peer are currently connected.  We use the set to store the
     // nodeid so that we can then get a unique count of peers with with to update the atomic counters.

--- a/src/blockrelay/compactblock.cpp
+++ b/src/blockrelay/compactblock.cpp
@@ -420,7 +420,7 @@ bool CompactReRequest::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     }
     else
     {
-        if (hdr->nHeight < (chainActive.Tip()->nHeight - DEFAULT_BLOCKS_FROM_TIP))
+        if (hdr->nHeight < (chainActive.Tip()->nHeight - (int)thinrelay.MAX_THINTYPE_BLOCKS_IN_FLIGHT))
             return error(CMPCT, "getblocktxn request too far from the tip");
 
         CBlock block;

--- a/src/blockrelay/graphene.cpp
+++ b/src/blockrelay/graphene.cpp
@@ -1728,7 +1728,7 @@ std::vector<CTransaction> TransactionsFromBlockByCheapHash(std::set<uint64_t> &v
     }
     else
     {
-        if (hdr->nHeight < (chainActive.Tip()->nHeight - DEFAULT_BLOCKS_FROM_TIP))
+        if (hdr->nHeight < (chainActive.Tip()->nHeight - (int)thinrelay.MAX_THINTYPE_BLOCKS_IN_FLIGHT))
             throw std::runtime_error("get_grblocktx request too far from the tip");
 
         CBlock block;

--- a/src/blockrelay/thinblock.cpp
+++ b/src/blockrelay/thinblock.cpp
@@ -433,7 +433,7 @@ bool CXRequestThinBlockTx::HandleMessage(CDataStream &vRecv, CNode *pfrom)
     }
     else
     {
-        if (hdr->nHeight < (chainActive.Tip()->nHeight - DEFAULT_BLOCKS_FROM_TIP))
+        if (hdr->nHeight < (chainActive.Tip()->nHeight - (int)thinrelay.MAX_THINTYPE_BLOCKS_IN_FLIGHT))
             return error(THIN, "get_xblocktx request too far from the tip");
 
         CBlock block;


### PR DESCRIPTION
When processing thintype block re-requests we were using the
DEFAULT_BLOCK_FROM_TIP to determing the chain length cutoff however
since we've started allowing multi thintype blocks we need
to use the MAX_THINTYPE_BLOCKS_IN_FLIGHT parameter.