### PR TITLE
Try to send xthin blocks via expedited only if when needed

### DIFF
--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -166,7 +166,7 @@ CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CMutableTransaction &tx, CT
 
 CTxMemPoolEntry TestMemPoolEntryHelper::FromTx(const CTransaction &txn, CTxMemPool *pool)
 {
-    bool hasNoDependencies = pool ? pool->HasNoInputsOf(txn) : hadNoDependencies;
+    bool hasNoDependencies = pool ? pool->HasNoInputsOf(MakeTransactionRef(txn)) : hadNoDependencies;
     // Hack to assume either its completely dependent on other mempool txs or not at all
     CAmount inChainValue = hasNoDependencies ? txn.GetValueOut() : 0;
 

--- a/src/txadmission.cpp
+++ b/src/txadmission.cpp
@@ -974,7 +974,7 @@ bool ParallelAcceptToMemoryPool(Snapshot &ss,
         }
 
         // Create a commit data entry
-        CTxMemPoolEntry entry(tx, nFees, GetTime(), dPriority, chainActive.Height(), pool.HasNoInputsOf(*tx),
+        CTxMemPoolEntry entry(tx, nFees, GetTime(), dPriority, chainActive.Height(), pool.HasNoInputsOf(tx),
             inChainInputValue, fSpendsCoinbase, nSigOps, lp);
         // Record the actual number of sigops executed for statistical purposes only
         entry.UpdateRuntimeSigOps(resourceTracker.GetSigOps(), resourceTracker.GetSighashBytes());

--- a/src/txmempool.cpp
+++ b/src/txmempool.cpp
@@ -1538,10 +1538,10 @@ void CTxMemPool::ClearPrioritisation(const uint256 hash)
     mapDeltas.erase(hash);
 }
 void CTxMemPool::_ClearPrioritisation(const uint256 hash) { mapDeltas.erase(hash); }
-bool CTxMemPool::HasNoInputsOf(const CTransaction &tx) const
+bool CTxMemPool::HasNoInputsOf(const CTransactionRef &tx) const
 {
-    for (unsigned int i = 0; i < tx.vin.size(); i++)
-        if (exists(tx.vin[i].prevout.hash))
+    for (unsigned int i = 0; i < tx->vin.size(); i++)
+        if (exists(tx->vin[i].prevout.hash))
             return false;
     return true;
 }

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -664,7 +664,7 @@ public:
      * Check that none of this transactions inputs are in the mempool, and thus
      * the tx is not dependent on other mempool transactions to be included in a block.
      */
-    bool HasNoInputsOf(const CTransaction &tx) const;
+    bool HasNoInputsOf(const CTransactionRef &tx) const;
 
     /** Affect CreateNewBlock prioritisation of transactions */
     void PrioritiseTransaction(const uint256 hash,

--- a/src/validation/validation.cpp
+++ b/src/validation/validation.cpp
@@ -3706,7 +3706,7 @@ bool ProcessNewBlock(CValidationState &state,
         // demerit the sender
         return error("%s: CheckBlockHeader FAILED", __func__);
     }
-    if (IsChainNearlySyncd() && !fImporting && !fReindex)
+    if (IsChainNearlySyncd() && !fImporting && !fReindex && connmgr->ExpeditedBlockNodes().size())
         SendExpeditedBlock(*pblock, pfrom);
 
     bool checked = CheckBlock(*pblock, state);


### PR DESCRIPTION
It is useless to try to send to such blocks to peers that are not Xpedited capable. This change does not alter the semantics of the code, it just move the check for Xpedited capability of a given node earlier in the process.

Based on top of #2192