### PR TITLE
[electrum] Introduce electrum.blocknotify

### DIFF
--- a/qa/rpc-tests/test_framework/electrumutil.py
+++ b/qa/rpc-tests/test_framework/electrumutil.py
@@ -27,6 +27,7 @@ def bitcoind_electrum_args():
     global ELECTRUM_PORT
     ELECTRUM_PORT = random.randint(40000, 60000)
     return ["-electrum=1", "-debug=electrum", "-debug=rpc",
+            "-electrum.blocknotify=1",
             "-electrum.port=" + str(ELECTRUM_PORT),
             "-electrum.monitoring.port=" + str(random.randint(40000, 60000)),
             "-electrum.rawarg=--cashaccount-activation-height=1"]

--- a/src/allowed_args.cpp
+++ b/src/allowed_args.cpp
@@ -730,6 +730,8 @@ static void addElectrumOptions(AllowedArgs &allowedArgs)
             "(example: -electrum.rawarg=\"--server-banner=\\\"Welcome to my server!\\\"\"). "
             "This option can be specified multiple times.")
         .addArg("electrum.shutdownonerror", optionalBool, "Shutdown if the electrum server exits unexpectedly")
+        .addArg("electrum.blocknotify", optionalBool, "Instantly notify electrum server of new blocks. "
+                                                      "Must only be used with ElectrsCash version greater than 1.1.1")
         .addDebugArg("electrum.exec", requiredStr, "Path to electrum daemon executable")
         .addDebugArg("electrum.monitoring.port", requiredStr, "Port to bind monitoring service")
         .addDebugArg("electrum.monitoring.host", requiredStr, "Host to bind monitoring service")

--- a/src/electrum/electrumserver.cpp
+++ b/src/electrum/electrumserver.cpp
@@ -10,6 +10,10 @@
 #include <chrono>
 #include <string>
 
+#if BOOST_OS_LINUX
+#include <signal.h>
+#endif
+
 //! give the program a second to complain about startup issues, such as invalid
 //! parameters.
 static bool startup_check(const SubProcess &p)
@@ -170,6 +174,18 @@ bool ElectrumServer::IsRunning() const
         return false;
     }
     return process->IsRunning();
+}
+
+void ElectrumServer::NotifyNewBlock()
+{
+    std::unique_lock<std::mutex> lock(process_cs);
+    if (!bool(process))
+    {
+        return;
+    }
+#if BOOST_OS_LINUX
+    process->SendSignal(SIGUSR1);
+#endif
 }
 
 ElectrumServer &ElectrumServer::Instance()

--- a/src/electrum/electrumserver.h
+++ b/src/electrum/electrumserver.h
@@ -27,6 +27,10 @@ public:
 
     void Stop();
     bool IsRunning() const;
+
+    // signal to the electrum server that a new block is avaialable.
+    void NotifyNewBlock();
+
     ~ElectrumServer();
 
 private:

--- a/src/utilprocess.h
+++ b/src/utilprocess.h
@@ -47,6 +47,7 @@ public:
     bool IsRunning() const { return is_running; }
     void Interrupt();
     void Terminate();
+    void SendSignal(int signal);
 
 
 private:
@@ -57,8 +58,6 @@ private:
     std::atomic<int> pid;
     std::atomic<bool> is_running;
     std::atomic<bool> run_started;
-
-    void SendSignal(int signal);
 };
 
 


### PR DESCRIPTION
With the introduction of https://github.com/BitcoinUnlimited/ElectrsCash/pull/78,  we can send SIGUSR1 signal to the electrum process, triggering instant block update.

Without this change the electrum qa tests take 270 seconds. With this change they take 146 seconds.