### PR TITLE
[qa] Multiple client electrum subscription test

### DIFF
--- a/qa/rpc-tests/electrum_subscriptions.py
+++ b/qa/rpc-tests/electrum_subscriptions.py
@@ -7,7 +7,8 @@ from test_framework.util import assert_equal, assert_raises
 from test_framework.test_framework import BitcoinTestFramework
 from test_framework.loginit import logging
 from test_framework.electrumutil import (ElectrumConnection,
-    address_to_scripthash, bitcoind_electrum_args, sync_electrum_height)
+    address_to_scripthash, bitcoind_electrum_args, sync_electrum_height,
+    wait_for_electrum_mempool)
 
 class ElectrumSubscriptionsTest(BitcoinTestFramework):
 
@@ -19,54 +20,60 @@ class ElectrumSubscriptionsTest(BitcoinTestFramework):
 
     def run_test(self):
         n = self.nodes[0]
-        n.generate(110)
+        n.generate(200)
         sync_electrum_height(n)
 
-        cli = ElectrumConnection()
-        self.test_unsubscribe_scripthash(n, cli)
-        self.test_subscribe_headers(n, cli)
-        self.test_subscribe_scripthash(n, cli)
 
-    def test_unsubscribe_scripthash(self, n, cli):
+        async def async_tests():
+            await self.test_multiple_client_subs(n)
+
+            cli = ElectrumConnection()
+            await cli.connect()
+            await self.test_unsubscribe_scripthash(n, cli)
+            await self.test_subscribe_headers(n, cli)
+            await self.test_subscribe_scripthash(n, cli)
+
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(async_tests())
+
+    async def test_unsubscribe_scripthash(self, n, cli):
         addr = n.getnewaddress()
         scripthash = address_to_scripthash(addr)
-        _, queue = cli.subscribe('blockchain.scripthash.subscribe', scripthash)
+        _, queue = await cli.subscribe('blockchain.scripthash.subscribe', scripthash)
 
         # Verify that we're receiving notifications
         n.sendtoaddress(addr, 10)
-        sh, _ = cli.loop.run_until_complete(
-                asyncio.wait_for(queue.get(), timeout = 10))
+        sh, _ = await asyncio.wait_for(queue.get(), timeout = 10)
         assert_equal(scripthash, sh)
 
-        ok = cli.call('blockchain.scripthash.unsubscribe', scripthash)
+        ok = await cli.call('blockchain.scripthash.unsubscribe', scripthash)
         assert(ok)
 
         # Verify that we're no longer receiving notifications
-        def wait():
-            cli.loop.run_until_complete(
-                asyncio.wait_for(queue.get(), timeout = 10))
-
         n.sendtoaddress(addr, 10)
-        assert_raises(asyncio.TimeoutError, wait)
+        try:
+            await asyncio.wait_for(queue.get(), timeout = 10)
+            assert(False) # Should have timed out.
+        except asyncio.TimeoutError:
+            pass
 
         # Unsubscribing from a hash we're not subscribed to should return false
