### PR TITLE
Do not shutdown bitcoind if ActivateBestChain() fails on startup

### DIFF
--- a/qa/rpc-tests/blockchain.py
+++ b/qa/rpc-tests/blockchain.py
@@ -301,6 +301,12 @@ class BlockchainTest(BitcoinTestFramework):
         self.nodes[0].reconsidermostworkchain(True)
         assert_equal(self.nodes[0].getbestblockhash(), bestblockhashfork3);
 
+        # check that we are already on the correct chain by issuing another reconsider
+        try:
+            self.nodes[0].reconsidermostworkchain()
+        except JSONRPCException as e:
+            logging.info (e.error['message'])
+            assert("Nothing to do. Already on the correct chain." in e.error['message'])
 
         # check that we can run reconsidermostworkchain when we're already on the correct chain
         try:

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -438,19 +438,16 @@ static void ReconsiderChainOnStartup()
             setTips = GetChainTips();
         }
 
-        // Find out if we're already synced to one of the chaintips. If so then we
-        // can and must skip reconsidermostworkchain().
-        bool fReconsider = false;
-        CBlockIndex *pMostWork = chainActive.Tip();
-        for (CBlockIndex *pTip : setTips)
-        {
-            if (pMostWork->nChainWork < pTip->nChainWork)
-                fReconsider = true;
-        }
-        if (fReconsider)
+        // Set the override to true so that we don't get stuck trying to reconsider which
+        // can happen when an operator failed to upgrade their node before a hard fork.
+        try
         {
             UniValue obj(UniValue::VARR);
             reconsidermostworkchain(obj, false);
+        }
+        catch (...)
+        {
+            LOGA("Checked for mostwork chain and we are already on the correct chain\n");
         }
     }
 }

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -431,12 +431,10 @@ static void ReconsiderChainOnStartup()
 {
     if (!fReindex && !(avoidReconsiderMostWorkChain.Value()))
     {
-        // Set the override to true so that we don't get stuck trying to reconsider which
-        // can happen when an operator failed to upgrade their node before a hard fork.
         try
         {
-            UniValue obj(UniValue::VARR);
-            reconsidermostworkchain(obj, false);
+            bool fOverride = false;
+            ReconsiderMostWorkChain(fOverride);
         }
         catch (...)
         {

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -427,6 +427,34 @@ void CleanupBlockRevFiles()
     }
 }
 
+static void ReconsiderChainOnStartup()
+{
+    if (!fReindex && !(avoidReconsiderMostWorkChain.Value()))
+    {
+        // Get the set of chaintips
+        std::set<CBlockIndex *, CompareBlocksByHeight> setTips;
+        {
+            LOCK(cs_main);
+            setTips = GetChainTips();
+        }
+
+        // Find out if we're already synced to one of the chaintips. If so then we
+        // can and must skip reconsidermostworkchain().
+        bool fReconsider = false;
+        CBlockIndex *pMostWork = chainActive.Tip();
+        for (CBlockIndex *pTip : setTips)
+        {
+            if (pMostWork->nChainWork < pTip->nChainWork)
+                fReconsider = true;
+        }
+        if (fReconsider)
+        {
+            UniValue obj(UniValue::VARR);
+            reconsidermostworkchain(obj, false);
+        }
+    }
+}
+
 void ThreadImport(std::vector<fs::path> vImportFiles, uint64_t nTxIndexCache)
 {
     const CChainParams &chainparams = Params();
@@ -510,42 +538,23 @@ void ThreadImport(std::vector<fs::path> vImportFiles, uint64_t nTxIndexCache)
             return;
     }
 
+    // In case a previous shutdown left the chain in an incorrect state, reconsider
+    // the most work chain.
+    ReconsiderChainOnStartup();
+
     // scan for better chains in the block chain database, that are not yet connected in the active best chain
     uiInterface.InitMessage(_("Activating best chain..."));
     CValidationState state;
     if (!ActivateBestChain(state, chainparams))
     {
-        StartShutdown();
-        return;
+        LOGA("WARNING: ActivateBestChain failed on startup\n");
     }
 
     // Reconsider the most work chain if we're not already synced. This is necessary
     // when switching from an ABC/BCHN client or when a operator failed to upgrade their BU
-    // node before a hardfork.
-    if (!fReindex && !(avoidReconsiderMostWorkChain.Value()))
-    {
-        // Get the set of chaintips
-        std::set<CBlockIndex *, CompareBlocksByHeight> setTips;
-        {
-            LOCK(cs_main);
-            setTips = GetChainTips();
-        }
-
-        // Find out if we're already synced to one of the chaintips. If so then we
-        // can and must skip reconsidermostworkchain().
-        bool fReconsider = false;
-        CBlockIndex *pMostWork = chainActive.Tip();
-        for (CBlockIndex *pTip : setTips)
-        {
-            if (pMostWork->nChainWork < pTip->nChainWork)
-                fReconsider = true;
-        }
-        if (fReconsider)
-        {
-            UniValue obj(UniValue::VARR);
-            reconsidermostworkchain(obj, false);
-        }
-    }
+    // node before a hardfork. This must be done directly after ActivateBestChain() or
+    // a switch from ABC/BCHN to a BU node may not work because some blocks may have been parked.
+    ReconsiderChainOnStartup();
 
     // Initialize the atomic flags used for determining whether we are in IBD or whether the chain
     // is almost synced.

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -431,13 +431,6 @@ static void ReconsiderChainOnStartup()
 {
     if (!fReindex && !(avoidReconsiderMostWorkChain.Value()))
     {
-        // Get the set of chaintips
-        std::set<CBlockIndex *, CompareBlocksByHeight> setTips;
-        {
-            LOCK(cs_main);
-            setTips = GetChainTips();
-        }
-
         // Set the override to true so that we don't get stuck trying to reconsider which
         // can happen when an operator failed to upgrade their node before a hard fork.
         try

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -447,7 +447,6 @@ static void ReconsiderChainOnStartup()
         }
         catch (...)
         {
-            LOGA("Checked for mostwork chain and we are already on the correct chain\n");
         }
     }
 }

--- a/src/rpc/blockchain.h
+++ b/src/rpc/blockchain.h
@@ -37,8 +37,15 @@ void CalculatePercentilesBySize(CAmount result[NUM_GETBLOCKSTATS_PERCENTILES],
     std::vector<std::pair<CAmount, int64_t> > &scores,
     int64_t total_size);
 
-UniValue reconsidermostworkchain(const UniValue &params, bool fHelp);
+/** Roll the chain back to the given height.  If the override flag is set to true
+ *  then you can rollback more than 100 blocks.
+ */
+std::string RollBackChain(int nRollBackHeight, bool fOverride);
+
+/** Check if we are on the most work chain and if not then re-org to it */
+std::string ReconsiderMostWorkChain(bool fOverride);
 std::set<CBlockIndex *, CompareBlocksByHeight> GetChainTips();
+
 UniValue mempoolToJSON(bool fVerbose = false);
 UniValue blockToJSON(const CBlock &block, const CBlockIndex *blockindex, bool txDetails = false, bool listTxns = true);
 


### PR DESCRIPTION
Log a message instead and continue to startup. This allows the node
to start and the operator to run commands such as getchaintips or
reconsidermostworkchain so they can then try to get the node startup
to complete.

Furthermore, we run reconsidermostworkchain() both before and after
ActivateBestChain(). We do it before in the case where a previous
shutdown left the chain in an invalid state, and we do it after, in
the case where an operator is switchin from an ABC/BCHN client to
a BU client (In this situation an ABC client could have parked a few
blocks which would make the BU node hang on startup).