### PR TITLE
Throw exceptions when a get/set tweak or a getstat is invalid

### DIFF
--- a/qa/rpc-tests/sendheaders.py
+++ b/qa/rpc-tests/sendheaders.py
@@ -316,11 +316,6 @@ class SendHeadersTest(BitcoinTestFramework):
 
     def run_test(self):
 
-        # Set the forktime to be far into the future.  Running the sript after forktime will cause a failure since
-        # we will be expecting a > 1MB block to begin with.
-        self.nodes[0].set("mining.forkTime=1901590000")
-        self.nodes[1].set("mining.forkTime=1901590000")
-
         # Setup the p2p connections and start up the network thread.
         inv_node = InvNode()
         test_node = TestNode()

--- a/src/tweak.cpp
+++ b/src/tweak.cpp
@@ -132,6 +132,7 @@ UniValue settweak(const UniValue &params, bool fHelp)
 
     // Now assign
     UniValue ret(UniValue::VARR);
+    UniValue names(UniValue::VARR);
     for (unsigned int i = 0; i < params.size(); i++)
     {
         string s = params[i].get_str();
@@ -151,6 +152,8 @@ UniValue settweak(const UniValue &params, bool fHelp)
             {
                 ret.push_back(tmp);
             }
+
+            names.push_back(name);
         }
         else
             throw std::invalid_argument("No tweak available for that selection");
@@ -159,5 +162,5 @@ UniValue settweak(const UniValue &params, bool fHelp)
     {
         return ret;
     }
-    return NullUniValue;
+    return gettweak(names, false);
 }

--- a/src/tweak.cpp
+++ b/src/tweak.cpp
@@ -156,7 +156,10 @@ UniValue settweak(const UniValue &params, bool fHelp)
             names.push_back(name);
         }
         else
-            throw std::invalid_argument("No tweak available for that selection");
+        {
+            std::string error = "No tweak available for " + name;
+            throw std::invalid_argument(error.c_str());
+        }
     }
     if (!ret.empty())
     {

--- a/src/tweak.cpp
+++ b/src/tweak.cpp
@@ -80,6 +80,9 @@ UniValue gettweak(const UniValue &params, bool fHelp)
             }
         }
     }
+    if (ret.empty())
+        throw std::invalid_argument("No tweak available for that selection");
+
     return ret;
 }
 // RPC Set a particular tweak
@@ -149,8 +152,9 @@ UniValue settweak(const UniValue &params, bool fHelp)
                 ret.push_back(tmp);
             }
         }
+        else
+            throw std::invalid_argument("No tweak available for that selection");
     }
-
     if (!ret.empty())
     {
         return ret;

--- a/src/tweak.cpp
+++ b/src/tweak.cpp
@@ -59,6 +59,7 @@ UniValue gettweak(const UniValue &params, bool fHelp)
 
     for (unsigned int i = 0; i < psize; i++)
     {
+        bool fMatch = false;
         string name = params[i].get_str();
         if (name == "help")
         {
@@ -77,7 +78,14 @@ UniValue gettweak(const UniValue &params, bool fHelp)
                     ret.pushKV(item->second->GetName(), item->second->GetHelp());
                 else
                     ret.pushKV(item->second->GetName(), item->second->Get());
+
+                fMatch = true;
             }
+        }
+        if (!fMatch)
+        {
+            std::string error = "No tweak available for " + name;
+            throw std::invalid_argument(error.c_str());
         }
     }
     if (ret.empty())

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1617,6 +1617,9 @@ UniValue getstat(const UniValue &params, bool fHelp)
 
         ret.push_back(ustat);
     }
+    if (ret.empty())
+        throw std::invalid_argument("No stat available for that selection");
+
     return ret;
 }
 


### PR DESCRIPTION
This PR fixes a relatively minor annoyance, when we get/set invalid tweaks or get invalid stats there are currently no messages that indicate that the user actions had failed. 