### PR TITLE
[rpc] getblockchaininfo: add size_on_disk, prune_target_size

### DIFF
--- a/contrib/electrs/build_electrs.py
+++ b/contrib/electrs/build_electrs.py
@@ -6,8 +6,8 @@ import sys
 import shutil
 PROJECT_NAME = "ElectrsCash"
 GIT_REPO = "https://github.com/BitcoinUnlimited/{}.git".format(PROJECT_NAME)
-GIT_BRANCH = "v1.1.1" # When released put a tag here
-EXPECT_HEAD = "6572f5d321bde6ed16427fb128addd96d426dbd2" # When released put a hash here: "aa95d64d050c286356dadb78d19c2e687dec85cf"
+GIT_BRANCH = "master" # When released put a tag here
+EXPECT_HEAD = None # When released put a hash here: "aa95d64d050c286356dadb78d19c2e687dec85cf"
 
 ROOT_DIR = os.path.realpath(
         os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))

--- a/doc/xversionmessage.md
+++ b/doc/xversionmessage.md
@@ -1,7 +1,9 @@
 # XVersionMessage: BCH node extended version and configuration fields
 
 DRAFT specification
-Version: 0.0.3
+Version: 0.1.0
+
+Authors: Awemany, Griffith
 
 ## Overview
 
@@ -15,32 +17,37 @@ It is deemed desirable to be able to announce further configuration
 and version information to peers. For example, this can then be used
 to version advanced block transmission protocols like Graphene.
 
-Notably, the `version` message can not be extended as there are
-clients on the current BCH network that will consider an oversized
-`version` message illegal (e.g. Bitcoin XT).
+Notably, the `version` message can not be extended as some
+clients might consider an oversized `version` message illegal.
 
 For this reason, an additional message type named `xversion` is
-specified here in, plus an acknowledgement named `xverack`. The
-`xversion` message transports a generic key-value map that is meant to
-hold the configuration and version parameters.
+specified here in. The `xversion` message transports a generic
+key-value map that is meant to hold the configuration and version
+parameters.
 
 As a general reminder, it should be noted that the values given in
 this extended `xversion` version and configuration map are, except for
 basic type checks and mappings, not in any way validated and a node
 can very easily lie about them. Care should be taken that any
 implementation depending for its configuration on the values in the
-xmap will properly account for this fact and ban or otherwise penalize
+mapping will properly account for this fact and ban or otherwise penalize
 nodes that do not conform with their advertised behavior.
 
