### PR TITLE
Disable reconsidermostworkchain during initial bootstrap when chain is not synced

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -510,6 +510,18 @@ CTweak<double> dMinLimiterTxFee("minlimitertxfee",
                                     DEFAULT_MINLIMITERTXFEE),
     DEFAULT_MINLIMITERTXFEE);
 
+/** Disable reconsidermostworkchain during initial bootstrap when chain is not synced.
+  * This is for testing purpose only and hence it is disabled by default.
+  * This tweak will be useful during multiple clients interop network upgrade tests.
+  * During this tests  official testnet is forked via invalidate block, that means that
+  * if for what ever reason you need to restart your client during the test, you need to
+  * rollbackchain and then reconsiderblock the first block of the forked testnet. This is because
+  * if more than 1 block at time have to be invalidated so that the utxo may get undone correctly.
+  */
+CTweak<bool> avoidReconsiderMostWorkChain("test.avoidReconsiderMostWorkChain",
+    "Disable reconsidermostworkchain during initial bootstrap when chain is not synced",
+    false);
+
 CRequestManager requester; // after the maps nodes and tweaks
 CState nodestate;
 

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -522,7 +522,7 @@ void ThreadImport(std::vector<fs::path> vImportFiles, uint64_t nTxIndexCache)
     // Reconsider the most work chain if we're not already synced. This is necessary
     // when switching from an ABC/BCHN client or when a operator failed to upgrade their BU
     // node before a hardfork.
-    if (!fReindex)
+    if (!fReindex && !(avoidReconsiderMostWorkChain.Value()))
     {
         // Get the set of chaintips
         std::set<CBlockIndex *, CompareBlocksByHeight> setTips;

--- a/src/init.h
+++ b/src/init.h
@@ -36,6 +36,7 @@ static const bool DEFAULT_PV_TESTMODE = false;
 
 extern CTweak<double> dMinLimiterTxFee;
 extern CTweak<double> dMaxLimiterTxFee;
+extern CTweak<bool> avoidReconsiderMostWorkChain;
 
 /** Returns licensing information (for -version) */
 std::string LicenseInfo();


### PR DESCRIPTION


This is for testing purposeonly and hence it is disabled by default.
This tweak will be useful during multiple clients interop network upgrade tests.
During this tests  official testnet is forked via invalidate block, that means that if for what ever reason you need to restart your client during the test, you need to rollbackchain and then reconsiderblock the first block of the forked testnet. This is because if more than 1 block at time have to be invalidated so that the utxo may get undone correctly.