### PR TITLE
output confirmations and more accurate time in some RPC calls in some edge conditions

### DIFF
--- a/src/index/txindex.cpp
+++ b/src/index/txindex.cpp
@@ -230,7 +230,7 @@ void TxIndex::BlockConnected(const CBlock &block, CBlockIndex *pindex)
 }
 
 bool TxIndex::IsSynced() { return fSynced.load(); }
-bool TxIndex::FindTx(const uint256 &txhash, uint256 &blockhash, CTransactionRef &ptx) const
+bool TxIndex::FindTx(const uint256 &txhash, uint256 &blockhash, CTransactionRef &ptx, int32_t &txTime) const
 {
     CDiskTxPos postx;
     if (!db->ReadTxPos(txhash, postx))
@@ -253,6 +253,7 @@ bool TxIndex::FindTx(const uint256 &txhash, uint256 &blockhash, CTransactionRef 
     blockhash = header.GetHash();
     if (ptx->GetHash() != txhash)
         return error("%s: txid mismatch", __func__);
+    txTime = header.nTime;
 
     return true;
 }

--- a/src/index/txindex.h
+++ b/src/index/txindex.h
@@ -67,7 +67,8 @@ public:
     bool IsSynced();
 
     /// Look up the on-disk location of a transaction by hash.
-    bool FindTx(const uint256 &txhash, uint256 &blockhash, CTransactionRef &ptx) const;
+    /// @returns A reference to the transaction, and the epoch time it was confirmed
+    bool FindTx(const uint256 &txhash, uint256 &blockhash, CTransactionRef &ptx, int32_t &time) const;
 
     /// Start initializes the sync state and registers the instance as a
     /// ValidationInterface so that it stays in sync with blockchain updates.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -290,7 +290,6 @@ bool GetTransaction(const uint256 &hash,
     const CBlockIndex *pindexSlow = blockIndex;
 
     CTransactionRef ptx;
-    txTime = 0;
     {
         READLOCK(mempool.cs_txmempool);
         CTxMemPool::txiter entryPtr = mempool.mapTx.find(hash);
@@ -308,8 +307,11 @@ bool GetTransaction(const uint256 &hash,
 
     if (g_txindex)
     {
-        if (g_txindex->FindTx(hash, hashBlock, txOut))
+        int32_t time = -1;
+        if (g_txindex->FindTx(hash, hashBlock, txOut, time))
         {
+            if (txTime != -1)
+                txTime = time;
             return true;
         }
     }
@@ -337,6 +339,7 @@ bool GetTransaction(const uint256 &hash,
                 return false;
             }
             txOut = block.vtx.at(pos);
+            txTime = block.nTime;
             return true;
         }
     }

--- a/src/main.h
+++ b/src/main.h
@@ -220,9 +220,18 @@ void PartitionCheck(bool (*initialDownloadCheck)(),
  * This function only returns the highest priority warning of the set selected by strFor.
  */
 std::string GetWarnings(const std::string &strFor);
-/** Retrieve a transaction (from memory pool, or from disk, if possible) */
+
+/** Retrieve a transaction (from memory pool, UTXO, txindex, or from disk)
+    @param tx (out) The transaction data
+    @param txTime (out) The time the transaction was confirmed or first seen
+    @param params Blockchain consensus parameters
+    @param hashBlock What block this transaction was in (or uint256() if no block)
+    @param fAllowSlow Use the UTXO and disk to find the transaction, if needed
+    @param blockIndex Help this API find this transaction quickly by providing this info if you have it
+*/
 bool GetTransaction(const uint256 &hash,
     CTransactionRef &tx,
+    int64_t &txTime,
     const Consensus::Params &params,
     uint256 &hashBlock,
     bool fAllowSlow = false,

--- a/src/main.h
+++ b/src/main.h
@@ -223,7 +223,8 @@ std::string GetWarnings(const std::string &strFor);
 
 /** Retrieve a transaction (from memory pool, UTXO, txindex, or from disk)
     @param tx (out) The transaction data
-    @param txTime (out) The time the transaction was confirmed or first seen
+    @param txTime (out) The time the transaction was confirmed or first seen.  If no information about this transaction
+                        exists, this parameter is untouched.
     @param params Blockchain consensus parameters
     @param hashBlock What block this transaction was in (or uint256() if no block)
     @param fAllowSlow Use the UTXO and disk to find the transaction, if needed

--- a/src/rest.cpp
+++ b/src/rest.cpp
@@ -62,7 +62,6 @@ struct CCoin
     }
 };
 
-extern void TxToJSON(const CTransaction &tx, const uint256 hashBlock, UniValue &entry);
 extern UniValue blockToJSON(const CBlock &block,
     const CBlockIndex *blockindex,
     bool txDetails = false,
@@ -387,7 +386,8 @@ static bool rest_tx(HTTPRequest *req, const std::string &strURIPart)
 
     CTransactionRef tx;
     uint256 hashBlock = uint256();
-    if (!GetTransaction(hash, tx, Params().GetConsensus(), hashBlock, true))
+    int64_t txTime = GetTime();
+    if (!GetTransaction(hash, tx, txTime, Params().GetConsensus(), hashBlock, true))
         return RESTERR(req, HTTP_NOT_FOUND, hashStr + " not found");
 
     CDataStream ssTx(SER_NETWORK, PROTOCOL_VERSION);
@@ -414,7 +414,7 @@ static bool rest_tx(HTTPRequest *req, const std::string &strURIPart)
     case RF_JSON:
     {
         UniValue objTx(UniValue::VOBJ);
-        TxToJSON(*tx, hashBlock, objTx);
+        TxToJSON(*tx, txTime, hashBlock, objTx);
         string strJSON = objTx.write() + "\n";
         req->WriteHeader("Content-Type", "application/json");
         req->WriteReply(HTTP_OK, strJSON);

--- a/src/rpc/blockchain.cpp
+++ b/src/rpc/blockchain.cpp
@@ -44,7 +44,6 @@ static uint32_t nDefaultRollbackLimit = 100;
 
 using namespace std;
 
-extern void TxToJSON(const CTransaction &tx, const uint256 hashBlock, UniValue &entry);
 void ScriptPubKeyToJSON(const CScript &scriptPubKey, UniValue &out, bool fIncludeHex);
 
 double GetDifficulty(const CBlockIndex *blockindex)
@@ -125,12 +124,13 @@ UniValue blockToJSON(const CBlock &block,
     UniValue txs(UniValue::VARR);
     if (listTxns)
     {
+        int64_t txTime = -1; // Don't display the time in the tx because its in the block data.
         for (const auto &tx : block.vtx)
         {
             if (txDetails)
             {
                 UniValue objTx(UniValue::VOBJ);
-                TxToJSON(*tx, uint256(), objTx);
+                TxToJSON(*tx, txTime, uint256(), objTx);
                 txs.push_back(objTx);
             }
             else

--- a/src/rpc/protocol.h
+++ b/src/rpc/protocol.h
@@ -14,7 +14,10 @@
 #include <stdint.h>
 #include <string>
 
+#include "uint256.h"
 #include "univalue/include/univalue.h"
+
+class CTransaction;
 
 //! HTTP status codes
 enum HTTPStatusCode
@@ -83,6 +86,11 @@ std::string JSONRPCRequest(const std::string &strMethod, const UniValue &params,
 UniValue JSONRPCReplyObj(const UniValue &result, const UniValue &error, const UniValue &id);
 std::string JSONRPCReply(const UniValue &result, const UniValue &error, const UniValue &id);
 UniValue JSONRPCError(int code, const std::string &message);
+
+// rawtransaction.cpp
+/** This function supplies transaction JSON data for different interfaces (REST and RPC).
+Pass -1 to txTime to not include (used to avoid redundancy when tx are being shown within a block) */
+void TxToJSON(const CTransaction &tx, const int64_t txTime, const uint256 hashBlock, UniValue &entry);
 
 /** Get name of RPC authentication cookie file */
 fs::path GetAuthCookieFile();

--- a/src/rpc/rawtransaction.cpp
+++ b/src/rpc/rawtransaction.cpp
@@ -70,7 +70,8 @@ void ScriptPubKeyToJSON(const CScript &scriptPubKey, UniValue &out, bool fInclud
     out.pushKV("addresses", a);
 }
 
-void TxToJSON(const CTransaction &tx, const uint256 hashBlock, UniValue &entry)
+
+void TxToJSON(const CTransaction &tx, const int64_t txTime, const uint256 hashBlock, UniValue &entry)
 {
     entry.pushKV("txid", tx.GetHash().GetHex());
     entry.pushKV("size", (int)tx.GetTxSize());
@@ -109,6 +110,7 @@ void TxToJSON(const CTransaction &tx, const uint256 hashBlock, UniValue &entry)
     }
     entry.pushKV("vout", vout);
 
+    bool confs = false;
     if (!hashBlock.IsNull())
     {
         entry.pushKV("blockhash", hashBlock.GetHex());
@@ -120,11 +122,18 @@ void TxToJSON(const CTransaction &tx, const uint256 hashBlock, UniValue &entry)
                 entry.pushKV("confirmations", 1 + chainActive.Height() - pindex->nHeight);
                 entry.pushKV("time", pindex->GetBlockTime());
                 entry.pushKV("blocktime", pindex->GetBlockTime());
+                confs = true;
             }
-            else
-                entry.pushKV("confirmations", 0);
         }
     }
+    // If the confirmations wasn't written with a valid block, then we have 0 confirmations.
+    if (!confs)
+    {
+        entry.pushKV("confirmations", 0);
+        if (txTime != -1)
+            entry.pushKV("time", txTime);
+    }
+
     entry.pushKV("hex", EncodeHexTx(tx));
 }
 
