### PR TITLE
On startup, use reconsidermostworkchain() when chain not synced

### DIFF
--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -7,7 +7,6 @@
 #include "rpc/blockchain.h"
 #include "amount.h"
 #include "blockstorage/blockstorage.h"
-#include "chain.h"
 #include "chainparams.h"
 #include "checkpoints.h"
 #include "coins.h"
@@ -1182,22 +1181,7 @@ UniValue getblockchaininfo(const UniValue &params, bool fHelp)
     return obj;
 }
 
-/** Comparison function for sorting the getchaintips heads.  */
-struct CompareBlocksByHeight
-{
-    bool operator()(const CBlockIndex *a, const CBlockIndex *b) const
-    {
-        /* Make sure that unequal blocks with the same height do not compare
-           equal. Use the pointers themselves to make a distinction. */
-
-        if (a->nHeight != b->nHeight)
-            return (a->nHeight > b->nHeight);
-
-        return a < b;
-    }
-};
-
-static std::set<CBlockIndex *, CompareBlocksByHeight> GetChainTips()
+std::set<CBlockIndex *, CompareBlocksByHeight> GetChainTips()
 {
     /*
      * Idea:  the set of chain tips is chainActive.tip, plus orphan blocks which do not have another orphan building off

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -5,6 +5,8 @@
 #ifndef BITCOIN_RPC_BLOCKCHAIN_H
 #define BITCOIN_RPC_BLOCKCHAIN_H
 
+#include "chain.h"
+
 #include <amount.h>
 #include <stdint.h>
 #include <vector>
@@ -15,9 +17,27 @@ class UniValue;
 
 static constexpr int NUM_GETBLOCKSTATS_PERCENTILES = 5;
 
+/** Comparison function for sorting the getchaintips heads.  */
+struct CompareBlocksByHeight
+{
+    bool operator()(const CBlockIndex *a, const CBlockIndex *b) const
+    {
+        /* Make sure that unequal blocks with the same height do not compare
+           equal. Use the pointers themselves to make a distinction. */
+
+        if (a->nHeight != b->nHeight)
+            return (a->nHeight > b->nHeight);
+
+        return a < b;
+    }
+};
+
 /** Used by getblockstats to get feerates at different percentiles by size  */
 void CalculatePercentilesBySize(CAmount result[NUM_GETBLOCKSTATS_PERCENTILES],
     std::vector<std::pair<CAmount, int64_t> > &scores,
     int64_t total_size);
+
+UniValue reconsidermostworkchain(const UniValue &params, bool fHelp);
+std::set<CBlockIndex *, CompareBlocksByHeight> GetChainTips();
 
 #endif


### PR DESCRIPTION
A problem exists when a node operator switches from and ABC/BCHN client
or fails to upgrade BU until after a hardfork has happened. In those
instances the correct chain will have been invalidated. In the case
of ABC nodes, they use the park functionality which causes the chain
to be temporarily invalidated when many blocks are received at once, as
happens during IBD.  A chain can also get invalidated when the operator
fails to upgrade BU before a hard fork. Then once the hardfork has
happend, the new blocks may no longer be in consensus causing the
chain to be invalidated. In those cases, running
reconsidermostworkchain() on startup will allow the node to
sync to the correct chain without operator intervention.

Testing:  I tested this out by partially syncing an ABC node and then switching to a node built from this branch.  Works fine. Also, has no issues when launching against a fully synced chain.

NOTE:  I think we may want to add a tweak here so that we can turn off this functionality when we do fork testing , since we don't always want to sync to the most work chain on startup.