### PR TITLE
Set net.unconfChainResendAction default value to 2

### DIFF
--- a/qa/rpc-tests/mempool_push.py
+++ b/qa/rpc-tests/mempool_push.py
@@ -37,11 +37,9 @@ class MyTest (BitcoinTestFramework):
              "-limitdescendantsize=%d" % (BCH_UNCONF_SIZE_KB*2),
              "-limitancestorcount=%d" % (BCH_UNCONF_DEPTH*2),
              "-limitdescendantcount=%d" % (BCH_UNCONF_DEPTH*2),
-             "-net.unconfChainResendAction=2",
              "-net.restrictInputs=0"],
             ["-blockprioritysize=2000000", "-limitdescendantcount=1000", "-limitancestorcount=1000",
-             "-limitancestorsize=1000", "-limitdescendantsize=1000", "-net.unconfChainResendAction=2",
-             "-net.restrictInputs=0"],
+             "-limitancestorsize=1000", "-limitdescendantsize=1000", "-net.restrictInputs=0"],
             ]
         self.nodes = start_nodes(3, self.options.tmpdir, mempoolConf)
         connect_nodes_full(self.nodes)

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -359,7 +359,7 @@ CTweak<unsigned int> unconfPushAction("net.unconfChainResendAction",
     "Action to take when this node thinks that a peer will now accept a previously unacceptable unconfirmed "
     "transaction (default: 2) "
     "0: do not resend, 1: send an INV, 2: send the TX",
-    0);
+    2);
 CTweak<bool> restrictInputs("net.restrictInputs",
     "Do we want to restrict max inputs to 1 for unconfirmed transaction chains that are longer than 25 (default: true)",
     true);


### PR DESCRIPTION
In #2080 we were supposed to turn intelligent forwarding on by default, but by chance we miss to do that.