### PR TITLE
[WIP] Create a lookahead function for blocks to extend the re-request interval

### DIFF
--- a/src/net.cpp
+++ b/src/net.cpp
@@ -678,13 +678,13 @@ static bool IsPriorityMsg(std::string strCommand)
 
 void CNode::LookAhead()
 {
-    // Do lookahead for CBlock messages.  If it's a block then get the blockhash
-    // and indicate we are downloading it so that we don't re-request the block
-    // prematurely. If it's downloading and fails then we can reset the re-request
-    // flag so that we can get another block from somewhere.
+    // Do lookahead for block downloads.  If it is a block or thintype block then get the blockhash
+    // and indicate we are downloading it so that we don't re-request the block prematurely.
     static const CBlockHeader temp_header;
     static const unsigned int nSizeHeader = ::GetSerializeSize(temp_header, SER_NETWORK, PROTOCOL_VERSION);
-    if (msg.hdr.GetCommand() == NetMsgType::BLOCK)
+    if (msg.hdr.GetCommand() == NetMsgType::BLOCK || msg.hdr.GetCommand() == NetMsgType::GRAPHENEBLOCK ||
+        msg.hdr.GetCommand() == NetMsgType::CMPCTBLOCK || msg.hdr.GetCommand() == NetMsgType::XTHINBLOCK ||
+        msg.hdr.GetCommand() == NetMsgType::THINBLOCK)
     {
         if (msg.nDataPos > nSizeHeader)
         {

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -676,7 +676,7 @@ static bool IsPriorityMsg(std::string strCommand)
     }
 }
 
-void CNode::LookAhead(CNetMessage &_msg)
+void CNode::LookAhead()
 {
     // Do lookahead for CBlock messages.  If it's a block then get the blockhash
     // and indicate we are downloading it so that we don't re-request the block
@@ -684,12 +684,12 @@ void CNode::LookAhead(CNetMessage &_msg)
     // flag so that we can get another block from somewhere.
     static const CBlockHeader temp_header;
     static const unsigned int nSizeHeader = ::GetSerializeSize(temp_header, SER_NETWORK, PROTOCOL_VERSION);
-    if (_msg.hdr.GetCommand() == NetMsgType::BLOCK)
+    if (msg.hdr.GetCommand() == NetMsgType::BLOCK)
     {
-        if (_msg.nDataPos > nSizeHeader)
+        if (msg.nDataPos > nSizeHeader)
         {
             CDataStream ss(SER_NETWORK, PROTOCOL_VERSION);
-            ss.append(_msg.vRecv, nSizeHeader);
+            ss.append(msg.vRecv, nSizeHeader);
 
             CBlockHeader header;
             ss >> header;
@@ -717,7 +717,7 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes)
 
             // Do a lookahead if we haven't already done one for this message.
             if (!fLookedOnce.load())
-                LookAhead(msg);
+                LookAhead();
         }
 
         if (handled < 0)

--- a/src/net.h
+++ b/src/net.h
@@ -669,7 +669,7 @@ public:
     }
 
     // Examine the current message (msg) to see if block or thintype blocks have begun downloading data.
-    std::atomic<bool> fLookedOnce{false};
+    std::atomic<bool> fDownloading{false};
     void LookAhead();
 
     // requires LOCK(cs_vRecvMsg)

--- a/src/net.h
+++ b/src/net.h
@@ -668,6 +668,10 @@ public:
         return vSendMsg.size();
     }
 
+    // Examine the current message (msg) to see if block or thintype blocks have begun downloading data.
+    std::atomic<bool> fLookedOnce{false};
+    void LookAhead(CNetMessage &_msg);
+
     // requires LOCK(cs_vRecvMsg)
     bool ReceiveMsgBytes(const char *pch, unsigned int nBytes) EXCLUSIVE_LOCKS_REQUIRED(cs_vRecvMsg);
 

--- a/src/net.h
+++ b/src/net.h
@@ -670,7 +670,7 @@ public:
 
     // Examine the current message (msg) to see if block or thintype blocks have begun downloading data.
     std::atomic<bool> fLookedOnce{false};
-    void LookAhead(CNetMessage &_msg);
+    void LookAhead();
 
     // requires LOCK(cs_vRecvMsg)
     bool ReceiveMsgBytes(const char *pch, unsigned int nBytes) EXCLUSIVE_LOCKS_REQUIRED(cs_vRecvMsg);

--- a/src/requestManager.h
+++ b/src/requestManager.h
@@ -87,6 +87,7 @@ public:
     typedef std::list<CNodeRequestData> ObjectSourceList;
     CInv obj;
     bool rateLimited;
+    int64_t nDownloadingSince; // last time we started downloading the object
     bool fProcessing; // object was received but is still being processed
     int64_t lastRequestTime; // In stopwatch time microseconds, 0 means no request
     unsigned int outstandingReqs;
@@ -96,6 +97,7 @@ public:
     CUnknownObj()
     {
         rateLimited = false;
+        nDownloadingSince = 0;
         fProcessing = false;
         outstandingReqs = 0;
         lastRequestTime = 0;
@@ -198,6 +200,9 @@ public:
 
     // Update the response time for this transaction request
     void UpdateTxnResponseTime(const CInv &obj, CNode *pfrom);
+
+    // Indicate that we got this object
+    void Downloading(const uint256 &hash, CNode *pfrom);
 
     // Indicate that we are processing this transaction
     void ProcessingTxn(const uint256 &hash, CNode *pfrom);

--- a/src/streams.h
+++ b/src/streams.h
@@ -142,6 +142,8 @@ public:
             vch.insert(it, first, last);
     }
 
+    // Append data from one datastream to this one.
+    void append(CDataStream &ss, const unsigned int nChars) { vch.insert(vch.end(), ss.begin(), ss.begin() + nChars); }
     void insert(iterator it, std::string::iterator first, std::string::iterator last)
     {
         if (last == first)


### PR DESCRIPTION
This is important for when the network becomes congested (as in giga-net testing). We need to be able to disable (or delay) re-requests if the block is currently being downloaded so that we don't end up re-requesting a block from every peer in the network , causing further node congestion.

Currently this feature is just delaying the re-request using a fixed value if a block is downloading but in the future it would be more ideal to dynamically adjust this value based on node and network conditions.