@@ -232,8 +241,9 @@ UniValue getrawtransaction(const UniValue &params, bool fHelp)
     }
 
     CTransactionRef tx;
+    int64_t txTime = GetTime(); // Will be overwritten by GetTransaction if we have a better value
     uint256 hash_block;
-    if (!GetTransaction(hash, tx, Params().GetConsensus(), hash_block, true, blockindex))
+    if (!GetTransaction(hash, tx, txTime, Params().GetConsensus(), hash_block, true, blockindex))
     {
         std::string errmsg;
         if (blockindex)
@@ -268,7 +278,7 @@ UniValue getrawtransaction(const UniValue &params, bool fHelp)
     UniValue result(UniValue::VOBJ);
     if (blockindex)
         result.pushKV("in_active_chain", in_active_chain);
-    TxToJSON(*tx, hash_block, result);
+    TxToJSON(*tx, txTime, hash_block, result);
     return result;
 }
 
@@ -415,7 +425,7 @@ UniValue getrawblocktransactions(const UniValue &params, bool fHelp)
 
         UniValue result(UniValue::VOBJ);
         result.pushKV("hex", strHex);
-        TxToJSON(*tx, block.GetHash(), result);
+        TxToJSON(*tx, 0, block.GetHash(), result); // txTime is 0 because block time will used
         resultSet.pushKV(tx->GetHash().ToString(), result);
     }
     return resultSet;
