### PR TITLE
[minor] Move TestConservativeBlockValidity into validation.cpp

### DIFF
--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -1428,39 +1428,6 @@ void LoadFilter(CNode *pfrom, CBloomFilter *filter)
     }
 }
 
-// Similar to TestBlockValidity but is very conservative in parameters (used in mining)
-bool TestConservativeBlockValidity(CValidationState &state,
-    const CChainParams &chainparams,
-    const CBlock &block,
-    CBlockIndex *pindexPrev,
-    bool fCheckPOW,
-    bool fCheckMerkleRoot)
-{
-    AssertLockHeld(cs_main);
-    assert(pindexPrev && pindexPrev == chainActive.Tip());
-    // Ensure that if there is a checkpoint on this height, that this block is the one.
-    if (fCheckpointsEnabled && !CheckAgainstCheckpoint(pindexPrev->nHeight + 1, block.GetHash(), chainparams))
-        return error("%s: CheckAgainstCheckpoint(): %s", __func__, state.GetRejectReason().c_str());
-
-    CCoinsViewCache viewNew(pcoinsTip);
-    CBlockIndex indexDummy(block);
-    indexDummy.pprev = pindexPrev;
-    indexDummy.nHeight = pindexPrev->nHeight + 1;
-
-    // NOTE: CheckBlockHeader is called by CheckBlock
-    if (!ContextualCheckBlockHeader(block, state, pindexPrev))
-        return false;
-    if (!CheckBlock(block, state, fCheckPOW, fCheckMerkleRoot))
-        return false;
-    if (!ContextualCheckBlock(block, state, pindexPrev, true))
-        return false;
-    if (!ConnectBlock(block, state, &indexDummy, viewNew, chainparams, true))
-        return false;
-    assert(state.IsValid());
-
-    return true;
-}
-
 // Statistics:
 
 CStatBase *FindStatistic(const char *name)

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -141,14 +141,6 @@ extern void UnlimitedAcceptBlock(const CBlock &block,
 
 extern void UnlimitedLogBlock(const CBlock &block, const std::string &hash, uint64_t receiptTime);
 
-// used during mining
-extern bool TestConservativeBlockValidity(CValidationState &state,
-    const CChainParams &chainparams,
-    const CBlock &block,
-    CBlockIndex *pindexPrev,
-    bool fCheckPOW,
-    bool fCheckMerkleRoot);
-
 // Check whether this block is bigger in some metric than we really want to accept
 extern bool CheckExcessive(const CBlock &block, uint64_t blockSize, uint64_t nTx, uint64_t largestTx);
 

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -1221,6 +1221,39 @@ bool TestBlockValidity(CValidationState &state,
     return true;
 }
 
+// Similar to TestBlockValidity but is very conservative in parameters (used in mining)
+bool TestConservativeBlockValidity(CValidationState &state,
+    const CChainParams &chainparams,
+    const CBlock &block,
+    CBlockIndex *pindexPrev,
+    bool fCheckPOW,
+    bool fCheckMerkleRoot)
+{
+    AssertLockHeld(cs_main);
+    assert(pindexPrev && pindexPrev == chainActive.Tip());
+    // Ensure that if there is a checkpoint on this height, that this block is the one.
+    if (fCheckpointsEnabled && !CheckAgainstCheckpoint(pindexPrev->nHeight + 1, block.GetHash(), chainparams))
+        return error("%s: CheckAgainstCheckpoint(): %s", __func__, state.GetRejectReason().c_str());
+
+    CCoinsViewCache viewNew(pcoinsTip);
+    CBlockIndex indexDummy(block);
+    indexDummy.pprev = pindexPrev;
+    indexDummy.nHeight = pindexPrev->nHeight + 1;
+
+    // NOTE: CheckBlockHeader is called by CheckBlock
+    if (!ContextualCheckBlockHeader(block, state, pindexPrev))
+        return false;
+    if (!CheckBlock(block, state, fCheckPOW, fCheckMerkleRoot))
+        return false;
+    if (!ContextualCheckBlock(block, state, pindexPrev, true))
+        return false;
+    if (!ConnectBlock(block, state, &indexDummy, viewNew, chainparams, true))
+        return false;
+    assert(state.IsValid());
+
+    return true;
+}
+
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params &consensusParams)
 {
     int halvings = nHeight / consensusParams.nSubsidyHalvingInterval;

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -1213,7 +1213,7 @@ bool TestBlockValidity(CValidationState &state,
         return false;
     if (!CheckBlock(block, state, fCheckPOW, fCheckMerkleRoot))
         return false;
-    if (!ContextualCheckBlock(block, state, pindexPrev))
+    if (!ContextualCheckBlock(block, state, pindexPrev, fConservative))
         return false;
     if (!ConnectBlock(block, state, &indexDummy, viewNew, chainparams, true))
         return false;
@@ -1230,29 +1230,7 @@ bool TestConservativeBlockValidity(CValidationState &state,
     bool fCheckPOW,
     bool fCheckMerkleRoot)
 {
-    AssertLockHeld(cs_main);
-    assert(pindexPrev && pindexPrev == chainActive.Tip());
-    // Ensure that if there is a checkpoint on this height, that this block is the one.
-    if (fCheckpointsEnabled && !CheckAgainstCheckpoint(pindexPrev->nHeight + 1, block.GetHash(), chainparams))
-        return error("%s: CheckAgainstCheckpoint(): %s", __func__, state.GetRejectReason().c_str());
-
-    CCoinsViewCache viewNew(pcoinsTip);
-    CBlockIndex indexDummy(block);
-    indexDummy.pprev = pindexPrev;
-    indexDummy.nHeight = pindexPrev->nHeight + 1;
-
-    // NOTE: CheckBlockHeader is called by CheckBlock
-    if (!ContextualCheckBlockHeader(block, state, pindexPrev))
-        return false;
-    if (!CheckBlock(block, state, fCheckPOW, fCheckMerkleRoot))
-        return false;
-    if (!ContextualCheckBlock(block, state, pindexPrev, true))
-        return false;
-    if (!ConnectBlock(block, state, &indexDummy, viewNew, chainparams, true))
-        return false;
-    assert(state.IsValid());
-
-    return true;
+    return TestBlockValidity(state, chainparams, block, pindexPrev, fCheckPOW, fCheckMerkleRoot, true);
 }
 
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params &consensusParams)

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -1194,7 +1194,8 @@ bool TestBlockValidity(CValidationState &state,
     const CBlock &block,
     CBlockIndex *pindexPrev,
     bool fCheckPOW,
-    bool fCheckMerkleRoot)
+    bool fCheckMerkleRoot,
+    bool fConservative)
 {
     AssertLockHeld(cs_main);
     assert(pindexPrev && pindexPrev == chainActive.Tip());

--- a/src/validation/validation.h
+++ b/src/validation/validation.h
@@ -87,7 +87,7 @@ bool TestBlockValidity(CValidationState &state,
     bool fConservative = false);
 
 // used during mining
-extern bool TestConservativeBlockValidity(CValidationState &state,
+bool TestConservativeBlockValidity(CValidationState &state,
     const CChainParams &chainparams,
     const CBlock &block,
     CBlockIndex *pindexPrev,

--- a/src/validation/validation.h
+++ b/src/validation/validation.h
@@ -85,6 +85,14 @@ bool TestBlockValidity(CValidationState &state,
     bool fCheckPOW = true,
     bool fCheckMerkleRoot = true);
 
+// used during mining
+extern bool TestConservativeBlockValidity(CValidationState &state,
+    const CChainParams &chainparams,
+    const CBlock &block,
+    CBlockIndex *pindexPrev,
+    bool fCheckPOW,
+    bool fCheckMerkleRoot);
+
 CAmount GetBlockSubsidy(int nHeight, const Consensus::Params &consensusParams);
 
 /**

--- a/src/validation/validation.h
+++ b/src/validation/validation.h
@@ -83,7 +83,8 @@ bool TestBlockValidity(CValidationState &state,
     const CBlock &block,
     CBlockIndex *pindexPrev,
     bool fCheckPOW = true,
-    bool fCheckMerkleRoot = true);
+    bool fCheckMerkleRoot = true,
+    bool fConservative = false);
 
 // used during mining
 extern bool TestConservativeBlockValidity(CValidationState &state,


### PR DESCRIPTION
For the next release (after 1.8.0) ..just a bit of cleanup and consolidation.