### PR TITLE
ignore exception thrown due to bug in communicate

### DIFF
--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -573,6 +573,10 @@ class RPCTestHandler:
                     got_outputs[0] = True
                 except subprocess.TimeoutExpired:
                     pass
+                except ValueError:
+                    # There is a bug in communicate that causes this exception if the child process has closed any pipes but is still running
+                    # see: https://bugs.python.org/issue35182
+                    pass
 
                 retval = proc.poll()
                 if not retval is None:


### PR DESCRIPTION
https://bugs.python.org/issue35182

We see:

Traceback (most recent call last):

  File "qa/pull-tester/rpc-tests.py", line 719, in <module>

    runtests()

  File "qa/pull-tester/rpc-tests.py", line 452, in runtests

    (name, retCode, coreOutput, stdout, stderr, stderr_filtered, passed, duration) = job_queue.get_next()

  File "qa/pull-tester/rpc-tests.py", line 566, in get_next

    comms(0.1)

  File "qa/pull-tester/rpc-tests.py", line 551, in comms

    stdout_data, stderr_data = proc.communicate(timeout=timeout)

  File "/usr/lib/python3.6/subprocess.py", line 863, in communicate

    stdout, stderr = self._communicate(input, endtime, timeout)

  File "/usr/lib/python3.6/subprocess.py", line 1527, in _communicate

    selector.register(self.stderr, selectors.EVENT_READ)

  File "/usr/lib/python3.6/selectors.py", line 351, in register

    key = super().register(fileobj, events, data)

  File "/usr/lib/python3.6/selectors.py", line 237, in register

    key = SelectorKey(fileobj, self._fileobj_lookup(fileobj), events, data)

  File "/usr/lib/python3.6/selectors.py", line 224, in _fileobj_lookup

    return _fileobj_to_fd(fileobj)

  File "/usr/lib/python3.6/selectors.py", line 39, in _fileobj_to_fd

    "{!r}".format(fileobj)) from None

ValueError: Invalid file object: <_io.TextIOWrapper name=9 encoding='UTF-8'>
