### PR TITLE
[electrum] Catch http_get error in GetElectrsInfo 

### DIFF
--- a/src/electrum/electrs.cpp
+++ b/src/electrum/electrs.cpp
@@ -225,9 +225,10 @@ void set_xversion_flags(CXVersionMessage &xver, const std::string &network)
         return;
     }
 
-    constexpr double PROTOCOL_VERSION = 1.4;
+    constexpr double ELECTRUM_PROTOCOL_VERSION = 1.4;
 
     xver.set_u64c(XVer::BU_ELECTRUM_SERVER_PORT_TCP, std::stoul(rpc_port(network)));
-    xver.set_u64c(XVer::BU_ELECTRUM_SERVER_PROTOCOL_VERSION, static_cast<uint64_t>(PROTOCOL_VERSION * 1000000));
+    xver.set_u64c(
+        XVer::BU_ELECTRUM_SERVER_PROTOCOL_VERSION, static_cast<uint64_t>(ELECTRUM_PROTOCOL_VERSION * 1000000));
 }
 } // ns electrum

--- a/src/electrum/electrumrpcinfo.cpp
+++ b/src/electrum/electrumrpcinfo.cpp
@@ -23,7 +23,15 @@ static int64_t get_index_height(const std::map<std::string, int64_t> &info)
 
 UniValue ElectrumRPCInfo::GetElectrumInfo() const
 {
-    auto electrsinfo = FetchElectrsInfo();
+    std::map<std::string, int64_t> electrsinfo;
+    try
+    {
+        electrsinfo = FetchElectrsInfo();
+    }
+    catch (const std::runtime_error &e)
+    {
+        LOGA("Electrum: %s: Failed to fetch electrs info %s", __func__, e.what());
+    }
     int64_t index_height = get_index_height(electrsinfo);
 
     UniValue info(UniValue::VOBJ);


### PR DESCRIPTION
This lets the method output status when the process is stopped, rather than error.

Output if ElectrsCash exits is now:
```
$ ./src/bitcoin-cli getelectruminfo
{
  "status": "stopped",
  "index_progress": 0,
  "index_height": -1,
  "debuginfo": {
  }
}
```

Fixes #2181 