### PR TITLE
qt: include QPainterPath header

### DIFF
--- a/src/qt/trafficgraphwidget.cpp
+++ b/src/qt/trafficgraphwidget.cpp
@@ -8,6 +8,7 @@
 
 #include <QColor>
 #include <QPainter>
+#include <QPainterPath>
 #include <QTimer>
 
 #include <cmath>

--- a/src/qt/transactiongraphwidget.cpp
+++ b/src/qt/transactiongraphwidget.cpp
@@ -8,6 +8,7 @@
 
 #include <QColor>
 #include <QPainter>
+#include <QPainterPath>
 
 #include <cmath>
 


### PR DESCRIPTION
Fixes build with Qt 5.15.0 and GCC 10.2:

	[  889s] /usr/include/qt5/QtGui/qmatrix.h:54:7: note: forward declaration of 'class QPainterPath'
	[  889s]    54 | class QPainterPath;

Build failed on Arch Linux.