### PR TITLE
Make getblockheader works both with block height and block hash

### DIFF
--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -138,6 +138,12 @@ class BlockchainTest(BitcoinTestFramework):
         assert isinstance(int(header['versionHex'], 16), int)
         assert isinstance(header['difficulty'], Decimal)
 
+        header_by_height = node.getblockheader(header['height'])
+        assert_equal (header_by_height, header)
+
+        header_by_height = node.getblockheader("200")
+        assert_equal (header_by_height, header)
+
     def _test_rollbackchain_and_reconsidermostworkchain(self):
         # Save the hash of the current chaintip and then mine 10 blocks
         blockcount = self.nodes[0].getblockcount()


### PR DESCRIPTION
This is basically the same as we did for getblockstats.
Probably we could isolate the code that deal with understanding
if the param is an integer or a string representing a block hash.