@@ -592,7 +602,7 @@ UniValue getrawtransactionssince(const UniValue &params, bool fHelp)
             }
             UniValue txDetails(UniValue::VOBJ);
             txDetails.pushKV("hex", strHex);
-            TxToJSON(*tx, block.GetHash(), txDetails);
+            TxToJSON(*tx, 0, block.GetHash(), txDetails); // txTime can be 0 because block time overrides
             blockResults.pushKV(tx->GetHash().ToString(), txDetails);
         }
         resultSet.pushKV(block.GetHash().GetHex(), blockResults);
@@ -661,7 +671,8 @@ UniValue gettxoutproof(const UniValue &params, bool fHelp)
     if (pblockindex == nullptr)
     {
         CTransactionRef tx;
-        if (!GetTransaction(oneTxid, tx, Params().GetConsensus(), hashBlock, false) || hashBlock.IsNull())
+        int64_t txTime = 0; // This data is not needed for this function
+        if (!GetTransaction(oneTxid, tx, txTime, Params().GetConsensus(), hashBlock, false) || hashBlock.IsNull())
         {
             std::string errmsg;
             if (!fTxIndex)
@@ -1014,7 +1025,7 @@ UniValue decoderawtransaction(const UniValue &params, bool fHelp)
         throw JSONRPCError(RPC_DESERIALIZATION_ERROR, "TX decode failed");
 
     UniValue result(UniValue::VOBJ);
-    TxToJSON(tx, uint256(), result);
+    TxToJSON(tx, -1, uint256(), result); // don't show the time since its not part of the tx serialized data
 
     return result;
 }


### PR DESCRIPTION
add confirmations=0 in getrawtransaction to behave similarly with gettransaction.  Provide the transaction time from the mempool if the transaction is discovered in the mempool.