### PR TITLE
port RpcMempool10k from BCHN

### DIFF
--- a/src/bench/rpc_mempool.cpp
+++ b/src/bench/rpc_mempool.cpp
@@ -47,4 +47,36 @@ static void RpcMempool(benchmark::State &state)
     }
 }
 
+static void RpcMempool10k(benchmark::State &state)
+{
+    CTxMemPool pool(CFeeRate(1000));
+
+    const size_t nTx = 10000, nIns = 10, nOuts = 10;
+
+    for (size_t i = 0; i < nTx; ++i)
+    {
+        CMutableTransaction tx = CMutableTransaction();
+        tx.vin.resize(nIns);
+        for (size_t j = 0; j < nIns; ++j)
+        {
+            tx.vin[j].scriptSig = CScript() << OP_1;
+        }
+        tx.vout.resize(nOuts);
+        for (size_t j = 0; j < nOuts; ++j)
+        {
+            tx.vin[j].scriptSig = CScript() << OP_1;
+            tx.vout[j].scriptPubKey = CScript() << OP_1 << OP_EQUAL;
+            tx.vout[j].nValue = int64_t(i * j) * CENT;
+        }
+        const CTransactionRef tx_r{MakeTransactionRef(tx)};
+        AddTx(tx_r, /* fee */ int64_t(i) * CENT, pool);
+    }
+
+    while (state.KeepRunning())
+    {
+        (void)mempoolToJSON(true);
+    }
+}
+
 BENCHMARK(RpcMempool, 40);
+BENCHMARK(RpcMempool10k, 10);

--- a/src/bench/rpc_mempool.cpp
+++ b/src/bench/rpc_mempool.cpp
@@ -12,8 +12,9 @@
 #include <list>
 #include <vector>
 
+extern CTxMemPool mempool;
 
-static void AddTx(const CTransactionRef &tx, const CAmount &nFee, CTxMemPool &pool)
+static void AddTx(const CTransactionRef &tx, const CAmount &nFee)
 {
     int64_t nTime = 0;
     double dPriority = 10.0;
@@ -21,13 +22,13 @@ static void AddTx(const CTransactionRef &tx, const CAmount &nFee, CTxMemPool &po
     bool spendsCoinbase = false;
     unsigned int sigOpCost = 4;
     LockPoints lp;
-    pool.addUnchecked(tx->GetHash(), CTxMemPoolEntry(tx, nFee, nTime, dPriority, nHeight, pool.HasNoInputsOf(tx),
-                                         tx->GetValueOut(), spendsCoinbase, sigOpCost, lp));
+    mempool.addUnchecked(tx->GetHash(), CTxMemPoolEntry(tx, nFee, nTime, dPriority, nHeight, mempool.HasNoInputsOf(tx),
+                                            tx->GetValueOut(), spendsCoinbase, sigOpCost, lp));
 }
 
 static void RpcMempool(benchmark::State &state)
 {
-    CTxMemPool pool(CFeeRate(1000));
+    mempool.clear();
 
     for (int i = 0; i < 1000; ++i)
     {
@@ -38,7 +39,7 @@ static void RpcMempool(benchmark::State &state)
         tx.vout[0].scriptPubKey = CScript() << OP_1 << OP_EQUAL;
         tx.vout[0].nValue = i * CENT;
         const CTransactionRef tx_r{MakeTransactionRef(tx)};
-        AddTx(tx_r, /* fee */ i * CENT, pool);
+        AddTx(tx_r, /* fee */ i * CENT);
     }
 
     while (state.KeepRunning())
@@ -49,7 +50,7 @@ static void RpcMempool(benchmark::State &state)
 
 static void RpcMempool10k(benchmark::State &state)
 {
-    CTxMemPool pool(CFeeRate(1000));
+    mempool.clear();
 
     const size_t nTx = 10000, nIns = 10, nOuts = 10;
 
@@ -69,7 +70,7 @@ static void RpcMempool10k(benchmark::State &state)
             tx.vout[j].nValue = int64_t(i * j) * CENT;
         }
         const CTransactionRef tx_r{MakeTransactionRef(tx)};
-        AddTx(tx_r, /* fee */ int64_t(i) * CENT, pool);
+        AddTx(tx_r, /* fee */ int64_t(i) * CENT);
     }
 
     while (state.KeepRunning())


### PR DESCRIPTION
This will come in handy in a short while for benchmarking new UniValue code changes/optimizations.

I added a new benchmark alongside the old "RpcMempool" benchmark (which
creates a tiny 1k mempool with simple tx's in it), called
"RpcMempool10k" which adds a similar test but with a larger mempool of
10k tx's, each tx being more comples (10 ins, 10 outs).

This new benchmark is a better test of UniValue -> JSON, amongst other
things.

The new benchmark takes ~21 seconds on my system to execute.

When the new optimizations that for UniValue are being prepared are in
place, that number will drop down to the expected 5 (all the other tests
take 5 seconds on my system to execute, give or take 1 second).

Note we need this in place in master before my upcoming changes to
UniValue to make testing easier -- you can switch between master and my
patches to characterize the effects of MR's I plan on submitting.

This commit maintains the predicate that we don't modify old benchmarks
for the time being (so as to compare regressions to ABC), and that we
only add new benchmarks alongside existing ones.