### PR TITLE
Fix bench_bitcoin command line flags parsing

### DIFF
--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -825,7 +825,7 @@ BitcoinCli::BitcoinCli() : AllowedArgs(true)
                                          "(recommended for sensitive information such as passphrases)"));
 }
 
-BitcoinBench::BitcoinBench() : AllowedArgs(false)
+BitcoinBench::BitcoinBench() : AllowedArgs(true)
 {
     addHelpOptions(*this);
 

--- a/src/bench/rpc_blockchain.cpp
+++ b/src/bench/rpc_blockchain.cpp
@@ -4,6 +4,8 @@
 
 #include <bench/bench.h>
 #include <bench/data.h>
+#include <chainparams.h>
+#include <test/test_bitcoin.h>
 
 #include <rpc/blockchain.h>
 #include <streams.h>
@@ -13,6 +15,7 @@
 
 static void BlockToJsonVerbose(benchmark::State &state)
 {
+    TestingSetup test_setup(CBaseChainParams::REGTEST);
     CDataStream stream(benchmark::data::block413567, SER_NETWORK, PROTOCOL_VERSION);
     char a = '\0';
     stream.write(&a, 1); // Prevent compaction


### PR DESCRIPTION
This makes you able to use, among others, `-filter` to reduce the number of bench to run for a give session, e.g.:

```bash
bench_bitcoin --filter=Block.\*
```

While at it fix a problem with `BlockToJsonVerbose` raised when running the bench in isolation. 