### PR TITLE
4 fix/cleanups

### DIFF
--- a/qa/rpc-tests/rpc_getblockstats.py
+++ b/qa/rpc-tests/rpc_getblockstats.py
@@ -177,5 +177,14 @@ class GetblockstatsTest(BitcoinTestFramework):
         assert_raises_rpc_error(-5, 'Block not found', self.nodes[0].getblockstats,
                                 '000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f')
 
+        # check genesis block stats
+        gb = self.nodes[0].getblock("0")
+        gbstats = self.nodes[0].getblockstats(gb["hash"])
+        assert_equal(gbstats['blockhash'], '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206')
+        assert_equal(gbstats['txs'], 1)
+        assert_equal(gbstats['utxo_increase'], 1)
+        assert_equal(gbstats['utxo_size_inc'], 117)
+
+
 if __name__ == '__main__':
     GetblockstatsTest().main()

--- a/src/blockstorage/blockstorage.cpp
+++ b/src/blockstorage/blockstorage.cpp
@@ -517,6 +517,8 @@ bool WriteUndoToDisk(const CBlockUndo &blockundo,
  */
 bool ReadUndoFromDisk(CBlockUndo &blockundo, const CDiskBlockPos &pos, const CBlockIndex *pindex)
 {
+    if (pindex == nullptr)
+        return error("Null block has no undo information");
     if (!pblockdb)
     {
         return ReadUndoFromDiskSequential(blockundo, pos, pindex->GetBlockHash());

--- a/src/cashlib/cashlib.cpp
+++ b/src/cashlib/cashlib.cpp
@@ -1142,8 +1142,9 @@ SLAPI int RandomBytes(unsigned char *buf, int num)
     javaEnv->DeleteLocalRef(bArray);
     return num;
 }
-// Implement API normally provided by random.cpp calling openssl
+// Implement APIs normally provided by random.cpp calling openssl
 void GetRandBytes(unsigned char *buf, int num) { RandomBytes(buf, num); }
+void GetStrongRandBytes(unsigned char *buf, int num) { RandomBytes(buf, num); }
 #define JAVA_ANDROID
 
 #endif

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -1792,7 +1792,7 @@ static UniValue getblockstats(const UniValue &params, bool fHelp)
     }
 
     const CBlock block = GetBlockChecked(pindex);
-    const CBlockUndo blockUndo = GetUndoChecked(pindex);
+    const CBlockUndo blockUndo = pindex->pprev ? GetUndoChecked(pindex) : CBlockUndo();
     // This property is required in the for loop below (and ofc every tx should have undo data)
     DbgAssert(blockUndo.vtxundo.size() >= block.vtx.size() - 1,
         throw JSONRPCError(RPC_DATABASE_ERROR, "Block undo data is corrupt"));

--- a/src/rpc/misc.cpp
+++ b/src/rpc/misc.cpp
@@ -90,9 +90,7 @@ UniValue getinfo(const UniValue &params, bool fHelp)
     }
 
 #ifdef ENABLE_WALLET
-    LOCK2(cs_main, pwalletMain ? &pwalletMain->cs_wallet : nullptr);
-#else
-    LOCK(cs_main);
+    LOCK(pwalletMain ? &pwalletMain->cs_wallet : nullptr);
 #endif
 
     proxyType proxy;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -510,7 +510,7 @@ std::string formatInfoUnit(double value)
 static const std::set<std::string> affirmativeStrings{"", "1", "t", "y", "true", "yes"};
 
 /** Interpret string as boolean, for argument parsing */
-static bool InterpretBool(const std::string &strValue) { return (affirmativeStrings.count(strValue) != 0); }
+bool InterpretBool(const std::string &strValue) { return (affirmativeStrings.count(strValue) != 0); }
 /** Turn -noX into -X=0 */
 static void InterpretNegativeSetting(std::string &strKey, std::string &strValue)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -497,6 +497,14 @@ void UnsetArg(const std::string &strArg);
  */
 void SetBoolArg(const std::string &strArg, bool fValue);
 
+/*
+ * Convert string into true/false
+ *
+ * @param strValue String to parse as a boolean
+ * @return true or false
+ */
+bool InterpretBool(const std::string &strValue);
+
 /**
  * Set an argument if it doesn't already have a value
  *


### PR DESCRIPTION
expose useful InterpretBool function, remove unnecessary cs_main lock on getinfo rpc, cleanup getblockstats, and add needed Android implementation of GetStrongRandBytes