-        ok = cli.call('blockchain.scripthash.unsubscribe',
+        ok = await cli.call('blockchain.scripthash.unsubscribe',
                 address_to_scripthash(n.getnewaddress()))
         assert(not ok)
 
-    def test_subscribe_scripthash(self, n, cli):
+    async def test_subscribe_scripthash(self, n, cli):
         logging.info("Testing scripthash subscription")
         addr = n.getnewaddress()
         scripthash = address_to_scripthash(addr)
-        statushash, queue = cli.subscribe('blockchain.scripthash.subscribe', scripthash)
+        statushash, queue = await cli.subscribe('blockchain.scripthash.subscribe', scripthash)
 
         logging.info("Unused address should not have a statushash")
         assert_equal(None, statushash)
 
         logging.info("Check notification on receiving coins")
         n.sendtoaddress(addr, 10)
-        sh, new_statushash1 = cli.loop.run_until_complete(
-                asyncio.wait_for(queue.get(), timeout = 10))
+        sh, new_statushash1 = await asyncio.wait_for(queue.get(), timeout = 10)
         assert_equal(scripthash, sh)
         assert(new_statushash1 != None and len(new_statushash1) == 64)
 
@@ -74,25 +81,23 @@ class ElectrumSubscriptionsTest(BitcoinTestFramework):
         assert(len(n.getrawmempool()) == 1)
         n.generate(1)
         assert(len(n.getrawmempool()) == 0)
-        sh, new_statushash2 = cli.loop.run_until_complete(
-                asyncio.wait_for(queue.get(), timeout = 10))
+        sh, new_statushash2 = await asyncio.wait_for(queue.get(), timeout = 10)
         assert_equal(scripthash, sh)
         assert(new_statushash2 != new_statushash1)
         assert(new_statushash2 != None)
 
         logging.info("Check that we get notification when spending funds from address")
         n.sendtoaddress(n.getnewaddress(), n.getbalance(), "", "", True)
-        sh, new_statushash3 = cli.loop.run_until_complete(
-                asyncio.wait_for(queue.get(), timeout = 10))
+        sh, new_statushash3 = await asyncio.wait_for(queue.get(), timeout = 10)
         assert_equal(scripthash, sh)
         assert(new_statushash3 != new_statushash2)
         assert(new_statushash3 != None)
 
-    def test_subscribe_headers(self, n, cli):
+    async def test_subscribe_headers(self, n, cli):
         headers = []
 
         logging.info("Calling subscribe should return the current best block header")
-        result, queue = cli.subscribe('blockchain.headers.subscribe')
+        result, queue = await cli.subscribe('blockchain.headers.subscribe')
         assert_equal(
                 n.getblockheader(n.getbestblockhash(), False),
                 result['hex'])
@@ -106,8 +111,49 @@ class ElectrumSubscriptionsTest(BitcoinTestFramework):
                 assert_equal(header_hex, notified.pop()['hex'])
 
         start = time.time()
-        cli.loop.run_until_complete(test())
+        await test()
         logging.info("Getting 10 block notifications took {} seconds".format(time.time() - start))
+
+
+    async def test_multiple_client_subs(self, n):
+        num_clients = 50
+        clients = [ ElectrumConnection() for _ in range(0, num_clients) ]
+        [ await c.connect() for c in clients ]
+
+        queues = []
+        addresses = [ n.getnewaddress() for _ in range(0, num_clients) ]
+
+        # Send coins so the addresses, so they get a statushash
+        [ n.sendtoaddress(addresses[i], 1) for i in range(0, num_clients) ]
+
+        wait_for_electrum_mempool(n, count = num_clients)
+
+        statushashes = []
+        queues = []
+        for i in range(0, num_clients):
+            cli = clients[i]
+            addr = addresses[i]
+            scripthash = address_to_scripthash(addr)
+            statushash, queue = await cli.subscribe('blockchain.scripthash.subscribe', scripthash)
+
+            # should be unique
+            assert(statushash is not None)
+            assert(statushash not in statushashes)
+            statushashes.append(statushash)
+            queues.append(queue)
+
+        # Send new coin to all, observe that all clients get a notification
+        [ n.sendtoaddress(addresses[i], 1) for i in range(0, num_clients) ]
+
+        for i in range(0, num_clients):
+            q = queues[i]
+            old_statushash = statushashes[i]
+
+            scripthash, new_statushash = await asyncio.wait_for(q.get(), timeout = 10)
+            assert_equal(scripthash, address_to_scripthash(addresses[i]))
+            assert(new_statushash != None)
+            assert(new_statushash != old_statushash)
+
 
 if __name__ == '__main__':
     ElectrumSubscriptionsTest().main()

--- a/qa/rpc-tests/test_framework/electrumutil.py
+++ b/qa/rpc-tests/test_framework/electrumutil.py
@@ -32,10 +32,8 @@ def bitcoind_electrum_args():
             "-electrum.rawarg=--cashaccount-activation-height=1"]
 
 class ElectrumConnection:
-    def __init__(self):
+    def __init__(self,):
         self.cli = StratumClient()
-        self.loop = asyncio.get_event_loop()
-        self.loop.run_until_complete(self.connect())
 
     async def connect(self):
         connect_timeout = 30
@@ -54,16 +52,13 @@ class ElectrumConnection:
             time.sleep(1)
 
 
-    def call(self, method, *args):
-        return self.loop.run_until_complete(self.cli.RPC(method, *args))
+    async def call(self, method, *args):
+        return await self.cli.RPC(method, *args)
 
-    def subscribe(self, method, *args):
+    async def subscribe(self, method, *args):
         future, queue = self.cli.subscribe(method, *args)
-        result = self.loop.run_until_complete(future)
+        result = await future
         return result, queue
-
-def create_electrum_connection():
-    return ElectrumConnection()
 
 def script_to_scripthash(script):
     import hashlib

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -142,6 +142,21 @@ def waitFor(timeout, fn, onError="timeout in waitFor", sleepAmt=1.0):
         time.sleep(sleepAmt)
         timeout -= sleepAmt
 
+async def waitForAsync(timeout, fn, onError="timeout in waitFor", sleepAmt=1.0):
+    """  Repeatedly calls fn while it returns None, raising an assert after timeout.  If fn returns non None, return that result
+    """
+    timeout = float(timeout)
+    while 1:
+        result = await fn()
+        if not (result is None or result is False):
+            return result
+        if timeout <= 0:
+            if callable(onError):
+                onError = onError()
+            raise TimeoutException(onError)
+        time.sleep(sleepAmt)
+        timeout -= sleepAmt
+
 def expectException(fn, ExcType, comparison=None):
     try:
         fn()
@@ -991,6 +1006,16 @@ def assert_greater_than(thing1, thing2):
 def assert_raises(exc, fun, *args, **kwds):
     try:
         fun(*args, **kwds)
+    except exc:
+        pass
+    except Exception as e:
+        raise AssertionError("Unexpected exception raised: "+type(e).__name__)
+    else:
+        raise AssertionError("No exception raised")
+
+async def assert_raises_async(exc, fun, *args, **kwds):
+    try:
+        await fun(*args, **kwds)
     except exc:
         pass
     except Exception as e:


### PR DESCRIPTION
A test that connects to electrum server with multiple clients that subscribe to a scripthash.

Includes a refactor commit. For the framework to support multiple clients, the asyncio loop needs to be outside of ElectrumClient object.

This test triggers the ElectrsCash issue fixed in https://github.com/BitcoinUnlimited/ElectrsCash/pull/77