### PR TITLE
fix comptool problem

### DIFF
--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -247,15 +247,30 @@ class TestManager(object):
     # Verify that the tip of each connection all agree with each other, and
     # with the expected outcome (if given)
     def check_results(self, blockhash, outcome):
+        waitLoop = 0
+        while 1:  # sometimes connection 0 hasn't figured itself out yet (but the network thread will handle this async)
+            cxn0bbh = self.connections[0].cb.bestblockhash
+            if cxn0bbh != None: break
+            time.sleep(.1)
+            waitLoop+=1
+            if waitLoop > 50:
+                raise AssertionError("Test malfunction -- connection 0 is has no best block for comparision")
         with mininode_lock:
+            if blockhash is None:
+                print("Blockhash is None in check_results")
+                raise AssertionError("Test failed -- passed check_results None as blockhash, was expecting %s" % str(outcome))
+            if cxn0bbh is None:
+                print("connection 0 bestblockhash is None in check_results")
+                raise AssertionError("Test failed -- passed check_results None as blockhash, was expecting %s" % str(outcome))
 
             for c in self.connections:
+                cxn_bbh = c.cb.bestblockhash
                 if outcome is None:
-                    if c.cb.bestblockhash != self.connections[0].cb.bestblockhash:
-                        print("Node ", c.addr, " has best block ", hex(c.cb.bestblockhash), ". Expecting ", hex(self.connections[0].cb.bestblockhash))
+                    if cxn_bbh != cxn0bbh:
+                        print("Node ", c.addr, " has best block ", hex(cxn_bbh), ". Expecting ", hex(cnx0bbh))
                         return False
                 elif isinstance(outcome, RejectResult): # Check that block was rejected w/ code
-                    if c.cb.bestblockhash == blockhash:
+                    if cxn_bbh == blockhash:
                         return False
                     if blockhash not in c.cb.block_reject_map:
                         print('Block not in reject map: %064x' % (blockhash))
@@ -263,8 +278,8 @@ class TestManager(object):
                     if not outcome.match(c.cb.block_reject_map[blockhash]):
                         print('Block rejected with %s instead of expected %s: %064x' % (c.cb.block_reject_map[blockhash], outcome, blockhash))
                         return False
-                elif ((c.cb.bestblockhash == blockhash) != outcome):
-                    print("Node ", c.addr, " has best block ", hex(c.cb.bestblockhash), ". Expecting ", hex(blockhash), outcome)
+                elif (cxn_bbh == blockhash) != outcome:
+                    print("Node ", c.addr, " has best block ", hex(cxn_bbh), ". Expecting ", hex(blockhash), outcome)
                     hsh = c.rpc.getbestblockhash()
                     print("Quick   RPC returns", hsh)
                     t = 0
@@ -337,7 +352,7 @@ class TestManager(object):
                 if isinstance(b_or_t, CBlock):  # Block test runner
                     block = b_or_t
                     block_outcome = outcome
-                    tip = block.sha256
+                    tip = block.gethash()
                     # each test_obj can have an optional third argument
                     # to specify the tip we should compare with
                     # (default is to use the block being tested)

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -254,13 +254,9 @@ class TestManager(object):
             time.sleep(.1)
             waitLoop+=1
             if waitLoop > 50:
-                raise AssertionError("Test malfunction -- connection 0 is has no best block for comparision")
+                raise AssertionError("Test malfunction -- connection 0 has no best block for comparision")
         with mininode_lock:
             if blockhash is None:
-                print("Blockhash is None in check_results")
-                raise AssertionError("Test failed -- passed check_results None as blockhash, was expecting %s" % str(outcome))
-            if cxn0bbh is None:
-                print("connection 0 bestblockhash is None in check_results")
                 raise AssertionError("Test failed -- passed check_results None as blockhash, was expecting %s" % str(outcome))
 
             for c in self.connections:


### PR DESCRIPTION
This happens in about 0.5% of the runs of this test

invalidtxrequest.py: Pass: False, Duration: 3 s
##################################################
- Process /home/stone/git/sigcount2/release/../qa/rpc-tests/invalidtxrequest.py --srcdir /home/stone/git/sigcount2/release/src --portseed=1635 return code: 0
- stdout --------------------------------------------------
 2020-04-06 17:51:35,960.INFO: Random seed: 1586209895
2020-04-06 17:51:35,960.INFO: Initializing test directory /tmp/test_invalidtxrequestpy_l5qjw_qx
2020-04-06 17:51:35,961.INFO: Started '/home/stone/git/sigcount2/release/src/bitcoind -datadir=/tmp/test_invalidtxrequestpy_l5qjw_qx/node0 -rest -mocktime=0 -debug -whitelist=127.0.0.1' 0 as pid 3681 at 127.0.0.1:18080 dir /tmp/test_invalidtxrequestpy_l5qjw_qx/node0  
2020-04-06 17:51:36,967.INFO: bitcoind 0 startup complete
MiniNode: Connecting to Bitcoin Node IP # 127.0.0.1:18080
2020-04-06 17:51:37,227.ERROR: Unexpected exception caught during testing: TypeError("'NoneType' object cannot be interpreted as an integer",)
2020-04-06 17:51:37,228.INFO: Stopping nodes
2020-04-06 17:51:38,977.INFO: mininode network processing thread completed
2020-04-06 17:51:38,996.INFO: Not cleaning up dir /tmp/test_invalidtxrequestpy_l5qjw_qx
2020-04-06 17:51:38,996.ERROR: Failed

- stderr --------------------------------------------------
   File "/home/stone/git/sigcount2/qa/rpc-tests/test_framework/test_framework.py", line 279, in main
    self.run_test()
  File "/home/stone/git/sigcount2/release/../qa/rpc-tests/invalidtxrequest.py", line 31, in run_test
    test.run()
  File "/home/stone/git/sigcount2/qa/rpc-tests/test_framework/comptool.py", line 371, in run
    if (not self.check_results(tip, outcome)):
  File "/home/stone/git/sigcount2/qa/rpc-tests/test_framework/comptool.py", line 267, in check_results
    print("Node ", c.addr, " has best block ", hex(c.cb.bestblockhash), ". Expecting ", hex(blockhash), outcome)
