### PR TITLE
[rpc] getblockchaininfo: add size_on_disk, prune_target_size

### DIFF
--- a/src/blockstorage/sequential_files.cpp
+++ b/src/blockstorage/sequential_files.cpp
@@ -143,6 +143,8 @@ bool ReadBlockFromDiskSequential(CBlock &block, const CDiskBlockPos &pos, const 
 /* Calculate the amount of disk space the block & undo files currently use */
 uint64_t CalculateCurrentUsage()
 {
+    LOCK(cs_LastBlockFile);
+
     uint64_t retval = 0;
     for (const CBlockFileInfo &file : vinfoBlockFile)
     {

--- a/src/blockstorage/sequential_files.h
+++ b/src/blockstorage/sequential_files.h
@@ -41,5 +41,7 @@ bool WriteUndoToDiskSequenatial(const CBlockUndo &blockundo,
     const CMessageHeader::MessageStartChars &messageStart);
 bool ReadUndoFromDiskSequential(CBlockUndo &blockundo, const CDiskBlockPos &pos, const uint256 &hashBlock);
 
+/** Calculate the amount of disk space the block & undo files currently use */
+uint64_t CalculateCurrentUsage();
 
 #endif // BLOCKDB_SEQUENTIAL_H

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1209,7 +1209,6 @@ UniValue getblockchaininfo(const UniValue &params, bool fHelp)
         assert(block);
         {
             READLOCK(cs_mapBlockIndex);
-            assert(block);
             while (block && block->pprev && (block->pprev->nStatus & BLOCK_HAVE_DATA))
             {
                 block = block->pprev;


### PR DESCRIPTION
- Fix pruneheight help text.
- Move fPruneMode block to match output ordering with help text.
- Add functional tests for new fields in getblockchaininfo.

This is a partial port of Core bitcoin/bitcoin#11367

same as #2188 which as been erroneously created against `release` 