### PR TITLE
fix doublespend issue in schnorrsig test 

### DIFF
--- a/qa/rpc-tests/test_framework/script.py
+++ b/qa/rpc-tests/test_framework/script.py
@@ -708,6 +708,8 @@ class CScript(bytes):
     def __new__(cls, value=b''):
         if isinstance(value, bytes) or isinstance(value, bytearray):
             return super(CScript, cls).__new__(cls, value)
+        elif isinstance(value, str):
+            return super(CScript, cls).__new__(cls, bytearray.fromhex(value))
         else:
             def coerce_iterable(iterable):
                 for instance in iterable:


### PR DESCRIPTION
where it assumes the first enqueued doublespend is the one that is committed to a block.  Since enqueuing is processed asynchronously, this assumption not guaranteed and is actually incorrect very rarely.