### PR TITLE
fix test not crossing misbehavior limit

### DIFF
--- a/src/test/exploit_tests.cpp
+++ b/src/test/exploit_tests.cpp
@@ -400,7 +400,11 @@ BOOST_AUTO_TEST_CASE(inv_tests)
 
     vRecv1 << vInv;
     ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetStopwatchMicros());
-    SendMessages(&dummyNode1); // send a fifth message will cause a ban
+    SendMessages(&dummyNode1); // sending a fifth message is on the cusp of banning, based on elapsed time
+    vRecv1.clear();
+    vRecv1 << vInv;
+    ProcessMessage(&dummyNode1, NetMsgType::INV, vRecv1, GetStopwatchMicros());
+    SendMessages(&dummyNode1); // send a sixth message will cause a ban
     BOOST_CHECK(vInv.size() > MAX_INV_SZ);
     BOOST_CHECK(dosMan.IsBanned(addr1));
 


### PR DESCRIPTION
misbehavior now ages.  This test exactly hits the misbehavior limit if no aging happens so would fail rarely on slower machines where aging did happen.