### PR TITLE
Implement xversion handshake state

### DIFF
--- a/qa/rpc-tests/xversion.py
+++ b/qa/rpc-tests/xversion.py
@@ -65,12 +65,14 @@ class XVersionTest(BitcoinTestFramework):
         conn = self.restart_node()
         nt = NetworkThread()
         nt.start()
-
+        print("sent version")
         conn.wait_for(lambda : conn.remote_xversion)
+        print("sent extversion")
         conn.send_message(msg_xversion({1000 : b"test string"}))
-
         conn.wait_for_verack()
+        print("sent verack")
         conn.send_message(msg_verack())
+
 
 
         # make sure xversion has actually been received properly
@@ -120,6 +122,25 @@ class XVersionTest(BitcoinTestFramework):
 
         conn.connection.disconnect_node()
         nt.join()
+
+        # Test versionbit mismatch
+
+        logging.info("Testing xversion service bit mismatch")
+
+        # test regular set up including xversion
+        conn = self.restart_node()
+        nt = NetworkThread()
+        nt.start()
+        print("sent version")
+        conn.wait_for(lambda : conn.remote_xversion)
+        # if we send verack instead of xversion we should get a verack response
+        print("sent verack")
+        conn.send_message(msg_verack())
+        conn.wait_for_verack()
+
+        conn.connection.disconnect_node()
+        nt.join()
+
 
 if __name__ == '__main__':
     xvt = XVersionTest()

--- a/src/net.h
+++ b/src/net.h
@@ -352,8 +352,8 @@ public:
     /** Maximum supported mempool synchronization version */
     uint64_t nMempoolSyncMaxVersionSupported = 0;
     /** set to true if this node support xVersion */
-    std::atomic<bool> xVersionEnabled {false};
-    std::atomic<bool> xVersionExpected {false};
+    std::atomic<bool> xVersionEnabled{false};
+    std::atomic<bool> xVersionExpected{false};
     /** set to true if this node is ok with no message checksum */
     bool skipChecksum;
 

--- a/src/net.h
+++ b/src/net.h
@@ -352,7 +352,8 @@ public:
     /** Maximum supported mempool synchronization version */
     uint64_t nMempoolSyncMaxVersionSupported = 0;
     /** set to true if this node support xVersion */
-    bool xVersionEnabled;
+    std::atomic<bool> xVersionEnabled {false};
+    std::atomic<bool> xVersionExpected {false};
     /** set to true if this node is ok with no message checksum */
     bool skipChecksum;
 


### PR DESCRIPTION
This will handle a service bit mismatch. If the peer sends service bit 11 but uses it for something that isnt xversion then this will skip waiting for an xversion response and complete a non xversion handshake