### PR TITLE
Activate Repo Lockdown bot

### DIFF
--- a/.github/lockdown.yml
+++ b/.github/lockdown.yml
@@ -1,0 +1,35 @@
+# Configuration for Repo Lockdown - https://github.com/dessant/repo-lockdown
+
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable
+skipCreatedBefore: 2020-07-01
+
+# Issues and pull requests with these labels will be ignored. Set to `[]` to disable
+exemptLabels: []
+
+# Comment to post before closing or locking. Set to `false` to disable
+comment: "BCH Unlimited git repo has been moved to https://gitlab.com/bitcoinunlimited/BCHUnlimited"
+
+# Label to add before closing or locking. Set to `false` to disable
+label: false
+
+# Close issues and pull requests
+close: true
+
+# Lock issues and pull requests
+lock: true
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings just for `issues` or `pulls`
+# issues:
+#   label: wontfix
+
+# pulls:
+#   comment: >
+#     This repository does not accept pull requests, see the README for details.
+#   lock: false
+
+# Repository to extend settings from
+# _extends: repo


### PR DESCRIPTION
Since we are moving actual development to GitLab all issues and PRs created starting from 2020-07-02 will be closed automatically. For the bot to be activated a conf file has to be created in the
default branch.