### PR TITLE
Add a new log category for priority queue messages

### DIFF
--- a/qa/rpc-tests/getlogcategories.py
+++ b/qa/rpc-tests/getlogcategories.py
@@ -45,10 +45,10 @@ class GetLogCategories (BitcoinTestFramework):
         self.is_network_split = False
 
     def run_test (self):
-        exp0 = "coindb tor addrman libevent http rpc partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks cmpctblock electrum mempoolsync"
-        exp1 = "libevent http partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks cmpctblock electrum mempoolsync"
-        exp2 = "libevent http partitioncheck bench prune reindex mempoolrej parallel rand req bloom estimatefee dbase selectcoins zmq qt ibd respend weakblocks cmpctblock electrum mempoolsync"
-        exp3 = "libevent http partitioncheck bench prune reindex mempoolrej parallel req bloom estimatefee dbase selectcoins respend weakblocks cmpctblock electrum mempoolsync"
+        exp0 = "coindb tor addrman libevent http rpc partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks cmpctblock electrum mempoolsync priorityq"
+        exp1 = "libevent http partitioncheck bench prune reindex mempoolrej blk evict parallel rand req bloom estimatefee lck proxy dbase selectcoins zmq qt ibd respend weakblocks cmpctblock electrum mempoolsync priorityq"
+        exp2 = "libevent http partitioncheck bench prune reindex mempoolrej parallel rand req bloom estimatefee dbase selectcoins zmq qt ibd respend weakblocks cmpctblock electrum mempoolsync priorityq"
+        exp3 = "libevent http partitioncheck bench prune reindex mempoolrej parallel req bloom estimatefee dbase selectcoins respend weakblocks cmpctblock electrum mempoolsync priorityq"
         exp4 = exp1
         exp5 = exp0
         exp6 = ""

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -730,9 +730,8 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes)
                         vPriorityRecvQ.push_back(std::make_pair<CNodeRef, CNetMessage>(CNodeRef(this), std::move(msg)));
                         msg = CNetMessage(GetMagic(Params()), SER_NETWORK, nRecvVersion);
 
-                        LOG(THIN | GRAPHENE | CMPCT,
-                            "Receive Queue: pushed %s to the priority queue, %d bytes, peer(%d)\n", strCommand,
-                            vPriorityRecvQ.back().second.hdr.nMessageSize, this->GetId());
+                        LOG(PRIORITYQ, "Receive Queue: pushed %s to the priority queue, %d bytes, peer(%d)\n",
+                            strCommand, vPriorityRecvQ.back().second.hdr.nMessageSize, this->GetId());
                         // Indicate we have a priority message to process
                         fPriorityRecvMsg.store(true);
                         fSendLowPriority = false;
@@ -3411,8 +3410,7 @@ void CNode::EndMessage() UNLOCK_FUNCTION(cs_vSend)
         it = vSendMsg.insert(vSendMsg.end(), CSerializeData());
         ssSend.GetAndClear(*it);
         nSendSize.fetch_add((*it).size());
-        LOG(THIN | GRAPHENE | CMPCT, "Send Queue: pushed %s to the priority queue, peer(%d)\n", strCommand,
-            this->GetId());
+        LOG(PRIORITYQ, "Send Queue: pushed %s to the priority queue, peer(%d)\n", strCommand, this->GetId());
 
         LOCK(cs_prioritySendQ);
         vPrioritySendQ.push_back(CNodeRef(this));

--- a/src/util.h
+++ b/src/util.h
@@ -202,7 +202,8 @@ enum
     CMPCT = 0x80000000, // compact blocks
 
     ELECTRUM = 0x100000000,
-    MPOOLSYNC = 0x200000000
+    MPOOLSYNC = 0x200000000,
+    PRIORITYQ = 0x400000000
 };
 
 namespace Logging
@@ -226,7 +227,7 @@ To add a new log category:
             {REQ, "req"}, {BLOOM, "bloom"}, {LCK, "lck"}, {PROXY, "proxy"}, {DBASE, "dbase"},                   \
             {SELECTCOINS, "selectcoins"}, {ESTIMATEFEE, "estimatefee"}, {QT, "qt"}, {IBD, "ibd"},               \
             {GRAPHENE, "graphene"}, {RESPEND, "respend"}, {WB, "weakblocks"}, {CMPCT, "cmpctblock"},            \
-            {ELECTRUM, "electrum"}, {MPOOLSYNC, "mempoolsync"},                                                 \
+            {ELECTRUM, "electrum"}, {MPOOLSYNC, "mempoolsync"}, {PRIORITYQ, "priorityq"},                       \
         {                                                                                                       \
             ZMQ, "zmq"                                                                                          \
         }                                                                                                       \


### PR DESCRIPTION
This gets rid of a great deal of log spam when we're also logging thinblock messages.