### PR TITLE
Remove SATOSHI constant from sigcache_tests.cpp

### DIFF
--- a/src/test/sigcache_tests.cpp
+++ b/src/test/sigcache_tests.cpp
@@ -84,7 +84,7 @@ BOOST_AUTO_TEST_CASE(sig_pubkey_hash_variations) {
         SER_NETWORK, PROTOCOL_VERSION);
     CTransaction dummyTx(deserialize, stream);
     PrecomputedTransactionData txdata(dummyTx);
-    CachingTransactionSignatureChecker checker(&dummyTx, 0, 0 * SATOSHI, true,
+    CachingTransactionSignatureChecker checker(&dummyTx, 0, 0, true,
                                                txdata);
 
     TestCachingTransactionSignatureChecker testChecker(checker);
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(flag_invariants) {
         SER_NETWORK, PROTOCOL_VERSION);
     CTransaction dummyTx(deserialize, stream);
     PrecomputedTransactionData txdata(dummyTx);
-    CachingTransactionSignatureChecker checker(&dummyTx, 0, 0 * SATOSHI, true,
+    CachingTransactionSignatureChecker checker(&dummyTx, 0, 0, true,
                                                txdata);
 
     TestCachingTransactionSignatureChecker testChecker(checker);


### PR DESCRIPTION
Such constant is never defined in our code base. After a quick check it seems like we got in our code by porting schnorr musig to BU from ABC.