### PR TITLE
increase port range to minimize conflicts when running rpc_tests.py

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -627,12 +627,15 @@ class RPCTestHandler:
 
                     # This is a list of expected messages on stderr. If they appear, they do not
                     # necessarily indicate final failure of a test.
+
+                    # These 2 are due to accidental port conflicts caused by running multiple tests simultaneously.
                     stderr_filtered = stderr.replace("Error: Unable to start HTTP server. See debug log for details.", "")
+                    stderr_filtered = stderr.replace("Error: Unable to start RPC services. See debug log for details.", "")
+
                     stderr_filtered = re.sub(r"Error: Unable to bind to 0.0.0.0:[0-9]+ on this computer\. BCH Unlimited is probably already running\.",
                                              "", stderr_filtered)
                     invalid_index = re.compile(r'.*?\n.*?EXCEPTION.*?\n.*?invalid index for tx.*?\n.*?ProcessMessages.*?\n', re.MULTILINE)
                     stderr_filtered = invalid_index.sub("", stderr_filtered)
-
                     stderr_filtered = stderr_filtered.replace("Error: Failed to listen on any port. Use -listen=0 if you want this.", "")
                     stderr_filtered = stderr_filtered.replace("Error: Failed to listen on all P2P ports. Failing as requested by -bindallorfail.", "")
                     stderr_filtered = stderr_filtered.replace(" ", "")

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -510,8 +510,8 @@ class RPCTestHandler:
         self.num_running = 0
         # In case there is a graveyard of zombie bitcoinds, we can apply a
         # pseudorandom offset to hopefully jump over them.
-        # (625 is PORT_RANGE/MAX_NODES)
-        self.portseed_offset = int(time.time() * 1000) % 625
+        # 3750 is PORT_RANGE/MAX_NODES defined in util, but awkward to import into rpc-test.py
+        self.portseed_offset = int(time.time() * 1000) % 3750
         self.jobs = []
 
     def get_next(self):

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -46,9 +46,9 @@ uBTC = 100
 # The maximum number of nodes a single test can spawn
 MAX_NODES = 8
 # Don't assign rpc or p2p ports lower than this
-PORT_MIN = 11000
+PORT_MIN = 5000
 # The number of ports to "reserve" for p2p and rpc, each
-PORT_RANGE = 5000
+PORT_RANGE = 30000
 
 debug_port_assignments = False
 


### PR DESCRIPTION
port range conflicts cause about 1-2% spurious failures.

The QA framework is capable of restarting bitcoind in some cases, but it was still seeing these cases as failed.  This PR also adds an exception for one of these benign failure modes (RPC port conflict).