-## Encoding of the `xversion` and `xverack` message types
+## Encoding of the `xversion` message type
+
+The message envelope command[1] for `xversion` in all specs prior to 0.1.0
+was `xversion`. In 0.1.0 the message envelope command changes to `extversion`.
+This change is necessary to allow for backwards compatibility with peers
+following the older specifications due to a change in the version handshake
+between spec versions 0.0.3 and 0.1.0 ([see below](#Handling-and-sequencing-of-xversion-messages)).
 
 The `xversion` message contains a single compound field which is a
 serialized key-value map henceforth named `xmap` that maps 64-bit
 integer values to variable-sized byte vectors. The message itself is
-encoded in the standard Bitcoin message frame that is documented elsewhere.
+encoded in the standard Bitcoin message frame[2].
 
-The `map` is encoded using Bitcoin's usual network de-/serialization
-schemes while using `COMPACTSIZE` size encodings whenever possible.
+The `xmap` is encoded using Bitcoin's usual network de-/serialization
+schemes while using `COMPACTSIZE` size[3] encodings whenever possible.
 Note that this is different from using the default encoding you would
 get when serializing through the `std::map` serializer (which is
 commonly found in `serialize.h` in most current C++ implementations based
@@ -69,11 +76,8 @@ serialization templates usually found in `serialize.h`:
 
 A node may serialize the `xmap` it wants to announce to its peers with
 any order of the key-value pairs. When receiving an `xmap`, entries
-with duplicate keys that are later in the message should override
+with duplicate keys that are later in the message override
 values that are that are closer to the start of the message.
-
-The `xverack` message, meant as an acknowledgement of proper
-`xversion` receipt is empty.
 
 ### Size limit
 
@@ -84,40 +88,50 @@ than this are illegal.
 ### Later extensions
 
 Implementations should allow extra bytes following the defined fields
-in the `xversion` message as well as any bytes in in the `xverack`
-message, to allow for further extensibility.
+in the `xversion` message to allow for further extensibility as long
+as the 100KB size constraint is not exceeded.
 
 
 ## Handling and sequencing of `xversion` messages
 
 A node should expect an `xversion` message to arrive after the
-acknowledgement ('verack') of the `version` message.  Only a single
-`xversion` message should arrive during the lifetime of a connection
-and receival of multiple such messages should be considered
-misbehavior of the remote peer.
+`version` message.  Only a single `xversion` message should arrive
+during the lifetime of a connection and receipt of multiple such
+messages should be considered misbehavior of the remote peer.
 
-After receival of an `xversion` message, a node must answer with an
-empty `xverack` message to confirm recept. Receival of an `xverack`
-without having ever send an `xversion` message should be handled as a
-protocol violation.
+After receipt of an `xversion` message, a node must answer with an
+empty `verack` message to confirm recept.
 
-An empty `xmap` for a peer has a defined reading (see below).
+A node signals that it is using xversion by setting service bit 11.
+
+When `xversion` is enabled the version handshake should be
+`version` `xversion` `verack`. When `xversion` is not enabled the
+handshake should be `version` `verack`.
+
+An empty `xmap` for a peer has a defined reading ([see below](#Interpretation-of-the-xmap)).
 However, to simplify node implementations, it is deemed acceptable to
 enable certain protocol features only after proper receipt of a
 corresponding `xversion` message.
 
 ## Interpretation of the `xmap`
 
-If a key cannot be found in the `xmap`, its value must be assumed to be an
-empty byte vector. An entry that has unknown meaning is to be ignored.
+Xmap keys are 64-bit in size. If a key cannot be found in the `xmap`,
+its value must be assumed to be an empty byte vector.
 
-If further structuring of a byte-vector value is desired, it should be
-done using the standard Bitcoin de-/serialization format.
+The value is a vector of bytes. These bytes can be an object that
+is itself serialized, but MUST exist within the vector "envelope"
+so that implementations that do not recognize a field can skip it.
+The serialization format of the bytes inside the "envelope" is defined
+by the creator of the key, however, Bitcoin P2P network serialization
+is recommended since it is also used to encode/decode most of the other
+the messages in the Bitcoin protocol.
+
+An entry that has unknown meaning is to be ignored.
 
 For obvious reasons, the enumeration of entries and their expected
 types in the map should be agreed upon between implementations. For
 this reason, a separate specification that lists configuration and
-version keys is introduced, named the `xmap directory` (see below).
+version keys is introduced, named the [`xmap directory`](#The-xmap-directory).
 
 The format of `std::vector<uint8_t>` is unwieldy for configuration and
 version parameters that could be expressed as simple integer to
@@ -127,13 +141,15 @@ expected to grow over time and this document correspondingly
 extended. For now, only a compact-size encoded unsigned 64-bit integer
 value named `u64c` is specified.
 
-### The `u64c` value type
+## Predefined value types
+
+#### The `u64c` value type
 
 Values in the `xmap` can be interpreted as compact-size encoded 64-bit
 unsigned integers (named `u64c`), allowing to use it as a simple
-unsigned to unsigned integer map.
+unsigned integer to unsigned integer map.
 
-A value of `type` is encoded in Bitcoin's message serialization as a
+A value of `u64c` type is encoded in Bitcoin's message serialization as a
 COMPACTSIZE integer *within* the generic byte vector value of the `xmap`.
 For example, a value of `0x1000` (4096) is encoded like this as the `xmap`
 value:
@@ -143,29 +159,26 @@ Which gets further encoded in the `xmap` encoding itself as:
 `03 FD 00 10`
 
 A special exception is added for empty value vectors. Empty value
-vectors are to be interpreted as value zero in the `u64c`
-reading. Thus missing entries in the `xmap` are interpreted as `u64c`
-zero values.
+vectors are to be interpreted as a missing value. The interpretation
+and handling of missing expected values in the `xmap` are left up to
+the receiver.
 
 When interpreting these `uint64_t` values from the table and certain
 bits of the value are unused for a given key, the implementer should
 mask out the needed bits using an AND-mask to allow for future use of
 the yet unused bits in a given value.
 
-If decoding as a compact size integer fails, a value of zero for
-the corresponding value should be assumed.
+If decoding as a compact size integer fails, a decode failure should
+be emitted to be handled at a higher level.
 
 ## The `xmap` directory
 
 A directory that lists the currently defined key values comes along
 with this specification and can be found in the file named
-`xversionkeys.dat`.
+`xversionkeys.h`.
 
-At the moment, and for more compact wire encoding, keys are assumed to
-be just 32-bit in size and the current specification format reflects
-this. They are assumed to consist of a 16-bit prefix in the more
-significant bits of the 64-bit integer (bits 16..31) followed by a
-16-bit suffix in the least significant bits (0..15).
+Keys are 64-bit in size. They consist of a 32-bit prefix (bits 32..63)
+followed by a 32-bit suffix (0..31).
 
 Different prefixes are meant for different implementations so that
 each implementation can extend the version map without needing
@@ -176,77 +189,30 @@ detailed interpretation of the fields in the `xmap` will obviously
 rely on external specifications that cannot ever be the scope of this
 document.
 
-The `xmap` directory is meant to be machine readable. For this reason,
-a simple `python` tool in the Bitcoin Unlimited implementation
-produces a C++ header file from this directory (see below).
-
-The rationale to not directly implement it as a simple C++ header is
-that this will make it easier for non-C++ implementations to extract
-the desired values from this table as well as ensuring that table
-stays simple.
-
-## `xmap` directory format
-The file is assumed to be ASCII-encoded and read
-line-by-line. Anything that follows a `#` is deemed a comment and
-ignored. Lines that are empty or consisting only of whitespace are
-ignored as well.
-
-Each line is interpreted as a string tuple. The entries in the tuple
-are separated by any positive amount of whitespace in the directory file.
-
-String tuples that have `KEY` as their first entry specify the key type, naming,
-prefix, suffix and data type of an entry in the `xmap`, in this order. For example:
-
-`KEY i BU_LISTEN_PORT                            0x0000                   0x0000         u64c`
-
-
-The name of a key should be an all-upper-case, underscore-separated string
-that is a valid C++ `enum` identifier, like in the above example.
-
-The keys in the table should be marked with either `INITIAL` or
-CHANGEABLE, expressed as `i` or `c`. Currently, only the meaning of
-INITIAL (`i`) is defined.
-
-The idea is that an initial value is marking values that are valid for
-the lifetime of the connection to the peer, whereas values marked as
-`c` could be updated with a to-be-defined update mechanism. This
-functionality, however, has not been implemented yet. And implementer
-that desires the functionality of a `CHANGEABLE` key is expected to
-update this very specification accordingly.
-
-Valid values for the data type specification are currently `vector` for an
-unspecified vector of bytes and `u64c` for a value that is assumed to
-be a compact-size encoded 64-bit unsigned integer like described
-above.
-
-Other tuples that do not start with `KEY` or have the above format are
-currently undefined and should be expected to produce an error in any
-`xmap` directory parsers that might be implemented (or potentially in
-any of the later processing and compilation stages).
-
 ## Implementation prefixes
 
-The implementations listed here should use the following prefixes:
-
-`bitcore           0x0005`
-`bcash             0x0001`
-`Parity Cash       0x0007`
-`bitprim           0x0006`
-`bchd              0x0004`
-`XT                0x0003`
-`BU                0x0002`
-`ABC               0x0000`
+The list of implementations prefixes can be found here:
+https://reference.cash/protocol/p2p/xversionkeys/
 
 An implementation not listed here, but wanting to extend the `xversion`
 map can pick an unused prefix but is strongly suggested to communicate
-the choice with the rest of the teams as early as possible. 
+the choice with the rest of the teams as early as possible. It is also
+strongly suggested to communicate with the rest of the teams before
+removing an implementation from this list.
 
-Experimental or temporary features should use the `0x1000` prefix.
+Versioning of the xversion message itself use the `0x00000000`
+prefix and the `0x00000000` suffix for the key. The value should
+reflect what version of the spec the client is following and use
+the following formula:
+(10000 * major) + (100 * minor) + (1 * revision)
+For example: spec version 0.1.0 should have a value of 100.
 
-(FIXME: List all known implementations. Feedback welcome)
+Experimental or temporary features use the `0x00000000` prefix and
+a non zero suffix as a key.
 
-## Notes on Bitcoin Unlimited implementation details
+## Notes on implementation details
 
+### Bitcoin Unlimited
 In the Bitcoin Unlimited reference implementation, the `xversion`
 message is handled using the `CXVersionMessage` class. The actual
 `xmap` is serialized and deserialized using the
@@ -256,6 +222,8 @@ internally using a salted siphash to map the keys.  The implementation
 can be found in the files `src/xversionmessage.h` and
 `src/xversionmessage.cpp` relative to the source root directory.
 
-The `xmap` directory resides in the file `src/xversionkeys.dat`. Using
-the script `contrib/devtools/xversionkeys.py`, this file is processed
-into the header file `xversionkeys.h`.
+
+## References
+- [1] https://reference.cash/protocol/#command
+- [2] https://reference.cash/protocol/network/messages/
+- [3] https://reference.cash/protocol/p2p/compact__int/

--- a/src/blockrelay/mempool_sync.cpp
+++ b/src/blockrelay/mempool_sync.cpp
@@ -17,7 +17,7 @@
 #include <random>
 
 extern CTxMemPool mempool;
-extern CTweak<uint64_t> syncMempoolWithPeers;
+extern CTweak<bool> syncMempoolWithPeers;
 extern CTweak<uint64_t> mempoolSyncMinVersionSupported;
 extern CTweak<uint64_t> mempoolSyncMaxVersionSupported;
 extern CCriticalSection cs_mempoolsync;

--- a/src/blockstorage/sequential_files.cpp
+++ b/src/blockstorage/sequential_files.cpp
@@ -143,6 +143,8 @@ bool ReadBlockFromDiskSequential(CBlock &block, const CDiskBlockPos &pos, const 
 /* Calculate the amount of disk space the block & undo files currently use */
 uint64_t CalculateCurrentUsage()
 {
+    LOCK(cs_LastBlockFile);
+
     uint64_t retval = 0;
     for (const CBlockFileInfo &file : vinfoBlockFile)
     {

--- a/src/blockstorage/sequential_files.h
+++ b/src/blockstorage/sequential_files.h
@@ -41,5 +41,7 @@ bool WriteUndoToDiskSequenatial(const CBlockUndo &blockundo,
     const CMessageHeader::MessageStartChars &messageStart);
 bool ReadUndoFromDiskSequential(CBlockUndo &blockundo, const CDiskBlockPos &pos, const uint256 &hashBlock);
 
+/** Calculate the amount of disk space the block & undo files currently use */
+uint64_t CalculateCurrentUsage();
 
 #endif // BLOCKDB_SEQUENTIAL_H

--- a/src/deadlock-detection/lockorder.cpp
+++ b/src/deadlock-detection/lockorder.cpp
@@ -160,6 +160,7 @@ void CLockOrderTracker::TrackLockOrderHistory(const CLockLocation &locklocation,
 
 void CLockOrderTracker::DeleteCritical(void *cs)
 {
+    std::lock_guard<std::mutex> lock(lot_mutex);
     std::map<void *, std::set<void *> >::iterator iter;
     iter = seenLockOrders.find(cs);
     if (iter != seenLockOrders.end())

--- a/src/electrum/electrs.cpp
+++ b/src/electrum/electrs.cpp
@@ -225,9 +225,10 @@ void set_xversion_flags(CXVersionMessage &xver, const std::string &network)
         return;
     }
 
-    constexpr double PROTOCOL_VERSION = 1.4;
+    constexpr double ELECTRUM_PROTOCOL_VERSION = 1.4;
 
     xver.set_u64c(XVer::BU_ELECTRUM_SERVER_PORT_TCP, std::stoul(rpc_port(network)));
-    xver.set_u64c(XVer::BU_ELECTRUM_SERVER_PROTOCOL_VERSION, static_cast<uint64_t>(PROTOCOL_VERSION * 1000000));
+    xver.set_u64c(
+        XVer::BU_ELECTRUM_SERVER_PROTOCOL_VERSION, static_cast<uint64_t>(ELECTRUM_PROTOCOL_VERSION * 1000000));
 }
 } // ns electrum

--- a/src/electrum/electrumrpcinfo.cpp
+++ b/src/electrum/electrumrpcinfo.cpp
@@ -23,7 +23,15 @@ static int64_t get_index_height(const std::map<std::string, int64_t> &info)
 
 UniValue ElectrumRPCInfo::GetElectrumInfo() const
 {
-    auto electrsinfo = FetchElectrsInfo();
+    std::map<std::string, int64_t> electrsinfo;
+    try
+    {
+        electrsinfo = FetchElectrsInfo();
+    }
+    catch (const std::runtime_error &e)
+    {
+        LOGA("Electrum: %s: Failed to fetch electrs info %s", __func__, e.what());
+    }
     int64_t index_height = get_index_height(electrsinfo);
 
     UniValue info(UniValue::VOBJ);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -767,7 +767,9 @@ bool AppInit2(Config &config, thread_group &threadGroup)
     nMaxConnections = std::min(nFD - MIN_CORE_FILEDESCRIPTORS - nBind, nMaxConnections);
 
     if (nMaxConnections < nUserMaxConnections)
-        InitWarning(strprintf(_("Reducing -maxconnections from %d to %d, because of system limitations."),
+        InitWarning(strprintf(_("Reducing -maxconnections from %d to %d because of file descriptor limitations (unix) "
+                                "or winsocket fd_set limitations (windows). If you are a windows user there is a hard "
+                                "upper limit of 1024 which cannot be changed by adjusting the node's configuration."),
             nUserMaxConnections, nMaxConnections));
 
 
@@ -784,7 +786,6 @@ bool AppInit2(Config &config, thread_group &threadGroup)
             nUserMaxOutConnections, nMaxConnections);
         nMaxOutConnections = nMaxConnections;
     }
-
 
 
     // ********************************************************* Step 3: parameter-to-internal-flags
@@ -971,7 +972,7 @@ bool AppInit2(Config &config, thread_group &threadGroup)
     LOGA("Default data directory %s\n", GetDefaultDataDir().string());
     LOGA("Using data directory %s\n", strDataDir);
     LOGA("Using config file %s\n", GetConfigFile(GetArg("-conf", BITCOIN_CONF_FILENAME)).string());
-    LOGA("Using at most %i connections (%i file descriptors available)\n", nMaxConnections, nFD);
+    LOGA("Using at most %i connections\n", nMaxConnections);
     std::ostringstream strErrors;
 
     // bip135 begin

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -778,9 +778,6 @@ bool AppInit2(Config &config, thread_group &threadGroup)
     nMaxOutConnections = std::max(nUserMaxOutConnections, 0);
     if (nMaxConnections < nMaxOutConnections)
     {
-        // uiInterface.ThreadSafeMessageBox((strprintf(_("Reducing -maxoutconnections from %d to %d, because this value
-        // is higher than max available connections."), nUserMaxOutConnections, nMaxConnections)),"",
-        // CClientUIInterface::MSG_WARNING);
         LOGA(
             "Reducing -maxoutconnections from %d to %d, because this value is higher than max available connections.\n",
             nUserMaxOutConnections, nMaxConnections);

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -760,11 +760,11 @@ bool AppInit2(Config &config, thread_group &threadGroup)
     nMaxConnections = std::max(nUserMaxConnections, 0);
 
     // Trim requested connection counts, to fit into system limitations
-    nMaxConnections = std::max(std::min(nMaxConnections, (int)(FD_SETSIZE - nBind - MIN_CORE_FILEDESCRIPTORS)), 0);
-    int nFD = RaiseFileDescriptorLimit(nMaxConnections + MIN_CORE_FILEDESCRIPTORS);
+    int nFD = RaiseFileDescriptorLimit(nMaxConnections + MIN_CORE_FILEDESCRIPTORS + nBind);
     if (nFD < MIN_CORE_FILEDESCRIPTORS)
         return InitError(_("Not enough file descriptors available."));
-    nMaxConnections = std::min(nFD - MIN_CORE_FILEDESCRIPTORS, nMaxConnections);
+
+    nMaxConnections = std::min(nFD - MIN_CORE_FILEDESCRIPTORS - nBind, nMaxConnections);
 
     if (nMaxConnections < nUserMaxConnections)
         InitWarning(strprintf(_("Reducing -maxconnections from %d to %d, because of system limitations."),

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -770,6 +770,23 @@ bool AppInit2(Config &config, thread_group &threadGroup)
         InitWarning(strprintf(_("Reducing -maxconnections from %d to %d, because of system limitations."),
             nUserMaxConnections, nMaxConnections));
 
+
+    // make outbound conns modifiable by the user
+    int nUserMaxOutConnections = GetArg("-maxoutconnections", DEFAULT_MAX_OUTBOUND_CONNECTIONS);
+    nMaxOutConnections = std::max(nUserMaxOutConnections, 0);
+    if (nMaxConnections < nMaxOutConnections)
+    {
+        // uiInterface.ThreadSafeMessageBox((strprintf(_("Reducing -maxoutconnections from %d to %d, because this value
+        // is higher than max available connections."), nUserMaxOutConnections, nMaxConnections)),"",
+        // CClientUIInterface::MSG_WARNING);
+        LOGA(
+            "Reducing -maxoutconnections from %d to %d, because this value is higher than max available connections.\n",
+            nUserMaxOutConnections, nMaxConnections);
+        nMaxOutConnections = nMaxConnections;
+    }
+
+
+
     // ********************************************************* Step 3: parameter-to-internal-flags
 
     fDebug = !mapMultiArgs["-debug"].empty();

--- a/src/miner.h
+++ b/src/miner.h
@@ -28,7 +28,6 @@ extern CCriticalSection cs_coinbaseFlags;
 extern std::atomic<int64_t> nTotalPackage;
 extern std::atomic<int64_t> nTotalScore;
 extern CTweak<bool> miningCPFP;
-extern CTweak<uint64_t> miningSigChecks;
 
 namespace Consensus
 {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -666,7 +666,7 @@ static bool IsPriorityMsg(std::string strCommand)
         strCommand == NetMsgType::GET_XBLOCKTX || strCommand == NetMsgType::XPEDITEDREQUEST ||
         strCommand == NetMsgType::XPEDITEDBLK || strCommand == NetMsgType::XPEDITEDTXN ||
         strCommand == NetMsgType::CMPCTBLOCK || strCommand == NetMsgType::GETBLOCKTXN ||
-        strCommand == NetMsgType::BLOCKTXN)
+        strCommand == NetMsgType::BLOCKTXN || strCommand == NetMsgType::BLOCK)
     {
         return true;
     }

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -5,8 +5,10 @@
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
 #include "rpc/blockchain.h"
+
 #include "amount.h"
 #include "blockstorage/blockstorage.h"
+#include "blockstorage/sequential_files.h"
 #include "chainparams.h"
 #include "checkpoints.h"
 #include "coins.h"
@@ -1079,8 +1081,12 @@ UniValue getblockchaininfo(const UniValue &params, bool fHelp)
             "  \"initialblockdownload\": xxxx, (bool) (debug information) estimate of whether this node is in Initial "
             "Block Download mode.\n"
             "  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n"
+            "  \"size_on_disk\": xxxxxx,   (numeric) the estimated size of the block and undo files on disk\n"
             "  \"pruned\": xx,             (boolean) if the blocks are subject to pruning\n"
-            "  \"pruneheight\": xxxxxx,    (numeric) lowest-height complete block stored\n"
+            "  \"pruneheight\": xxxxxx,    (numeric) lowest-height complete block stored (only present if pruning is "
+            "enabled)\n"
+            "  \"prune_target_size\": xxxxxx,  (numeric) the target size used by pruning (only present if automatic "
+            "pruning is enabled)\n"
             "  \"softforks\": [            (array) status of softforks in progress\n"
             "     {\n"
             "        \"id\": \"xxxx\",        (string) name of softfork\n"
@@ -1138,7 +1144,26 @@ UniValue getblockchaininfo(const UniValue &params, bool fHelp)
         "verificationprogress", Checkpoints::GuessVerificationProgress(Params().Checkpoints(), chainActive.Tip()));
     obj.pushKV("initialblockdownload", IsInitialBlockDownload());
     obj.pushKV("chainwork", chainActive.Tip()->nChainWork.GetHex());
+    obj.pushKV("size_on_disk", CalculateCurrentUsage());
     obj.pushKV("pruned", fPruneMode);
+    if (fPruneMode)
+    {
+        CBlockIndex *block = chainActive.Tip();
+        assert(block);
+        {
+            READLOCK(cs_mapBlockIndex);
+            assert(block);
+            while (block && block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA))
+            {
+                block = block->pprev;
+            }
+        }
+
+        if (block != nullptr)
+            obj.pushKV("pruneheight", block->nHeight);
+
+        obj.pushKV("prune_target_size", nPruneTarget);
+    }
 
     const Consensus::Params &consensusParams = Params().GetConsensus();
     CBlockIndex *tip = chainActive.Tip();
@@ -1166,18 +1191,6 @@ UniValue getblockchaininfo(const UniValue &params, bool fHelp)
     obj.pushKV("bip135_forks", bip135_forks);
     // bip135 end
 
-    if (fPruneMode)
-    {
-        CBlockIndex *block = chainActive.Tip();
-        {
-            READLOCK(cs_mapBlockIndex);
-            while (block && block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA))
-                block = block->pprev;
-        }
-
-        if (block != nullptr)
-            obj.pushKV("pruneheight", block->nHeight);
-    }
     return obj;
 }
 

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1152,7 +1152,6 @@ UniValue getblockchaininfo(const UniValue &params, bool fHelp)
         assert(block);
         {
             READLOCK(cs_mapBlockIndex);
-            assert(block);
             while (block && block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA))
             {
                 block = block->pprev;

--- a/src/unlimited.cpp
+++ b/src/unlimited.cpp
@@ -487,21 +487,6 @@ void UnlimitedSetup(void)
         mallocedStats.push_front(new CStatHistory<uint64_t>("net/send/msg/" + *i));
     }
 
-    // make outbound conns modifiable by the user
-    int nUserMaxOutConnections = GetArg("-maxoutconnections", DEFAULT_MAX_OUTBOUND_CONNECTIONS);
-    nMaxOutConnections = std::max(nUserMaxOutConnections, 0);
-
-    if (nMaxConnections < nMaxOutConnections)
-    {
-        // uiInterface.ThreadSafeMessageBox((strprintf(_("Reducing -maxoutconnections from %d to %d, because this value
-        // is higher than max available connections."), nUserMaxOutConnections, nMaxConnections)),"",
-        // CClientUIInterface::MSG_WARNING);
-        LOGA(
-            "Reducing -maxoutconnections from %d to %d, because this value is higher than max available connections.\n",
-            nUserMaxOutConnections, nMaxConnections);
-        nMaxOutConnections = nMaxConnections;
-    }
-
     // Start Internal CPU miner
     // Generate coins in the background
     GenerateBitcoins(GetBoolArg("-gen", DEFAULT_GENERATE), GetArg("-genproclimit", DEFAULT_GENERATE_THREADS), Params());

--- a/src/unlimited.h
+++ b/src/unlimited.h
@@ -288,9 +288,7 @@ std::string Bip135VoteValidator(const std::string &value, std::string *item, boo
 std::string ForkTimeValidator(const uint64_t &value, uint64_t *item, bool validate);
 
 extern CTweak<unsigned int> maxTxSize;
-extern CTweak<uint64_t> blockSigopsPerMb;
 extern CTweak<uint64_t> coinbaseReserve;
-extern CTweak<uint64_t> blockMiningSigopsPerMb;
 extern CTweak<unsigned int> unconfPushAction;
 
 extern std::list<CStatBase *> mallocedStats;


### PR DESCRIPTION
Fix pruneheight help text.
Move fPruneMode block to match output ordering with help text.
Add functional tests for new fields in getblockchaininfo.

This is a partial port of Core #11367
