### PR TITLE
Fix formatting for `cashlib/cashlib.cpp`

### DIFF
--- a/src/cashlib/cashlib.cpp
+++ b/src/cashlib/cashlib.cpp
@@ -872,15 +872,17 @@ extern "C" JNIEXPORT jstring JNICALL Java_bitcoinunlimited_libbitcoincash_PayAdd
     uint160 tmp((const uint8_t *)data);
 
     CTxDestination dst = CNoDestination();
-    if (typ == 2 /* P2PKH */) {
+    if (typ == 2 /* P2PKH */)
+    {
         dst = CKeyID(tmp);
     }
-    else if (typ == 3 /* P2PSH */) {
+    else if (typ == 3 /* P2PSH */)
+    {
         dst = CScriptID(tmp);
     }
-    else {
-        triggerJavaIllegalStateException(env,
-                "Address type cannot be encoded to cashaddr");
+    else
+    {
+        triggerJavaIllegalStateException(env, "Address type cannot be encoded to cashaddr");
         return nullptr;
     }
 


### PR DESCRIPTION
for some reason travis didn't run #2219 and so we didn't catch this formatting issue.