### PR TITLE
Fix debug ui -> blockcount and size not updating

### DIFF
--- a/src/qt/rpcconsole.cpp
+++ b/src/qt/rpcconsole.cpp
@@ -396,7 +396,7 @@ void RPCConsole::setClientModel(ClientModel *model)
         setNumConnections(model->getNumConnections());
         connect(model, SIGNAL(numConnectionsChanged(int)), this, SLOT(setNumConnections(int)));
 
-        setNumBlocks(model->getNumBlocks(), model->getLastBlockDate(), model->getVerificationProgress(nullptr));
+        setNumBlocks(model->getNumBlocks(), model->getLastBlockDate(), model->getVerificationProgress(nullptr), false);
         connect(model, SIGNAL(numBlocksChanged(int, QDateTime, double, bool)), this,
             SLOT(setNumBlocks(int, QDateTime, double, bool)));
         connect(model, SIGNAL(timeSinceLastBlockChanged(qint64)), this, SLOT(updateTimeSinceLastBlock(qint64)));
@@ -639,18 +639,21 @@ void RPCConsole::setNumConnections(int count)
     ui->numberOfConnections->setText(connections);
 }
 
-void RPCConsole::setNumBlocks(int count, const QDateTime &blockDate, double nVerificationProgress)
+void RPCConsole::setNumBlocks(int count, const QDateTime &blockDate, double nVerificationProgress, bool fHeader)
 {
-    ui->numberOfBlocks->setText(QString::number(count));
-    ui->lastBlockTime->setText(blockDate.toString(time_format));
+    if (!fHeader)
+    {
+        ui->numberOfBlocks->setText(QString::number(count));
+        ui->lastBlockTime->setText(blockDate.toString(time_format));
 
-    ui->lastBlockSize->setText(QString::number(nBlockSizeAtChainTip.load()));
-    if (nBlockSizeAtChainTip.load() == 0)
-        ui->lastBlockSize->setText("N/A");
-    else if (nBlockSizeAtChainTip.load() < 1000000)
-        ui->lastBlockSize->setText(QString::number(nBlockSizeAtChainTip.load() / 1000.0, 'f', 2) + " KB");
-    else
-        ui->lastBlockSize->setText(QString::number(nBlockSizeAtChainTip.load() / 1000000.0, 'f', 2) + " MB");
+        ui->lastBlockSize->setText(QString::number(nBlockSizeAtChainTip.load()));
+        if (nBlockSizeAtChainTip.load() == 0)
+            ui->lastBlockSize->setText("N/A");
+        else if (nBlockSizeAtChainTip.load() < 1000000)
+            ui->lastBlockSize->setText(QString::number(nBlockSizeAtChainTip.load() / 1000.0, 'f', 2) + " KB");
+        else
+            ui->lastBlockSize->setText(QString::number(nBlockSizeAtChainTip.load() / 1000000.0, 'f', 2) + " MB");
+    }
 }
 
 void RPCConsole::updateTimeSinceLastBlock(qint64 lastBlockTime)

--- a/src/qt/rpcconsole.h
+++ b/src/qt/rpcconsole.h
@@ -95,7 +95,7 @@ public Q_SLOTS:
     /** Set number of connections shown in the UI */
     void setNumConnections(int count);
     /** Set number of blocks and last block date shown in the UI */
-    void setNumBlocks(int count, const QDateTime &blockDate, double nVerificationProgress);
+    void setNumBlocks(int count, const QDateTime &blockDate, double nVerificationProgress, bool fHeader);
     /** Set time since last block shown in the UI */
     void updateTimeSinceLastBlock(qint64 blockDate);
     /** Set size (number of transactions and memory usage) of the mempool in the UI */


### PR DESCRIPTION
After the modal overlay update the rpc console setNumBlocks() was no
longer getting called because of the introduction of the bool flag
fHeader.