### PR TITLE
[WIP] Fix gcc 8/9 -Wdeprecated-copy warnings for implicit copy constructor and assignment operator

### DIFF
--- a/src/amount.h
+++ b/src/amount.h
@@ -59,6 +59,7 @@ public:
     friend bool operator==(const CFeeRate &a, const CFeeRate &b) { return a.nSatoshisPerK == b.nSatoshisPerK; }
     friend bool operator<=(const CFeeRate &a, const CFeeRate &b) { return a.nSatoshisPerK <= b.nSatoshisPerK; }
     friend bool operator>=(const CFeeRate &a, const CFeeRate &b) { return a.nSatoshisPerK >= b.nSatoshisPerK; }
+    CFeeRate &operator=(const CFeeRate &a) = default;
     CFeeRate &operator+=(const CFeeRate &a)
     {
         nSatoshisPerK += a.nSatoshisPerK;

--- a/src/key.h
+++ b/src/key.h
@@ -68,6 +68,7 @@ public:
 
     //! Destructor (again necessary because of memlocking).
     ~CKey() { UnlockObject(vch); }
+    CKey &operator=(const CKey &a) = default;
     friend bool operator==(const CKey &a, const CKey &b)
     {
         return a.fCompressed == b.fCompressed && a.size() == b.size() && memcmp(&a.vch[0], &b.vch[0], a.size()) == 0;

--- a/src/txmempool.h
+++ b/src/txmempool.h
@@ -131,6 +131,8 @@ public:
         LockPoints lp);
     CTxMemPoolEntry(const CTxMemPoolEntry &other);
 
+    CTxMemPoolEntry &operator=(const CTxMemPoolEntry &) = default;
+
     const CTransaction &GetTx() const { return *this->tx; }
     CTransactionRef GetSharedTx() const { return this->tx; }
     /**


### PR DESCRIPTION
For more details see

https://gcc.gnu.org/onlinedocs/gcc-9.1.0/gcc/C_002b_002b-Dialect-Options.html#index-Wdeprecated-copy

https://github.com/oneapi-src/oneTBB/issues/161